### PR TITLE
src: mixin_mixout: Don't invalidate or writeback source/bink buffers

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -122,7 +122,6 @@ static int mixin_init(struct processing_module *mod)
 
 	dev->ipc_config.frame_fmt = frame_fmt;
 	mod->simple_copy = true;
-	mod->skip_src_buffer_invalidate = true;
 
 	return 0;
 }
@@ -151,7 +150,6 @@ static int mixout_init(struct processing_module *mod)
 
 	dev->ipc_config.frame_fmt = frame_fmt;
 	mod->simple_copy = true;
-	mod->skip_sink_buffer_writeback = true;
 
 	return 0;
 }
@@ -378,18 +376,11 @@ static int mixin_process(struct processing_module *mod,
 	}
 
 	if (source_avail_frames > 0) {
-		struct comp_buffer __sparse_cache *source_c;
-
 		frames_to_copy = MIN(source_avail_frames, sinks_free_frames);
 		bytes_to_consume_from_source_buf =
 			audio_stream_period_bytes(input_buffers[0].data, frames_to_copy);
-		if (bytes_to_consume_from_source_buf > 0) {
+		if (bytes_to_consume_from_source_buf > 0)
 			input_buffers[0].consumed = bytes_to_consume_from_source_buf;
-			source_c = attr_container_of(input_buffers[0].data,
-						     struct comp_buffer __sparse_cache,
-						     stream, __sparse_cache);
-			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
-		}
 	} else {
 		/* if source does not produce any data -- do NOT block mixing but generate
 		 * silence as that source output.

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -646,8 +646,7 @@ module_single_sink_setup(struct comp_dev *dev,
 	list_for_item(blist, &dev->bsource_list) {
 		comp_get_copy_limits_frame_aligned(source_c[i], sinks_c[0], &c);
 
-		if (!mod->skip_src_buffer_invalidate)
-			buffer_stream_invalidate(source_c[i], c.frames * c.source_frame_bytes);
+		buffer_stream_invalidate(source_c[i], c.frames * c.source_frame_bytes);
 
 		/*
 		 * note that the size is in number of frames not the number of
@@ -699,8 +698,7 @@ module_single_source_setup(struct comp_dev *dev,
 
 	num_output_buffers = i;
 
-	if (!mod->skip_src_buffer_invalidate)
-		buffer_stream_invalidate(source_c[0], min_frames * source_frame_bytes);
+	buffer_stream_invalidate(source_c[0], min_frames * source_frame_bytes);
 
 	/* note that the size is in number of frames not the number of bytes */
 	mod->input_buffers[0].size = min_frames;
@@ -791,8 +789,7 @@ static int module_adapter_simple_copy(struct comp_dev *dev)
 					   struct comp_buffer __sparse_cache,
 					   stream, __sparse_cache);
 
-		if (!mod->skip_sink_buffer_writeback)
-			buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
+		buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
 		comp_update_buffer_produce(sink_c, mod->output_buffers[i].size);
 	}
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -196,18 +196,6 @@ struct processing_module {
 	/* flag to indicate module does not pause */
 	bool no_pause;
 
-	/*
-	 * flag to indicate that the sink buffer writeback should be skipped. It will be handled
-	 * in the module's process callback
-	 */
-	bool skip_sink_buffer_writeback;
-
-	/*
-	 * flag to indicate that the source buffer invalidate should be skipped. It will be handled
-	 * in the module's process callback
-	 */
-	bool skip_src_buffer_invalidate;
-
 	/* table containing the list of connected sources */
 	struct module_source_info *source_info;
 


### PR DESCRIPTION
Handle the source/sink buffer invalidate/writeback in the module adapter instead. Remove the 2 flags in struct processing_module as these are not needed anymore.