### PR TITLE
[DNM] test for 7191 bug

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -836,6 +836,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 
+		assert(hd->dma_buffer->stream.addr != 0);
+
 		dma_buf_c = buffer_acquire(hd->dma_buffer);
 		buffer_set_params(dma_buf_c, params, BUFFER_UPDATE_FORCE);
 


### PR DESCRIPTION
I noticed the rimage update triggers #7191 again very easily. Add an assert and see if we get this systematically.