### PR TITLE
RTNR adapter fixups

### DIFF
--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -381,7 +381,7 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 
 	/* set source/sink stream channels */
 	cd->sources_stream[0].channels = audio_stream_get_channels(&source_c->stream);
-	audio_stream_set_channels(&cd->sink_stream, audio_stream_get_channels(&sink_c->stream));
+	cd->sink_stream.channels = audio_stream_get_channels(&sink_c->stream);
 
 	/* set source/sink stream overrun/underrun permitted */
 	cd->sources_stream[0].overrun_permitted = audio_stream_get_overrun(&source_c->stream);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -67,7 +67,7 @@ DECLARE_TR_CTX(rtnr_tr, SOF_UUID(rtnr_uuid), LOG_LEVEL_INFO);
 
 /* Static functions */
 static int rtnr_set_config_bytes(struct comp_dev *dev,
-				 unsigned char *data, uint32_t size);
+				 const unsigned char *data, uint32_t size);
 
 /* Called by the processing library for debugging purpose */
 void rtnr_printf(int a, int b, int c, int d, int e)
@@ -530,7 +530,7 @@ static int rtnr_reconfigure(struct comp_dev *dev)
 }
 
 static int rtnr_set_config_bytes(struct comp_dev *dev,
-				 unsigned char *data, uint32_t size)
+				 const unsigned char *data, uint32_t size)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int ret;

--- a/src/include/sof/audio/rtnr/rtklib/include/RTK_MA_API.h
+++ b/src/include/sof/audio/rtnr/rtklib/include/RTK_MA_API.h
@@ -7,6 +7,8 @@
 #ifndef _RTK_MA_API_H_
 #define _RTK_MA_API_H_
 
+#include <sof/audio/rtnr/rtnr.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/include/sof/audio/rtnr/rtnr.h
+++ b/src/include/sof/audio/rtnr/rtnr.h
@@ -9,7 +9,9 @@
 #define __SOF_AUDIO_RTNR_RTNR_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <sof/platform.h>
+#include <sof/audio/component.h>
 #include <ipc/stream.h>
 #include <user/rtnr.h>
 


### PR DESCRIPTION
Fixes
- Invalid buffer access change
- Arg attributes
- Missing headers