### PR TITLE
Audio: Crossover: Convert to module adapter

### DIFF
--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -229,7 +229,7 @@ static void crossover_s32_default(struct comp_data *cd,
 
 	for (ch = 0; ch < nch; ch++) {
 		idx = ch;
-		state = &cd->state[0];
+		state = &cd->state[ch];
 		for (i = 0; i < frames; i++) {
 			x = audio_stream_read_frag_s32(source_stream, idx);
 			cd->crossover_split(*x, out, state);

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -4,12 +4,13 @@
 //
 // Author: Sebastiano Carlucci <scarlucci@google.com>
 
-#include <stdint.h>
-#include <sof/audio/format.h>
+#include <ipc/stream.h>
+#include <sof/audio/module_adapter/module/module_interface.h>
 #include <sof/audio/component.h>
-#include <sof/audio/format.h>
 #include <sof/audio/crossover/crossover.h>
+#include <sof/audio/format.h>
 #include <sof/math/iir_df2t.h>
+#include <stdint.h>
 
 /*
  * \brief Splits x into two based on the coefficients set in the lp
@@ -86,13 +87,13 @@ static void crossover_generic_split_4way(int32_t in,
 }
 
 #if CONFIG_FORMAT_S16LE
-static void crossover_s16_default_pass(const struct comp_dev *dev,
-				       const struct comp_buffer __sparse_cache *source,
+static void crossover_s16_default_pass(struct comp_data *cd,
+				       struct input_stream_buffer *bsource,
 				       struct comp_buffer __sparse_cache *sinks[],
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *source_stream = &source->stream;
+	const struct audio_stream __sparse_cache *source_stream = bsource->data;
 	int16_t *x;
 	int32_t *y;
 	int i, j;
@@ -111,13 +112,13 @@ static void crossover_s16_default_pass(const struct comp_dev *dev,
 #endif /* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
-static void crossover_s32_default_pass(const struct comp_dev *dev,
-				       const struct comp_buffer __sparse_cache *source,
+static void crossover_s32_default_pass(struct comp_data *cd,
+				       struct input_stream_buffer *bsource,
 				       struct comp_buffer __sparse_cache *sinks[],
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *source_stream = &source->stream;
+	const struct audio_stream __sparse_cache *source_stream = bsource->data;
 	int32_t *x, *y;
 	int i, j;
 	int n = audio_stream_get_channels(source_stream) * frames;
@@ -135,15 +136,14 @@ static void crossover_s32_default_pass(const struct comp_dev *dev,
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S16LE
-static void crossover_s16_default(const struct comp_dev *dev,
-				  const struct comp_buffer __sparse_cache *source,
+static void crossover_s16_default(struct comp_data *cd,
+				  struct input_stream_buffer *bsource,
 				  struct comp_buffer __sparse_cache *sinks[],
 				  int32_t num_sinks,
 				  uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = &source->stream;
+	const struct audio_stream __sparse_cache *source_stream = bsource->data;
 	struct audio_stream __sparse_cache *sink_stream;
 	int16_t *x, *y;
 	int ch, i, j;
@@ -174,15 +174,14 @@ static void crossover_s16_default(const struct comp_dev *dev,
 #endif /* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-static void crossover_s24_default(const struct comp_dev *dev,
-				  const struct comp_buffer __sparse_cache *source,
+static void crossover_s24_default(struct comp_data *cd,
+				  struct input_stream_buffer *bsource,
 				  struct comp_buffer __sparse_cache *sinks[],
 				  int32_t num_sinks,
 				  uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = &source->stream;
+	const struct audio_stream __sparse_cache *source_stream = bsource->data;
 	struct audio_stream __sparse_cache *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;
@@ -213,15 +212,14 @@ static void crossover_s24_default(const struct comp_dev *dev,
 #endif /* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-static void crossover_s32_default(const struct comp_dev *dev,
-				  const struct comp_buffer __sparse_cache *source,
+static void crossover_s32_default(struct comp_data *cd,
+				  struct input_stream_buffer *bsource,
 				  struct comp_buffer __sparse_cache *sinks[],
 				  int32_t num_sinks,
 				  uint32_t frames)
 {
-	struct comp_data *cd = comp_get_drvdata(dev);
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = &source->stream;
+	const struct audio_stream __sparse_cache *source_stream = bsource->data;
 	struct audio_stream __sparse_cache *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -710,7 +710,6 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 
 /* declared modules */
 void sys_comp_asrc_init(void);
-void sys_comp_crossover_init(void);
 void sys_comp_dai_init(void);
 void sys_comp_dcblock_init(void);
 void sys_comp_host_init(void);
@@ -718,6 +717,7 @@ void sys_comp_kpb_init(void);
 void sys_comp_multiband_drc_init(void);
 void sys_comp_selector_init(void);
 
+void sys_comp_module_crossover_interface_init(void);
 void sys_comp_module_demux_interface_init(void);
 void sys_comp_module_drc_interface_init(void);
 void sys_comp_module_eq_fir_interface_init(void);

--- a/src/include/sof/audio/crossover/crossover.h
+++ b/src/include/sof/audio/crossover/crossover.h
@@ -7,10 +7,11 @@
 #ifndef __SOF_AUDIO_CROSSOVER_CROSSOVER_H__
 #define __SOF_AUDIO_CROSSOVER_CROSSOVER_H__
 
-#include <stdint.h>
-#include <sof/platform.h>
+#include <sof/audio/module_adapter/module/module_interface.h>
 #include <sof/math/iir_df2t.h>
+#include <sof/platform.h>
 #include <user/crossover.h>
+#include <stdint.h>
 
 struct comp_buffer;
 struct comp_dev;
@@ -66,8 +67,10 @@ struct crossover_state {
 	struct iir_state_df2t highpass[CROSSOVER_MAX_LR4];
 };
 
-typedef void (*crossover_process)(const struct comp_dev *dev,
-				  const struct comp_buffer __sparse_cache *source,
+struct comp_data;
+
+typedef void (*crossover_process)(struct comp_data *cd,
+				  struct input_stream_buffer *bsource,
 				  struct comp_buffer __sparse_cache *sinks[],
 				  int32_t num_sinks,
 				  uint32_t frames);
@@ -79,6 +82,10 @@ typedef void (*crossover_split)(int32_t in, int32_t out[],
 struct comp_data {
 	/**< filter state */
 	struct crossover_state state[PLATFORM_MAX_CHANNELS];
+#if CONFIG_IPC_MAJOR_4
+	uint32_t output_pin_index[SOF_CROSSOVER_MAX_STREAMS];
+	uint32_t num_output_pins;
+#endif
 	struct comp_data_blob_handler *model_handler;
 	struct sof_crossover_config *config;      /**< pointer to setup blob */
 	enum sof_ipc_frame source_format;         /**< source frame format */

--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -45,12 +45,12 @@ int tb_setup(struct sof *sof, struct testbench_prm *tp)
 	sys_comp_init(sof);
 	sys_comp_file_init();
 	sys_comp_asrc_init();
-	sys_comp_crossover_init();
 	sys_comp_dcblock_init();
 	sys_comp_multiband_drc_init();
 	sys_comp_selector_init();
 
 	/* Module adapter components */
+	sys_comp_module_crossover_interface_init();
 	sys_comp_module_demux_interface_init();
 	sys_comp_module_drc_interface_init();
 	sys_comp_module_eq_fir_interface_init();


### PR DESCRIPTION
This patch contains basic changes to run crossover component as module adapter client in IPC3 system. Additional changes are needed for IPC4.