### PR TITLE
ipc3: get_drv: Check comp_type also when driver is matched with UUID

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1671,7 +1671,7 @@ static struct module_interface gain_interface = {
 	.free = volume_free
 };
 
-DECLARE_MODULE_ADAPTER(gain_interface, gain_uuid, gain_tr);
+DECLARE_MODULE_ADAPTER_WITH_TYPE(gain_interface, gain_uuid, gain_tr, SOF_COMP_VOLUME);
 SOF_MODULE_INIT(gain, sys_comp_module_gain_interface_init);
 #endif
 #endif

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -1058,5 +1058,5 @@ static struct module_interface src_interface = {
 	.free = src_free,
 };
 
-DECLARE_MODULE_ADAPTER(src_interface, src_uuid, src_tr);
+DECLARE_MODULE_ADAPTER_WITH_TYPE(src_interface, src_uuid, src_tr, SOF_COMP_SRC);
 SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -33,7 +33,7 @@
 				(value)); \
 	} while (0)
 
-#define DECLARE_MODULE_ADAPTER(adapter, uuid, tr) \
+#define DECLARE_MODULE_ADAPTER_WITH_TYPE(adapter, uuid, tr, comp_type)		\
 static struct comp_dev *module_##adapter##_shim_new(const struct comp_driver *drv, \
 					 const struct comp_ipc_config *config, \
 					 const void *spec) \
@@ -42,7 +42,7 @@ static struct comp_dev *module_##adapter##_shim_new(const struct comp_driver *dr
 } \
 \
 static const struct comp_driver comp_##adapter##_module = { \
-	.type = SOF_COMP_MODULE_ADAPTER, \
+	.type = comp_type, \
 	.uid = SOF_RT_UUID(uuid), \
 	.tctx = &(tr), \
 	.ops = { \
@@ -74,6 +74,9 @@ UT_STATIC void sys_comp_module_##adapter##_init(void) \
 } \
 \
 DECLARE_MODULE(sys_comp_module_##adapter##_init)
+
+#define DECLARE_MODULE_ADAPTER(adapter, uuid, tr) \
+	DECLARE_MODULE_ADAPTER_WITH_TYPE(adapter, uuid, tr, SOF_COMP_MODULE_ADAPTER)
 
 /**
  * \enum module_state


### PR DESCRIPTION
Add a safe guard against malformed SOF_IPC_TPLG_COMP_NEW messages where the UUID matched driver type does not match the component type in the message.

Reported-by: Curtis Malainey <curtis@malainey.com>

related discussions can be found here: https://github.com/thesofproject/sof/pull/7830