### PR TITLE
Fast mode task config + vendor config task

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2384,9 +2384,19 @@ static int kpb_set_large_config(struct comp_dev *dev, uint32_t param_id,
 				uint32_t data_offset,
 				const char *data)
 {
+	/* We can use extended param id for both extended
+	 * and standard param id
+	 */
+	const struct byte_array_simple *ba = (struct byte_array_simple *)data;
+	union ipc4_extended_param_id extended_param_id;
+
 	comp_info(dev, "kpb_set_large_config()");
 
-	switch (param_id) {
+	extended_param_id.full = param_id;
+
+	switch (extended_param_id.part.parameter_type) {
+//	case 1:
+//		return 0;
 	case KP_BUF_CLIENT_MIC_SELECT:
 		return kpb_set_micselect(dev, data, data_offset);
 	default:

--- a/src/include/ipc4/kpb.h
+++ b/src/include/ipc4/kpb.h
@@ -19,4 +19,15 @@
 struct ipc4_kpb_module_cfg {
 	struct ipc4_base_module_cfg base_cfg;
 } __packed __aligned(4);
+
+enum ipc4_kpb_module_config_params {
+	//! Configure the module ID's which would be part of the Fast mode tasks
+	KP_BUF_CFG_FM_MODULE = 1,
+	/* Mic selector for client - sets microphone id for real time sink mic selector
+	 * IPC4-compatible ID - please do not change the number
+	 */
+	KP_BUF_CLIENT_MIC_SELECT = 11,
+};
+
 #endif
+

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -36,6 +36,9 @@
 #define SOF_IPC4_DST_QUEUE_ID_BITFIELD_SIZE	3
 #define SOF_IPC4_SRC_QUEUE_ID_BITFIELD_SIZE	3
 
+/* Special large_param_id values */
+#define VENDOR_CONFIG_PARAM 0xFF
+
 enum sof_ipc4_module_type {
 	SOF_IPC4_MOD_INIT_INSTANCE		= 0,
 	SOF_IPC4_MOD_CONFIG_GET			= 1,
@@ -202,6 +205,35 @@ struct ipc4_module_bind_unbind {
 		} r;
 	} extension;
 } __attribute__((packed, aligned(4)));
+
+union ipc4_extended_param_id {
+	uint32_t full;
+	struct{
+		uint32_t parameter_type     : 8;
+		uint32_t parameter_instance : 24;
+	} part;
+};
+
+/* Casting IPC payload to this, address of param_data
+ * becomes the address of the start of actual data.
+ * TLV_DATA_OFFSET is the offset to the actual data from
+ * the beginning of the structure.
+ */
+struct ipc4_mod_conf_param {
+	//! parameter id
+	uint32_t param_id;
+	//! size of value (in bytes)
+	uint32_t param_size;
+	//! value (padded w/ zeroes to align to dword)
+	uint32_t param_data[1];
+};
+
+static const uint32_t TLV_DATA_OFFSET = sizeof(struct ipc4_mod_conf_param) - sizeof(uint32_t);
+
+struct byte_array_simple {
+	uint8_t *data;
+	uint32_t size;
+};
 
 struct ipc4_module_large_config {
 	union {

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -43,6 +43,7 @@ struct comp_buffer;
 	(KPB_SAMPLE_CONTAINER_SIZE(sw) / 8) * KPB_MAX_BUFF_TIME * \
 	 (channels_number))
 #define KPB_MAX_NO_OF_CLIENTS 2
+#define KPB_MAX_SINK_CNT (1 + KPB_MAX_NO_OF_CLIENTS)
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100
 #define KPB_NO_OF_MEM_POOLS 3
@@ -66,6 +67,9 @@ struct comp_buffer;
  * i.e. number of max supported channels - reference channels)
  */
 #define KPB_MAX_MICSEL_CHANNELS 4
+/* Used in FMT */
+#define FAST_MODE_TASK_MAX_MODULES_COUNT 16
+static const uint32_t REALTIME_PIN_ID; //= 0;
 
 /** All states below as well as relations between them are documented in
  * the sof-dosc in [kpbm-state-diagram]
@@ -159,18 +163,89 @@ struct history_data {
 	struct history_buffer *c_hb; /**< current buffer used for writing */
 };
 
-enum ipc4_kpb_module_config_params {
-	/* Mic selector for client - sets microphone id for real time sink mic selector
-	 * IPC4-compatible ID - please do not change the number
-	 */
-	KP_BUF_CLIENT_MIC_SELECT = 11,
-};
+/* moved to ipc4/kpb.h */
+/* enum ipc4_kpb_module_config_params */
 
 /* Stores KPB mic selector config */
 struct kpb_micselector_config {
 	/* channel bit set to 1 implies channel selection */
 	uint32_t mask;
 };
+
+struct kpb_task_params {
+	/* If largeconfigset is set to KP_POS_IN_BUFFER then number of modules must
+	 * correspond to number of modules between kpb and copier attached to hostdma.
+	 * Once draining path is configured, cannot be reinitialized/changed.
+	 */
+	uint32_t        number_of_modules;
+	struct {
+		uint16_t module_id;
+		uint16_t instance_id;
+	}		    dev_ids[1];
+};
+
+/* fmt namespace: */
+#define FAST_MODE_TASK_MAX_LIST_COUNT 5
+
+struct fast_mode_task {
+	/*! Array of pointers to all module lists to be processed. */
+	struct device_list *device_list_[FAST_MODE_TASK_MAX_LIST_COUNT];
+};
+
+/* The +1 is here because we also push the kbp device
+ * handle in addition to the max number of modules
+ */
+#define DEVICE_LIST_SIZE (FAST_MODE_TASK_MAX_MODULES_COUNT + 1)
+
+/* Devicelist type
+ * Originally ACE KPB used Bi-dir lists to store modules for FMT. It is possible that lists are
+ * not necessary, but in case it might be wrong, here we use an array
+ * with a list interface to switch it to a list easily.
+ */
+struct device_list {
+	struct comp_dev **devs[DEVICE_LIST_SIZE];
+	size_t count; //number of items AND index of next empty box
+};
+
+/*
+ *
+ *
+ *	KPB FMT config set steps:
+ *	1. Get dev_ids of module instances from IPC
+ *	2. Alloc this kpb module instance on kpb_list_item_, save address of where it was allocated
+ *	3. Push the address on dev_list.device_list_
+ *	2. For each dev_id get device handler(module instance)
+ *	3. Alloc device handler in modules_list_item, save address of where it was allocated
+ *	4. Register this address in fmt.device_list_
+ *
+ *	Pointer structure:
+ *
+ *		COMP_DEVS
+ *		  ^
+ *		  |
+ *		dev_list.modules_list_item(comp_dev* )
+ *		  ^
+ *		  |
+ *		dev_list.device_list_(comp_dev**)
+ *		  ^
+ *		  |
+ *		fmt.device_list_(device_list_*)
+ *
+ *
+ */
+
+/* KpbFastModeTaskModulesList Namespace */
+struct kpb_fmt_dev_list {
+	/*! Array of  all module lists to be processed. */
+	struct device_list device_list_[FAST_MODE_TASK_MAX_LIST_COUNT];
+	//One for each sinkpin.
+	struct comp_dev *kpb_list_item_[KPB_MAX_SINK_CNT];
+
+	struct comp_dev *modules_list_item_[FAST_MODE_TASK_MAX_MODULES_COUNT];
+
+	struct comp_dev *kpb_mi_ptr_;
+};
+
 #ifdef UNIT_TEST
 void sys_comp_kpb_init(void);
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -952,6 +952,7 @@ static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ip
 		ret = drv->ops.set_large_config(dev, config.extension.r.large_param_id,
 			config.extension.r.init_block, config.extension.r.final_block,
 			config.extension.r.data_off_size, (const char *)MAILBOX_HOSTBOX_BASE);
+
 		if (ret < 0) {
 			ipc_cmd_err(&ipc_tr, "failed to set large_config_module_instance %x : %x",
 				    (uint32_t)config.primary.r.module_id,


### PR DESCRIPTION
First PR here, open to heavy criticism.

Adding vendor config set and fmt(fast mode task) config as first steps to fmt implementation. Fixes IPC error on fmt config due to no fmt implementation.