### PR TITLE
copier: fix no consume for multi endpoint copy

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -561,6 +561,10 @@ static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_de
 
 	ret = dai_zephyr_multi_endpoint_copy(cd->dd, dev, cd->multi_endpoint_buffer,
 					     cd->endpoint_num);
+	if (!ret) {
+		comp_update_buffer_consume(src_c, processed_data.source_bytes);
+		cd->input_total_data_processed += processed_data.source_bytes;
+	}
 err:
 	buffer_release(src_c);
 


### PR DESCRIPTION
In last time copier code split, it split multi-endpoint copy and module copy with commit: e424b87, source buffer consume was missed, added it back with this PR.

Fixes:#7979