### PR TITLE
module_interface.h: add forward struct comp_dev and timestamp_data

### DIFF
--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -67,6 +67,8 @@ struct output_stream_buffer {
 	uint32_t size; /* size of data in the buffer */
 };
 
+struct comp_dev;
+struct timestamp_data;
 /**
  * \struct module_endpoint_ops
  * \brief Ops relevant only for the endpoint devices such as the host copier or DAI copier.


### PR DESCRIPTION
Fixes commit 9cc6454df6d2 ("module_adapter: Extend the module interface for endpoint devices")

As the endpoint_ops methods use only pointers to these two objects, it's not necessary to make their entire object structure visible. However a forward declaration is required to make them known to endpoint_ops users and fix the following warning:

```
error: 'struct comp_dev' declared inside parameter list will not be
visible outside of this definition or declaration [-Werror]
```