### PR TITLE
west.yml: Update rimage revision to aa0ac9ea

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 48777207f5fdc49314dd4709d660e891c48d5ba9
+      revision: aa0ac9eae67506b86e30d66ec75b6f514d729150
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Pull in following rimage changes:
aa0ac9eae675 rimage.c: fix bug where -p requires a new and ignored parameter

Signed-off-by: Andrey Borisovich <andrey.borisovich@intel.com>