### PR TITLE
Audio: Normalize the 16/16 bit format peak meter to 32 bits.

### DIFF
--- a/src/audio/module_adapter/module/volume/volume.c
+++ b/src/audio/module_adapter/module/volume/volume.c
@@ -1208,6 +1208,9 @@ static int volume_process(struct processing_module *mod,
 		cd->peak_cnt = 0;
 		peak_vol_update(cd);
 		memset(cd->peak_regs.peak_meter, 0, sizeof(cd->peak_regs.peak_meter));
+#ifdef VOLUME_HIFI4
+		memset(cd->peak_vol, 0, sizeof(int32_t) * SOF_IPC_MAX_CHANNELS * 4);
+#endif
 	}
 #endif
 

--- a/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_generic_with_peakvol.c
@@ -288,7 +288,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	int nmax, n, i, j;
 	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
-	int32_t tmp;
+	uint32_t tmp;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
@@ -310,6 +310,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 							      Q_SHIFT_BITS_32(15, VOL_QXY_Y, 15));
 				tmp = MAX(abs(x0[i]), tmp);
 			}
+			tmp <<= PEAK_16S_32C_ADJUST;
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
@@ -342,7 +343,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 	int nmax, n, i, j;
 	const int nch = audio_stream_get_channels(source);
 	int remaining_samples = frames * nch;
-	int32_t tmp;
+	uint32_t tmp;
 
 	x = audio_stream_wrap(source, (char *)audio_stream_get_rptr(source) + bsource->consumed);
 	y = audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink) + bsink->size);
@@ -362,6 +363,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				y0[i] = x0[i];
 				tmp = MAX(abs(x0[i]), tmp);
 			}
+			tmp <<= PEAK_16S_32C_ADJUST;
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;

--- a/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi3_with_peakvol.c
@@ -369,6 +369,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 				// AE_SA16X4_IC(out_sample, outu, out);
 				AE_S16_0_XP(out_sample, out, inc);
 			}
+			peak_vol = AE_SLAA32(peak_vol, PEAK_16S_32C_ADJUST);
 			peak_meter[channel] = AE_MAX32(peak_vol, peak_meter[channel]);
 		}
 		out0 = audio_stream_wrap(sink, out0 + n);
@@ -430,6 +431,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				/* store the output */
 				AE_S16_0_XP(in_sample, out, inc);
 			}
+			peak_vol = AE_SLAA32(peak_vol, PEAK_16S_32C_ADJUST);
 			peak_meter[channel] = AE_MAX32(peak_vol, peak_meter[channel]);
 		}
 		out0 = audio_stream_wrap(sink, out0 + n);

--- a/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
@@ -74,7 +74,6 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 
@@ -169,7 +168,6 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 
@@ -243,7 +241,6 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 
@@ -341,7 +338,6 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data twice) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 2);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 	bsource->consumed += VOL_S32_SAMPLES_TO_BYTES(samples);
@@ -414,7 +410,6 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data 4 times) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 4);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 4);
 
@@ -523,7 +518,6 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 	ae_f32x2 *peakvol = (ae_f32x2 *)cd->peak_vol;
 
 	/* Set peakvol(which stores the peak volume data 4 times) as circular buffer */
-	memset(peakvol, 0, sizeof(ae_f32) * channels_count * 4);
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 4);
 

--- a/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/module_adapter/module/volume/volume_hifi4_with_peakvol.c
@@ -488,7 +488,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 		m = MAX(cd->peak_vol[i], cd->peak_vol[i + channels_count]);
 		m = MAX(m, cd->peak_vol[i + channels_count * 2]);
 		m = MAX(m, cd->peak_vol[i + channels_count * 3]);
-		cd->peak_regs.peak_meter[i] = m;
+		cd->peak_regs.peak_meter[i] = m << PEAK_16S_32C_ADJUST;
 	}
 }
 
@@ -558,7 +558,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		m = MAX(cd->peak_vol[i], cd->peak_vol[i + channels_count]);
 		m = MAX(m, cd->peak_vol[i + channels_count * 2]);
 		m = MAX(m, cd->peak_vol[i + channels_count * 3]);
-		cd->peak_regs.peak_meter[i] = m;
+		cd->peak_regs.peak_meter[i] = m << PEAK_16S_32C_ADJUST;
 	}
 }
 #endif /* CONFIG_FORMAT_S16LE */

--- a/src/include/sof/audio/volume.h
+++ b/src/include/sof/audio/volume.h
@@ -100,6 +100,12 @@ struct sof_ipc_ctrl_value_chan;
 #define PEAK_24S_32C_ADJUST 8
 
 /**
+ * \brief left shift 16 bits to put the valid 16 bits into
+ * higher part of 32 bits container.
+ */
+#define PEAK_16S_32C_ADJUST 16
+
+/**
  * \brief Volume maximum value.
  * TODO: This should be 1 << (VOL_QX_BITS + VOL_QY_BITS - 1) - 1 but
  * the current volume code cannot handle the full Q1.16 range correctly.


### PR DESCRIPTION
   Shift left the peak meter of 16/16 bit format 16 bits to normalize this value to 32 bits to meet the CI test requirement.