### PR TITLE
topolgoy2: sdw-jack-generic: Fix the number of input pins

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -130,6 +130,7 @@ IncludeByKey.PASSTHROUGH {
 				index 1
 				type dai_in
 				direction	playback
+				num_input_pins 1
 				Object.Base.input_audio_format [
 					{
 						in_bit_depth            16


### PR DESCRIPTION
This was missed earlier.

Fixes: f8ad12734db1 (i"topology2: cavs-sdw: Add option for passthrough pipelines")