### PR TITLE
west.yml: upgrade Zephyr revision - Restore IDC interrupt on D3 exit

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 23b3cae1b1d91cd064d31cdeb78e3a6127b5051d
+      revision: 431108d89e1750dbea05dce64dbb7fd329aa610e
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
After exiting D3 state if IMR context save is enabled, IDC interrupt must be re-enabled again for all cores. It fixes multicore CI test issue.

431108d89e175: intel_adsp: ace: Restore IDC interrupt on D3 exit

fix https://github.com/thesofproject/sof/issues/7885 [MTL][Multicore] IPC timed out for GLB_CREATE_PIPELINE