### PR TITLE
Fix CI build issue for i.MX8M

### DIFF
--- a/submanifests/sof-ci-jenkins/zephyr-override-template.yml
+++ b/submanifests/sof-ci-jenkins/zephyr-override-template.yml
@@ -24,3 +24,4 @@ manifest:
         # Download only what sof-ci-jenkins uses to save a lot of time
         name-allowlist:
           - hal_xtensa
+          - hal_nxp


### PR DESCRIPTION
This commit allows the CI to make use of the nxp_hal which
is required by i.MX8M. Without it, the build would fail.

Fixes: e9f1531b50d6674a8effda9d4118cfd5ff85264c

Signed-off-by: Laurentiu Mihalcea <laurentiu.mihalcea@nxp.com>