### PR TITLE
Audio: Aria: Convert aria to module adapter interface

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -112,7 +112,6 @@ static int init_aria(struct comp_dev *dev, const struct comp_ipc_config *config,
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)spec, sizeof(*aria));
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
 	if (!cd) {
 		comp_free(dev);

--- a/src/audio/aria/aria_generic.c
+++ b/src/audio/aria/aria_generic.c
@@ -19,10 +19,9 @@ const uint8_t INDEX_TAB[] = {
 		0,    1,    2,    3
 };
 
-inline void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
+inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 				struct audio_stream __sparse_cache *source, int frames)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
 	int32_t max_data = 0;
 	int32_t sample_abs;
 	uint32_t att = cd->att;
@@ -50,9 +49,10 @@ inline void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
 	cd->gains[gain_idx] = (int32_t)(gain >> (att + 1));
 }
 
-void aria_algo_get_data(struct comp_dev *dev, struct audio_stream __sparse_cache *sink, int frames)
+void aria_algo_get_data(struct processing_module *mod,
+			struct audio_stream __sparse_cache *sink, int frames)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
+	struct aria_data *cd = module_get_private_data(mod);
 	int32_t step, in_sample;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
@@ -96,7 +96,7 @@ void aria_algo_get_data(struct comp_dev *dev, struct audio_stream __sparse_cache
 	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
 }
 
-aria_get_data_func aria_algo_get_data_func(struct comp_dev *dev)
+aria_get_data_func aria_algo_get_data_func(struct processing_module *mod)
 {
 	return aria_algo_get_data;
 }

--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -20,10 +20,9 @@ const uint8_t INDEX_TAB[] = {
 		0,    1,    2,    3
 };
 
-inline void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
+inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 				struct audio_stream __sparse_cache *source, int frames)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
 	/* detecting maximum value in data chunk */
 	ae_int32x2 in_sample;
 	ae_int32x2 max_data = AE_ZERO32();
@@ -61,11 +60,11 @@ inline void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
 	cd->gains[gain_idx] = (int32_t)(gain >> (att + 1));
 }
 
-void aria_algo_get_data_odd_channel(struct comp_dev *dev,
+void aria_algo_get_data_odd_channel(struct processing_module *mod,
 				    struct audio_stream __sparse_cache *sink,
 				    int frames)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
+	struct aria_data *cd = module_get_private_data(mod);
 	size_t i, m, n, ch;
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
@@ -118,11 +117,11 @@ void aria_algo_get_data_odd_channel(struct comp_dev *dev,
 	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
 }
 
-void aria_algo_get_data_even_channel(struct comp_dev *dev,
+void aria_algo_get_data_even_channel(struct processing_module *mod,
 				     struct audio_stream __sparse_cache *sink,
 				     int frames)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
+	struct aria_data *cd = module_get_private_data(mod);
 	size_t i, m, n, ch;
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
@@ -174,9 +173,9 @@ void aria_algo_get_data_even_channel(struct comp_dev *dev,
 	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
 }
 
-aria_get_data_func aria_algo_get_data_func(struct comp_dev *dev)
+aria_get_data_func aria_algo_get_data_func(struct processing_module *mod)
 {
-	struct aria_data *cd = comp_get_drvdata(dev);
+	struct aria_data *cd = module_get_private_data(mod);
 
 	if (cd->chan_cnt & 1)
 		return aria_algo_get_data_odd_channel;

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -21,6 +21,7 @@
 #include <sof/trace/trace.h>
 #include <ipc/stream.h>
 #include <ipc4/module.h>
+#include <sof/audio/module_adapter/module/generic.h>
 #include <ipc4/base-config.h>
 #include <user/trace.h>
 #include <stddef.h>
@@ -46,23 +47,22 @@
 /**
  * \brief aria get data function interface
  */
-typedef void (*aria_get_data_func)(struct comp_dev *dev,
+typedef void (*aria_get_data_func)(struct processing_module *mod,
 				   struct audio_stream __sparse_cache *sink, int frames);
 
+struct aria_data;
 /**
  * \brief Aria gain processing function
  */
-void aria_algo_calc_gain(struct comp_dev *dev, size_t gain_idx,
+void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 			 struct audio_stream __sparse_cache *source, int frames);
 
-aria_get_data_func aria_algo_get_data_func(struct comp_dev *dev);
+aria_get_data_func aria_algo_get_data_func(struct processing_module *mod);
 
 /**
  * \brief Aria component private data.
  */
 struct aria_data {
-	struct ipc4_base_module_cfg base;
-
 	/* channels count */
 	size_t chan_cnt;
 	/* sample groups to process count */


### PR DESCRIPTION
Convert the component aria to use module adapter interface.