### PR TITLE
audio: mixer: Set correct number of sources

### DIFF
--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -56,6 +56,8 @@ static int mixer_init(struct processing_module *mod)
 	mod_data->private = md;
 	mod->verify_params_flags = BUFF_PARAMS_CHANNELS;
 	mod->no_pause = true;
+	mod->max_sources = MIXER_MAX_SOURCES;
+
 	return 0;
 }
 

--- a/src/include/sof/audio/mixer.h
+++ b/src/include/sof/audio/mixer.h
@@ -30,6 +30,8 @@ void sys_comp_module_mixer_interface_init(void);
 
 #endif
 
+#define MIXER_MAX_SOURCES	2
+
 /* mixer component private data */
 struct mixer_data {
 	void (*mix_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,


### PR DESCRIPTION
After commit 867ada28f we only allocate 1 buffer for mixer even if there could be 2 input sources.

So, set correct number of sources for mixer.

Fixes 867ada28f ("audio: module_adapter: Allocate max number of input/output buffers")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>