### PR TITLE
Topology2: hdmi: use macro to set HDMI BE name

### DIFF
--- a/tools/topology/topology2/platform/intel/hdmi-default.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-default.conf
@@ -20,4 +20,8 @@ Define {
 	HDMI2_PCM_CAPS			"HDMI2 Playback"
 	HDMI3_PCM_CAPS			"HDMI3 Playback"
 	HDMI4_PCM_CAPS			"HDMI4 Playback"
+	HDMI1_STREAM			"iDisp1"
+	HDMI2_STREAM			"iDisp2"
+	HDMI3_STREAM			"iDisp3"
+	HDMI4_STREAM			"iDisp4"
 }

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -1,7 +1,7 @@
 Object.Dai.HDA [
 	{
 		dai_index 4
-		name iDisp1
+		name $HDMI1_STREAM
 		id $HDMI1_ID
 		default_hw_conf_id 1
 		Object.Base.hw_config.1 {
@@ -11,7 +11,7 @@ Object.Dai.HDA [
 	}
 	{
 		dai_index 5
-		name iDisp2
+		name $HDMI2_STREAM
 		id $HDMI2_ID
 		default_hw_conf_id 2
 		Object.Base.hw_config.1 {
@@ -21,7 +21,7 @@ Object.Dai.HDA [
 	}
 	{
 		dai_index 6
-		name iDisp3
+		name $HDMI3_STREAM
 		id $HDMI3_ID
 		default_hw_conf_id 3
 		Object.Base.hw_config.1 {
@@ -215,7 +215,7 @@ IncludeByKey.NUM_HDMIS {
 		Object.Dai.HDA [
 			{
 				dai_index 7
-				name iDisp4
+				name $HDMI4_STREAM
 				id $HDMI4_ID
 				default_hw_conf_id 3
 				Object.Base.hw_config.1 {


### PR DESCRIPTION
HDMI BE name may not be iDispx.