### PR TITLE
Audio: Fix IPC4 sink component buffer parameters set for S24_LE

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -190,7 +190,7 @@ static int eq_fir_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	comp_params.frame_fmt = frame_fmt;
+	comp_params.frame_fmt = valid_fmt;
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		comp_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -853,7 +853,7 @@ static int eq_iir_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	comp_params.frame_fmt = frame_fmt;
+	comp_params.frame_fmt = valid_fmt;
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		comp_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -121,7 +121,7 @@ static int google_rtc_audio_processing_params(
 		audio_stream_set_rate(&sink_c->stream, cd->config.output_fmt.sampling_frequency);
 
 		sink_c->buffer_fmt = out_fmt->interleaving_style;
-		params->frame_fmt = frame_fmt;
+		params->frame_fmt = valid_fmt;
 
 		sink_c->hw_params_configured = true;
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -275,7 +275,7 @@ static void kpb_set_params(struct comp_dev *dev,
 				    &frame_fmt, &valid_fmt,
 				    kpb->ipc4_cfg.base_cfg.audio_fmt.s_type);
 
-	params->frame_fmt = frame_fmt;
+	params->frame_fmt = valid_fmt;
 }
 
 /**

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -120,7 +120,7 @@ static int mixin_init(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	dev->ipc_config.frame_fmt = frame_fmt;
+	dev->ipc_config.frame_fmt = valid_fmt;
 	mod->skip_src_buffer_invalidate = true;
 
 	return 0;
@@ -148,7 +148,7 @@ static int mixout_init(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	dev->ipc_config.frame_fmt = frame_fmt;
+	dev->ipc_config.frame_fmt = valid_fmt;
 	mod->skip_sink_buffer_writeback = true;
 
 	return 0;
@@ -748,7 +748,7 @@ static void base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *
 				    base_cfg->audio_fmt.valid_bit_depth,
 				    &frame_fmt, &valid_fmt,
 				    base_cfg->audio_fmt.s_type);
-	params->frame_fmt = frame_fmt;
+	params->frame_fmt = valid_fmt;
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		params->chmap[i] = (base_cfg->audio_fmt.ch_map >> i * 4) & 0xf;

--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1139,7 +1139,7 @@ static int volume_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	vol_params.frame_fmt = frame_fmt;
+	vol_params.frame_fmt = valid_fmt;
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		vol_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -551,7 +551,7 @@ static int src_set_params(struct processing_module *mod, struct sof_sink __spars
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	src_params.frame_fmt = frame_fmt;
+	src_params.frame_fmt = valid_fmt;
 	component_set_nearest_period_frames(dev, src_params.rate);
 
 	ret = sink_set_params(sink, &src_params, true);

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -343,7 +343,7 @@ static void test_keyword_set_params(struct comp_dev *dev,
 				    &frame_fmt, &valid_fmt,
 				    cd->base_cfg.audio_fmt.s_type);
 
-	params->frame_fmt = frame_fmt;
+	params->frame_fmt = valid_fmt;
 }
 
 static int test_keyword_set_config(struct comp_dev *dev, const char *data,


### PR DESCRIPTION
The frame_fmt from
audio_stream_fmt_conversion(32, 24, &frame_fmt, &valid_fmt) is SOF_IPC_FRAME_S32_LE (2). valid_fmt is SOF_IPC_FRAME_S24_4LE (1).

Set of member frame_fmt from struct sof_ipc_stream_params should be done with valid_fmt instead to get the components to handle the S24_LE stream correctly.