### PR TITLE
[Not for main] Tools: Topology2: Add a development HDA generic MCPS b…

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -1,0 +1,171 @@
+Define {
+	ANALOG_PLAYBACK_PCM		'Analog Playback'
+	ANALOG_CAPTURE_PCM		'Analog Capture'
+	HDA_ANALOG_DAI_NAME      	'Analog'
+	DEEP_BUFFER_PIPELINE_ID		15
+	DEEP_BUFFER_PCM_ID		31
+	DEEP_BUFFER_PIPELINE_SRC	'mixin.15.1'
+	DEEP_BUFFER_PIPELINE_SINK	'mixout.2.1'
+	DEEP_BUFFER_PCM_NAME		'Deepbuffer HDA Analog'
+}
+
+Object.Dai.HDA [
+	{
+		name $HDA_ANALOG_DAI_NAME
+		dai_index 0
+		id 4
+		default_hw_conf_id 4
+		Object.Base.hw_config.1 {
+			name	"HDA0"
+		}
+		direction duplex
+	}
+]
+
+Object.Pipeline {
+	mixout-dai-copier-playback [
+		{
+			index 3
+
+			Object.Widget.dai-copier.1 {
+				node_type $HDA_LINK_OUTPUT_CLASS
+				stream_name $HDA_ANALOG_DAI_NAME
+				dai_type "HDA"
+				copier_type "HDA"
+			}
+		}
+	]
+
+	mixout-aria-gain-mixin-playback [
+		{
+			index 2
+
+			Object.Widget.gain.1 {
+				Object.Control.mixer.1 {
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM Volume'
+				}
+			}
+			Object.Widget.aria.1 {
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				# 32-bit 48KHz 2ch
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     32
+					}
+				]
+				Object.Control.bytes."1" {
+					name "SSP2 Aria Control"
+				}
+			}
+		}
+	]
+
+	host-copier-gain-mixin-playback [
+		{
+			index 1
+
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_PLAYBACK_PCM
+				pcm_id 0
+			}
+
+			Object.Widget.gain.1 {
+				Object.Control.mixer.1 {
+					name 'Pre Mixer $ANALOG_PLAYBACK_PCM Volume'
+				}
+			}
+		}
+	]
+
+	host-gateway-capture [
+		{
+			index 	3
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_CAPTURE_PCM
+				pcm_id 0
+			}
+		}
+	]
+
+	highpass-capture-be [
+		{
+			index		4
+			direction	capture
+
+			Object.Widget.dai-copier."1" {
+				dai_type 	"HDA"
+				type		"dai_out"
+				copier_type	"HDA"
+				stream_name	$HDA_ANALOG_DAI_NAME
+				node_type	$HDA_LINK_INPUT_CLASS
+				Object.Base.audio_format.1 {
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			}
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes."1" {
+					name '4 Main capture Iir Eq'
+				}
+			}
+		}
+	]
+}
+Object.PCM.pcm [
+	{
+		id 0
+		name 'HDA Analog'
+		Object.Base.fe_dai.1 {
+			name "HDA Analog"
+		}
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name $ANALOG_PLAYBACK_PCM
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name $ANALOG_CAPTURE_PCM
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		direction duplex
+	}
+]
+
+# top-level pipeline connections
+Object.Base.route [
+	{
+		sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+		source 'mixout.3.1'
+	}
+	{
+		source 'mixin.2.1'
+		sink 'mixout.3.1'
+	}
+	{
+		source 'mixin.1.1'
+		sink 'mixout.2.1'
+	}
+	{
+		source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+		sink 'eqiir.4.1'
+	}
+	{
+		source 'eqiir.4.1'
+		sink 'host-copier.0.capture'
+	}
+	{
+		source 'host-copier.0.playback'
+		sink 'gain.1.1'
+	}
+]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -88,5 +88,11 @@ PLATFORM=mtl"
 # BT offload loopback test topology (lbm) for mtl
 "cavs-nocodec-bt\;sof-nocodec-bt-mtl-lbm\;BT_LOOPBACK_MODE=true,PLATFORM=mtl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-mtl-lbm.bin"
+
+# CAVS HDA topology for benchmarking performance
+# Copier - peak volume - mixin - mixout - aria - peak volume - mixin - mixout - copier
+"sof-hda-generic\;sof-hda-benchmark-generic-tgl\;PLATFORM=TGL,HDA_CONFIG=benchmark,USE_CHAIN_DMA=true"
+"sof-hda-generic\;sof-hda-benchmark-generic-mtl\;PLATFORM=MTL,HDA_CONFIG=benchmark,USE_CHAIN_DMA=true"
+"sof-hda-generic\;sof-hda-benchmark-generic-lnl\;PLATFORM=LNL,HDA_CONFIG=benchmark,USE_CHAIN_DMA=true"
 )
 

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
@@ -1,0 +1,97 @@
+#
+# BE playback pipeline: mixout-aria-gain-mixin.
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-aria-gain-mixin-playback.N.attribute_name"
+#
+# Usage: mixout-aria-gain-mixin-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-aria-gain-mixin-playback."N" {
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/mixin.conf>
+<include/components/gain.conf>
+<include/components/mixout.conf>
+<include/components/aria.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."mixout-aria-gain-mixin-playback" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# mixout-aria-gain-mixin-playback objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		mixout."1" {}
+		aria."1" {}
+		gain."1" {
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+
+			# 32-bit 48KHz 2ch
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+		mixin.1 {}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	Object.Base {
+		route.1 {
+			source mixout.$index.1
+			sink	aria.$index.1
+		}
+		route.2 {
+			source	aria.$index.1
+			sink	gain.$index.1
+		}
+		route.3 {
+			source	gain.$index.1
+			sink	mixin.$index.1
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
@@ -1,0 +1,80 @@
+#
+# BE playback pipeline: mixout-dai-copier.
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-dai-copier-playback.N.attribute_name"
+#
+# Usage: mixout-dai-copier-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-dai-copier-playback."N" {
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/dai-copier.conf>
+<include/components/mixout.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."mixout-dai-copier-playback" {
+
+	DefineAttribute."index" {}
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		#
+		# mixout-gain-dai-copier-playback objects instantiated within the same alsaconf node must have
+		# unique pipeline_id attribute
+		#
+		unique	"instance"
+	}
+
+	Object.Widget {
+		mixout."1" {}
+		dai-copier."1" {
+			type dai_in
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_input_pins 1
+
+			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+
+		pipeline."1" {
+			priority		0
+			lp_mode		0
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	2
+	channels_max	2
+	rate		48000
+	rate_min	48000
+	rate_max	48000
+}

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -13,7 +13,9 @@
 <host-gateway-capture.conf>
 <host-copier-gain-mixin-playback.conf>
 <host-copier-gain-src-mixin-playback.conf>
+<mixout-dai-copier-playback.conf>
 <mixout-gain-dai-copier-playback.conf>
+<mixout-aria-gain-mixin-playback.conf>
 <mixout-gain-efx-dai-copier-playback.conf>
 <mixout-gain-host-copier-capture.conf>
 <dai-copier-eqiir-module-copier-capture.conf>
@@ -61,6 +63,7 @@ IncludeByKey.HDA_CONFIG {
 	"mix"		"cavs-mixin-mixout-hda.conf"
 	"efx"		"cavs-mixin-mixout-efx-hda.conf"
 	"src"		"cavs-src-mixin-mixout-hda.conf"
+	"benchmark"	"cavs-benchmark-hda.conf"
 }
 
 # include DMIC config if needed.


### PR DESCRIPTION
…enchmark topology

This patch builds new development topologies
sof-hda-benchmark-generic-<tgl/mtl/lnl>.tplg to evaluate performance of a set of playback components.

The topology for PCM0P playback is

host-copier.0 --> gain.1.1 --> mixin.1.1 -->
	mixout.2.1 --> aria.2.1 --> gain.2.1  --> mixin
	mixout.3.1 --> dai-copier.HDA