### PR TITLE
module adapter and copier performance optimization

### DIFF
--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -970,12 +970,6 @@ static int host_reset(struct comp_dev *dev)
 	return 0;
 }
 
-/* copy and process stream data from source to sink buffers */
-int host_common_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
-{
-	return hd->copy(hd, dev, cb);
-}
-
 static int host_copy(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -1077,12 +1077,6 @@ static int host_reset(struct comp_dev *dev)
 	return 0;
 }
 
-/* copy and process stream data from source to sink buffers */
-int host_common_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
-{
-	return hd->copy(hd, dev, cb);
-}
-
 static int host_copy(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -880,7 +880,11 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* handle special case of HOST/DAI type components */
 	if (dev->ipc_config.type == SOF_COMP_HOST || dev->ipc_config.type == SOF_COMP_DAI)
+#if CONFIG_IPC_MAJOR_3
 		return module_process_legacy(mod, NULL, 0, NULL, 0);
+#else
+		return module_process_stream(mod, NULL, 0, NULL, 0);
+#endif
 
 	if (mod->stream_copy_single_to_single)
 		return module_adapter_audio_stream_copy_1to1(dev);

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -112,7 +112,11 @@ void host_common_reset(struct host_data *hd, uint16_t state);
 int host_common_trigger(struct host_data *hd, struct comp_dev *dev, int cmd);
 int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params, notifier_callback_t cb);
-int host_common_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb);
+/* copy and process stream data from source to sink buffers */
+static inline int host_common_copy(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
+{
+	return hd->copy(hd, dev, cb);
+}
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes);
 void host_common_one_shot(struct host_data *hd, uint32_t bytes);
 int copier_host_create(struct comp_dev *dev, struct copier_data *cd,

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -356,4 +356,16 @@ int find_module_source_index(struct module_source_info __sparse_cache *msi,
 	return -EINVAL;
 }
 
+static inline int module_process_stream(struct processing_module *mod,
+					struct input_stream_buffer *input_buffers,
+					int num_input_buffers,
+					struct output_stream_buffer *output_buffers,
+					int num_output_buffers)
+{
+	struct module_data *md = &mod->priv;
+
+	return md->ops->process_audio_stream(mod, input_buffers, num_input_buffers,
+					     output_buffers, num_output_buffers);
+}
+
 #endif /* __SOF_AUDIO_MODULE_GENERIC__ */

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -168,6 +168,10 @@ struct dai_data {
 
 	/* llp slot info in memory windows */
 	struct llp_slot_info slot_info;
+	/* save current sampling for current dai device */
+	uint32_t sampling;
+	/* fast mode, use one byte memory to save repreated cycles */
+	bool fast_mode;
 };
 
 /* these 3 are here to satisfy clk.c and ssp.h interconnection, will be removed leter */


### PR DESCRIPTION
this PR did following things:
    optimize module adapter and copier, reduce host and dai performance increase caused by #7890.
    below is the rough result:
![image](https://github.com/thesofproject/sof/assets/17277136/967f2599-36b0-4671-85c6-0e8aef07523a)
