### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -137,7 +137,6 @@ void aria_algo_get_data_even_channel(struct comp_dev *dev,
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	ae_int32x2 in_sample, out_sample;
-	const int inc = sizeof(ae_int32);
 	ae_int32x2 gain;
 	const int ch_n = cd->chan_cnt;
 

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -99,6 +99,7 @@ void SystemAgent::CheckIn(ProcessingModuleInterface& processing_module,
 		core_id_,
 		module_size_
 		);
+	(void)module_adapter;
 	log_handle = reinterpret_cast<LogHandle*>(log_handle_);
 }
 

--- a/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
@@ -156,7 +156,6 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 	ae_f32x2 in_sample = AE_ZERO32();
 
 	int i, n, m;
-	ae_f32x2 *vol;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
 	ae_f32x2 *in = (ae_f32x2 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)


### PR DESCRIPTION
When trying to build a sofa with the -Wall and -Werror flags enabled, the compiler reported errors about unused variables. This PR fix it.