### PR TITLE
topology2: Rename remaining non mixer kcontrols to follow new naming scheme

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -102,7 +102,7 @@ Object.Pipeline {
 			}
 			Object.Widget.eqiir.1 {
 				Object.Control.bytes."1" {
-					name '4 Main capture Iir Eq'
+					name '$ANALOG_CAPTURE_PCM IIR Eq'
 				}
 			}
 		}

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -236,7 +236,7 @@ IncludeByKey.PASSTHROUGH {
 					}
 
 					Object.Control.bytes."1" {
-						name smart_amp_init
+						name "Main Playback and $SSP0_PCM_NAME smart_amp_init"
 					}
 				}
 			}

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -231,7 +231,7 @@ IncludeByKey.PASSTHROUGH {
 						out_valid_bit_depth	32
 					}
 					Object.Control.bytes."1" {
-						name 'DMIC0 capture Iir Eq'
+						name 'DMIC0 Capture IIR Eq'
 					}
 				}
 				Object.Widget.pipeline."1" {

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -288,7 +288,7 @@ IncludeByKey.PASSTHROUGH {
 
 			Object.Control.bytes."1" {
 				<include/components/eqiir/highpass_40hz_0db_48khz.conf>
-				name '4 Main capture Iir Eq'
+				name '$JACK_CAPTURE_PCM_NAME Capture IIR Eq'
 			}
 		}
 	]


### PR DESCRIPTION
Rename all remaining kcontrols to follow the new naming scheme that is already used for all mixers.

This commit changes kcontrol names as follows:

cavs-nocodec.conf:
'smart_amp_init' -> 'Main Playback and Port0 smart_amp_init'

cavs-mixin-mixout-hda.conf:
'4 Main capture Iir Eq' -> 'Analog Capture Iir Eq'

dmic-generic.conf:
'DMIC0 capture Iir Eq' -> 'DMIC0 Capture Iir Eq'

sdw-jack-generic.conf:
'4 Main capture Iir Eq' -> 'Jack In Capture Iir Eq'