### PR TITLE
ace_version: change to correct version

### DIFF
--- a/src/platform/intel/ace/include/ace/version.h
+++ b/src/platform/intel/ace/include/ace/version.h
@@ -8,16 +8,6 @@
 #ifndef __ACE_VERSION_H__
 #define __ACE_VERSION_H__
 
-#define ACE_VERSION_1_5		0x10500
-#define ACE_VERSION_2_0		0x20000
-
-/* ACE version defined by CONFIG_ACE_VER_ */
-#if CONFIG_ACE_VERSION_1_5
-#define ACE_VERSION		ACE_VERSION_1_5
-#elif CONFIG_ACE_VERSION_2_0
-#define ACE_VERSION		ACE_VERSION_2_0
-#endif
-
-#define HW_CFG_VERSION		ACE_VERSION
+#define HW_CFG_VERSION		0
 
 #endif /* __ACE_VERSION_H__ */


### PR DESCRIPTION
For ACE we expect HW_CFG_VERSION 0x0.