### PR TITLE
topology2: cavs-sdw: fix bad index in passthrough mode

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -259,7 +259,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 		"true" {
 			Object.Base.route [
 				{
-					source  "host-copier.0.playback"
+					source  "host-copier.2.playback"
 					sink    "virtual.sdw-amp"
 				}
 			]


### PR DESCRIPTION
When PASSTHROUGH is true, the topology generation throws this error:

ALSA lib dapm.c:247:(tplg_build_routes) undefined source widget/stream 'host-copier.0.playback'

using the pcm_id 2 used for the host copier fixes the issue.