### PR TITLE
audio/selector: Don't assert on input-controllable memcpy_s failure

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -193,7 +193,11 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 	comp_set_drvdata(dev, cd);
 
 	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
-	assert(!ret);
+	if (ret) {
+		rfree(cd);
+		rfree(dev);
+		return NULL;
+	}
 
 	dev->state = COMP_STATE_READY;
 	return dev;


### PR DESCRIPTION
The size argument to the memcpy_s() here is under the control of external data and can fail on garbage.  That needs to be a runtime failure, not an assertion.