### PR TITLE
module adapter: avoid module init crash in case of ipc data invalid

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -130,6 +130,8 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 			goto err;
 		}
 		dst->init_data = dst->data;
+	} else {
+		goto err;
 	}
 #else
 	if (drv->type == SOF_COMP_MODULE_ADAPTER) {


### PR DESCRIPTION
In ipc3 module creation, it is possible that ipc data is invalid or corrupted, in this case, module init may crash.
This patch is adding error handling to avoid crash.