### PR TITLE
format: stream: pcm_converter: Add support for 8-bit formats

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -525,6 +525,12 @@ endmenu # "Audio components"
 
 menu "Data formats"
 
+config FORMAT_U8
+	bool "Support U8"
+	default n
+	help
+	  Support unsigned 8 bit processing data format
+
 config FORMAT_S16LE
 	bool "Support S16LE"
 	default y

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -561,6 +561,12 @@ config FORMAT_CONVERT_HIFI3
 	help
 	  Use HIFI3 extensions for optimized format conversion (experimental).
 
+config PCM_CONVERTER_FORMAT_U8
+	bool "Support U8"
+	default n
+	help
+	  Support 8 bit processing data format without sign
+
 config PCM_CONVERTER_FORMAT_S16LE
 	bool "Support S16LE"
 	default y

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
-//
-// Copyright(c) 2019 Intel Corporation. All rights reserved.
-//
-// Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+/*
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Tomasz Lauda <tomasz.lauda@linux.intel.com>
+ *	   Adrian Warecki <adrian.warecki@intel.com>
+ */
 
 /**
  * \file audio/pcm_converter/pcm_converter_generic.c
  * \brief PCM converter generic processing implementation
  * \authors Tomasz Lauda <tomasz.lauda@linux.intel.com>
  * \authors Karol Trzcinski <karolx.trzcinski@linux.intel.com>
+ * \authors Adrian Warecki <adrian.warecki@intel.com>
  */
 
 #include <sof/audio/pcm_converter.h>
@@ -484,6 +487,9 @@ static int pcm_convert_f_to_s32(const struct audio_stream __sparse_cache *source
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
 const struct pcm_func_map pcm_func_map[] = {
+#if CONFIG_PCM_CONVERTER_FORMAT_U8
+	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, audio_stream_copy },
+#endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 */
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
@@ -493,7 +499,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
 	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, audio_stream_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
-#if  CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
+#if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
@@ -841,6 +847,10 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
 		ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
 #endif
+#if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8,
+		ipc4_gtw_all, ipc4_bidirection, audio_stream_copy },
+#endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
 		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host | ipc4_gtw_dmic),

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -56,6 +56,7 @@ enum sof_ipc_frame {
 	SOF_IPC_FRAME_FLOAT,
 	/* other formats here */
 	SOF_IPC_FRAME_S24_3LE,
+	SOF_IPC_FRAME_U8,
 };
 
 /* stream buffer format */

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 26
+#define SOF_ABI_MINOR 27
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1040,6 +1040,14 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 	*frame_fmt = (depth >> 3) - 2;
 	*valid_fmt = (valid >> 3) - 2;
 
+#ifdef CONFIG_FORMAT_U8
+	if (depth == 8)
+		*frame_fmt = SOF_IPC_FRAME_U8;
+
+	if (valid == 8)
+		*valid_fmt = SOF_IPC_FRAME_U8;
+#endif /* CONFIG_FORMAT_U8 */
+
 	/* really 24_3LE */
 	if (valid == 24 && depth == 24) {
 		*frame_fmt = SOF_IPC_FRAME_S24_3LE;

--- a/src/include/sof/audio/format.h
+++ b/src/include/sof/audio/format.h
@@ -172,6 +172,8 @@ static inline uint32_t get_sample_bytes(enum sof_ipc_frame fmt)
 		return 2;
 	case SOF_IPC_FRAME_S24_3LE:
 		return 3;
+	case SOF_IPC_FRAME_U8:
+		return 1;
 	default:
 		return 4;
 	}

--- a/src/include/sof/audio/format_generic.h
+++ b/src/include/sof/audio/format_generic.h
@@ -40,4 +40,14 @@ static inline int16_t sat_int16(int32_t x)
 		return (int16_t)x;
 }
 
+static inline int8_t sat_int8(int32_t x)
+{
+	if (x > INT8_MAX)
+		return INT8_MAX;
+	else if (x < INT8_MIN)
+		return INT8_MIN;
+	else
+		return (int8_t)x;
+}
+
 #endif /* __SOF_AUDIO_FORMAT_GENERIC_H__ */

--- a/src/include/sof/audio/format_hifi3.h
+++ b/src/include/sof/audio/format_hifi3.h
@@ -27,4 +27,14 @@ static inline int16_t sat_int16(int32_t x)
 	return AE_SAT16X4(x, x);
 }
 
+static inline int8_t sat_int8(int32_t x)
+{
+	if (x > INT8_MAX)
+		return INT8_MAX;
+	else if (x < INT8_MIN)
+		return INT8_MIN;
+	else
+		return (int8_t)x;
+}
+
 #endif /* __SOF_AUDIO_FORMAT_HIFI3_H__ */

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -440,6 +440,7 @@ static void test_audio_sel(void **state)
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
 	/* TODO: add S24_3LE support */
+	/* TODO: add U8 support */
 	default:
 		break;
 	}

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -438,8 +438,9 @@ static void test_audio_sel(void **state)
 		fill_source_s32(sel_state);
 		break;
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
-/* TODO: add S24_3LE support */
-	case SOF_IPC_FRAME_S24_3LE:
+
+	/* TODO: add S24_3LE support */
+	default:
 		break;
 	}
 

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -280,6 +280,7 @@ static void test_audio_vol(void **state)
 		break;
 
 	/* TODO: add 3LE support */
+	/* TODO: add U8 support */
 	default:
 		break;
 	}

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -278,8 +278,9 @@ static void test_audio_vol(void **state)
 	case SOF_IPC_FRAME_FLOAT:
 		fill_source_s32(vol_state);
 		break;
-	case SOF_IPC_FRAME_S24_3LE:
-		/* TODO: add 3LE support */
+
+	/* TODO: add 3LE support */
+	default:
 		break;
 	}
 


### PR DESCRIPTION
This PR adds basic support for unsigned 8 bit format. 8 bit samples in 8 and 16 bit container and conversion between 32 bit signed format is supported.