### PR TITLE
Audio: SRC: Add safeguard against missing, wrong size or type init data

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -986,6 +986,18 @@ static int src_init(struct processing_module *mod)
 	struct comp_data *cd = NULL;
 
 	comp_dbg(dev, "src_init()");
+#if CONFIG_IPC_MAJOR_3
+	if (dev->ipc_config.type != SOF_COMP_SRC) {
+		comp_err(dev, "src_init(): Wrong IPC config type %u",
+			 dev->ipc_config.type);
+		return -EINVAL;
+	}
+#endif
+	if (!cfg->init_data || cfg->size != sizeof(cd->ipc_config)) {
+		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
+			 cfg->size);
+		return -EINVAL;
+	}
 
 	/* validate init data - either SRC sink or source rate must be set */
 	if (src_rate_check(cfg->init_data) < 0) {


### PR DESCRIPTION
In some error situations the configuration init_data may be NULL, and in such a situations we should fail gracefully and not crash. Also adds check that the IPC message is of correct type and for IPC3 only that it is of correct type.

This is a reincarnation of https://github.com/thesofproject/sof/pull/7830 that was reverted due to CI problems: https://github.com/thesofproject/sof/pull/7985

The message type check is now done for IPC3 only.