### PR TITLE
Topology2: sdw-amp-generic: add 2nd amp feedback when SDW_AMP_FEEDBACK is true

### DIFF
--- a/tools/topology/topology2/avs-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/avs-tplg/tplg-targets.cmake
@@ -21,6 +21,8 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1316-rt714.bin"
 
 "cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
+"cavs-sdw\;sof-tgl-rt711-rt1308-rt715\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,SDW_AMP_FEEDBACK=false"
+
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -192,33 +192,39 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 						}
 					]
 				}
-				{
-					index $ALH_2ND_SPK_IN_ID
-					type dai_out
-					stream_name	$SDW_SPK_IN_STREAM
-					dai_index	1
-					type		"dai_out"
-					direction	"capture"
-					node_type $ALH_LINK_INPUT_CLASS
-					num_input_audio_formats 1
-					num_output_audio_formats 1
-					num_output_pins 1
+			]
+			IncludeByKey.SDW_AMP_FEEDBACK {
+				"true" {
+					alh-copier [
+						{
+							index $ALH_2ND_SPK_IN_ID
+							type dai_out
+							stream_name	$SDW_SPK_IN_STREAM
+							dai_index	1
+							type		"dai_out"
+							direction	"capture"
+							node_type $ALH_LINK_INPUT_CLASS
+							num_input_audio_formats 1
+							num_output_audio_formats 1
+							num_output_pins 1
 
-					# 32-bit 48KHz 2ch
-					Object.Base.input_audio_format [
-						{
-							in_bit_depth            32
-							in_valid_bit_depth      32
-						}
-					]
-					Object.Base.output_audio_format [
-						{
-							out_bit_depth            32
-							out_valid_bit_depth      32
+							# 32-bit 48KHz 2ch
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth            32
+									in_valid_bit_depth      32
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth            32
+									out_valid_bit_depth      32
+								}
+							]
 						}
 					]
 				}
-			]
+			}
 			pipeline [
 				{
 					index		$ALH_2ND_SPK_ID


### PR DESCRIPTION
Currently, we add the 2nd sdw amp feedback unconditionally. It will lead
to an issue when aggregated apms don't support feedback function.

Also, adding sof-tgl-rt711-rt1308-rt715.tplg in this PR.