### PR TITLE
west.yml: upgrade Zephyr revision - update usage of IPC4 ipc_platform_send_msg function signature

### DIFF
--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -169,11 +169,7 @@ int ipc_platform_send_msg(const struct ipc_msg *msg)
 	/* prepare the message and copy to mailbox */
 	struct ipc_cmd_hdr *hdr = ipc_prepare_to_send(msg);
 
-	if (!intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, hdr->pri, hdr->ext))
-		/* IPC device is busy with something else */
-		return -EBUSY;
-
-	return 0;
+	return intel_adsp_ipc_send_message(INTEL_ADSP_IPC_HOST_DEV, hdr->pri, hdr->ext);
 }
 
 void ipc_platform_send_msg_direct(const struct ipc_msg *msg)

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: e2e3dc0771188f2a01e3aaa792f81e6c6a611eb6
+      revision: 23b3cae1b1d91cd064d31cdeb78e3a6127b5051d
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
During last changes in Zephyr that implemented power transition for the IPC Device, signature of the intel_adsp_ipc_send_message had changed and now returns negative int error codes (previously bool on success). Updated single function reference in SOF IPC4 `ipc_platform_send_msg()`.
Implementation had not changed as the function may return only `-EBUSY` error code until the Zephyr Device Power Management option is disabled.

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>