### PR TITLE
host: zephyr: zero dma_block_config before use

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -891,6 +891,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	hd->chan->period = config->period;
 
 	memset(dma_cfg, 0, sizeof(*dma_cfg));
+	memset(&dma_block_cfg, 0, sizeof(dma_block_cfg));
 
 	dma_cfg->block_count = 1;
 	dma_cfg->source_data_size = config->src_width;


### PR DESCRIPTION
As host_common_params() only sets a subset of the fields, initialize the Zephyr DMA interface struct "dma_block_config" with zeroes before use.

Issue found in code review.