### PR TITLE
module_adapter: add forward declarations for comp_dev/timestamp_data

### DIFF
--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -67,6 +67,9 @@ struct output_stream_buffer {
 	uint32_t size; /* size of data in the buffer */
 };
 
+struct comp_dev;
+struct timestamp_data;
+
 /**
  * \struct module_endpoint_ops
  * \brief Ops relevant only for the endpoint devices such as the host copier or DAI copier.


### PR DESCRIPTION
Commit 9cc6454df6d2 ("module_adapter: Extend the module interface for endpoint devices") added use of struct comp_dev and struct timestamp_data to module_interface.h without required include header and/or forward declarations. This leads to compiler warnings. Address the issue by adding forward declarations for these structs as implementation details are not needed in this header.