### PR TITLE
Fixes for multi-core support

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -55,7 +55,7 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	dev->ipc_config = *config;
 	dev->drv = drv;
 
-	mod = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*mod));
+	mod = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*mod));
 	if (!mod) {
 		comp_err(dev, "module_adapter_new(), failed to allocate memory for module");
 		rfree(dev);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -122,7 +122,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	heap_trace_all(0);
 
 	/* allocate new pipeline */
-	p = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
+	p = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*p));
 	if (!p) {
 		pipe_cl_err("pipeline_new(): Out of Memory");
 		return NULL;


### PR DESCRIPTION
(1)
module_adapter: Fix for multi-core usage
ipc4_create_buffer() to get ibs/obs size uses comp_get_attribute(, COMP_ATTR_BASE_CONFIG, ) which returns module's struct processing_module::priv.cfg.base_cfg. Since buffer and module could be created on different cores, this fix makes sure module's struct processing_module is allocated in non-cached memory and can be read from any core.

(2)
Fix pipeline allocation for multi-core usage
pipeline_get_dai_comp_latency() iterates over all pipelines and reaches to struct pipeline::pipeline_id. If pipeline was created on core different from the core making pipeline_get_dai_comp_latency() call, reading pipeline_id returns wrong value. This fix ensures that struct pipeline can be read from any core.

WARNING: these fixes could potentially affect performance. I did not do any performance measurements with and without these modifications.

It might be possible to fix same problems without simply using non-cached memory but with some more complex solution. So the ideas are welcomed whether we can merge these fixes as is or we could come out with better solutions.

These are backports of fixes we already have on mtl-005-drop-stable.