### PR TITLE
audio_stream: add const for necessary parameters

### DIFF
--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1056,13 +1056,13 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
  * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
 static inline struct sof_source __sparse_cache *
-audio_stream_get_source(struct audio_stream __sparse_cache *audio_stream)
+audio_stream_get_source(const struct audio_stream __sparse_cache *audio_stream)
 {
 	return &audio_stream->source_api;
 }
 
 static inline struct sof_sink __sparse_cache *
-audio_stream_get_sink(struct audio_stream __sparse_cache *audio_stream)
+audio_stream_get_sink(const struct audio_stream __sparse_cache *audio_stream)
 {
 	return &audio_stream->sink_api;
 }


### PR DESCRIPTION
Follow up with #7941, need add const to function parameter to show its range are not changed.