### PR TITLE
samples: Fix zephyr config

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -686,14 +686,16 @@ zephyr_library_sources_ifdef(CONFIG_COMP_RTNR
 	${SOF_AUDIO_PATH}/rtnr/rtnr.c
 )
 
-if(CONFIG_IPC_MAJOR_3)
-	zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
-		${SOF_SAMPLES_PATH}/audio/smart_amp_test_ipc3.c
-	)
-elseif(CONFIG_IPC_MAJOR_4)
-	zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
-		${SOF_SAMPLES_PATH}/audio/smart_amp_test_ipc4.c
-	)
+if (CONFIG_SAMPLES)
+	if(CONFIG_IPC_MAJOR_3)
+		zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
+			${SOF_SAMPLES_PATH}/audio/smart_amp_test_ipc3.c
+		)
+	elseif(CONFIG_IPC_MAJOR_4)
+		zephyr_library_sources_ifdef(CONFIG_SAMPLE_SMART_AMP
+			${SOF_SAMPLES_PATH}/audio/smart_amp_test_ipc4.c
+		)
+	endif()
 endif()
 
 zephyr_library_sources_ifdef(CONFIG_COMP_TDFB


### PR DESCRIPTION
Samples should not be built without the kconfig option