### PR TITLE
topology2: ssp: add quirks for NHLT table endpoints

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -164,7 +164,7 @@ Object.Dai.SSP [
 			}
 			"true" {
 				direction	"duplex"
-				quirks		"lbm_mode"
+				quirks		"lbm_mode,render_feedback"
 			}
 		}
 		name		$SPEAKER_CODEC_NAME

--- a/tools/topology/topology2/include/dais/ssp.conf
+++ b/tools/topology/topology2/include/dais/ssp.conf
@@ -91,9 +91,17 @@ Class.Dai."SSP" {
 		constraints {
 			!valid_values [
 				"lbm_mode"
+				"bt_sideband"
+				"render_feedback"
+				"lbm_mode,bt_sideband"
+				"lbm_mode,render_feedback"
 			]
 			!tuple_values [
 				64
+				128
+				256
+				192
+				320
 			]
 
 		}

--- a/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
@@ -6,7 +6,7 @@ Object.Dai.SSP [
 		name			$BT_NAME
 		default_hw_conf_id	0
 		sample_bits		16
-		quirks			"lbm_mode"
+		quirks			"lbm_mode,bt_sideband"
 		io_clk			$BT_MCLK
 		Object.Base.hw_config.1 {
 			id		0

--- a/tools/topology/topology2/platform/intel/bt-ssp-config.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config.conf
@@ -6,6 +6,7 @@ Object.Dai.SSP [
 		name			$BT_NAME
 		default_hw_conf_id	0
 		sample_bits		16
+		quirks			"bt_sideband"
 		io_clk			$BT_MCLK
 		Object.Base.hw_config.1 {
 			id		0


### PR DESCRIPTION
Two quirk flags are added. The quirk "bt_sideband" will set the device type of corresponding NHLT endpoints to BT(4) and others to Codec(0).

The other quirk "render_feedback" is for speaker path with echo reference or IV sense feedback. The endpoint direction will use Render with loopback(3) and Feedback for render(4) instead of Render(0) and Capture(1).