### PR TITLE
Mixin/Mixout Optimization for simple pipelines

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -125,7 +125,6 @@ static int mixin_init(struct processing_module *mod)
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
 	dev->ipc_config.frame_fmt = frame_fmt;
-	dev->bypass_capable = true;
 
 	return 0;
 }

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -92,6 +92,10 @@ struct mixout_data {
 	 * by mixin but not yet produced in mixout.
 	 */
 	uint32_t pending_frames[MIXOUT_MAX_SOURCES];
+
+	void (*mix_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream __sparse_cache **sources, uint32_t count,
+			 uint32_t frames);
 };
 
 static int mixin_init(struct processing_module *mod)
@@ -121,14 +125,14 @@ static int mixin_init(struct processing_module *mod)
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
 	dev->ipc_config.frame_fmt = frame_fmt;
-	mod->skip_src_buffer_invalidate = true;
+	dev->bypass_capable = true;
 
 	return 0;
 }
 
 static int mixout_init(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_data *mod_data = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	struct mixout_data *mo_data;
 	enum sof_ipc_frame frame_fmt, valid_fmt;
@@ -139,9 +143,7 @@ static int mixout_init(struct processing_module *mod)
 	if (!mo_data)
 		return -ENOMEM;
 
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	mod_source_info->private = mo_data;
-	module_source_info_release(mod_source_info);
+	mod_data->private = mo_data;
 
 	audio_stream_fmt_conversion(mod->priv.cfg.base_cfg.audio_fmt.depth,
 				    mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth,
@@ -149,7 +151,6 @@ static int mixout_init(struct processing_module *mod)
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
 	dev->ipc_config.frame_fmt = frame_fmt;
-	mod->skip_sink_buffer_writeback = true;
 
 	return 0;
 }
@@ -167,307 +168,44 @@ static int mixin_free(struct processing_module *mod)
 
 static int mixout_free(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct mixout_data *md = module_get_private_data(mod);
 
 	comp_dbg(mod->dev, "mixout_free()");
-
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	rfree(mod_source_info->private);
-	mod_source_info->private = NULL;
-	module_source_info_release(mod_source_info);
+	rfree(md);
 
 	return 0;
 }
 
-static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_data,
-			 uint16_t sink_index, struct audio_stream __sparse_cache *sink,
-			 uint32_t start_frame, uint32_t mixed_frames,
-			 const struct audio_stream __sparse_cache *source, uint32_t frame_count)
+static int mixin_mixout_process_single_source(struct input_stream_buffer *input_buffer,
+					      struct output_stream_buffer *output_buffer)
 {
-	const struct mixin_sink_config *sink_config;
+	uint32_t bytes;
 
-	if (sink_index >= MIXIN_MAX_SINKS) {
-		comp_err(dev, "Sink index out of range: %u, max sinks count: %u",
-			 (uint32_t)sink_index, MIXIN_MAX_SINKS);
-		return -EINVAL;
-	}
+	audio_stream_copy(input_buffer->data, 0, output_buffer->data, 0,
+			  input_buffer->size * audio_stream_get_channels(input_buffer->data));
 
-	sink_config = &mixin_data->sink_config[sink_index];
-
-	if (sink_config->mixer_mode == IPC4_MIXER_NORMAL_MODE) {
-		/* Mix streams. mix_channel() is reused here to mix streams, not individual
-		 * channels. To do so, (multichannel) stream is treated as single channel:
-		 * channel count is passed as 1, channel index is 0, frame indices (start_frame
-		 * and mixed_frame) and frame count are multiplied by real stream channel count.
-		 */
-		mixin_data->normal_mix_channel(sink, start_frame * audio_stream_get_channels(sink),
-					       mixed_frames * audio_stream_get_channels(sink),
-					       source,
-					       frame_count * audio_stream_get_channels(sink),
-					       sink_config->gain);
-	} else if (sink_config->mixer_mode == IPC4_MIXER_CHANNEL_REMAPPING_MODE) {
-		int i;
-
-		for (i = 0; i < audio_stream_get_channels(sink); i++) {
-			uint8_t source_channel =
-				(sink_config->output_channel_map >> (i * 4)) & 0xf;
-
-			if (source_channel == 0xf) {
-				mixin_data->mute_channel(sink, i, start_frame, mixed_frames,
-							 frame_count);
-			} else {
-				if (source_channel >= audio_stream_get_channels(source)) {
-					comp_err(dev, "Out of range chmap: 0x%x, src channels: %u",
-						 sink_config->output_channel_map,
-						 audio_stream_get_channels(source));
-					return -EINVAL;
-				}
-				mixin_data->remap_mix_channel(sink, i,
-							      audio_stream_get_channels(sink),
-							      start_frame, mixed_frames,
-							      source, source_channel,
-							      audio_stream_get_channels(source),
-							      frame_count, sink_config->gain);
-			}
-		}
-	} else {
-		comp_err(dev, "Unexpected mixer mode: %d", sink_config->mixer_mode);
-		return -EINVAL;
-	}
+	/*
+	 * mixout does not modify the format or number of channels, so the number of
+	 * bytes consumed and produced are identical
+	 */
+	bytes = input_buffer->size * audio_stream_frame_bytes(input_buffer->data);
+	input_buffer->consumed = bytes;
+	output_buffer->size = bytes;
 
 	return 0;
 }
 
-/* mix silence into stream, i.e. set not yet mixed data in stream to zero */
-static void silence(struct audio_stream __sparse_cache *stream, uint32_t start_frame,
-		    uint32_t mixed_frames, uint32_t frame_count)
-{
-	uint32_t skip_mixed_frames;
-	uint8_t *ptr;
-	uint32_t size;
-	int n;
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-
-	size = audio_stream_period_bytes(stream, frame_count - skip_mixed_frames);
-	ptr = (uint8_t *)audio_stream_get_wptr(stream) +
-		audio_stream_period_bytes(stream, mixed_frames);
-
-	while (size) {
-		ptr = audio_stream_wrap(stream, ptr);
-		n = MIN(audio_stream_bytes_without_wrap(stream, ptr), size);
-		memset(ptr, 0, n);
-		size -= n;
-		ptr += n;
-	}
-}
-
-/* Most of the mixing is done here on mixin side. mixin mixes its source data
- * into each connected mixout sink buffer. Basically, if mixout sink buffer has
- * no data, mixin copies its source data into mixout sink buffer. If mixout sink
- * buffer has some data (written there by other mixin), mixin reads mixout sink
- * buffer data, mixes it with its source data and writes back to mixout sink
- * buffer. So after all mixin mixin_process() calls, mixout sink buffer contains
- * mixed data. Every mixin calls xxx_consume() on its processed source data, but
- * they do not call xxx_produce(). That is done on mixout side in mixout_process().
- *
- * Since there is no garantie that mixout processing is done in time we have
- * to account for a possibility having not yet produced data in mixout sink
- * buffer that was written there on previous run(s) of mixin_process(). So for each
- * mixin <--> mixout pair we track consumed_yet_not_produced data amount.
- * That value is also used in mixout_process() to calculate how many data was
- * actually mixed and so xxx_produce() is called for that amount.
- */
 static int mixin_process(struct processing_module *mod,
 			 struct input_stream_buffer *input_buffers, int num_input_buffers,
 			 struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
-	struct mixin_data *mixin_data = module_get_private_data(mod);
-	struct comp_dev *dev = mod->dev;
-	uint32_t source_avail_frames, sinks_free_frames;
-	struct comp_dev *active_mixouts[MIXIN_MAX_SINKS];
-	uint16_t sinks_ids[MIXIN_MAX_SINKS];
-	uint32_t bytes_to_consume_from_source_buf;
-	uint32_t frames_to_copy;
-	int source_index;
-	int i, ret;
+	int i;
 
-	comp_dbg(dev, "mixin_process()");
-
-	source_avail_frames = audio_stream_get_avail_frames(input_buffers[0].data);
-	sinks_free_frames = INT32_MAX;
-
-	/* block mixin pipeline until at least one mixout pipeline started */
-	if (num_output_buffers == 0)
+	if (num_input_buffers != 1)
 		return 0;
 
-	if (num_output_buffers > MIXIN_MAX_SINKS) {
-		comp_err(dev, "mixin_process(): Invalid output buffer count %d",
-			 num_output_buffers);
-		return -EINVAL;
-	}
-
-	/* first, let's find out how many frames can be now processed --
-	 * it is a nimimal value among frames available in source buffer
-	 * and frames free in each connected mixout sink buffer.
-	 */
-	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *unused_in_between_buf_c;
-		struct comp_dev *mixout;
-		uint16_t sink_id;
-		struct comp_buffer *sink;
-		struct mixout_data *mixout_data;
-		struct processing_module *mixout_mod;
-		struct module_source_info __sparse_cache *mod_source_info;
-		struct comp_buffer __sparse_cache *sink_c;
-		uint32_t free_frames, pending_frames;
-
-		/* unused buffer between mixin and mixout */
-		unused_in_between_buf_c = attr_container_of(output_buffers[i].data,
-							    struct comp_buffer __sparse_cache,
-							    stream, __sparse_cache);
-		mixout = unused_in_between_buf_c->sink;
-		sink_id = IPC4_SRC_QUEUE_ID(unused_in_between_buf_c->id);
-
-		active_mixouts[i] = mixout;
-		sinks_ids[i] = sink_id;
-
-		sink = list_first_item(&mixout->bsink_list, struct comp_buffer, source_list);
-
-		mixout_mod = comp_get_drvdata(mixout);
-		mod_source_info = module_source_info_acquire(mixout_mod->source_info);
-		mixout_data = mod_source_info->private;
-		source_index = find_module_source_index(mod_source_info, dev);
-		if (source_index < 0) {
-			comp_err(dev, "No source info");
-			module_source_info_release(mod_source_info);
-			return -EINVAL;
-		}
-
-		sink_c = buffer_acquire(sink);
-
-		/* Normally this should never happen as we checked above
-		 * that mixout is in active state and so its sink buffer
-		 * should be already initialized in mixout .params().
-		 */
-		if (!sink_c->hw_params_configured) {
-			comp_err(dev, "Uninitialized mixout sink buffer!");
-			buffer_release(sink_c);
-			module_source_info_release(mod_source_info);
-			return -EINVAL;
-		}
-
-		free_frames = audio_stream_get_free_frames(&sink_c->stream);
-
-		/* mixout sink buffer may still have not yet produced data -- data
-		 * consumed and written there by mixin on previous mixin_process() run.
-		 * We do NOT want to overwrite that data.
-		 */
-		pending_frames = mixout_data->pending_frames[source_index];
-		assert(free_frames >= pending_frames);
-		sinks_free_frames = MIN(sinks_free_frames, free_frames - pending_frames);
-
-		buffer_release(sink_c);
-		module_source_info_release(mod_source_info);
-	}
-
-	if (source_avail_frames > 0) {
-		struct comp_buffer __sparse_cache *source_c;
-
-		frames_to_copy = MIN(source_avail_frames, sinks_free_frames);
-		bytes_to_consume_from_source_buf =
-			audio_stream_period_bytes(input_buffers[0].data, frames_to_copy);
-		if (bytes_to_consume_from_source_buf > 0) {
-			input_buffers[0].consumed = bytes_to_consume_from_source_buf;
-			source_c = attr_container_of(input_buffers[0].data,
-						     struct comp_buffer __sparse_cache,
-						     stream, __sparse_cache);
-			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
-		}
-	} else {
-		/* if source does not produce any data -- do NOT block mixing but generate
-		 * silence as that source output.
-		 *
-		 * here frames_to_copy is silence size.
-		 */
-		frames_to_copy = MIN(dev->frames, sinks_free_frames);
-	}
-
-	/* iterate over all connected mixouts and mix source data into each mixout sink buffer */
-	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_dev *mixout;
-		struct comp_buffer *sink;
-		struct mixout_data *mixout_data;
-		struct module_source_info __sparse_cache *mod_source_info;
-		struct processing_module *mixout_mod;
-		uint32_t start_frame;
-		struct comp_buffer __sparse_cache *sink_c;
-		uint32_t writeback_size;
-
-		mixout = active_mixouts[i];
-		sink = list_first_item(&mixout->bsink_list, struct comp_buffer, source_list);
-
-		mixout_mod = comp_get_drvdata(mixout);
-		mod_source_info = module_source_info_acquire(mixout_mod->source_info);
-		mixout_data = mod_source_info->private;
-		source_index = find_module_source_index(mod_source_info, dev);
-		if (source_index < 0) {
-			comp_err(dev, "No source info");
-			module_source_info_release(mod_source_info);
-			return -EINVAL;
-		}
-
-		/* Skip data from previous run(s) not yet produced in mixout_process().
-		 * Normally start_frame would be 0 unless mixout pipeline has serious
-		 * performance problems with processing data on time in mixout.
-		 */
-		start_frame = mixout_data->pending_frames[source_index];
-
-		sink_c = buffer_acquire(sink);
-
-		/* if source does not produce any data but mixin is in active state -- generate
-		 * silence instead of that source data
-		 */
-		if (source_avail_frames == 0) {
-			/* generate silence */
-			silence(&sink_c->stream, start_frame, mixout_data->mixed_frames,
-				frames_to_copy);
-		} else {
-			/* basically, if sink buffer has no data -- copy source data there, if
-			 * sink buffer has some data (written by another mixin) mix that data
-			 * with source data.
-			 */
-			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink_c->stream,
-					    start_frame, mixout_data->mixed_frames,
-					    input_buffers[0].data, frames_to_copy);
-			if (ret < 0) {
-				buffer_release(sink_c);
-				module_source_info_release(mod_source_info);
-				return ret;
-			}
-		}
-
-		/* it would be better to writeback memory region starting from start_frame and
-		 * of frames_to_copy size (converted to bytes, of course). However, seems
-		 * there is no appropreate API. Anyway, start_frame would be 0 most of the time.
-		 */
-		writeback_size = audio_stream_period_bytes(&sink_c->stream,
-							   frames_to_copy + start_frame);
-		if (writeback_size > 0)
-			buffer_stream_writeback(sink_c, writeback_size);
-		buffer_release(sink_c);
-
-		mixout_data->pending_frames[source_index] += frames_to_copy;
-
-		if (frames_to_copy + start_frame > mixout_data->mixed_frames)
-			mixout_data->mixed_frames = frames_to_copy + start_frame;
-
-		module_source_info_release(mod_source_info);
-	}
+	for (i = 0; i < num_output_buffers; i++)
+		mixin_mixout_process_single_source(&input_buffers[0], &output_buffers[i]);
 
 	return 0;
 }
@@ -479,88 +217,68 @@ static int mixout_process(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,
 			  struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
-	struct comp_dev *dev = mod->dev;
+	/* if there's only one active source, simply copy the source samples to the sink */
+	if (num_input_buffers == 1 & num_output_buffers == 1 && input_buffers[0].size)
+		return mixin_mixout_process_single_source(&input_buffers[0], &output_buffers[0]);
+
+	const struct audio_stream __sparse_cache *sources_stream[PLATFORM_MAX_STREAMS];
 	struct mixout_data *md;
-	uint32_t frames_to_produce = INT32_MAX;
-	uint32_t pending_frames;
-	uint32_t sink_bytes;
+	int sources_indices[PLATFORM_MAX_STREAMS];
+	uint32_t frames = mod->dev->frames;
+	uint32_t bytes;
+	uint32_t j = 0;
 	int i;
 
-	comp_dbg(dev, "mixout_process()");
+	comp_dbg(mod->dev, "mixout_process()");
 
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	md = mod_source_info->private;
+	if (num_input_buffers > MIXOUT_MAX_SOURCES) {
+		comp_err(mod->dev, "Number of input buffers: %d exceeds max\n", num_input_buffers);
+		return -EINVAL;
+	}
 
-	/* iterate over all connected mixins to find minimal value of frames they consumed
-	 * (i.e., mixed into mixout sink buffer). That is the amount that can/should be
-	 * produced now.
-	 */
+	if (num_output_buffers != 1) {
+		comp_err(mod->dev, "Invalid number of output buffers: %d\n", num_output_buffers);
+		return -EINVAL;
+	}
+
 	for (i = 0; i < num_input_buffers; i++) {
-		const struct audio_stream __sparse_cache *source_stream;
-		struct comp_buffer __sparse_cache *unused_in_between_buf;
-		struct comp_dev *source;
-		int source_index;
-
-		source_stream = input_buffers[i].data;
-		unused_in_between_buf = attr_container_of(source_stream,
-							  struct comp_buffer __sparse_cache,
-							  stream, __sparse_cache);
-
-		source = unused_in_between_buf->source;
-
-		source_index = find_module_source_index(mod_source_info, source);
-		/* this shouldn't happen but skip even if it does and move to the next source */
-		if (source_index < 0)
+		if (input_buffers[i].size == 0)
 			continue;
 
-		pending_frames = md->pending_frames[source_index];
-
-		if (source->state == COMP_STATE_ACTIVE || pending_frames)
-			frames_to_produce = MIN(frames_to_produce, pending_frames);
+		sources_stream[j] = mod->input_buffers[i].data;
+		sources_indices[j++] = i;
+		frames = MIN(frames, input_buffers[i].size);
 	}
 
-	if (frames_to_produce > 0 && frames_to_produce < INT32_MAX) {
-		for (i = 0; i < num_input_buffers; i++) {
-			const struct audio_stream __sparse_cache *source_stream;
-			struct comp_buffer __sparse_cache *unused_in_between_buf;
-			struct comp_dev *source;
-			int source_index;
-			uint32_t pending_frames;
+	/* generate silence if no data available from any of the sources */
+	if (!j) {
+		/*
+		 * Generate silence when sources are inactive. When
+		 * sources change to active, additionally keep
+		 * generating silence until at least one of the
+		 * sources start to have data available (frames!=0).
+		 */
+		bytes = mod->dev->frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+		if (!audio_stream_set_zero(mod->output_buffers[0].data, bytes))
+			mod->output_buffers[0].size = bytes;
 
-			source_stream = input_buffers[i].data;
-			unused_in_between_buf = attr_container_of(source_stream,
-								  struct comp_buffer __sparse_cache,
-								  stream, __sparse_cache);
-
-			source = unused_in_between_buf->source;
-
-			source_index = find_module_source_index(mod_source_info, source);
-			if (source_index < 0)
-				continue;
-
-			pending_frames = md->pending_frames[source_index];
-			if (pending_frames >= frames_to_produce)
-				md->pending_frames[source_index] -= frames_to_produce;
-			else
-				md->pending_frames[source_index] = 0;
-		}
-
-		assert(md->mixed_frames >= frames_to_produce);
-		md->mixed_frames -= frames_to_produce;
-
-		sink_bytes = frames_to_produce *
-				audio_stream_frame_bytes(output_buffers[0].data);
-		output_buffers[0].size = sink_bytes;
-	} else {
-		sink_bytes = dev->frames * audio_stream_frame_bytes(output_buffers[0].data);
-		if (!audio_stream_set_zero(output_buffers[0].data, sink_bytes))
-			output_buffers[0].size = sink_bytes;
-		else
-			output_buffers[0].size = 0;
+		return 0;
 	}
 
-	module_source_info_release(mod_source_info);
+	/* mix streams */
+	md = module_get_private_data(mod);
+	md->mix_func(mod->dev, mod->output_buffers[0].data, sources_stream, j, frames);
+
+	/*
+	 * mixin and mixout do not modify the format or number of channels, so the number of
+	 * bytes consumed and produced are identical
+	 */
+	bytes = frames * audio_stream_frame_bytes(mod->output_buffers[0].data);
+	mod->output_buffers[0].size = bytes;
+
+	/* update source buffer consumed bytes */
+	for (i = 0; i < j; i++)
+		mod->input_buffers[sources_indices[i]].consumed = bytes;
 
 	return 0;
 }
@@ -611,9 +329,9 @@ static int mixout_reset(struct processing_module *mod)
 
 static void base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *base_cfg,
 					     struct sof_ipc_stream_params *params);
-
-/* params are derived from base config for ipc4 path */
-static int mixin_params(struct processing_module *mod)
+static int mixin_prepare(struct processing_module *mod,
+			 struct sof_source __sparse_cache **sources, int num_of_sources,
+			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct mixin_data *md = module_get_private_data(mod);
@@ -621,13 +339,10 @@ static int mixin_params(struct processing_module *mod)
 	struct list_item *blist;
 	int ret;
 
-	comp_dbg(dev, "mixin_params()");
+	comp_dbg(dev, "mixin_prepare()");
 
 	base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 
-	/* Buffers between mixins and mixouts are not used (mixin writes data directly to mixout
-	 * sink). But, anyway, let's setup these buffers properly just in case.
-	 */
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink;
 		struct comp_buffer __sparse_cache *sink_c;
@@ -645,7 +360,7 @@ static int mixin_params(struct processing_module *mod)
 		 */
 		sink_id = IPC4_SRC_QUEUE_ID(sink_c->id);
 		if (sink_id >= MIXIN_MAX_SINKS) {
-			comp_err(dev, "Sink index out of range: %u, max sink count: %u",
+			comp_err(dev, "mixin_prepare(): Sink index out of range: %u, max sink count: %u",
 				 (uint32_t)sink_id, MIXIN_MAX_SINKS);
 			buffer_release(sink_c);
 			return -EINVAL;
@@ -671,59 +386,7 @@ static int mixin_params(struct processing_module *mod)
 	/* use BUFF_PARAMS_CHANNELS to skip updating channel count */
 	ret = comp_verify_params(dev, BUFF_PARAMS_CHANNELS, params);
 	if (ret < 0) {
-		comp_err(dev, "mixin_params(): comp_verify_params() failed!");
-		return -EINVAL;
-	}
-
-	return 0;
-}
-
-/*
- * Prepare the mixer. The mixer may already be running at this point with other
- * sources. Make sure we only prepare the "prepared" source streams and not
- * the active or inactive sources.
- *
- * We should also make sure that we propagate the prepare call to downstream
- * if downstream is not currently active.
- */
-static int mixin_prepare(struct processing_module *mod,
-			 struct sof_source __sparse_cache **sources, int num_of_sources,
-			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
-{
-	struct mixin_data *md = module_get_private_data(mod);
-	struct comp_dev *dev = mod->dev;
-	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
-	enum sof_ipc_frame fmt;
-	int ret;
-
-	comp_info(dev, "mixin_prepare()");
-
-	ret = mixin_params(mod);
-	if (ret < 0)
-		return ret;
-
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
-	fmt = audio_stream_get_valid_fmt(&sink_c->stream);
-	buffer_release(sink_c);
-
-	/* currently inactive so setup mixer */
-	switch (fmt) {
-	case SOF_IPC_FRAME_S16_LE:
-	case SOF_IPC_FRAME_S24_4LE:
-	case SOF_IPC_FRAME_S32_LE:
-		md->normal_mix_channel = normal_mix_get_processing_function(fmt);
-		md->remap_mix_channel = remap_mix_get_processing_function(fmt);
-		md->mute_channel = mute_mix_get_processing_function(fmt);
-		break;
-	default:
-		comp_err(dev, "unsupported data format %d", fmt);
-		return -EINVAL;
-	}
-
-	if (!md->normal_mix_channel || !md->remap_mix_channel || !md->mute_channel) {
-		comp_err(dev, "have not found the suitable processing function");
+		comp_err(dev, "mixin_prepare(): comp_verify_params() failed!");
 		return -EINVAL;
 	}
 
@@ -811,10 +474,11 @@ static int mixout_prepare(struct processing_module *mod,
 			  struct sof_source __sparse_cache **sources, int num_of_sources,
 			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct mixout_data *md = module_get_private_data(mod);
+	struct comp_buffer __sparse_cache *sink_c;
 	struct comp_dev *dev = mod->dev;
-	struct mixout_data *md;
-	int ret, i;
+	struct comp_buffer *sink;
+	int ret;
 
 	ret = mixout_params(mod);
 	if (ret < 0)
@@ -822,17 +486,16 @@ static int mixout_prepare(struct processing_module *mod,
 
 	comp_dbg(dev, "mixout_prepare()");
 
-	/*
-	 * Since mixout sink buffer stream is reset on .prepare(), let's
-	 * reset counters for not yet produced frames in that buffer.
-	 */
-	mod_source_info = module_source_info_acquire(mod->source_info);
-	md = mod_source_info->private;
-	md->mixed_frames = 0;
+	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
+			       source_list);
+	sink_c = buffer_acquire(sink);
+	md->mix_func = mixer_get_processing_function(dev, sink_c);
+	buffer_release(sink_c);
 
-	for (i = 0; i < MIXOUT_MAX_SOURCES; i++)
-		md->pending_frames[i] = 0;
-	module_source_info_release(mod_source_info);
+	if (!md->mix_func) {
+		comp_err(dev, "mixout_prepare(): no mix function");
+		return -EINVAL;
+	}
 
 	return 0;
 }

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -5,424 +5,164 @@
 // Author: Andrula Song <xiaoyuan.song@intel.com>
 
 #include <ipc4/mixin_mixout.h>
+#include <sof/audio/mixer.h>
 #include <sof/common.h>
 #include <rtos/string.h>
 
 #ifdef MIXIN_MIXOUT_GENERIC
 
 #if CONFIG_FORMAT_S16LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 16 bit PCM source streams to one sink stream */
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, i;
+	int16_t *src[PLATFORM_MAX_CHANNELS];
+	int16_t *dest;
+	int32_t val;
+	int nmax;
+	int i, j, n, ns;
+	int processed = 0;
+	int nch = audio_stream_get_channels(sink);
+	int samples = frames * nch;
 
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int16_t *dst = (int16_t *)audio_stream_get_wptr(sink) + start_frame;
-	int16_t *src = audio_stream_get_rptr(source);
+	dest = audio_stream_get_wptr(sink);
+	for (j = 0; j < num_sources; j++)
+		src[j] = audio_stream_get_rptr(sources[j]);
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
+	while (processed < samples) {
+		nmax = samples - processed;
+		n = audio_stream_samples_without_wrap_s16(sink, dest);
 		n = MIN(n, nmax);
+		for (i = 0; i < num_sources; i++) {
+			ns = audio_stream_samples_without_wrap_s16(sources[i], src[i]);
+			n = MIN(n, ns);
+		}
 		for (i = 0; i < n; i++) {
-			*dst = sat_int16(*dst + *src++);
-			dst++;
-		}
-	}
+			val = 0;
+			for (j = 0; j < num_sources; j++) {
+				val += *src[j];
+				src[j]++;
+			}
 
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = MIN(n, nmax);
-		memcpy_s(dst, n * sizeof(int16_t), src, n * sizeof(int16_t));
-		dst += n;
-		src += n;
+			/* Saturate to 16 bits */
+			*dest = sat_int16(val);
+			dest++;
+		}
+		processed += n;
+		dest = audio_stream_wrap(sink, dest);
+		for (i = 0; i < num_sources; i++)
+			src[i] = audio_stream_wrap(sources[i], src[i]);
 	}
 }
-
-static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int16_t *dst, *src;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i, samples;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int16_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int16_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int16((int32_t)*dst +
-			       q_mults_16x16(*src, gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int16_t)q_mults_16x16(*src, gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
-			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
-{
-	int32_t skip_mixed_frames, n, left_frames, i, channel_count, frames, samples;
-	int16_t *ptr;
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-	frame_count -= skip_mixed_frames;
-	channel_count = audio_stream_get_channels(stream);
-	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (int16_t *)audio_stream_get_wptr(stream) +
-		mixed_frames * audio_stream_get_channels(stream) +
-		channel_index;
-
-	for (left_frames = frame_count; left_frames; left_frames -= frames) {
-		ptr = audio_stream_wrap(stream, ptr);
-		n = audio_stream_samples_without_wrap_s16(stream, ptr);
-		samples = left_frames * channel_count;
-		n = MIN(samples, n);
-		frames = 0;
-		for (i = 0; i < n; i += channel_count) {
-			*ptr = 0;
-			ptr += channel_count;
-			frames++;
-		}
-	}
-}
-#endif	/* CONFIG_FORMAT_S16LE */
+#endif /* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 24 bit PCM source streams to one sink stream */
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, i;
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
-	int32_t *src = audio_stream_get_rptr(source);
+	int32_t *src[PLATFORM_MAX_CHANNELS];
+	int32_t *dest;
+	int32_t val;
+	int32_t x;
+	int nmax;
+	int i, j, n, ns;
+	int processed = 0;
+	int nch = audio_stream_get_channels(sink);
+	int samples = frames * nch;
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
+	dest = audio_stream_get_wptr(sink);
+	for (j = 0; j < num_sources; j++)
+		src[j] = audio_stream_get_rptr(sources[j]);
 
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
+	while (processed < samples) {
+		nmax = samples - processed;
+		n = audio_stream_samples_without_wrap_s24(sink, dest);
 		n = MIN(n, nmax);
+		for (i = 0; i < num_sources; i++) {
+			ns = audio_stream_samples_without_wrap_s24(sources[i], src[i]);
+			n = MIN(n, ns);
+		}
 		for (i = 0; i < n; i++) {
-			*dst = sat_int24(sign_extend_s24(*dst) + sign_extend_s24(*src++));
-			dst++;
-		}
-	}
+			val = 0;
+			for (j = 0; j < num_sources; j++) {
+				x = *src[j] << 8;
+				val += x >> 8; /* Sign extend */
+				src[j]++;
+			}
 
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = MIN(n, nmax);
-		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
-		dst += n;
-		src += n;
+			/* Saturate to 24 bits */
+			*dest = sat_int24(val);
+			dest++;
+		}
+		processed += n;
+		dest = audio_stream_wrap(sink, dest);
+		for (i = 0; i < num_sources; i++)
+			src[i] = audio_stream_wrap(sources[i], src[i]);
 	}
 }
-
-static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int32_t *dst, *src;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, i, frames, samples;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int24(sign_extend_s24(*dst) +
-					  (int32_t)q_mults_32x32(sign_extend_s24(*src),
-					  gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int32_t)q_mults_32x32(sign_extend_s24(*src),
-							   gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
-#endif	/* CONFIG_FORMAT_S24LE */
+#endif /* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 32 bit PCM source streams to one sink stream */
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, i;
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
-	int32_t *src = audio_stream_get_rptr(source);
+	int32_t *src[PLATFORM_MAX_CHANNELS];
+	int32_t *dest;
+	int64_t val;
+	int nmax;
+	int i, j, n, ns;
+	int processed = 0;
+	int nch = audio_stream_get_channels(sink);
+	int samples = frames * nch;
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
+	dest = audio_stream_get_wptr(sink);
+	for (j = 0; j < num_sources; j++)
+		src[j] = audio_stream_get_rptr(sources[j]);
 
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
+	while (processed < samples) {
+		nmax = samples - processed;
+		n = audio_stream_samples_without_wrap_s32(sink, dest);
 		n = MIN(n, nmax);
+		for (i = 0; i < num_sources; i++) {
+			ns = audio_stream_samples_without_wrap_s32(sources[i], src[i]);
+			n = MIN(n, ns);
+		}
 		for (i = 0; i < n; i++) {
-			*dst = sat_int32((int64_t)*dst + (int64_t)*src++);
-			dst++;
-		}
-	}
+			val = 0;
+			for (j = 0; j < num_sources; j++) {
+				val += *src[j];
+				src[j]++;
+			}
 
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		n = MIN(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = MIN(n, nmax);
-		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
-		dst += n;
-		src += n;
+			/* Saturate to 32 bits */
+			*dest = sat_int32(val);
+			dest++;
+		}
+		processed += n;
+		dest = audio_stream_wrap(sink, dest);
+		for (i = 0; i < num_sources; i++)
+			src[i] = audio_stream_wrap(sources[i], src[i]);
 	}
 }
+#endif /* CONFIG_FORMAT_S32LE */
 
-static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i, samples;
-	int32_t *dst, *src;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (int32_t *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = mixed_frames - start_frame;
-	frames_to_mix = MIN(frames_to_mix, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = MIN(n, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = sat_int32((int64_t)*dst +
-					  q_mults_32x32(*src, gain, IPC4_MIXIN_GAIN_SHIFT));
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		samples = left_frames * source_channel_count;
-		n = MIN(samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = MIN(n, nmax);
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			*dst = (int32_t)q_mults_32x32(*src, gain, IPC4_MIXIN_GAIN_SHIFT);
-			src += source_channel_count;
-			dst += sink_channel_count;
-			frames++;
-		}
-	}
-}
-
-#endif	/* CONFIG_FORMAT_S32LE */
-
-#if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
-			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
-{
-	int32_t skip_mixed_frames, left_frames, n, channel_count, i, frames, samples;
-	int32_t *ptr;
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-	frame_count -= skip_mixed_frames;
-	channel_count = audio_stream_get_channels(stream);
-
-	ptr = (int32_t *)audio_stream_get_wptr(stream) +
-		mixed_frames * audio_stream_get_channels(stream) +
-		channel_index;
-
-	for (left_frames = frame_count; left_frames > 0; left_frames -= frames) {
-		ptr = audio_stream_wrap(stream, ptr);
-		n = audio_stream_samples_without_wrap_s32(stream, ptr);
-		samples = left_frames * channel_count;
-		n =  MIN(samples, n);
-		frames = 0;
-		for (i = 0; i < n; i += channel_count) {
-			*ptr = 0;
-			ptr += channel_count;
-			frames++;
-		}
-	}
-}
-
-#endif
-
-const struct mix_func_map mix_func_map[] = {
+const struct mixer_func_map mixer_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, remap_mix_channel_s16, mute_channel_s16},
+	{ SOF_IPC_FRAME_S16_LE, mix_n_s16 },
 #endif
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, remap_mix_channel_s24, mute_channel_s32},
+	{ SOF_IPC_FRAME_S24_4LE, mix_n_s24 },
 #endif
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, remap_mix_channel_s32, mute_channel_s32}
+	{ SOF_IPC_FRAME_S32_LE, mix_n_s32 },
 #endif
 };
 
-const size_t mix_count = ARRAY_SIZE(mix_func_map);
+const size_t mixer_func_count = ARRAY_SIZE(mixer_func_map);
 
 #endif

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -5,592 +5,175 @@
 // Author: Andrula Song <xiaoyuan.song@intel.com>
 
 #include <ipc4/mixin_mixout.h>
+#include <sof/audio/mixer.h>
 #include <sof/common.h>
 
 #ifdef MIXIN_MIXOUT_HIFI3
+#if __XCC__ && (XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4)
+
+#include <xtensa/tie/xt_hifi3.h>
 
 #if CONFIG_FORMAT_S16LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 16 bit PCM source streams to one sink stream */
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, i, m, left;
-	ae_int16x4 in_sample;
-	ae_int16x4 out_sample;
-	ae_int16x4 *in;
-	ae_int16x4 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
-	ae_valign outu2 = AE_ZALIGN64();
-	/* audio_stream_wrap() is required and is done below in a loop */
-	ae_int16 *dst = (ae_int16 *)audio_stream_get_wptr(sink) + start_frame;
-	ae_int16 *src = audio_stream_get_rptr(source);
+	ae_int16x4 * in[PLATFORM_MAX_CHANNELS];
+	ae_int16x4 *out = audio_stream_get_wptr(sink);
+	ae_int16x4 sample = AE_ZERO16();
+	ae_int16x4 res = AE_ZERO16();
+	ae_int32x2 val1;
+	ae_int32x2 val2;
+	ae_int32x2 sample_1;
+	ae_int32x2 sample_2;
+	unsigned int n, m, nmax, i, j, left_samples;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-	n = 0;
+	for (j = 0; j < num_sources; j++)
+		in[j] = audio_stream_get_rptr(sources[j]);
 
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int16x4 *)src;
-		out = (ae_int16x4 *)dst;
-		inu = AE_LA64_PP(in);
-		outu1 = AE_LA64_PP(out);
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		out = audio_stream_wrap(sink,  out);
+		nmax = audio_stream_samples_without_wrap_s16(sink, out);
+		n = MIN(left_samples, nmax);
+		for (j = 0; j < num_sources; j++) {
+			in[j] = audio_stream_wrap(sources[j], in[j]);
+			nmax = audio_stream_samples_without_wrap_s16(sources[j], in[j]);
+			n = MIN(n, nmax);
+		}
 		m = n >> 2;
-		left = n & 0x03;
-		/* process 4 frames per loop */
+
 		for (i = 0; i < m; i++) {
-			AE_LA16X4_IP(in_sample, inu, in);
-			AE_LA16X4_IP(out_sample, outu1, out);
-			out--;
-			out_sample = AE_ADD16S(in_sample, out_sample);
-			AE_SA16X4_IP(out_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
+			val1 = AE_ZERO32();
+			val2 = AE_ZERO32();
+			for (j = 0; j < num_sources; j++) {
+				/* load four 16 bit samples, 8 is sizeof(ae_int16x4) */
+				AE_L16X4_IP(sample, in[j], 8);
+				sample_1 = AE_SEXT32X2D16_32(sample);
+				sample_2 = AE_SEXT32X2D16_10(sample);
+				val1 = AE_ADD32S(val1, sample_1);
+				val2 = AE_ADD32S(val2, sample_2);
+			}
+			/*Saturate to 16 bits */
+			val1 = AE_SRAA32S(AE_SLAA32S(val1, 16), 16);
+			val2 = AE_SRAA32S(AE_SLAA32S(val2, 16), 16);
 
-		/* process the left samples that less than 4
-		 * one by one to avoid memory access overrun
-		 */
-		for (i = 0; i < left ; i++) {
-			AE_L16_IP(in_sample, (ae_int16 *)in, sizeof(ae_int16));
-			AE_L16_IP(out_sample, (ae_int16 *)out, 0);
-			out_sample = AE_ADD16S(in_sample, out_sample);
-			AE_S16_0_IP(out_sample, (ae_int16 *)out, sizeof(ae_int16));
-		}
-	}
+			/* truncate the LSB 16bit of four 32-bit signed elements*/
+			res = AE_CVT16X4(val1, val2);
 
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int16x4 *)src;
-		out = (ae_int16x4 *)dst;
-		inu = AE_LA64_PP(in);
-		m = n >> 2;
-		left = n & 0x03;
-		/* process 4 frames per loop */
-		for (i = 0; i < m; i++) {
-			AE_LA16X4_IP(in_sample, inu, in);
-			AE_SA16X4_IP(in_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
-
-		/* process the left samples that less than 4
-		 * one by one to avoid memory access overrun
-		 */
-		for (i = 0; i < left ; i++) {
-			AE_L16_IP(in_sample, (ae_int16 *)in, sizeof(ae_int16));
-			AE_S16_0_IP(in_sample, (ae_int16 *)out, sizeof(ae_int16));
+			/* store four 16 bit samples, 8 is sizeof(ae_int16x4) */
+			AE_S16X4_IP(res, out, 8);
 		}
 	}
 }
-
-static void remap_mix_channel_s16(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	ae_int16 *dst, *src;
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, frames, i;
-	int inoff = source_channel_count * sizeof(ae_int16);
-	int outoff = sink_channel_count * sizeof(ae_int16);
-	ae_int16x4 in;
-	ae_int16x4 out;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	ae_int32x2 temp, out1;
-
-	dst = (ae_int16 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int16 *)audio_stream_get_rptr(source) + source_channel_index;
-	src = audio_stream_wrap(source, src);
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		/* audio_stream_wrap() is required and is done below in a loop */
-		dst = audio_stream_wrap(sink, dst);
-
-		/* calculate the remaining samples of sink*/
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L16_XC(in, src, inoff);
-			AE_L16_XP(out, dst, 0);
-			/* Q1.15 * Q1.15 to Q2.30*/
-			temp = AE_MULF16SS_00(in, gain_v);
-			temp = AE_SRAI32R(temp, IPC4_MIXIN_GAIN_SHIFT + 1);
-			out1 = AE_SEXT32X2D16_10(out);
-			temp = AE_ADD32S(temp, out1);
-			temp = AE_SLAI32S(temp, 16);
-			out = AE_ROUND16X4F32SSYM(temp, temp);
-			AE_S16_0_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L16_XC(in, src, inoff);
-			AE_L16_XP(out, dst, 0);
-			temp = AE_MULF16SS_00(in, gain_v);
-			temp = AE_SRAI32R(temp, IPC4_MIXIN_GAIN_SHIFT + 1);
-			temp = AE_SLAI32S(temp, 16);
-			out = AE_ROUND16X4F32SSYM(temp, temp);
-			AE_S16_0_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
-			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
-{
-	int skip_mixed_frames, left_frames;
-	int off = audio_stream_get_channels(stream) * sizeof(ae_int16);
-	ae_int16 *ptr;
-	ae_int16x4 zero = AE_ZERO16();
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-	frame_count -= skip_mixed_frames;
-
-	AE_SETCBEGIN0(audio_stream_get_addr(stream));
-	AE_SETCEND0(audio_stream_get_end_addr(stream));
-
-	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int16 *)audio_stream_get_wptr(stream) +
-		mixed_frames * audio_stream_get_channels(stream) +
-		channel_index;
-	ptr = audio_stream_wrap(stream, ptr);
-
-	for (left_frames = frame_count ; left_frames; left_frames--)
-		AE_S16_0_XC(zero, ptr, off);
-}
-#endif	/* CONFIG_FORMAT_S16LE */
+#endif /* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 24 bit PCM source streams to one sink stream */
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, i, m, left;
-	ae_int32x2 in_sample;
-	ae_int32x2 out_sample;
-	ae_int32x2 *in;
-	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
-	ae_valign outu2 = AE_ZALIGN64();
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
-	int32_t *src = audio_stream_get_rptr(source);
+	ae_int32x2 *in[PLATFORM_MAX_CHANNELS];
+	ae_int32x2 *out = audio_stream_get_wptr(sink);
+	ae_int32x2 val;
+	ae_int32x2 sample = AE_ZERO32();
+	unsigned int n, m, nmax, i, j, left_samples;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-	n = 0;
+	for (j = 0; j < num_sources; j++)
+		in[j] = audio_stream_get_rptr(sources[j]);
 
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int32x2 *)src;
-		out = (ae_int32x2 *)dst;
-		inu = AE_LA64_PP(in);
-		outu1 = AE_LA64_PP(out);
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		out = audio_stream_wrap(sink,  out);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(left_samples, nmax);
+		for (j = 0; j < num_sources; j++) {
+			in[j] = audio_stream_wrap(sources[j], in[j]);
+			nmax = audio_stream_samples_without_wrap_s32(sources[j], in[j]);
+			n = MIN(n, nmax);
+		}
 		m = n >> 1;
-		left = n & 1;
-		/* process 2 samples per time */
 		for (i = 0; i < m; i++) {
-			AE_LA32X2_IP(in_sample, inu, in);
-			AE_LA32X2_IP(out_sample, outu1, out);
-			out--;
-			out_sample = AE_ADD24S(in_sample, out_sample);
-			AE_SA32X2_IP(out_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
+			val = AE_ZERO32();
+			for (j = 0; j < num_sources; j++) {
+				/* load two 32 bit samples, 8 is sizeof(ae_int32x2) */
+				AE_L32X2_IP(sample, in[j], 8);
+				/* Sign extend */
+				sample = AE_SRAA32RS(AE_SLAI32(sample, 8), 8);
+				val = AE_ADD32S(val, sample);
+			}
+			/*Saturate to 24 bits */
+			val = AE_SRAA32S(AE_SLAA32S(val, 8), 8);
 
-		/* process the left sample to avoid memory access overrun */
-		if (left) {
-			AE_L32_IP(in_sample, (ae_int32 *)in, sizeof(ae_int32));
-			AE_L32_IP(out_sample, (ae_int32 *)out, 0);
-			out_sample = AE_ADD24S(in_sample, out_sample);
-			AE_S32_L_IP(out_sample, (ae_int32 *)out, sizeof(ae_int32));
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int32x2 *)src;
-		out = (ae_int32x2 *)dst;
-		inu = AE_LA64_PP(in);
-		m = n >> 1;
-		left = n & 1;
-		for (i = 0; i < m; i++) {
-			AE_LA32X2_IP(in_sample, inu, in);
-			AE_SA32X2_IP(in_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
-		/* process the left sample to avoid memory access overrun */
-		if (left) {
-			AE_L32_IP(in_sample, (ae_int32 *)in, sizeof(ae_int32));
-			AE_S32_L_IP(in_sample, (ae_int32 *)out, sizeof(ae_int32));
+			/* store two 32 bit samples, 8 is sizeof(ae_int32x2) */
+			AE_S32X2_IP(val, out, 8);
 		}
 	}
 }
-
-static void remap_mix_channel_s24(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, i, frames;
-	int inoff = source_channel_count * sizeof(ae_int32);
-	int outoff = sink_channel_count * sizeof(ae_int32);
-	ae_int32x2 in;
-	ae_int32x2 out;
-	ae_int64 tmp;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	ae_int32 *dst, *src;
-
-	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
-	src = audio_stream_wrap(source, src);
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			/*shift the significant 8 bits to the left*/
-			in = AE_SLAI32(in, 8);
-			AE_L32_XP(out, dst, 0);
-			out = AE_SLAI32(out, 8);
-			out = AE_SRAI32(out, 8);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-
-			/* shift should be IPC4_MIXIN_GAIN_SHIFT + 8(shift right for in)
-			 * - 16(to keep the valid LSB bits of ae_int64)
-			 */
-			in = AE_ROUND32F48SSYM(AE_SRAI64(tmp, IPC4_MIXIN_GAIN_SHIFT - 8));
-			out = AE_ADD32S(out, in);
-			out = AE_SLAI32S(out, 8);
-			out = AE_SRAI32(out, 8);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			/*shift the significant bit to the left*/
-			in = AE_SLAI32(in, 8);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-			out = AE_ROUND32F48SSYM(AE_SRAI64(tmp, IPC4_MIXIN_GAIN_SHIFT - 8));
-			out = AE_SLAI32S(out, 8);
-			out = AE_SRAI32(out, 8);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
-#endif	/* CONFIG_FORMAT_S24LE */
+#endif /* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-/* Instead of using audio_stream_get_channels(sink) and audio_stream_get_channels(source),
- * sink_channel_count and source_channel_count are supplied as parameters. This is done to reuse
- * the function to also mix an entire stream. In this case the function is called with fake stream
- * parameters: multichannel stream is treated as single channel and so the entire stream
- * contents is mixed.
- */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
-				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
-				   int32_t frame_count, uint16_t gain)
+/* Mix n 32 bit PCM source streams to one sink stream */
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+		      uint32_t frames)
 {
-	int frames_to_mix, frames_to_copy, left_frames;
-	int n, nmax, i, m, left;
-	ae_int32x2 in_sample;
-	ae_int32x2 out_sample;
-	ae_int32x2 *in;
-	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
-	ae_valign outu2 = AE_ZALIGN64();
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_frame;
-	int32_t *src = audio_stream_get_rptr(source);
+	ae_q32s * in[PLATFORM_MAX_CHANNELS];
+	ae_int32 *out = audio_stream_get_wptr(sink);
+	ae_int64 sample;
+	ae_int64 val;
+	ae_int32x2 res;
+	unsigned int n, nmax, i, j, left_samples;
+	unsigned int m = 0;
+	unsigned int samples = frames * audio_stream_get_channels(sink);
 
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-	n = 0;
+	for (j = 0; j < num_sources; j++)
+		in[j] = audio_stream_get_rptr(sources[j]);
 
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int32x2 *)src;
-		out = (ae_int32x2 *)dst;
-		inu = AE_LA64_PP(in);
-		outu1 = AE_LA64_PP(out);
-		m = n >> 1;
-		left = n & 1;
+	for (left_samples = samples; left_samples; left_samples -= n) {
+		out = audio_stream_wrap(sink,  out);
+		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		n = MIN(left_samples, nmax);
+		for (j = 0; j < num_sources; j++) {
+			in[j] = audio_stream_wrap(sources[j], in[j] + m);
+			nmax = audio_stream_samples_without_wrap_s32(sources[j], in[j]);
+			n = MIN(n, nmax);
+		}
+		/*record the processed samples for next address iteration */
+		m = n;
 		for (i = 0; i < m; i++) {
-			AE_LA32X2_IP(in_sample, inu, in);
-			AE_LA32X2_IP(out_sample, outu1, out);
-			out--;
-			out_sample = AE_ADD32S(in_sample, out_sample);
-			AE_SA32X2_IP(out_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
+			val =  AE_ZERO64();
+			for (j = 0; j < num_sources; j++) {
+				/* load one 32 bit sample */
+				sample = AE_L32M_X(in[j],  i * sizeof(ae_q32s));
+				val = AE_ADD64S(val, sample);
+			}
+			/*Saturate to 32 bits */
+			res =  AE_ROUND32X2F48SSYM(val, val);
 
-		/* process the left sample to avoid memory access overrun */
-		if (left) {
-			AE_L32_IP(in_sample, (ae_int32 *)in, sizeof(ae_int32));
-			AE_L32_IP(out_sample, (ae_int32 *)out, 0);
-			out_sample = AE_ADD32S(in_sample, out_sample);
-			AE_S32_L_IP(out_sample, (ae_int32 *)out, sizeof(ae_int32));
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= n) {
-		src = audio_stream_wrap(source, src + n);
-		dst = audio_stream_wrap(sink, dst + n);
-		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
-		n = AE_MIN_32_signed(left_frames, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(n, nmax);
-		in = (ae_int32x2 *)src;
-		out = (ae_int32x2 *)dst;
-		inu = AE_LA64_PP(in);
-		m = n >> 1;
-		left = n & 1;
-		for (i = 0; i < m; i++) {
-			AE_LA32X2_IP(in_sample, inu, in);
-			AE_SA32X2_IP(in_sample, outu2, out);
-		}
-		AE_SA64POS_FP(outu2, out);
-
-		/* process the left sample to avoid memory access overrun */
-		if (left) {
-			AE_L32_IP(in_sample, (ae_int32 *)in, sizeof(ae_int32));
-			AE_S32_L_IP(in_sample, (ae_int32 *)out, sizeof(ae_int32));
+			/* store one 32 bit samples */
+			AE_S32_L_IP(res, out, sizeof(ae_int32));
 		}
 	}
 }
+#endif /* CONFIG_FORMAT_S32LE */
 
-static void remap_mix_channel_s32(struct audio_stream __sparse_cache *sink,
-				  int32_t sink_channel_index,  int32_t sink_channel_count,
-				  int32_t start_frame, int32_t mixed_frames,
-				  const struct audio_stream __sparse_cache *source,
-				  int32_t source_channel_index, int32_t source_channel_count,
-				  int32_t frame_count, uint16_t gain)
-{
-	int inoff = source_channel_count * sizeof(ae_int32);
-	int outoff = sink_channel_count * sizeof(ae_int32);
-	ae_int32x2 in;
-	ae_int32x2 out;
-	ae_int64 tmp, tmp1;
-	ae_int16 *pgain = (ae_int16 *)&gain;
-	ae_int16x4 gain_v;
-	int32_t frames_to_mix, frames_to_copy, left_frames;
-	int32_t n, nmax, frames, i;
-	ae_int32 *dst, *src;
-
-	/* audio_stream_wrap() is required and is done below in a loop */
-	dst = (ae_int32 *)audio_stream_get_wptr(sink) + start_frame * sink_channel_count +
-		sink_channel_index;
-	src = (ae_int32 *)audio_stream_get_rptr(source) + source_channel_index;
-
-	assert(mixed_frames >= start_frame);
-	frames_to_mix = AE_MIN_32_signed(mixed_frames - start_frame, frame_count);
-	frames_to_copy = frame_count - frames_to_mix;
-	/* store gain to a AE_DR register gain_v*/
-	AE_L16_IP(gain_v, pgain, 0);
-	/* set source as circular buffer, hifi3 only have 1 circular buffer*/
-	AE_SETCBEGIN0(audio_stream_get_addr(source));
-	AE_SETCEND0(audio_stream_get_end_addr(source));
-	src = audio_stream_wrap(source, src);
-
-	for (left_frames = frames_to_mix; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			AE_L32_XP(out, dst, 0);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-
-			/* shift should be -(IPC4_MIXIN_GAIN_SHIFT
-			 * - 16(to keep the valid LSB bits of ae_int64))
-			 */
-			tmp = AE_SLAI64S(tmp, 16 - IPC4_MIXIN_GAIN_SHIFT);
-			tmp1 = AE_CVT48A32(out);
-			tmp = AE_ADD64S(tmp, tmp1);
-			out = AE_ROUND32F48SSYM(tmp);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-
-	for (left_frames = frames_to_copy; left_frames > 0; left_frames -= frames) {
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
-		n = AE_MIN_32_signed(left_frames * sink_channel_count, nmax);
-		/* frames is the processed frame count in this loop*/
-		frames = 0;
-
-		for (i = 0; i < n; i += source_channel_count) {
-			AE_L32_XC(in, src, inoff);
-			tmp = AE_MUL32X16_H0(in, gain_v);
-			tmp = AE_SLAI64S(tmp, 16 - IPC4_MIXIN_GAIN_SHIFT);
-			out = AE_ROUND32F48SSYM(tmp);
-			AE_S32_L_XP(out, dst, outoff);
-			frames++;
-		}
-	}
-}
-
-#endif	/* CONFIG_FORMAT_S32LE */
-
-#if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
-			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
-{
-	int skip_mixed_frames, left_frames;
-	ae_int32 *ptr;
-	int off = audio_stream_get_channels(stream) * sizeof(ae_int32);
-	ae_int32x2 zero = AE_ZERO32();
-
-	assert(mixed_frames >= start_frame);
-	skip_mixed_frames = mixed_frames - start_frame;
-
-	if (frame_count <= skip_mixed_frames)
-		return;
-	frame_count -= skip_mixed_frames;
-
-	AE_SETCBEGIN0(audio_stream_get_addr(stream));
-	AE_SETCEND0(audio_stream_get_end_addr(stream));
-
-	/* audio_stream_wrap() is needed here and it is just below in a loop */
-	ptr = (ae_int32 *)audio_stream_get_wptr(stream) +
-		mixed_frames * audio_stream_get_channels(stream) +
-		channel_index;
-	ptr = audio_stream_wrap(stream, ptr);
-
-	for (left_frames = frame_count ; left_frames > 0; left_frames--)
-		AE_S32_L_XC(zero, ptr, off);
-}
-
-#endif
-
-const struct mix_func_map mix_func_map[] = {
+const struct mixer_func_map mixer_func_map[] = {
 #if CONFIG_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, normal_mix_channel_s16, remap_mix_channel_s16, mute_channel_s16},
+	{ SOF_IPC_FRAME_S16_LE, mix_n_s16 },
 #endif
 #if CONFIG_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, normal_mix_channel_s24, remap_mix_channel_s24, mute_channel_s32},
+	{ SOF_IPC_FRAME_S24_4LE, mix_n_s24 },
 #endif
 #if CONFIG_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, normal_mix_channel_s32, remap_mix_channel_s32, mute_channel_s32}
+	{ SOF_IPC_FRAME_S32_LE, mix_n_s32 },
 #endif
 };
 
-const size_t mix_count = ARRAY_SIZE(mix_func_map);
+const size_t mixer_func_count = ARRAY_SIZE(mixer_func_map);
+
+#endif
 
 #endif

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -805,6 +805,7 @@ static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 	struct comp_buffer __sparse_cache *sink_c;
 	struct comp_dev *source_dev;
 	uint32_t num_output_buffers = 0;
+	uint32_t num_input_buffers = 0;
 	uint32_t frames;
 	int ret;
 
@@ -835,7 +836,10 @@ static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 	if (sink_c->sink->state == dev->state)
 		num_output_buffers = 1;
 
-	ret = module_process_legacy(mod, mod->input_buffers, 1,
+	if (source_c->source->state == dev->state)
+		num_input_buffers = 1;
+
+	ret = module_process_legacy(mod, mod->input_buffers, num_input_buffers,
 				    mod->output_buffers, num_output_buffers);
 
 	/* consume from the input buffer */

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -803,11 +803,21 @@ static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_buffer __sparse_cache *source_c;
 	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_dev *source_dev;
 	uint32_t num_output_buffers = 0;
 	uint32_t frames;
 	int ret;
 
 	source_c = buffer_acquire(mod->source_comp_buffer);
+	source_dev = source_c->source;
+
+	/* bypass the source dev processing if it has enabled bypass */
+	if (source_dev->bypass_processing) {
+		struct processing_module *source_mod = comp_get_drvdata(source_dev);
+
+		buffer_release(source_c);
+		source_c = buffer_acquire(source_mod->source_comp_buffer);
+	}
 	sink_c = buffer_acquire(mod->sink_comp_buffer);
 	frames = audio_stream_avail_frames_aligned(&source_c->stream, &sink_c->stream);
 	mod->input_buffers[0].size = frames;
@@ -857,8 +867,12 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 	uint32_t num_output_buffers = 0;
 	int ret, i = 0;
 
-	if (mod->stream_copy_single_to_single)
+	if (mod->stream_copy_single_to_single) {
+		if (mod->dev->bypass_processing)
+			return 0;
+
 		return module_adapter_audio_stream_copy_1to1(dev);
+	}
 
 	/* acquire all sink and source buffers */
 	list_for_item(blist, &dev->bsink_list) {
@@ -869,10 +883,20 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 	}
 	i = 0;
 	list_for_item(blist, &dev->bsource_list) {
+		struct comp_dev *source_dev;
 		struct comp_buffer *source;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
-		source_c[i++] = buffer_acquire(source);
+		source_c[i] = buffer_acquire(source);
+		source_dev = source_c[i]->source;
+		/* bypass the source dev processing if it has enabled bypass */
+		if (source_dev->bypass_processing) {
+			struct processing_module *source_mod = comp_get_drvdata(source_dev);
+
+			buffer_release(source_c[i]);
+			source_c[i] = buffer_acquire(source_mod->source_comp_buffer);
+		}
+		i++;
 	}
 
 	/* setup active input/output buffers for processing */
@@ -1509,13 +1533,18 @@ static bool module_adapter_multi_sink_source_check(struct comp_dev *dev)
 
 	comp_dbg(dev, "num_sources=%d num_sinks=%d", num_sources, num_sinks);
 
-	if (num_sources != 1 || num_sinks != 1)
+	if (num_sources != 1 || num_sinks != 1) {
+		mod->dev->bypass_processing = false;
 		return true;
+	}
 
 	/* re-assign the source/sink modules */
 	mod->sink_comp_buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	mod->source_comp_buffer = list_first_item(&dev->bsource_list,
 						  struct comp_buffer, sink_list);
+
+	if (mod->dev->bypass_capable)
+		mod->dev->bypass_processing = true;
 
 	return false;
 }

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -599,6 +599,15 @@ struct comp_dev {
 	struct list_item bsource_list;	/**< list of source buffers */
 	struct list_item bsink_list;	/**< list of sink buffers */
 
+	/*
+	 * When a module sets bypass_processing, the module adapter will skip invoking its module
+	 * process callback.
+	 * TODO: this flag should ideally be in struct processing_module but since all modules
+	 * have not been converted to use the module adapter yet, keep this here for now.
+	 */
+	bool bypass_processing; /**< module processing can be bypassed */
+	bool bypass_capable; /**< module is bypass capable */
+
 	/* private data - core does not touch this */
 	void *priv_data;	/**< private data */
 


### PR DESCRIPTION
Includes the patch from #7792 

For a pipeline like: host-copier->gain->mixin->mixout->gain->dai-copier
The original MCPS (Measured on TGL chromebook) is:
```
            host-copier.2.playback,   comp:0 0x40000,     3.46,     6.89
                          gain.5.1,   comp:0 0x60000,     2.17,     9.22
                         mixin.5.1,   comp:0 0x20000,     2.62,     5.94
                        mixout.6.1,   comp:1 0x30000,     1.89,     2.42
                          gain.6.1,   comp:1 0x60001,     2.22,    16.57
 dai-copier.SSP.NoCodec-2.playback,   comp:1 0x40001,     6.05,     6.41
                                  ,                 ,    18.42,    47.44

```
And the optimized performance is:
```
                              Name,        Mtrace id, avg MCPS, max MCPS
            host-copier.2.playback,   comp:0 0x40000,     3.42,     6.86
                          gain.5.1,   comp:0 0x60000,     2.19,     9.24
                         mixin.5.1,   comp:0 0x20000,     0.80,     0.82
                        mixout.6.1,   comp:1 0x30000,     2.14,     2.44
                          gain.6.1,   comp:1 0x60001,     2.19,     9.34
 dai-copier.SSP.NoCodec-2.playback,   comp:1 0x40001,     5.90,    13.75
                                  ,                 ,    16.64,    42.46

```