### PR TITLE
topology2: fix conditional inclusion of DMIC snippets for nocodec topology

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -300,184 +300,189 @@ Object.Pipeline.io-gateway-capture [
 
 IncludeByKey.PASSTHROUGH {
 "false" {
-		Object.Pipeline.gain-module-copier [
-			{
-				index		19
-				core_id $DMIC_CORE_ID
-				direction	"capture"
-				Object.Widget.pipeline.1 {
-					stream_name $DMIC0_DAI_COPIER
-					core $DMIC_CORE_ID
-				}
-				Object.Widget.module-copier.1 {
-					stream_name 'Gain Capture 19'
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.Pipeline.gain-module-copier [
+					{
+						index		19
+						core_id $DMIC_CORE_ID
+						direction	"capture"
+						Object.Widget.pipeline.1 {
+							stream_name $DMIC0_DAI_COPIER
+							core $DMIC_CORE_ID
+						}
+						Object.Widget.module-copier.1 {
+							stream_name 'Gain Capture 19'
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
+							}
+						}
 					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
-					}
-				}
-			}
-		]
+				]
 
-		Object.Pipeline.gain-capture [
-			{
-				format		$FORMAT
-				core_id		$DMIC_CORE_ID
-				index		18
-				Object.Widget.pipeline.1 {
-					stream_name "$DMIC0_PCM_0_NAME"
-					core	$DMIC_CORE_ID
-				}
-				Object.Widget.host-copier.1 {
-					stream_name "Gain Capture 18"
-					pcm_id	$DMIC0_PCM_0_PCM_ID
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
+				Object.Pipeline.gain-capture [
+					{
+						format		$FORMAT
+						core_id		$DMIC_CORE_ID
+						index		18
+						Object.Widget.pipeline.1 {
+							stream_name "$DMIC0_PCM_0_NAME"
+							core	$DMIC_CORE_ID
+						}
+						Object.Widget.host-copier.1 {
+							stream_name "Gain Capture 18"
+							pcm_id	$DMIC0_PCM_0_PCM_ID
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
+							}
+						}
 					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
+					{
+						format		$FORMAT
+						index		22
+						core_id		$DMIC_CORE_ID
+						Object.Widget.pipeline.1 {
+							stream_name "$DMIC0_PCM_1_NAME"
+							core	$DMIC_CORE_ID
+						}
+						Object.Widget.host-copier.1 {
+							stream_name "Gain Capture 22"
+							pcm_id	$DMIC0_PCM_1_PCM_ID
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
+							}
+						}
 					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
-					}
-				}
+				]
 			}
-			{
-				format		$FORMAT
-				index		22
-				core_id		$DMIC_CORE_ID
-				Object.Widget.pipeline.1 {
-					stream_name "$DMIC0_PCM_1_NAME"
-					core	$DMIC_CORE_ID
-				}
-				Object.Widget.host-copier.1 {
-					stream_name "Gain Capture 22"
-					pcm_id	$DMIC0_PCM_1_PCM_ID
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
-					}
-				}
-			}
-		]
+		}
+
 	}
 }
 
@@ -526,36 +531,40 @@ Object.PCM.pcm [
 
 IncludeByKey.PASSTHROUGH {
 "false" {
-		Object.PCM.pcm [
-			{
-				name	"$DMIC0_PCM_0_NAME"
-				id	$DMIC0_PCM_0_PCM_ID
-				direction	"capture"
-				Object.Base.fe_dai."$DMIC0_PCM_0_NAME" {}
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.PCM.pcm [
+					{
+						name	"$DMIC0_PCM_0_NAME"
+						id	$DMIC0_PCM_0_PCM_ID
+						direction	"capture"
+						Object.Base.fe_dai."$DMIC0_PCM_0_NAME" {}
 
-				Object.PCM.pcm_caps."capture" {
-					name "Gain Capture 18"
-					# only 32-bit capture supported now
-					formats 'S32_LE'
-					channels_min $NUM_DMICS
-					channels_max $NUM_DMICS
-				}
-			}
-			{
-				name	"$DMIC0_PCM_1_NAME"
-				id	$DMIC0_PCM_1_PCM_ID
-				direction	"capture"
-				Object.Base.fe_dai."$DMIC0_PCM_1_NAME" {}
+						Object.PCM.pcm_caps."capture" {
+							name "Gain Capture 18"
+							# only 32-bit capture supported now
+							formats 'S32_LE'
+							channels_min $NUM_DMICS
+							channels_max $NUM_DMICS
+						}
+					}
+					{
+						name	"$DMIC0_PCM_1_NAME"
+						id	$DMIC0_PCM_1_PCM_ID
+						direction	"capture"
+						Object.Base.fe_dai."$DMIC0_PCM_1_NAME" {}
 
-				Object.PCM.pcm_caps."capture" {
-					name "Gain Capture 22"
-					# only 32-bit capture supported now
-					formats 'S32_LE'
-					channels_min $NUM_DMICS
-					channels_max $NUM_DMICS
-				}
+						Object.PCM.pcm_caps."capture" {
+							name "Gain Capture 22"
+							# only 32-bit capture supported now
+							formats 'S32_LE'
+							channels_min $NUM_DMICS
+							channels_max $NUM_DMICS
+						}
+					}
+				]
 			}
-		]
+		}
 	}
 }
 
@@ -596,28 +605,32 @@ Object.Base.route [
 
 IncludeByKey.PASSTHROUGH {
 "false" {
-		Object.Base.route [
-			{
-				source	$DMIC0_DAI_PIPELINE_SRC
-				sink	gain.19.1
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.Base.route [
+					{
+						source	$DMIC0_DAI_PIPELINE_SRC
+						sink	gain.19.1
+					}
+					{
+						source	module-copier.19.1
+						sink	gain.18.1
+					}
+					{
+						source	module-copier.19.1
+						sink	gain.22.1
+					}
+					{
+						source	"gain.18.1"
+						sink	"host-copier.$DMIC0_PCM_0_PCM_ID.capture"
+					}
+					{
+						source	"gain.22.1"
+						sink	"host-copier.$DMIC0_PCM_1_PCM_ID.capture"
+					}
+				]
 			}
-			{
-				source	module-copier.19.1
-				sink	gain.18.1
-			}
-			{
-				source	module-copier.19.1
-				sink	gain.22.1
-			}
-			{
-				source	"gain.18.1"
-				sink	"host-copier.$DMIC0_PCM_0_PCM_ID.capture"
-			}
-			{
-				source	"gain.22.1"
-				sink	"host-copier.$DMIC0_PCM_1_PCM_ID.capture"
-			}
-		]
+		}
 	}
 }
 

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -292,63 +292,67 @@ IncludeByKey.PASSTHROUGH {
 			}
 		]
 
-		Object.Pipeline.gain-module-copier [
-			{
-				index		19
-				direction	"capture"
-				Object.Widget.pipeline.1 {
-					stream_name $DMIC0_DAI_COPIER
-				}
-				Object.Widget.module-copier.1 {
-					stream_name 'Gain Capture 19'
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.Pipeline.gain-module-copier [
+					{
+						index		19
+						direction	"capture"
+						Object.Widget.pipeline.1 {
+							stream_name $DMIC0_DAI_COPIER
+						}
+						Object.Widget.module-copier.1 {
+							stream_name 'Gain Capture 19'
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
+							}
+						}
 					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
-					}
-				}
+				]
 			}
-		]
+		}
 
 		Object.Pipeline.dai-copier-gain-module-copier-capture [
 			{
@@ -640,120 +644,124 @@ Object.Pipeline.io-gateway-capture [
 
 IncludeByKey.PASSTHROUGH {
 "false" {
-		Object.Pipeline.gain-capture [
-			{
-				format		$FORMAT
-				index		18
-				Object.Widget.pipeline.1 {
-					stream_name "$DMIC0_PCM_0_NAME"
-				}
-				Object.Widget.host-copier.1 {
-					stream_name "Gain Capture 18"
-					pcm_id	27
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.Pipeline.gain-capture [
+					{
+						format		$FORMAT
+						index		18
+						Object.Widget.pipeline.1 {
+							stream_name "$DMIC0_PCM_0_NAME"
+						}
+						Object.Widget.host-copier.1 {
+							stream_name "Gain Capture 18"
+							pcm_id	27
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
+							}
+						}
 					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
+					{
+						format		$FORMAT
+						index		20
+						Object.Widget.pipeline.1 {
+							stream_name "$DMIC0_PCM_1_NAME"
+						}
+						Object.Widget.host-copier.1 {
+							stream_name "Gain Capture 20"
+							pcm_id 28
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+						}
+						Object.Widget.gain.1 {
+							num_input_audio_formats 2
+							num_output_audio_formats 2
+							Object.Base.audio_format.1 {
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+							Object.Base.audio_format.2 {
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map	$CHANNEL_MAP_3_POINT_1
+								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map	$CHANNEL_MAP_3_POINT_1
+							}
+							Object.Control.mixer.1 {
+								name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
+							}
+						}
 					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
-					}
-				}
+				]
 			}
-			{
-				format		$FORMAT
-				index		20
-				Object.Widget.pipeline.1 {
-					stream_name "$DMIC0_PCM_1_NAME"
-				}
-				Object.Widget.host-copier.1 {
-					stream_name "Gain Capture 20"
-					pcm_id 28
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-				}
-				Object.Widget.gain.1 {
-					num_input_audio_formats 2
-					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
-					Object.Control.mixer.1 {
-						name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
-					}
-				}
-			}
-		]
+		}
 	}
 }
 
@@ -856,6 +864,33 @@ Object.Base.route [
 
 IncludeByKey.PASSTHROUGH {
 "false" {
+		IncludeByKey.NUM_DMICS {
+			"[1-4]" {
+				Object.Base.route [
+					{
+						source  module-copier.14.2
+						sink    gain.19.1
+					}
+					{
+						source  module-copier.19.1
+						sink    gain.18.1
+					}
+					{
+						source  module-copier.19.1
+						sink    gain.20.1
+					}
+					{
+						source	"gain.18.1"
+						sink	"host-copier.27.capture"
+					}
+					{
+						source	"gain.20.1"
+						sink	"host-copier.28.capture"
+					}
+				]
+			}
+		}
+
 		Object.Base.route [
 			{
 				source	"smart_amp.2.1"
@@ -882,18 +917,6 @@ IncludeByKey.PASSTHROUGH {
 				sink	"module-copier.17.2"
 			}
 			{
-				source  module-copier.14.2
-				sink    gain.19.1
-			}
-			{
-				source  module-copier.19.1
-				sink    gain.18.1
-			}
-			{
-				source  module-copier.19.1
-				sink    gain.20.1
-			}
-			{
 				source	"dai-copier.SSP.NoCodec-0.capture"
 				sink	"smart_amp.2.1"
 			}
@@ -904,14 +927,6 @@ IncludeByKey.PASSTHROUGH {
 			{
 				source 'host-copier.2.playback'
 				sink 'gain.5.1'
-			}
-			{
-				source	"gain.18.1"
-				sink	"host-copier.27.capture"
-			}
-			{
-				source	"gain.20.1"
-				sink	"host-copier.28.capture"
 			}
 			{
 				source	"gain.7.1"


### PR DESCRIPTION
DMIC now is controlled by two variables, PASSHTHROUGH and NUM_DMICS,
we should consider the values for both variables to decide the inclusion of DMIC
pipelines, routes, widgets, etc.

Fixes: #7931

Without this PR, there are DMIC components declared in the topology even with NUM_DMICS=0, and our tplgtool.py will fail to parse the topology because of a widget apprears in SectionRoute, but not in SectionWidget. Or there is an incomplete and isolated route in the topology graph.