### PR TITLE
Revert "Audio: SRC: Add safeguard against missing, wrong size or type…

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -921,12 +921,6 @@ static int src_init(struct processing_module *mod)
 
 	comp_dbg(dev, "src_init()");
 
-	if (dev->ipc_config.type != SOF_COMP_SRC || !cfg->init_data ||
-	    cfg->size != sizeof(cd->ipc_config)) {
-		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
-			 cfg->size);
-		return -EINVAL;
-	}
 	/* validate init data - either SRC sink or source rate must be set */
 	if (src_rate_check(cfg->init_data) < 0) {
 		comp_err(dev, "src_init(): SRC sink and source rate are not set");


### PR DESCRIPTION
… init data"

This reverts commit 4849a71ada60085542722cfc6ca7e82c2b428ecf.

The commit has been merged with CI test fail
The test is now failing constantly making CI unusabe

Either CI test or the code requires changes before merging

FW logs:

[    0.122168] <inf> init: print_version_banner: FW ABI 0x301b000 DBG ABI 0x5003000 tags SOF:v2.5-stable-branch-733-g8683d2d265d1 zephyr:zephyr-v3.4.0-496-g431108d89e17 src hash 0x4b68d789 (ref hash 0x4b68d789)
[    0.122183] <inf> clock: clock_set_freq: clock 0 set freq 400000000Hz freq_idx 2
[    0.122190] <inf> clock: clock_set_freq: clock 1 set freq 400000000Hz freq_idx 2
[    0.122196] <inf> clock: clock_set_freq: clock 2 set freq 400000000Hz freq_idx 2
*** Booting Zephyr OS build zephyr-v3.4.0-496-g431108d89e17 ***
[    0.122378] <inf> main: main: SOF on intel_adsp_ace15_mtpm
[    0.122386] <inf> main: main: SOF initialized
[    0.157836] <inf> ipc: ipc_cmd: rx    : 0x43000000|0x30701000
[    0.160618] <inf> ipc: ipc_cmd: rx    : 0x43000000|0x30801000
[    0.171581] <inf> ipc: ipc_cmd: rx    : 0x44000000|0x3070000c
[    0.171590] <wrn> basefw: basefw_set_large_config: returning success for Set FW_CONFIG without handling it
[    0.174833] <inf> ipc: ipc_cmd: rx    : 0x44000000|0x3070000c
[    0.174846] <wrn> basefw: basefw_set_large_config: returning success for Set FW_CONFIG without handling it
[    0.179795] <inf> ipc: ipc_cmd: rx    : 0x44000000|0x31400008
[    0.181086] <inf> ipc: ipc_cmd: rx    : 0x44000000|0x30600064
[    0.241513] <inf> ipc: ipc_cmd: rx    : 0x11000006|0x0
[    0.241518] <inf> pipe: pipeline_new: pipeline new pipe_id 0 priority 0
[    0.242786] <inf> ipc: ipc_cmd: rx    : 0x40000004|0x15
[    0.242833] <inf> dma: dma_get: dma_get() ID 0 sref = 1 busy channels 0
[    0.271751] <inf> ipc: ipc_cmd: rx    : 0x40000008|0x1000000b
**[    0.271781] <err> src: src_init: comp:0 0x80000 src_init(): Missing or bad size (44) init data**
[    0.271786] <err> module_adapter: module_init: comp:0 0x80000 module_init() error -22: module specific init failed, comp id 524288
[    0.271790] <err> module_adapter: module_adapter_new: comp:0 0x80000 module_adapter_new() -22: module initialization failed
[    0.271801] <err> ipc: ipc4_init_module_instance: error: failed to init module 8 : 0
[    0.271811] <err> ipc: ipc_cmd: ipc4: MODULE_MSG failed with err 104
[    0.272753] <inf> ipc: ipc_cmd: rx    : 0x46000004|0x8
[    0.272763] <err> ipc: ipc_comp_disconnect: failed to find src 40000, or dst 80000
[    0.272766] <err> ipc: ipc_cmd: ipc4: MODULE_MSG failed with err 9
