### PR TITLE
smart amp : Do not use DYNAMIC topology

### DIFF
--- a/tools/topology/topology1/sof-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-smart-amplifier.m4
@@ -19,6 +19,11 @@ DEBUG_START
 # define the default macros.
 # define them in your specific platform .m4 if needed.
 
+#undefine the DYNAMIC flag (if enabled, save it) for smart amplifier as it uses volatile kcontrols
+ifdef(`DYNAMIC', `define(`SAVED_DYNAMIC', DYNAMIC)',`')
+undefine(`DYNAMIC')
+
+
 # define(`SMART_AMP_CORE', 1) define the DSP core that the DSM pipeline will be run on, if not done yet
 ifdef(`SMART_AMP_CORE',`',`define(`SMART_AMP_CORE', 0)')
 
@@ -235,5 +240,8 @@ DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
 		      SSP_TDM(8, 32, 15, 255),
 		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 32, 0, SMART_SSP_QUIRK)))
 ')
+
+#Re-enable DYNAMIC flag if it was enabled for other pipelines
+ifdef(`SAVED_DYNAMIC', `define(`DYNAMIC', 1)',`')
 
 DEBUG_END


### PR DESCRIPTION
DYNAMIC topology should not be used for pipeline with volatile Kcontrols.
Hence ensuring the flag is un defined before processing smart amp related PCM and DAI configs

Suggested-by: Sridharan, Ranjani <ranjani.sridharan@linux.intel.com>
Signed-off-by: Sathya Prakash M R <sathya.prakash.m.r@intel.com>
(cherry picked from commit 214f98378f12ed179bd22f0c4feb09b0b3aaea81)