### PR TITLE
ace: copier: hda: synchronized FPI updates of HD-A gateways

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -32,6 +32,16 @@ config HOST_DMA_RELOAD_THRESHOLD
 	  The DMA buffer threshold in milliseconds to trigger host DMA
 	  reloading.
 
+config HOST_DMA_STREAM_SYNCHRONIZATION
+	bool "Stream DMA Transfers Synchronization"
+	default y if ACE
+	default n
+	help
+	  Enable synchronized Firmware Pointer Increment (FPI) register updates of HD-A gateways
+	  belonging to a group defined by the driver. The driver may also specify an update period
+	  for each group, different than the default one determined by the system tick frequency.
+	  This feature will allow host lower power consumption in scenarios with deep buffering.
+
 config COMP_DAI
 	bool "DAI component"
 	default y

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -119,6 +119,14 @@ enum ipc4_copier_features {
 	IPC4_COPIER_FAST_MODE = 0
 };
 
+#if CONFIG_HOST_DMA_STREAM_SYNCHRONIZATION
+#define HDA_SYNC_FPI_UPDATE_GROUP 0
+struct ipc4_copier_sync_group {
+	uint32_t group_id;
+	uint32_t fpi_update_period_usec;
+} __packed __aligned(4);
+#endif
+
 struct ipc4_copier_gateway_cfg {
 	/* ID of Gateway Node. If node_id is valid, i.e. != -1, copier instance is connected to the
 	 * specified gateway using either input pin 0 or output pin 0 depending on

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -544,15 +544,15 @@ struct comp_driver_info {
  * Audio component base configuration from IPC at creation.
  */
 struct comp_ipc_config {
-	uint32_t core;		/**< core we run on */
-	uint32_t id;		/**< component id */
-	uint32_t pipeline_id;	/**< component pipeline id */
-	uint32_t proc_domain;   /**< processing domain - LL or DP */
+	uint32_t core;			/**< core we run on */
+	uint32_t id;			/**< component id */
+	uint32_t pipeline_id;		/**< component pipeline id */
+	uint32_t proc_domain;		/**< processing domain - LL or DP */
 	enum sof_comp_type type;	/**< component type */
-	uint32_t periods_sink;	/**< 0 means variable */
-	uint32_t periods_source;/**< 0 means variable */
-	uint32_t frame_fmt;	/**< SOF_IPC_FRAME_ */
-	uint32_t xrun_action;	/**< action we should take on XRUN */
+	uint32_t periods_sink;		/**< 0 means variable */
+	uint32_t periods_source;	/**< 0 means variable */
+	uint32_t frame_fmt;		/**< SOF_IPC_FRAME_ */
+	uint32_t xrun_action;		/**< action we should take on XRUN */
 #if CONFIG_IPC_MAJOR_4
 	uint32_t ipc_config_size;	/**< size of a config received by ipc */
 #endif

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -553,6 +553,9 @@ struct comp_ipc_config {
 	uint32_t periods_source;/**< 0 means variable */
 	uint32_t frame_fmt;	/**< SOF_IPC_FRAME_ */
 	uint32_t xrun_action;	/**< action we should take on XRUN */
+#if CONFIG_IPC_MAJOR_4
+	uint32_t ipc_config_size;	/**< size of a config received by ipc */
+#endif
 };
 
 /**

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -96,6 +96,12 @@ struct host_data {
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */
 	struct ipc_msg *msg;	/**< host notification */
+#if CONFIG_HOST_DMA_STREAM_SYNCHRONIZATION
+	bool is_grouped;
+	uint8_t group_id;
+	uint64_t next_sync;
+	uint64_t period_in_cycles;
+#endif
 };
 
 int host_common_new(struct host_data *hd, struct comp_dev *dev,

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -103,6 +103,7 @@ struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init)
 	ipc_config.id = comp_id;
 	ipc_config.pipeline_id = module_init->extension.r.ppl_instance_id;
 	ipc_config.core = module_init->extension.r.core_id;
+	ipc_config.ipc_config_size = module_init->extension.r.param_block_size * sizeof(uint32_t);
 
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 	if (module_init->extension.r.proc_domain)


### PR DESCRIPTION
This PR adds synchronized FPI updates of HD-A gateways. Driver can define group of such gateways via module init IPC. The driver may also specify an update period for each group, different than the default one determined by the system tick frequency.

In addition, a change has been introduced that makes it possible to read config size in module init function.  Each module receive its own configuration at creation (MODULE_INIT IPC). In case of a gateway those configurations can contain additional value (aux_conf). The only way to check if such config was received is to compare size of the data received via ipc and standard configuration size.