### PR TITLE
[DNM] west.yml: update Zephyr to 3.4.99

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2ad1a24fd60d0df8cb45fb6ed6acf7b0d3820754
+      revision: e2e3dc0771188f2a01e3aaa792f81e6c6a611eb6
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
First Zephyr update after 3.4.0 release.

    Contains 554 commits, including following directly affecting
    SOF targets:
    
    2958a407f8f1 adsp: dmic: Add source clock selection support
    0ee64528168b adsp: ace: dmic: Add missing registers definitions
    fbb55d1d5e19 adsp: dmic: Moved registers definitions to a separate file
    e2e3dc077118 dts: xtensa: intel: add imr entry to cavs25_tgph
    6c9a360647c8 drivers: intel_adsp_gpdma: Fix typo in reg name
    a8b28f13c195 soc: intel_adsp: cavs: add simple IMR functionality
    339b00de11e5 soc: xtensa: intel_adsp: fix memory bank shutdown
    5dfaf23f47b7 xtensa: intel_adsp: lnl: Fix dspcs struct
    09085ef63c02 dts: xtensa: intel: update cavs25 sram size
    b871138fae1f soc/intel_adsp: fix typo in L1EXP definition
    9db44fa2813c toolchain: xtensa: enable C11 features with xt-clang
    2ba7855ddf23 modules: mipi-syst: support minimal C library
