### PR TITLE
iadk/array.h: do not redefine assert() to nothing in an unrelated .h 

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -175,6 +175,7 @@ jobs:
       - name: build
         run: cd workspace && ./sof/zephyr/docker-run.sh
              ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
+             --cmake-args=-DEXTRA_CXXFLAGS=-Werror
              --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
              --cmake-args=--warn-uninitialized
              ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
@@ -321,6 +322,7 @@ jobs:
         run: python sof/scripts/xtensa-build-zephyr.py
           --no-interactive
           --cmake-args=-DEXTRA_CFLAGS=-Werror
+          --cmake-args=-DEXTRA_CXXFLAGS=-Werror
           --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
           --cmake-args=--warn-uninitialized ${{ matrix.build_opts }} ${{ matrix.platforms }}
 

--- a/src/include/sof/audio/module_adapter/iadk/utilities/array.h
+++ b/src/include/sof/audio/module_adapter/iadk/utilities/array.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include <rtos/panic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,8 +58,6 @@ static inline uint8_t *array_alloc_from(byte_array_t *ba,
 #endif
 
 #ifdef __cplusplus
-/* clang-format off */
-#define assert(cond)
 
 static inline uint8_t *array_get_data(const byte_array_t &ba)
 {


### PR DESCRIPTION
Do not unconditionally define assert() to nothing in some obscure and
unrelated array.h file.

This looks like it was a temporary hack that was missed in commit
https://github.com/thesofproject/sof/commit/6f366e2eefe4fa4aaaa8d692fe7d276d8580d8d5 ("Add definition of interfaces of Intel IADK modules."),
part of PR https://github.com/thesofproject/sof/pull/5848 too massive to be properly reviewed.
(docs.zephyrproject.org/latest/contribute/contributor_expectations.html)

In addition to enabling asserts when requested by a debug build (!), fix
the following messenger warning:

```
In file included
   from src/include/sof/common.h:30,
   from src/include/sof/audio/sink_api.h:10,
   from src/include/sof/audio/module_adapter/module/module_interface.h:17,
   from src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h:19,
   from src/audio/module_adapter/iadk/system_agent.cpp:22:
 zephyr/include/rtos/panic.h:19: error: "assert" redefined [-Werror]
   19 | #define assert(x) __ASSERT_NO_MSG(x)
      |

In file included from
  src/audio/module_adapter/iadk/system_agent.cpp:16:
  src/include/sof/audio/module_adapter/iadk/utilities/array.h:60:
   note:  this is the location of the previous definition
   60 | #define assert(cond)
```

This warning appeared only later in messenger commit
https://github.com/thesofproject/sof/commit/002d4a3f666fb689a0fdba21e0689f12f81c6ee4 ("Pipeline2.0: change module API to use various data")
because it started to include audio/sink_api.h in
module_interface.h. This led to the two definitions finally clashing
with each other.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
