### PR TITLE
ipc3: helper: Fix mixer scenario

### DIFF
--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -284,6 +284,8 @@ static int comp_specific_builder(struct sof_ipc_comp *comp,
 		config->process.data = proc->data;
 #endif
 		break;
+	case SOF_COMP_MIXER:
+		break;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
With mixer after commit 21ed10abf8a2 ("ipc3: helper: Do not silently accept unrecognized component type in IPC") we get the following error

dma-trace  src/ipc/ipc3/helper.c:333  ERROR comp_new(): component type not recognized

This happens because now we return an error from comp_specific_builder() with the default case.

Fix this by adding a case for mixer.

Fixes: 21ed10abf8a2 ("ipc3: helper: Do not silently accept unrecognized component type in IPC")