### PR TITLE
app: add logging_mipisystcat_overlay.conf overlay config

### DIFF
--- a/app/logging_mipisystcat_overlay.conf
+++ b/app/logging_mipisystcat_overlay.conf
@@ -1,0 +1,9 @@
+# Enable MIPI Sys-T Catalog FW logging
+# ref: https://docs.zephyrproject.org/latest/samples/subsys/logging/syst/README.html
+CONFIG_LOG_MIPI_SYST_ENABLE=y
+CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+
+# set as output type of all SOF backends
+CONFIG_LOG_BACKEND_ADSP_OUTPUT_SYST=y
+CONFIG_LOG_BACKEND_ADSP_OUTPUT_SYST=y
+CONFIG_LOG_BACKEND_ADSP_MTRACE_OUTPUT_SYST=y


### PR DESCRIPTION
Add an overlay config to build SOF with MIPI Sys-T Catalog logging enabled.

This adds MIPI Sys-T Catalog as an overlay option. There are still issues (tracked in https://github.com/thesofproject/sof/issues/7703 ) with using this output in SOF, and some of the SOF CI infra is not prepare to handle binary-encoded logs, so this option cannot yet be enabled across the board.
