### PR TITLE
Audio: SRC: Add safeguard against completely missing init_data

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -987,6 +987,12 @@ static int src_init(struct processing_module *mod)
 
 	comp_dbg(dev, "src_init()");
 
+	if (dev->ipc_config.type != SOF_COMP_SRC || !cfg->init_data ||
+	    cfg->size != sizeof(cd->ipc_config)) {
+		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
+			 cfg->size);
+		return -EINVAL;
+	}
 	/* validate init data - either SRC sink or source rate must be set */
 	if (src_rate_check(cfg->init_data) < 0) {
 		comp_err(dev, "src_init(): SRC sink and source rate are not set");


### PR DESCRIPTION
In some error situations the configuration init_data may be NULL, and in such a situations we should fail gracefully and not crash.