### PR TITLE
src: copier_hifi: update apply_attenuation function

### DIFF
--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -27,7 +27,8 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	int n;
 	int nmax;
 	int remaining_samples = frame * audio_stream_get_channels(&sink->stream);
-	int32_t *dst = audio_stream_get_rptr(&sink->stream);
+	uint32_t bytes = frame * audio_stream_frame_bytes(&sink->stream);
+	uint32_t *dst = audio_stream_rewind_wptr_by_bytes(&sink->stream, bytes);
 
 	/* only support attenuation in format of 32bit */
 	switch (audio_stream_get_frm_fmt(&sink->stream)) {

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -31,7 +31,8 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	ae_valign uu = AE_ZALIGN64();
 	ae_valign su = AE_ZALIGN64();
 	int remaining_samples = frame * audio_stream_get_channels(&sink->stream);
-	uint32_t *dst = audio_stream_get_rptr(&sink->stream);
+	uint32_t bytes = frame * audio_stream_frame_bytes(&sink->stream);
+	uint32_t *dst = audio_stream_rewind_wptr_by_bytes(&sink->stream, bytes);
 	ae_int32x2 *in = (ae_int32x2 *)dst;
 	ae_int32x2 *out = (ae_int32x2 *)dst;
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -774,6 +774,29 @@ audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache 
 }
 
 /**
+ * @brief Calculate position of write pointer to the position before the data was copied
+ * to source buffer.
+ * @param source Stream to get information from.
+ * @param bytes  Number of bytes copied to source buffer.
+ * @return Previous position of the write pointer.
+ */
+static inline uint32_t
+*audio_stream_rewind_wptr_by_bytes(const struct audio_stream __sparse_cache *source,
+				       const uint32_t bytes)
+{
+	void *wptr = audio_stream_get_wptr(source);
+	int to_begin = audio_stream_rewind_bytes_without_wrap(source, wptr);
+
+	assert((intptr_t)wptr >= (intptr_t)source->addr);
+	assert((intptr_t)source->end_addr > (intptr_t)wptr);
+
+	if (to_begin > bytes)
+		return (uint32_t *)((intptr_t)wptr - bytes);
+	else
+		return (uint32_t *)((intptr_t)source->end_addr - (bytes - to_begin));
+}
+
+/**
  * @brief Calculates numbers of s16 samples to buffer wrap when buffer
  * is read forward towards end address.
  * @param source Stream to get information from.


### PR DESCRIPTION
The function applying the attenuation should be based on write pointer and the current number of copied data in the current systick.