### PR TITLE
platform: Kconfig: config INCOHERENT by default for all ACE and CAVS

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -479,8 +479,7 @@ if XTENSA
 
 config INCOHERENT
 	bool "Enable cached data access via the Coherent API"
-	default y if TIGERLAKE
-	default y if METEORLAKE
+	default y if CAVS || ACE
 	default n
 	help
 	  The architecture is cache incoherent. i.e FW has to manually manage


### PR DESCRIPTION
All available ACE and CAVS platforms use INCOHERENT config, so set it by default.