### PR TITLE
topology2: use pass-through pipeline for multicore test on cavs

### DIFF
--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -43,10 +43,12 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec-ssp0-ssp2.bin,DEEPBUFFER_F
 DEEPBUFFER_D0I3_COMPATIBLE=true"
 
 "cavs-nocodec-multicore\;sof-mtl-nocodec-multicore\;PLATFORM=mtl,SSP1_ENABLED=true,SSP0_CORE_ID=0,\
-SSP1_CORE_ID=1,SSP2_CORE_ID=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec-multicore.bin"
+SSP1_CORE_ID=1,SSP2_CORE_ID=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec-multicore.bin,\
+PASSTHROUGH=true"
 
 "cavs-nocodec-multicore\;sof-mtl-nocodec-multicore-ssp0-ssp2\;PLATFORM=mtl,SSP1_ENABLED=false,\
-SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec-multicore-ssp0-ssp2.bin"
+SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec-multicore-ssp0-ssp2.bin,\
+PASSTHROUGH=true"
 
 "cavs-nocodec-multicore\;sof-mtl-nocodec-multicore-4ch\;PLATFORM=mtl,SSP1_ENABLED=false,\
 SSP0_CORE_ID=0,DMIC_CORE_ID=1,SSP2_CORE_ID=2,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -21,10 +21,12 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec.bin,DEEPBUFFER_FW_DMA_MS=1
 PLATFORM=adl"
 
 "cavs-nocodec-multicore\;sof-tgl-nocodec-multicore-ssp0-ssp2\;PLATFORM=tgl,SSP1_ENABLED=false,\
-SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-multicore-ssp0-ssp2.bin"
+SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-multicore-ssp0-ssp2.bin,\
+PASSTHROUGH=true"
 
 "cavs-nocodec-multicore\;sof-adl-nocodec-multicore-ssp0-ssp2\;PLATFORM=adl,SSP1_ENABLED=false,\
-SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec-multicore-ssp0-ssp2.bin"
+SSP2_CORE_ID=1,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-adl-nocodec-multicore-ssp0-ssp2.bin,\
+PASSTHROUGH=true"
 
 # SDW topology for MTL
 "cavs-sdw\;mtl-sdw\;NUM_HDMIS=0"


### PR DESCRIPTION
platforms

Fix daily CI issuse: failed to load multicore topology

It is caused by : https://github.com/thesofproject/sof/pull/7847. Currently DMIC is not enabled by daily CI test on CAVS platforms, so we need to set pass-though = true.

fix https://github.com/thesofproject/sof/issues/7931