### PR TITLE
zephyr: s/MP_NUM_CPUS/MP_MAX_NUM_CPUS/

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -221,7 +221,7 @@ config MAX_CORE_COUNT
 
 config CORE_COUNT
 	int "Number of cores"
-	default MP_NUM_CPUS if KERNEL_BIN_NAME = "zephyr"
+	default MP_MAX_NUM_CPUS if KERNEL_BIN_NAME = "zephyr"
 	default MAX_CORE_COUNT
 	range 1 MAX_CORE_COUNT
 	help

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -24,7 +24,7 @@
 
 #if CONFIG_MULTICORE && CONFIG_SMP
 
-extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
 static atomic_t start_flag;
@@ -216,7 +216,7 @@ int cpu_enabled_cores(void)
 	unsigned int i;
 	int mask = 0;
 
-	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++)
+	for (i = 0; i < CONFIG_MP_MAX_NUM_CPUS; i++)
 		if (arch_cpu_active(i))
 			mask |= BIT(i);
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -36,7 +36,7 @@
 
 LOG_MODULE_REGISTER(zephyr, CONFIG_SOF_LOG_LEVEL);
 
-extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_NUM_CPUS,
+extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
 /* 300aaad4-45d2-8313-25d0-5e1d6086cdd1 */
@@ -284,8 +284,8 @@ void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
  */
 #if CONFIG_MULTICORE && CONFIG_SMP
 
-static struct idc idc[CONFIG_MP_NUM_CPUS];
-static struct idc *p_idc[CONFIG_MP_NUM_CPUS];
+static struct idc idc[CONFIG_MP_MAX_NUM_CPUS];
+static struct idc *p_idc[CONFIG_MP_MAX_NUM_CPUS];
 
 struct idc **idc_get(void)
 {


### PR DESCRIPTION
Zephyr uses MP_MAX_NUM_CPUS internally to represent the number of cores available and consequently to allocate resources. It is even expected, and checked through assert, that these two symbols have the same value. Use different value can lead to an undesired behavior, so lets use MP_MAX_NUM_CPUS.