### PR TITLE
Remaining mixer renames

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -96,6 +96,8 @@ Define {
 	BT_PB_PIPELINE_STREAM_NAME "dai-copier.SSP.10.1"
 	GOOGLE_RTC_AEC_SUPPORT		0
 	GOOGLE_RTC_AEC_REF_SOURCE	'module-copier.8.2'
+	HEADSET_PCM_NAME		"Headset"
+	SPEAKER_PCM_NAME		"Speakers"
 }
 
 # override defaults with platform-specific config
@@ -204,7 +206,7 @@ Object.Pipeline {
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name	'Playback Volume 1'
+					name	'Pre Mixer $HEADSET_PCM_NAME Playback Volume'
 				}
 			}
 		}
@@ -217,7 +219,7 @@ Object.Pipeline {
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name	'Playback Volume 3'
+					name	'Pre Mixer $SPEAKER_PCM_NAME Playback Volume'
 				}
 			}
 		}
@@ -237,7 +239,7 @@ Object.Pipeline {
 
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name	'Main Playback Volume 2'
+					name	'Post Mixer $HEADSET_PCM_NAME Playback Volume'
 				}
 			}
 		}
@@ -254,7 +256,7 @@ Object.Pipeline {
 
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
-					name	'Main Playback Volume 4'
+					name	'Post Mixer $SPEAKER_PCM_NAME Playback Volume'
 				}
 			}
 		}
@@ -296,11 +298,11 @@ Object.Pipeline {
 
 Object.PCM.pcm [
 	{
-		name	"Headset"
+		name	"$HEADSET_PCM_NAME"
 		id	0
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
-			name	"Headset"
+			name	"$HEADSET_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -316,11 +318,11 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Speakers"
+		name	"$SPEAKER_PCM_NAME"
 		id	1
 		direction	"playback"
 		Object.Base.fe_dai.1 {
-			name	"Speakers"
+			name	"$SPEAKER_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {

--- a/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
+++ b/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
@@ -33,6 +33,8 @@ Define {
 	SDW_CAPTURE_PCM		'SDW0-Capture'
 	PLAYBACK_LINK_ID	0
 	CAPTURE_LINK_ID		1
+	JACK_OUT_PCM_NAME	"Jack Out"
+	JACK_IN_PCM_NAME	"Jack In"
 }
 
 #
@@ -86,7 +88,7 @@ Object.Pipeline {
 			}
 		        Object.Widget.gain.1{
 		                Object.Control.mixer.1 {
-		                        name 'Src Playback Volume'
+		                        name 'Pre Mixer $JACK_OUT_PCM_NAME Playback Volume'
 		                }
 		        }
 
@@ -105,7 +107,7 @@ Object.Pipeline {
 
 		        Object.Widget.gain.1 {
 		                Object.Control.mixer.1 {
-		                        name 'Main Playback Volume'
+		                        name 'Post Mixer $JACK_OUT_PCM_NAME Playback Volume'
 		                }
 		        }
 		}
@@ -168,11 +170,11 @@ Object.Widget {
 
 Object.PCM.pcm [
 	{
-		name	"Jack out"
+		name	"$JACK_OUT_PCM_NAME"
 		id 0
 		direction	"playback"
 		Object.Base.fe_dai.1 {
-			name	"Jack out"
+			name	"$JACK_OUT_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -183,11 +185,11 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Jack in"
+		name	"$JACK_IN_PCM_NAME"
 		id 1
 		direction	"capture"
 		Object.Base.fe_dai.1 {
-			name	"Jack in"
+			name	"$JACK_IN_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -7,6 +7,11 @@ IncludeByKey.PASSTHROUGH {
 }
 }
 
+Define {
+       JACK_PLAYBACK_PCM_NAME	"Jack Out"
+       JACK_CAPTURE_PCM_NAME	"Jack In"
+}
+
 #
 # List of all DAIs
 #
@@ -57,7 +62,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name '1 Playback Volume 0'
+							name 'Pre Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
 						}
 				}
 			}
@@ -73,7 +78,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
-						name '2 Main Playback Volume'
+						name 'Post Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
 					}
 				}
 			}
@@ -246,11 +251,11 @@ IncludeByKey.PASSTHROUGH {
 
 Object.PCM.pcm [
 	{
-		name	"Jack out"
+		name	"$JACK_PLAYBACK_PCM_NAME"
 		id 0
 		direction	"playback"
 		Object.Base.fe_dai.1 {
-			name	"Jack out"
+			name	"$JACK_PLAYBACK_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {
@@ -259,11 +264,11 @@ Object.PCM.pcm [
 		}
 	}
 	{
-		name	"Jack in"
+		name	"$JACK_CAPTURE_PCM_NAME"
 		id 1
 		direction	"capture"
 		Object.Base.fe_dai.1 {
-			name	"Jack in"
+			name	"$JACK_CAPTURE_PCM_NAME"
 		}
 
 		Object.PCM.pcm_caps.1 {


### PR DESCRIPTION
Hopefully the final PR to complete "all controls and PCM names SHALL have a meaningful name."
in https://github.com/thesofproject/sof/issues/6576

This (and the previous PRs) all touch the PCM names, but does not change them. @plbossart if you would like to see some changes in the PCM names, you can comment that in this PR.

