### PR TITLE
DP: changes in sink/source

### DIFF
--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -37,9 +37,14 @@ static int audio_stream_commit_buffer(struct sof_sink __sparse_cache *sink, size
 	struct audio_stream __sparse_cache *audio_stream =
 			attr_container_of(sink, struct audio_stream __sparse_cache,
 					  sink_api, __sparse_cache);
+	struct comp_buffer __sparse_cache *buffer_c =
+			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+					  stream, __sparse_cache);
 
-	if (commit_size)
+	if (commit_size) {
+		buffer_stream_writeback(buffer_c, commit_size);
 		audio_stream_produce(audio_stream, commit_size);
+	}
 
 	return 0;
 }
@@ -60,8 +65,14 @@ static int audio_stream_get_data(struct sof_source __sparse_cache *source, size_
 			attr_container_of(source, struct audio_stream __sparse_cache,
 					  source_api, __sparse_cache);
 
+	struct comp_buffer __sparse_cache *buffer_c =
+			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+					  stream, __sparse_cache);
+
 	if (req_size > audio_stream_get_data_available(source))
 		return -ENODATA;
+
+	buffer_stream_invalidate(buffer_c, req_size);
 
 	/* get circular buffer parameters */
 	*data_ptr = audio_stream->r_ptr;

--- a/src/audio/sink_api_helper.c
+++ b/src/audio/sink_api_helper.c
@@ -175,3 +175,13 @@ int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
 		return sink->ops->set_alignment_constants(sink, byte_align, frame_align_req);
 	return 0;
 }
+
+void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs)
+{
+	sink->obs = obs;
+}
+
+size_t sink_get_obs(struct sof_sink __sparse_cache *sink)
+{
+	return sink->obs;
+}

--- a/src/audio/source_api_helper.c
+++ b/src/audio/source_api_helper.c
@@ -165,3 +165,13 @@ int source_set_alignment_constants(struct sof_source __sparse_cache *source,
 		return source->ops->set_alignment_constants(source, byte_align, frame_align_req);
 	return 0;
 }
+
+void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs)
+{
+	source->ibs = ibs;
+}
+
+size_t source_get_ibs(struct sof_source __sparse_cache *source)
+{
+	return source->ibs;
+}

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -566,15 +566,6 @@ struct comp_dev {
 	uint32_t frames;	   /**< number of frames we copy to sink */
 	struct pipeline *pipeline; /**< pipeline we belong to */
 
-	uint32_t min_sink_bytes;   /**< min free sink buffer size measured in
-				     *  bytes required to run component's
-				     *  processing
-				     */
-	uint32_t min_source_bytes; /**< amount of data measured in bytes
-				     *  available at source buffer required
-				     *  to run component's processing
-				     */
-
 	struct task *task;	/**< component's processing task used
 				  *  1) for components running on different core
 				  *    than the rest of the pipeline

--- a/src/include/sof/audio/sink_api.h
+++ b/src/include/sof/audio/sink_api.h
@@ -129,6 +129,8 @@ int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate);
 int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channels);
 int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitted);
 int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fmt);
+void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs);
+size_t sink_get_obs(struct sof_sink __sparse_cache *sink);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params

--- a/src/include/sof/audio/sink_api_implementation.h
+++ b/src/include/sof/audio/sink_api_implementation.h
@@ -69,9 +69,10 @@ struct sink_ops {
 
 /** internals of sink API. NOT TO BE MODIFIED OUTSIDE OF sink_api_helper.h */
 struct sof_sink {
-	const struct sink_ops *ops;	/** operations interface */
+	const struct sink_ops *ops;	  /** operations interface */
 	size_t requested_write_frag_size; /** keeps number of bytes requested by get_buffer() */
-	size_t num_of_bytes_processed; /** processed bytes counter */
+	size_t num_of_bytes_processed;	  /** processed bytes counter */
+	size_t obs;			  /** output buffer size as declared in module bind IPC */
 	struct sof_audio_stream_params *audio_stream_params; /** pointer to audio params */
 };
 

--- a/src/include/sof/audio/source_api.h
+++ b/src/include/sof/audio/source_api.h
@@ -140,6 +140,8 @@ int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate)
 int source_set_channels(struct sof_source __sparse_cache *source, unsigned int channels);
 int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_permitted);
 int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buffer_fmt);
+void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs);
+size_t source_get_ibs(struct sof_source __sparse_cache *source);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params

--- a/src/include/sof/audio/source_api_implementation.h
+++ b/src/include/sof/audio/source_api_implementation.h
@@ -70,8 +70,9 @@ struct source_ops {
 /** internals of source API. NOT TO BE MODIFIED OUTSIDE OF source_api_helper.h */
 struct sof_source {
 	const struct source_ops *ops;
-	size_t requested_read_frag_size;	/** keeps size of data obtained by get_data() */
-	size_t num_of_bytes_processed;	/** processed bytes counter */
+	size_t requested_read_frag_size; /** keeps size of data obtained by get_data() */
+	size_t num_of_bytes_processed;	 /** processed bytes counter */
+	size_t ibs;			 /** input buffer size as declared in module bind IPC */
 	struct sof_audio_stream_params *audio_stream_params;
 };
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -327,20 +327,14 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 }
 
 static struct comp_buffer *ipc4_create_buffer(struct comp_dev *src, struct comp_dev *sink,
-					      uint32_t src_queue, uint32_t dst_queue)
+					      uint32_t src_obs, uint32_t src_queue,
+					      uint32_t dst_queue)
 {
-	struct ipc4_base_module_cfg src_cfg;
 	struct sof_ipc_buffer ipc_buf;
-	int buf_size, ret;
-
-	ret = comp_get_attribute(src, COMP_ATTR_BASE_CONFIG, &src_cfg);
-	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to get base config for src %#x", dev_comp_id(src));
-		return NULL;
-	}
+	int buf_size;
 
 	/* double it since obs is single buffer size */
-	buf_size = src_cfg.obs * 2;
+	buf_size = src_obs * 2;
 
 	memset(&ipc_buf, 0, sizeof(ipc_buf));
 	ipc_buf.size = buf_size;
@@ -356,6 +350,8 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	struct comp_buffer *buffer;
 	struct comp_dev *source;
 	struct comp_dev *sink;
+	struct ipc4_base_module_cfg source_src_cfg;
+	struct ipc4_base_module_cfg sink_src_cfg;
 	uint32_t flags;
 	int src_id, sink_id;
 	int ret;
@@ -375,12 +371,32 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	if (!cpu_is_me(source->ipc_config.core) && source->ipc_config.core == sink->ipc_config.core)
 		return ipc4_process_on_core(source->ipc_config.core, false);
 
-	buffer = ipc4_create_buffer(source, sink, bu->extension.r.src_queue,
+	ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &source_src_cfg);
+	if (ret < 0) {
+		tr_err(&ipc_tr, "failed to get base config for module %#x", dev_comp_id(source));
+		return IPC4_FAILURE;
+	}
+
+	ret = comp_get_attribute(sink, COMP_ATTR_BASE_CONFIG, &sink_src_cfg);
+	if (ret < 0) {
+		tr_err(&ipc_tr, "failed to get base config for module %#x", dev_comp_id(sink));
+		return IPC4_FAILURE;
+	}
+
+	buffer = ipc4_create_buffer(source, sink, source_src_cfg.obs, bu->extension.r.src_queue,
 				    bu->extension.r.dst_queue);
 	if (!buffer) {
 		tr_err(&ipc_tr, "failed to allocate buffer to bind %d to %d", src_id, sink_id);
 		return IPC4_OUT_OF_MEMORY;
 	}
+
+	/*
+	 * set ibs and obs in sink/src api of created buffer
+	 *	IBS of a buffer is OBS of source component
+	 *	OBS of a buffer is IBS of destination component
+	 */
+	source_set_ibs(audio_stream_get_source(&buffer->stream), source_src_cfg.obs);
+	sink_set_obs(audio_stream_get_sink(&buffer->stream), sink_src_cfg.ibs);
 
 	/*
 	 * Connect and bind the buffer to both source and sink components with the interrupts
@@ -404,6 +420,7 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		tr_err(&ipc_tr, "failed to connect internal buffer to sink %d", sink_id);
 		goto e_sink_connect;
 	}
+
 
 	ret = comp_bind(source, bu);
 	if (ret < 0)


### PR DESCRIPTION
1) add min_free / min_available 
Its obvious that to process, a module must have enough data on all inputs (sources) and enough space on all outputs (sinks). 
For each input/output the amount of required data/space may be different. 

This PR adds min_free/min_available) to sink/source

This information will be used by DP Scheduler to determine if the module may be scheduled.

2) add data invalidation to audio_stream sink/src implementation

Audio_stream is not making cache operations on data
buffer itself, it requires that the module to
call data invalidation/writeback

Sink/source interface works differently, it removes any
responsibility from the module providing a ready to
use pointers in cached memory

this PR adds cache operations to audio_stream sink/src implementation
