### PR TITLE
Topology2: sdw-amp-generic: add missing num_input_pins

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -111,6 +111,7 @@ IncludeByKey.PASSTHROUGH {
 			{
 				stream_name $SDW_SPK_STREAM
 				node_type $ALH_LINK_OUTPUT_CLASS
+				num_input_pins 1
 				num_input_audio_formats 3
 				direction	playback
 				type	dai_in


### PR DESCRIPTION
num_input_pins was missing in passthrough mode.

Fixes: #7899