### PR TITLE
Audio: Volume: Add Kconfig to distinguish the peak volume and gain

### DIFF
--- a/src/audio/module_adapter/CMakeLists.txt
+++ b/src/audio/module_adapter/CMakeLists.txt
@@ -7,14 +7,19 @@ endif()
 
 if((NOT CONFIG_LIBRARY) OR CONFIG_LIBRARY_STATIC)
 	if(CONFIG_COMP_VOLUME)
-	add_local_sources(sof
-		module/volume/volume_generic.c
-		module/volume/volume_hifi3.c
-		module/volume/volume_hifi4.c
-		module/volume/volume_generic_with_peakvol.c
-		module/volume/volume_hifi3_with_peakvol.c
-		module/volume/volume_hifi4_with_peakvol.c
-		module/volume/volume.c)
+		if(CONFIG_COMP_PEAK_VOL)
+			add_local_sources(sof
+				module/volume/volume_generic_with_peakvol.c
+				module/volume/volume_hifi3_with_peakvol.c
+				module/volume/volume_hifi4_with_peakvol.c
+				module/volume/volume.c)
+		else()
+			add_local_sources(sof
+				module/volume/volume_generic.c
+				module/volume/volume_hifi3.c
+				module/volume/volume_hifi4.c
+				module/volume/volume.c)
+		endif()
 	endif()
 
 	if(CONFIG_CADENCE_CODEC)

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -176,13 +176,24 @@ config COMP_VOLUME_LINEAR_RAMP
        help
          This option enables volume linear ramp shape.
 
-config COMP_PEAK_VOL
+choice "COMP_VOLUME_TYPE"
+	prompt "The processing type of volume"
+	default COMP_PEAK_VOL
+	depends on IPC_MAJOR_4
+
+	config COMP_PEAK_VOL
        bool "Report peak vol data to host"
-	   default y
-	   depends on IPC_MAJOR_4
        help
          This option enables reporting to host peak vol regs.
          See: struct ipc4_peak_volume_regs
+
+	config COMP_GAIN
+	bool "GAIN component"
+	help
+	  This option enables gain to change volume. It works
+	  as peak volume without updating peak vol to host
+endchoice
+
 
 choice "PEAK_METER_UPDATE_PERIOD_CHOICE"
 	prompt "The periods(ms) of updating peak meter value"
@@ -220,13 +231,6 @@ config PEAK_METER_UPDATE_PERIOD
 	help
 	  Decide which period of update the peak volume meter value
 
-config COMP_GAIN
-	bool "GAIN component"
-	default y
-	depends on IPC_MAJOR_4
-	help
-	  This option enables gain to change volume. It works
-	  as peak volume without updating peak vol to host
 
 endif # volume
 

--- a/src/audio/module_adapter/module/volume/volume_generic.c
+++ b/src/audio/module_adapter/module/volume/volume_generic.c
@@ -29,8 +29,6 @@ LOG_MODULE_DECLARE(volume_generic, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_GENERIC
 
-#if (!CONFIG_COMP_PEAK_VOL)
-
 #if CONFIG_FORMAT_S24LE
 /**
  * \brief Volume s24 to s24 multiply function
@@ -335,5 +333,4 @@ const struct comp_func_map volume_func_map[] = {
 
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
 
-#endif
 #endif

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -25,8 +25,6 @@ LOG_MODULE_DECLARE(volume_generic, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_GENERIC
 
-#if CONFIG_COMP_PEAK_VOL
-
 #if CONFIG_FORMAT_S24LE
 /**
  * \brief Volume s24 to s24 multiply function
@@ -384,5 +382,4 @@ const struct comp_func_map volume_func_map[] = {
 };
 
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
-#endif
 #endif

--- a/src/audio/module_adapter/module/volume/volume_hifi3.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3.c
@@ -23,8 +23,6 @@ LOG_MODULE_DECLARE(volume_hifi3, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_HIFI3
 
-#if (!CONFIG_COMP_PEAK_VOL)
-
 #include <xtensa/tie/xt_hifi3.h>
 
 /**
@@ -482,5 +480,4 @@ const struct comp_func_map volume_func_map[] = {
 };
 
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
-#endif
 #endif

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -23,8 +23,6 @@ LOG_MODULE_DECLARE(volume_hifi3, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_HIFI3
 
-#if CONFIG_COMP_PEAK_VOL
-
 #include <xtensa/tie/xt_hifi3.h>
 
 #if CONFIG_FORMAT_S24LE
@@ -454,5 +452,4 @@ const struct comp_func_map volume_func_map[] = {
 };
 
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
-#endif
 #endif

--- a/src/audio/module_adapter/module/volume/volume_hifi4.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4.c
@@ -23,8 +23,6 @@ LOG_MODULE_DECLARE(volume_hifi4, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_HIFI4
 
-#if (!CONFIG_COMP_PEAK_VOL)
-
 #include <xtensa/tie/xt_hifi4.h>
 
 /**
@@ -480,5 +478,4 @@ const struct comp_func_map volume_func_map[] = {
 #endif
 };
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
-#endif
 #endif

--- a/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
@@ -23,7 +23,6 @@ LOG_MODULE_DECLARE(volume_hifi4, CONFIG_SOF_LOG_LEVEL);
 
 #ifdef VOLUME_HIFI4
 
-#if CONFIG_COMP_PEAK_VOL
 #include <xtensa/tie/xt_hifi4.h>
 
 static inline void vol_store_gain(struct vol_data *cd, const int channels_count)
@@ -577,5 +576,4 @@ const struct comp_func_map volume_func_map[] = {
 };
 
 const size_t volume_func_count = ARRAY_SIZE(volume_func_map);
-#endif
 #endif

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -136,7 +136,7 @@ typedef uint32_t (*vol_zc_func)(const struct audio_stream __sparse_cache *source
  */
 
 struct vol_data {
-#if CONFIG_IPC_MAJOR_4
+#if CONFIG_COMP_PEAK_VOL
 	uint32_t mailbox_offset;		/**< store peak volume in mailbox */
 
 	/**< these values will be stored to mailbox for host (IPC4) */

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -10,12 +10,9 @@ target_include_directories(volume_process PRIVATE ${PROJECT_SOURCE_DIR}/src/audi
 # about unused missing references
 
 add_compile_options(-DUNIT_TEST)
-
+if(CONFIG_COMP_PEAK_VOL)
 add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume.c
-	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_generic.c
-	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi3.c
-	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi4.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
@@ -38,6 +35,32 @@ add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/component.c
 	${PROJECT_SOURCE_DIR}/src/math/numbers.c
 )
+else()
+add_library(audio_for_volume STATIC
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_generic.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi3.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/volume/volume_hifi4.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
+	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
+	${PROJECT_SOURCE_DIR}/src/audio/source_api_helper.c
+	${PROJECT_SOURCE_DIR}/src/audio/sink_api_helper.c
+	${PROJECT_SOURCE_DIR}/src/audio/sink_source_utils.c
+	${PROJECT_SOURCE_DIR}/src/audio/audio_stream.c
+	${PROJECT_SOURCE_DIR}/src/ipc/ipc3/helper.c
+	${PROJECT_SOURCE_DIR}/src/ipc/ipc-common.c
+	${PROJECT_SOURCE_DIR}/src/ipc/ipc-helper.c
+	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
+	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-graph.c
+	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-params.c
+	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-schedule.c
+	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-stream.c
+	${PROJECT_SOURCE_DIR}/src/audio/pipeline/pipeline-xrun.c
+	${PROJECT_SOURCE_DIR}/src/audio/component.c
+	${PROJECT_SOURCE_DIR}/src/math/numbers.c
+)
+endif()
 sof_append_relative_path_definitions(audio_for_volume)
 
 target_link_libraries(audio_for_volume PRIVATE sof_options)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -563,16 +563,21 @@ zephyr_library_sources_ifdef(CONFIG_IPC4_GATEWAY
 zephyr_library_sources_ifdef(CONFIG_SAMPLE_KEYPHRASE
 	${SOF_SAMPLES_PATH}/audio/detect_test.c
 )
-
-zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi4.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi3.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_generic.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi4_with_peakvol.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi3_with_peakvol.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume_generic_with_peakvol.c
-	${SOF_AUDIO_MODULES_PATH}/volume/volume.c
-)
+if(CONFIG_COMP_PEAK_VOL)
+	zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi4_with_peakvol.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi3_with_peakvol.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_generic_with_peakvol.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume.c
+	)
+else()
+	zephyr_library_sources_ifdef(CONFIG_COMP_VOLUME
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi4.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_hifi3.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume_generic.c
+		${SOF_AUDIO_MODULES_PATH}/volume/volume.c
+	)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_COMP_MODULE_ADAPTER
 	${SOF_AUDIO_PATH}/module_adapter/module_adapter.c


### PR DESCRIPTION
Since the gain and peak volume are mutually exclusive, add kconfig choice to compile the specific code. The default value if peak volume.