### PR TITLE
[DNM] POC: ] Direct use of cached / not-cached shared memory alias instead of coherent.h in case of buffers

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -72,8 +72,8 @@ static int aria_algo_init(struct aria_data *cd, void *buffer_desc,
 }
 
 static inline void aria_process_data(struct processing_module *mod,
-				     struct audio_stream __sparse_cache *source,
-				     struct audio_stream __sparse_cache *sink,
+				     struct audio_stream *source,
+				     struct audio_stream *sink,
 				     size_t frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -165,7 +165,7 @@ static void aria_set_stream_params(struct comp_buffer *buffer,
 
 static int aria_prepare(struct processing_module *mod,
 			struct sof_source **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct comp_buffer *source, *sink;

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -153,19 +153,14 @@ static int aria_free(struct processing_module *mod)
 static void aria_set_stream_params(struct comp_buffer *buffer,
 				   struct processing_module *mod)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
 	const struct ipc4_audio_format *audio_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
 
-	buffer_c = buffer_acquire(buffer);
-
-	ipc4_update_buffer_format(buffer_c, audio_fmt);
+	ipc4_update_buffer_format(buffer, audio_fmt);
 #ifdef ARIA_GENERIC
-	audio_stream_init_alignment_constants(1, 1, &buffer_c->stream);
+	audio_stream_init_alignment_constants(1, 1, &buffer->stream);
 #else
-	audio_stream_init_alignment_constants(8, 1, &buffer_c->stream);
+	audio_stream_init_alignment_constants(8, 1, &buffer->stream);
 #endif
-
-	buffer_release(buffer_c);
 }
 
 static int aria_prepare(struct processing_module *mod,

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -164,7 +164,7 @@ static void aria_set_stream_params(struct comp_buffer *buffer,
 }
 
 static int aria_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
+			struct sof_source **sources, int num_of_sources,
 			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	int ret;

--- a/src/audio/aria/aria_generic.c
+++ b/src/audio/aria/aria_generic.c
@@ -20,7 +20,7 @@ const uint8_t INDEX_TAB[] = {
 };
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-				struct audio_stream __sparse_cache *source, int frames)
+				struct audio_stream *source, int frames)
 {
 	int32_t max_data = 0;
 	int32_t sample_abs;
@@ -50,7 +50,7 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 }
 
 void aria_algo_get_data(struct processing_module *mod,
-			struct audio_stream __sparse_cache *sink, int frames)
+			struct audio_stream *sink, int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
 	int32_t step, in_sample;

--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -21,7 +21,7 @@ const uint8_t INDEX_TAB[] = {
 };
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-				struct audio_stream __sparse_cache *source, int frames)
+				struct audio_stream *source, int frames)
 {
 	/* detecting maximum value in data chunk */
 	ae_int32x2 in_sample;
@@ -61,7 +61,7 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 }
 
 void aria_algo_get_data_odd_channel(struct processing_module *mod,
-				    struct audio_stream __sparse_cache *sink,
+				    struct audio_stream *sink,
 				    int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
@@ -118,7 +118,7 @@ void aria_algo_get_data_odd_channel(struct processing_module *mod,
 }
 
 void aria_algo_get_data_even_channel(struct processing_module *mod,
-				     struct audio_stream __sparse_cache *sink,
+				     struct audio_stream *sink,
 				     int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -48,8 +48,8 @@
 #define COEF_C2		Q_CONVERT_FLOAT(0.99, 30)
 
 typedef void (*asrc_proc_func)(struct comp_dev *dev,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int *consumed,
 			       int *produced);
 
@@ -122,8 +122,8 @@ static inline void src_inc_wrap_s16(int16_t **ptr, int16_t *end, size_t size)
 
 /* A fast copy function for same in and out rate */
 static void src_copy_s32(struct comp_dev *dev,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -194,8 +194,8 @@ static void src_copy_s32(struct comp_dev *dev,
 }
 
 static void src_copy_s16(struct comp_dev *dev,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -534,7 +534,6 @@ static int asrc_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	int err;
 
 	comp_info(dev, "asrc_params()");
@@ -554,25 +553,19 @@ static int asrc_params(struct comp_dev *dev,
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 #if CONFIG_IPC_MAJOR_4
 	/* update the source/sink buffer formats. Sink rate will be modified below */
-	ipc4_update_buffer_format(source_c, &cd->ipc_config.base.audio_fmt);
-	ipc4_update_buffer_format(sink_c, &cd->ipc_config.base.audio_fmt);
+	ipc4_update_buffer_format(sourceb, &cd->ipc_config.base.audio_fmt);
+	ipc4_update_buffer_format(sinkb, &cd->ipc_config.base.audio_fmt);
 #endif
 
 	/* Don't change sink rate if value from IPC is 0 (auto detect) */
 	if (asrc_get_sink_rate(&cd->ipc_config))
-		audio_stream_set_rate(&sink_c->stream, asrc_get_sink_rate(&cd->ipc_config));
+		audio_stream_set_rate(&sinkb->stream, asrc_get_sink_rate(&cd->ipc_config));
 
 	/* set source/sink_frames/rate */
-	cd->source_rate = audio_stream_get_rate(&source_c->stream);
-	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	cd->source_rate = audio_stream_get_rate(&sourceb->stream);
+	cd->sink_rate = audio_stream_get_rate(&sinkb->stream);
 
 	if (!cd->sink_rate) {
 		comp_err(dev, "asrc_params(), zero sink rate");
@@ -604,7 +597,6 @@ static int asrc_params(struct comp_dev *dev,
 static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	int pid;
 
 	/* Get current pipeline ID and walk to find the DAI */
@@ -615,9 +607,7 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 		do {
 			sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
-			sink_c = buffer_acquire(sinkb);
-			dev = sink_c->sink;
-			buffer_release(sink_c);
+			dev = sinkb->sink;
 
 			if (!dev) {
 				comp_cl_err(&comp_asrc, "At end, no DAI found.");
@@ -635,9 +625,7 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 		do {
 			sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 
-			source_c = buffer_acquire(sourceb);
-			dev = source_c->source;
-			buffer_release(source_c);
+			dev = sourceb->source;
 
 			if (!dev) {
 				comp_cl_err(&comp_asrc, "At beginning, no DAI found.");
@@ -722,7 +710,6 @@ static int asrc_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	uint32_t source_period_bytes;
 	uint32_t sink_period_bytes;
 	int sample_bytes;
@@ -748,23 +735,20 @@ static int asrc_prepare(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list,
 				struct comp_buffer, source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* get source data format and period bytes */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	source_period_bytes = audio_stream_period_bytes(&source_c->stream,
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	source_period_bytes = audio_stream_period_bytes(&sourceb->stream,
 							cd->source_frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
+	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
+	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      cd->sink_frames);
 
-	if (audio_stream_get_size(&sink_c->stream) <
+	if (audio_stream_get_size(&sinkb->stream) <
 	    dev->ipc_config.periods_sink * sink_period_bytes) {
 		comp_err(dev, "asrc_prepare(): sink buffer size %d is insufficient < %d * %d",
-			 audio_stream_get_size(&sink_c->stream), dev->ipc_config.periods_sink,
+			 audio_stream_get_size(&sinkb->stream), dev->ipc_config.periods_sink,
 			 sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
@@ -783,7 +767,7 @@ static int asrc_prepare(struct comp_dev *dev)
 	}
 
 	/* ASRC supports S16_LE, S24_4LE and S32_LE formats */
-	switch (audio_stream_get_frm_fmt(&source_c->stream)) {
+	switch (audio_stream_get_frm_fmt(&sourceb->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		cd->asrc_func = src_copy_s16;
 		break;
@@ -801,7 +785,7 @@ static int asrc_prepare(struct comp_dev *dev)
 	}
 
 	/* Allocate input and output data buffer for ASRC processing */
-	frame_bytes = audio_stream_frame_bytes(&source_c->stream);
+	frame_bytes = audio_stream_frame_bytes(&sourceb->stream);
 	cd->buf_size = (cd->source_frames_max + cd->sink_frames_max) *
 		frame_bytes;
 
@@ -815,8 +799,8 @@ static int asrc_prepare(struct comp_dev *dev)
 		goto err;
 	}
 
-	sample_bytes = frame_bytes / audio_stream_get_channels(&source_c->stream);
-	for (i = 0; i < audio_stream_get_channels(&source_c->stream); i++) {
+	sample_bytes = frame_bytes / audio_stream_get_channels(&sourceb->stream);
+	for (i = 0; i < audio_stream_get_channels(&sourceb->stream); i++) {
 		cd->ibuf[i] = cd->buf + i * sample_bytes;
 		cd->obuf[i] = cd->ibuf[i] + cd->source_frames_max * frame_bytes;
 	}
@@ -824,7 +808,7 @@ static int asrc_prepare(struct comp_dev *dev)
 	/* Get required size and allocate memory for ASRC */
 	sample_bits = sample_bytes * 8;
 	ret = asrc_get_required_size(dev, &cd->asrc_size,
-				     audio_stream_get_channels(&source_c->stream),
+				     audio_stream_get_channels(&sourceb->stream),
 				     sample_bits);
 	if (ret) {
 		comp_err(dev, "asrc_prepare(), get_required_size_bytes failed");
@@ -850,7 +834,7 @@ static int asrc_prepare(struct comp_dev *dev)
 		fs_sec = cd->source_rate;
 	}
 
-	ret = asrc_initialise(dev, cd->asrc_obj, audio_stream_get_channels(&source_c->stream),
+	ret = asrc_initialise(dev, cd->asrc_obj, audio_stream_get_channels(&sourceb->stream),
 			      fs_prim, fs_sec,
 			      ASRC_IOF_INTERLEAVED, ASRC_IOF_INTERLEAVED,
 			      ASRC_BM_LINEAR, cd->frames, sample_bits,
@@ -886,9 +870,6 @@ static int asrc_prepare(struct comp_dev *dev)
 		goto err_free_asrc;
 	}
 
-	buffer_release(sink_c);
-	buffer_release(source_c);
-
 	return 0;
 
 err_free_asrc:
@@ -901,8 +882,6 @@ err_free_buf:
 	cd->buf = NULL;
 
 err:
-	buffer_release(sink_c);
-	buffer_release(source_c);
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return ret;
 }
@@ -978,8 +957,8 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 	return 0;
 }
 
-static void asrc_process(struct comp_dev *dev, struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink)
+static void asrc_process(struct comp_dev *dev, struct comp_buffer *source,
+			 struct comp_buffer *sink)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int consumed = 0;
@@ -1005,7 +984,6 @@ static int asrc_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	int frames_src;
 	int frames_snk;
 	int ret;
@@ -1022,11 +1000,8 @@ static int asrc_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	source_c = buffer_acquire(source);
-	sink_c = buffer_acquire(sink);
-
-	frames_src = audio_stream_get_avail_frames(&source_c->stream);
-	frames_snk = audio_stream_get_free_frames(&sink_c->stream);
+	frames_src = audio_stream_get_avail_frames(&source->stream);
+	frames_snk = audio_stream_get_free_frames(&sink->stream);
 
 	if (cd->mode == ASRC_OM_PULL) {
 		/* Let ASRC access max number of source frames in pull mode.
@@ -1052,10 +1027,7 @@ static int asrc_copy(struct comp_dev *dev)
 	}
 
 	if (cd->source_frames && cd->sink_frames)
-		asrc_process(dev, source_c, sink_c);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+		asrc_process(dev, source, sink);
 
 	return 0;
 }

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -49,22 +49,17 @@ static int audio_stream_commit_buffer(struct sof_sink __sparse_cache *sink, size
 	return 0;
 }
 
-static size_t audio_stream_get_data_available(struct sof_source __sparse_cache *source)
+static size_t audio_stream_get_data_available(struct sof_source *source)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	return audio_stream_get_avail_bytes(audio_stream);
 }
 
-static int audio_stream_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 				 void  **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
-					  source_api, __sparse_cache);
-
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 	struct comp_buffer __sparse_cache *buffer_c =
 			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
@@ -81,7 +76,7 @@ static int audio_stream_get_data(struct sof_source __sparse_cache *source, size_
 	return 0;
 }
 
-static int audio_stream_release_data(struct sof_source __sparse_cache *source, size_t free_size)
+static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
 	struct audio_stream __sparse_cache *audio_stream =
 			attr_container_of(source, struct audio_stream __sparse_cache,
@@ -93,13 +88,11 @@ static int audio_stream_release_data(struct sof_source __sparse_cache *source, s
 	return 0;
 }
 
-static int audio_stream_set_ipc_params_source(struct sof_source __sparse_cache *source,
+static int audio_stream_set_ipc_params_source(struct sof_source *source,
 					      struct sof_ipc_stream_params *params,
 					      bool force_update)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 	struct comp_buffer __sparse_cache *buffer =
 			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
@@ -121,13 +114,11 @@ static int audio_stream_set_ipc_params_sink(struct sof_sink __sparse_cache *sink
 	return buffer_set_params(buffer, params, force_update);
 }
 
-static int audio_stream_source_set_alignment_constants(struct sof_source __sparse_cache *source,
+static int audio_stream_source_set_alignment_constants(struct sof_source *source,
 						       const uint32_t byte_align,
 						       const uint32_t frame_align_req)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
 

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -134,8 +134,7 @@ static const struct sink_ops audio_stream_sink_ops = {
 	.set_alignment_constants = audio_stream_sink_set_alignment_constants
 };
 
-void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
-		       void *buff_addr, uint32_t size)
+void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint32_t size)
 {
 	audio_stream->size = size;
 	audio_stream->addr = buff_addr;
@@ -148,10 +147,8 @@ void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
 	audio_stream_init_alignment_constants(1, 1, audio_stream);
 
 	source_init(audio_stream_get_source(audio_stream), &audio_stream_source_ops,
-		    (__sparse_force struct sof_audio_stream_params *)
 		    &audio_stream->runtime_stream_params);
 	sink_init(audio_stream_get_sink(audio_stream), &audio_stream_sink_ops,
-		  (__sparse_force struct sof_audio_stream_params *)
 		  &audio_stream->runtime_stream_params);
 	audio_stream_reset(audio_stream);
 }

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -31,12 +31,10 @@ static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
 	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
-	struct comp_buffer __sparse_cache *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
-					  stream, __sparse_cache);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (commit_size) {
-		buffer_stream_writeback(buffer_c, commit_size);
+		buffer_stream_writeback(buffer, commit_size);
 		audio_stream_produce(audio_stream, commit_size);
 	}
 
@@ -54,14 +52,12 @@ static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 				 void  **data_ptr, void **buffer_start, size_t *buffer_size)
 {
 	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
-	struct comp_buffer __sparse_cache *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
-					  stream, __sparse_cache);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (req_size > audio_stream_get_data_available(source))
 		return -ENODATA;
 
-	buffer_stream_invalidate(buffer_c, req_size);
+	buffer_stream_invalidate(buffer, req_size);
 
 	/* get circular buffer parameters */
 	*data_ptr = audio_stream->r_ptr;
@@ -85,9 +81,7 @@ static int audio_stream_set_ipc_params_source(struct sof_source *source,
 					      bool force_update)
 {
 	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
-	struct comp_buffer __sparse_cache *buffer =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
-					  stream, __sparse_cache);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
 }
@@ -97,9 +91,7 @@ static int audio_stream_set_ipc_params_sink(struct sof_sink *sink,
 					    bool force_update)
 {
 	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
-	struct comp_buffer __sparse_cache *buffer =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
-					  stream, __sparse_cache);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
 }

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -6,21 +6,17 @@
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/buffer.h>
 
-static size_t audio_stream_get_free_size(struct sof_sink __sparse_cache *sink)
+static size_t audio_stream_get_free_size(struct sof_sink *sink)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	return audio_stream_get_free_bytes(audio_stream);
 }
 
-static int audio_stream_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 				   void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	if (req_size > audio_stream_get_free_size(sink))
 		return -ENODATA;
@@ -32,11 +28,9 @@ static int audio_stream_get_buffer(struct sof_sink __sparse_cache *sink, size_t 
 	return 0;
 }
 
-static int audio_stream_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
+static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 	struct comp_buffer __sparse_cache *buffer_c =
 			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
@@ -78,9 +72,7 @@ static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 
 static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	if (free_size)
 		audio_stream_consume(audio_stream, free_size);
@@ -100,13 +92,11 @@ static int audio_stream_set_ipc_params_source(struct sof_source *source,
 	return buffer_set_params(buffer, params, force_update);
 }
 
-static int audio_stream_set_ipc_params_sink(struct sof_sink __sparse_cache *sink,
+static int audio_stream_set_ipc_params_sink(struct sof_sink *sink,
 					    struct sof_ipc_stream_params *params,
 					    bool force_update)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 	struct comp_buffer __sparse_cache *buffer =
 			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
 					  stream, __sparse_cache);
@@ -125,13 +115,11 @@ static int audio_stream_source_set_alignment_constants(struct sof_source *source
 	return 0;
 }
 
-static int audio_stream_sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 						     const uint32_t byte_align,
 						     const uint32_t frame_align_req)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
 

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -73,7 +73,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	return buffer;
 }
 
-void buffer_zero(struct comp_buffer __sparse_cache *buffer)
+void buffer_zero(struct comp_buffer *buffer)
 {
 	buf_dbg(buffer, "stream_zero()");
 
@@ -84,7 +84,7 @@ void buffer_zero(struct comp_buffer __sparse_cache *buffer)
 					audio_stream_get_size(&buffer->stream));
 }
 
-int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment)
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment)
 {
 	void *new_ptr = NULL;
 
@@ -120,7 +120,7 @@ int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, ui
 	return 0;
 }
 
-int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
+int buffer_set_params(struct comp_buffer *buffer,
 		      struct sof_ipc_stream_params *params, bool force_update)
 {
 	int ret;
@@ -149,7 +149,7 @@ int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
 	return 0;
 }
 
-bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
+bool buffer_params_match(struct comp_buffer *buffer,
 			 struct sof_ipc_stream_params *params, uint32_t flag)
 {
 	assert(params);
@@ -203,7 +203,7 @@ void buffer_free(struct comp_buffer *buffer)
  * choice but to use our knowledge of the local notifier behaviour and pass
  * locked buffers to notification recipients.
  */
-void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 {
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
@@ -242,7 +242,7 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 #endif
 }
 
-void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -27,7 +27,8 @@ DECLARE_SOF_RT_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 
-struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align)
+struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align,
+				 bool is_shared)
 {
 	struct comp_buffer *buffer;
 	struct comp_buffer __sparse_cache *buffer_c;
@@ -42,11 +43,11 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 		return NULL;
 	}
 
-	/*
-	 * allocate new buffer, align the allocation size to a cache line for
-	 * the coherent API
-	 */
-	buffer = coherent_init_thread(struct comp_buffer, c);
+	/* allocate new buffer	 */
+	enum mem_zone zone = is_shared ? SOF_MEM_ZONE_RUNTIME_SHARED : SOF_MEM_ZONE_RUNTIME;
+
+	buffer = rzalloc(zone, 0, SOF_MEM_CAPS_RAM, sizeof(*buffer));
+
 	if (!buffer) {
 		tr_err(&buffer_tr, "buffer_alloc(): could not alloc structure");
 		return NULL;
@@ -69,18 +70,6 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	audio_stream_set_overrun(&buffer_c->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
 
 	buffer_release(buffer_c);
-
-	/*
-	 * The buffer hasn't yet been marked as shared, hence buffer_release()
-	 * hasn't written back and invalidated the cache. Therefore we have to
-	 * do this manually now before adding to the lists. Buffer list
-	 * structures are always accessed uncached and they're never modified at
-	 * run-time, i.e. buffers are never relinked. So we have to make sure,
-	 * that what we have written into buffer's cache is in RAM before
-	 * modifying that RAM bypassing cache, and that after this cache is
-	 * re-loaded again.
-	 */
-	dcache_writeback_invalidate_region(uncache_to_cache(buffer), sizeof(*buffer));
 
 	list_init(&buffer->source_list);
 	list_init(&buffer->sink_list);
@@ -303,30 +292,7 @@ void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint3
 void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)
 {
 	struct list_item *list = buffer_comp_list(buffer, dir);
-	struct list_item __sparse_cache *needs_sync;
-	bool further_buffers_exist;
-
-	/*
-	 * There can already be buffers on the target list. If we just link this
-	 * buffer, we modify the first buffer's list header via uncached alias,
-	 * so its cached copy can later be written back, overwriting the
-	 * modified header. FIXME: this is still a problem with different cores.
-	 */
-	further_buffers_exist = !list_is_empty(head);
-	needs_sync = uncache_to_cache(head->next);
-	if (further_buffers_exist)
-		dcache_writeback_region(needs_sync, sizeof(struct list_item));
-	/* The cache line can be prefetched here, invalidate it after prepending */
 	list_item_prepend(list, head);
-	if (further_buffers_exist)
-		dcache_invalidate_region(needs_sync, sizeof(struct list_item));
-#if CONFIG_INTEL
-	/*
-	 * Until now the buffer object wasn't in cache, but uncached access to it could have
-	 * triggered a cache prefetch. Drop that cache line to avoid using stale data in it.
-	 */
-	dcache_invalidate_region(uncache_to_cache(list), sizeof(*list));
-#endif
 }
 
 /*
@@ -335,32 +301,6 @@ void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)
  */
 void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir)
 {
-	struct list_item __sparse_cache *needs_sync_prev, *needs_sync_next;
-	bool buffers_after_exist, buffers_before_exist;
 	struct list_item *buf_list = buffer_comp_list(buffer, dir);
-
-	/*
-	 * There can be more buffers linked together with this one, that will
-	 * still be staying on their respective pipelines and might get used via
-	 * their cached aliases. If we just unlink this buffer, we modify their
-	 * list header via uncached alias, so their cached copy can later be
-	 * written back, overwriting the modified header. FIXME: this is still a
-	 * problem with different cores.
-	 */
-	buffers_after_exist = head != buf_list->next;
-	buffers_before_exist = head != buf_list->prev;
-	needs_sync_prev = uncache_to_cache(buf_list->prev);
-	needs_sync_next = uncache_to_cache(buf_list->next);
-	if (buffers_after_exist)
-		dcache_writeback_region(needs_sync_next, sizeof(struct list_item));
-	if (buffers_before_exist)
-		dcache_writeback_region(needs_sync_prev, sizeof(struct list_item));
-	dcache_writeback_region(uncache_to_cache(buf_list), sizeof(*buf_list));
-	/* buffers before or after can be prefetched here */
 	list_item_del(buf_list);
-	dcache_invalidate_region(uncache_to_cache(buf_list), sizeof(*buf_list));
-	if (buffers_after_exist)
-		dcache_invalidate_region(needs_sync_next, sizeof(struct list_item));
-	if (buffers_before_exist)
-		dcache_invalidate_region(needs_sync_prev, sizeof(struct list_item));
 }

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -31,7 +31,6 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 				 bool is_shared)
 {
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
 	void *stream_addr;
 
 	tr_dbg(&buffer_tr, "buffer_alloc()");
@@ -62,14 +61,11 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	}
 
 	/* From here no more uncached access to the buffer object, except its list headers */
-	buffer_c = buffer_acquire(buffer);
-	audio_stream_set_addr(&buffer_c->stream, stream_addr);
-	buffer_init(buffer_c, size, caps);
+	audio_stream_set_addr(&buffer->stream, stream_addr);
+	buffer_init(buffer, size, caps);
 
-	audio_stream_set_underrun(&buffer_c->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
-	audio_stream_set_overrun(&buffer_c->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
-
-	buffer_release(buffer_c);
+	audio_stream_set_underrun(&buffer->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
+	audio_stream_set_overrun(&buffer->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
 
 	list_init(&buffer->source_list);
 	list_init(&buffer->sink_list);

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -238,11 +238,8 @@ static enum task_state chain_task_run(void *data)
 		 * mode task will update read position based on transferred data size to avoid
 		 * overwriting valid data and write position by half buffer size.
 		 */
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(cd->dma_buffer);
-		const size_t buff_size = audio_stream_get_size(&buffer_c->stream);
+		const size_t buff_size = audio_stream_get_size(&cd->dma_buffer->stream);
 		const size_t half_buff_size = buff_size / 2;
-
-		buffer_release(buffer_c);
 
 		if (!cd->first_data_received && host_avail_bytes > half_buff_size) {
 			ret = dma_reload(cd->chan_link->dma->z_dev,
@@ -510,7 +507,6 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 		    uint32_t fifo_size)
 {
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t addr_align;
 	size_t buff_size;
 	void *buff_addr;
@@ -598,11 +594,9 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	}
 
 	/* clear dma buffer */
-	buffer_c = buffer_acquire(cd->dma_buffer);
-	buffer_zero(buffer_c);
-	buff_addr = audio_stream_get_addr(&buffer_c->stream);
-	buff_size = audio_stream_get_size(&buffer_c->stream);
-	buffer_release(buffer_c);
+	buffer_zero(cd->dma_buffer);
+	buff_addr = audio_stream_get_addr(&cd->dma_buffer->stream);
+	buff_size = audio_stream_get_size(&cd->dma_buffer->stream);
 
 	ret = chain_init(dev, buff_addr, buff_size);
 	if (ret < 0) {

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -588,8 +588,8 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	}
 
 	fifo_size = ALIGN_UP_INTERNAL(fifo_size, addr_align);
-
-	cd->dma_buffer = buffer_alloc(fifo_size, SOF_MEM_CAPS_DMA, 0, addr_align);
+	/* allocate not shared buffer */
+	cd->dma_buffer = buffer_alloc(fifo_size, SOF_MEM_CAPS_DMA, 0, addr_align, false);
 
 	if (!cd->dma_buffer) {
 		comp_err(dev, "chain_task_init(): failed to alloc dma buffer");

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -158,8 +158,8 @@ void sys_comp_init(struct sof *sof)
 	k_spinlock_init(&sof->comp_drivers->lock);
 }
 
-void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
-			  struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits(struct comp_buffer *source,
+			  struct comp_buffer *sink,
 			  struct comp_copy_limits *cl)
 {
 	cl->frames = audio_stream_avail_frames(&source->stream, &sink->stream);
@@ -169,8 +169,8 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
 }
 
-void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache *source,
-					const struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
+					const struct comp_buffer *sink,
 					struct comp_copy_limits *cl)
 {
 	cl->frames = audio_stream_avail_frames_aligned(&source->stream, &sink->stream);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -182,8 +182,8 @@ void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache 
 
 #ifdef STREAMCOPY_HIFI3
 
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	ae_int16x4 *src = (ae_int16x4 *)((int8_t *)audio_stream_get_rptr(source) + ioffset * ssize);
@@ -227,8 +227,8 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 
 #else
 
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	uint8_t *src = audio_stream_wrap(source, (uint8_t *)audio_stream_get_rptr(source) +
@@ -279,7 +279,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
 }
 
 void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(sink); /* src fmt == sink fmt */
@@ -300,7 +300,7 @@ void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
 	}
 }
 
-void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *source, int ioffset,
+void audio_stream_copy_to_linear(const struct audio_stream *source, int ioffset,
 				 void *linear_sink, int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -178,7 +178,7 @@ static int copier_free(struct processing_module *mod)
 static int copier_params(struct processing_module *mod);
 
 static int copier_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
+			  struct sof_source **sources, int num_of_sources,
 			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct copier_data *cd = module_get_private_data(mod);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -179,7 +179,7 @@ static int copier_params(struct processing_module *mod);
 
 static int copier_prepare(struct processing_module *mod,
 			  struct sof_source **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct copier_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -391,8 +391,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 static int do_conversion_copy(struct comp_dev *dev,
 			      struct copier_data *cd,
-			      struct comp_buffer __sparse_cache *src,
-			      struct comp_buffer __sparse_cache *sink,
+			      struct comp_buffer *src,
+			      struct comp_buffer *sink,
 			      struct comp_copy_limits *processed_data)
 {
 	int i;
@@ -418,7 +418,7 @@ static int do_conversion_copy(struct comp_dev *dev,
 }
 
 static int copier_copy_to_sinks(struct copier_data *cd, struct comp_dev *dev,
-				struct comp_buffer __sparse_cache *src_c,
+				struct comp_buffer *src_c,
 				struct comp_copy_limits *processed_data)
 {
 	struct list_item *sink_list;
@@ -458,26 +458,23 @@ static int copier_module_copy(struct processing_module *mod,
 			      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *src_c;
+	struct comp_buffer *src_c;
 	struct comp_copy_limits processed_data;
 	int i;
 
 	if (!num_input_buffers || !num_output_buffers)
 		return 0;
 
-	src_c = attr_container_of(input_buffers[0].data, struct comp_buffer __sparse_cache,
-				  stream, __sparse_cache);
+	src_c = container_of(input_buffers[0].data, struct comp_buffer, stream);
 
 	processed_data.source_bytes = 0;
 
 	/* convert format and copy to each active sink */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *sink_c;
+		struct comp_buffer *sink_c;
 		struct comp_dev *sink_dev;
 
-		sink_c = attr_container_of(output_buffers[i].data,
-					   struct comp_buffer __sparse_cache,
-					   stream, __sparse_cache);
+		sink_c = container_of(output_buffers[i].data, struct comp_buffer, stream);
 		sink_dev = sink_c->sink;
 		processed_data.sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -395,7 +395,6 @@ static int copy_single_channel_c32(const struct audio_stream __sparse_cache *src
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index)
 {
-	struct comp_buffer __sparse_cache *buf_c;
 	struct sof_ipc_stream_params demuxed_params = *params;
 	const struct ipc4_audio_format *in_fmt = &cd->config.base.audio_fmt;
 	const struct ipc4_audio_format *out_fmt = &cd->config.out_fmt;
@@ -438,15 +437,11 @@ int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 	if (ret < 0)
 		return ret;
 
-	buf_c = buffer_acquire(cd->dd[dai_index]->dma_buffer);
 	for (j = 0; j < SOF_IPC_MAX_CHANNELS; j++)
-		buf_c->chmap[j] = (cd->chan_map[dai_index] >> j * 4) & 0xf;
-	buffer_release(buf_c);
+		cd->dd[dai_index]->dma_buffer->chmap[j] = (cd->chan_map[dai_index] >> j * 4) & 0xf;
 
 	/* set channel copy func */
-	buf_c = buffer_acquire(cd->multi_endpoint_buffer);
-	container_size = audio_stream_sample_bytes(&buf_c->stream);
-	buffer_release(buf_c);
+	container_size = audio_stream_sample_bytes(&cd->multi_endpoint_buffer->stream);
 
 	switch (container_size) {
 	case 2:

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -310,9 +310,9 @@ int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd)
 	return 0;
 }
 
-static int copy_single_channel_c16(const struct audio_stream __sparse_cache *src,
+static int copy_single_channel_c16(const struct audio_stream *src,
 				   unsigned int src_channel,
-				   struct audio_stream __sparse_cache *dst,
+				   struct audio_stream *dst,
 				   unsigned int dst_channel, unsigned int frame_count)
 {
 	int16_t *r_ptr = (int16_t *)audio_stream_get_rptr(src) + src_channel;
@@ -351,9 +351,9 @@ static int copy_single_channel_c16(const struct audio_stream __sparse_cache *src
 	return 0;
 }
 
-static int copy_single_channel_c32(const struct audio_stream __sparse_cache *src,
+static int copy_single_channel_c32(const struct audio_stream *src,
 				   unsigned int src_channel,
-				   struct audio_stream __sparse_cache *dst,
+				   struct audio_stream *dst,
 				   unsigned int dst_channel, unsigned int frame_count)
 {
 	int32_t *r_ptr = (int32_t *)audio_stream_get_rptr(src) + src_channel;

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -204,8 +204,8 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	ipc_buf.size = buf_size;
 	ipc_buf.comp.pipeline_id = config->pipeline_id;
 	ipc_buf.comp.core = config->core;
-
-	buffer = buffer_new(&ipc_buf);
+	/* allocate not shared buffer */
+	buffer = buffer_new(&ipc_buf, false);
 	if (!buffer)
 		return -ENOMEM;
 

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(copier, CONFIG_SOF_LOG_LEVEL);
 #include <stdint.h>
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
-		      struct comp_buffer __sparse_cache *sink, int frame)
+		      struct comp_buffer *sink, int frame)
 {
 	int i;
 	int n;

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -93,7 +93,6 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 	const struct ipc4_ipc_gateway_cmd_data *in;
 	struct comp_dev *dev;
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
 	uint32_t data_size;
 	struct ipc4_ipc_gateway_cmd_data_reply *out;
 
@@ -110,15 +109,12 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	buf = get_buffer(dev);
 
-	if (buf) {
-		buf_c = buffer_acquire(buf);
-	} else {
+	if (!buf) {
 		/* NOTE: this func is called from IPC processing task and can be potentially
 		 * called before pipeline start even before buffer has been attached. In such
 		 * case do not report error but return 0 bytes available for GET_DATA and
 		 * 0 bytes free for SET_DATA.
 		 */
-		buf_c = NULL;
 		comp_warn(dev, "copier_ipcgtw_process(): no buffer found");
 	}
 
@@ -126,13 +122,13 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	switch (cmd->primary.r.cmd) {
 	case IPC4_IPCGWCMD_GET_DATA:
-		if (buf_c) {
+		if (buf) {
 			data_size = MIN(cmd->extension.r.data_size, SOF_IPC_MSG_MAX_SIZE - 4);
-			data_size = MIN(data_size, audio_stream_get_avail_bytes(&buf_c->stream));
-			buffer_stream_invalidate(buf_c, data_size);
-			audio_stream_copy_bytes_to_linear(&buf_c->stream, out->payload, data_size);
-			comp_update_buffer_consume(buf_c, data_size);
-			out->u.size_avail = audio_stream_get_avail_bytes(&buf_c->stream);
+			data_size = MIN(data_size, audio_stream_get_avail_bytes(&buf->stream));
+			buffer_stream_invalidate(buf, data_size);
+			audio_stream_copy_bytes_to_linear(&buf->stream, out->payload, data_size);
+			comp_update_buffer_consume(buf, data_size);
+			out->u.size_avail = audio_stream_get_avail_bytes(&buf->stream);
 			*reply_payload_size = data_size + 4;
 		} else {
 			out->u.size_avail = 0;
@@ -141,18 +137,18 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 		break;
 
 	case IPC4_IPCGWCMD_SET_DATA:
-		if (buf_c) {
+		if (buf) {
 			data_size = MIN(cmd->extension.r.data_size,
-					audio_stream_get_free_bytes(&buf_c->stream));
+					audio_stream_get_free_bytes(&buf->stream));
 			dcache_invalidate_region((__sparse_force void __sparse_cache *)
 						 MAILBOX_HOSTBOX_BASE,
 						 data_size +
 						 offsetof(struct ipc4_ipc_gateway_cmd_data,
 							  payload));
-			audio_stream_copy_bytes_from_linear(in->payload, &buf_c->stream,
+			audio_stream_copy_bytes_from_linear(in->payload, &buf->stream,
 							    data_size);
-			buffer_stream_writeback(buf_c, data_size);
-			comp_update_buffer_produce(buf_c, data_size);
+			buffer_stream_writeback(buf, data_size);
+			comp_update_buffer_produce(buf, data_size);
 			out->u.size_consumed = data_size;
 			*reply_payload_size = 4;
 		} else {
@@ -163,20 +159,16 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	case IPC4_IPCGWCMD_FLUSH_DATA:
 		*reply_payload_size = 0;
-		if (buf_c)
-			audio_stream_reset(&buf_c->stream);
+		if (buf)
+			audio_stream_reset(&buf->stream);
 		break;
 
 	default:
 		comp_err(dev, "copier_ipcgtw_process(): unexpected cmd: %u",
 			 (unsigned int)cmd->primary.r.cmd);
-		if (buf_c)
-			buffer_release(buf_c);
 		return -EINVAL;
 	}
 
-	if (buf_c)
-		buffer_release(buf_c);
 	return 0;
 }
 
@@ -184,7 +176,6 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 			 struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
 	int err;
 
 	comp_dbg(dev, "ipcgtw_params()");
@@ -196,9 +187,7 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 	}
 
 	/* resize buffer to size specified in IPC gateway config blob */
-	buf_c = buffer_acquire(buf);
-	err = buffer_set_size(buf_c, ipcgtw_data->buf_size, 0);
-	buffer_release(buf_c);
+	err = buffer_set_size(buf, ipcgtw_data->buf_size, 0);
 
 	if (err < 0) {
 		comp_err(dev, "ipcgtw_params(): failed to resize buffer to %u bytes",
@@ -214,10 +203,7 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	struct comp_buffer *buf = get_buffer(dev);
 
 	if (buf) {
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(buf);
-
-		audio_stream_reset(&buf_c->stream);
-		buffer_release(buf_c);
+		audio_stream_reset(&buf->stream);
 	} else {
 		comp_warn(dev, "ipcgtw_reset(): no buffer found");
 	}

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -37,7 +37,7 @@ static struct comp_dev *find_ipcgtw_by_node_id(union ipc4_connector_node_id node
 }
 
 static inline void audio_stream_copy_bytes_from_linear(const void *linear_source,
-						       struct audio_stream __sparse_cache *sink,
+						       struct audio_stream *sink,
 						       unsigned int bytes)
 {
 	const uint8_t *src = (const uint8_t *)linear_source;
@@ -55,7 +55,7 @@ static inline void audio_stream_copy_bytes_from_linear(const void *linear_source
 }
 
 static inline
-void audio_stream_copy_bytes_to_linear(const struct audio_stream __sparse_cache *source,
+void audio_stream_copy_bytes_to_linear(const struct audio_stream *source,
 				       void *linear_sink, unsigned int bytes)
 {
 	uint8_t *src = audio_stream_wrap(source, audio_stream_get_rptr(source));

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -617,7 +617,7 @@ static int crossover_process_audio_stream(struct processing_module *mod,
 	bool enabled_buffers[PLATFORM_MAX_STREAMS] = { false };
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
 	uint32_t num_sinks;
 	uint32_t num_assigned_sinks = 0;
 	/* The frames count to process from module adapter applies for source buffer and

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -711,7 +711,7 @@ static void crossover_params(struct processing_module *mod)
  */
 static int crossover_prepare(struct processing_module *mod,
 			     struct sof_source **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -710,7 +710,7 @@ static void crossover_params(struct processing_module *mod)
  * \return Error code.
  */
 static int crossover_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
+			     struct sof_source **sources, int num_of_sources,
 			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd =  module_get_private_data(mod);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -133,7 +133,6 @@ static int crossover_assign_sinks(struct processing_module *mod,
 	struct sof_crossover_config *config = cd->config;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct list_item *sink_list;
 	int num_sinks = 0;
 	int i;
@@ -143,14 +142,12 @@ static int crossover_assign_sinks(struct processing_module *mod,
 		unsigned int sink_id, state;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 #if CONFIG_IPC_MAJOR_4
 		sink_id = cd->output_pin_index[j];
 #else
-		sink_id = sink_c->pipeline_id;
+		sink_id = sink->pipeline_id;
 #endif
-		state = sink_c->sink->state;
-		buffer_release(sink_c);
+		state = sink->sink->state;
 		if (state != dev->state) {
 			j++;
 			continue;
@@ -486,7 +483,6 @@ static int crossover_check_sink_assign(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct list_item *sink_list;
 	int num_assigned_sinks = 0;
 	uint8_t assigned_sinks[SOF_CROSSOVER_MAX_STREAMS] = {0};
@@ -496,9 +492,7 @@ static int crossover_check_sink_assign(struct processing_module *mod,
 		unsigned int pipeline_id;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		pipeline_id = sink_c->pipeline_id;
-		buffer_release(sink_c);
+		pipeline_id = sink->pipeline_id;
 
 		i = crossover_get_stream_index(mod, config, pipeline_id);
 		if (i < 0) {
@@ -691,7 +685,6 @@ static int crossover_process_audio_stream(struct processing_module *mod,
 static void crossover_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct list_item *sink_list;
 	struct comp_dev *dev = mod->dev;
@@ -702,15 +695,11 @@ static void crossover_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	list_for_item(sink_list, &dev->bsink_list) {
 		sinkb = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sinkb);
-		ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-		buffer_release(sink_c);
+		ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 	}
 }
 #endif
@@ -727,7 +716,6 @@ static int crossover_prepare(struct processing_module *mod,
 	struct comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct list_item *sink_list;
 	int channels;
 	int ret = 0;
@@ -741,27 +729,23 @@ static int crossover_prepare(struct processing_module *mod,
 	/* Crossover has a variable number of sinks */
 	mod->max_sinks = SOF_CROSSOVER_MAX_STREAMS;
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(source);
 
 	/* Get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	channels = audio_stream_get_channels(&source_c->stream);
-	audio_stream_init_alignment_constants(1, 1, &source_c->stream);
-	buffer_release(source_c);
+	cd->source_format = audio_stream_get_frm_fmt(&source->stream);
+	channels = audio_stream_get_channels(&source->stream);
+	audio_stream_init_alignment_constants(1, 1, &source->stream);
 
 	/* Validate frame format and buffer size of sinks */
 	list_for_item(sink_list, &dev->bsink_list) {
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		if (cd->source_format == audio_stream_get_frm_fmt(&sink_c->stream)) {
-			audio_stream_init_alignment_constants(1, 1, &sink_c->stream);
+		if (cd->source_format == audio_stream_get_frm_fmt(&sink->stream)) {
+			audio_stream_init_alignment_constants(1, 1, &sink->stream);
 		} else {
 			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different.",
-				 cd->source_format, audio_stream_get_frm_fmt(&sink_c->stream));
+				 cd->source_format, audio_stream_get_frm_fmt(&sink->stream));
 			ret = -EINVAL;
 		}
 
-		buffer_release(sink_c);
 		if (ret < 0)
 			return ret;
 	}

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -93,8 +93,8 @@ static void crossover_s16_default_pass(struct comp_data *cd,
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *sink_stream;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
+	const struct audio_stream *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
 	int16_t *x;
 	int32_t *y;
 	int i, j;
@@ -121,8 +121,8 @@ static void crossover_s32_default_pass(struct comp_data *cd,
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *sink_stream;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
+	const struct audio_stream *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
 	int32_t *x, *y;
 	int i, j;
 	int n = audio_stream_get_channels(source_stream) * frames;
@@ -149,8 +149,8 @@ static void crossover_s16_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int16_t *x, *y;
 	int ch, i, j;
 	int idx;
@@ -187,8 +187,8 @@ static void crossover_s24_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;
@@ -225,8 +225,8 @@ static void crossover_s32_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -113,26 +113,21 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		next->status = DMA_CB_STATUS_END;
 	}
 
-	dma_buf = buffer_acquire(dd->dma_buffer);
-
 	/* is our pipeline handling an XRUN ? */
 	if (dd->xrun) {
 		/* make sure we only playback silence during an XRUN */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			/* fill buffer with silence */
-			buffer_zero(dma_buf);
-		buffer_release(dma_buf);
+			buffer_zero(dd->dma_buffer);
 
 		return;
 	}
 
-	local_buf = buffer_acquire(dd->local_buffer);
-
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		ret = dma_buffer_copy_to(local_buf, dma_buf,
+		ret = dma_buffer_copy_to(dd->local_buffer, dma_buf,
 					 dd->process, bytes);
 	} else {
-		ret = dma_buffer_copy_from(dma_buf, local_buf,
+		ret = dma_buffer_copy_from(dma_buf, dd->local_buffer,
 					   dd->process, bytes);
 	}
 
@@ -141,9 +136,9 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		struct comp_buffer __sparse_cache *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					local_buf : dma_buf;
+					dd->local_buffer : dma_buf;
 		sink_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					dma_buf : local_buf;
+					dma_buf : dd->local_buffer;
 		comp_err(dev, "dai_dma_cb() dma buffer copy failed, dir %d bytes %d avail %d free %d",
 			 dev->direction, bytes,
 			 audio_stream_get_avail_samples(&source_c->stream) *
@@ -154,9 +149,6 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		/* update host position (in bytes offset) for drivers */
 		dd->total_data_processed += bytes;
 	}
-
-	buffer_release(local_buf);
-	buffer_release(dma_buf);
 }
 
 int dai_common_new(struct dai_data *dd, struct comp_dev *dev, const struct ipc_config_dai *dai)
@@ -357,23 +349,18 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo;
 	int err = 0;
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
 
-	buffer_release(local_buf);
-
 	if (!dd->process) {
 		comp_err(dev, "dai_playback_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
-		err = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* set up DMA configuration */
@@ -401,15 +388,12 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
+				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
-
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -419,23 +403,18 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo;
 	int err = 0;
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(dma_fmt, local_fmt);
 
-	buffer_release(local_buf);
-
 	if (!dd->process) {
 		comp_err(dev, "dai_capture_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
-		err = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* set up DMA configuration */
@@ -474,15 +453,12 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
+				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
-
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -565,13 +541,9 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	buffer_c = buffer_acquire(dd->local_buffer);
-
 	/* calculate frame size */
 	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     audio_stream_get_channels(&buffer_c->stream));
-
-	buffer_release(buffer_c);
+				     audio_stream_get_channels(&dd->local_buffer->stream));
 
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
@@ -589,9 +561,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		err = buffer_set_size(buffer_c, buffer_size, addr_align);
-		buffer_release(buffer_c);
+		err = buffer_set_size(dd->dma_buffer, buffer_size, addr_align);
 
 		if (err < 0) {
 			comp_err(dev, "dai_params(): buffer_set_size() failed, buffer_size = %u",
@@ -613,10 +583,8 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		 * frame_fmt's (using pcm converter).
 		 */
 		hw_params.frame_fmt = dev->ipc_config.frame_fmt;
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		buffer_set_params(buffer_c, &hw_params,
+		buffer_set_params(dd->dma_buffer, &hw_params,
 				  BUFFER_UPDATE_FORCE);
-		buffer_release(buffer_c);
 	}
 
 	return dev->direction == SOF_IPC_STREAM_PLAYBACK ?
@@ -703,9 +671,7 @@ int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	/* clear dma buffer to avoid pop noise */
-	buffer_c = buffer_acquire(dd->dma_buffer);
-	buffer_zero(buffer_c);
-	buffer_release(buffer_c);
+	buffer_zero(dd->dma_buffer);
 
 	/* dma reconfig not required if XRUN handling */
 	if (dd->xrun) {
@@ -815,11 +781,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		 * this is only supported at capture mode.
 		 */
 		if (dev->direction == SOF_IPC_STREAM_CAPTURE) {
-			struct comp_buffer __sparse_cache *buffer_c =
-				buffer_acquire(dd->dma_buffer);
-
-			buffer_zero(buffer_c);
-			buffer_release(buffer_c);
+			buffer_zero(dd->dma_buffer);
 		}
 
 		/* only start the DAI if we are not XRUN handling */
@@ -947,17 +909,14 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
-		comp_underrun(dev, buf_c, bytes);
+		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
 		comp_err(dev, "dai_report_xrun(): overrun due to no space available");
-		comp_overrun(dev, buf_c, bytes);
+		comp_overrun(dev, dd->local_buffer, bytes);
 	}
-
-	buffer_release(buf_c);
 }
 
 /* copy and process stream data from source to sink buffers */
@@ -981,23 +940,17 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		return ret;
 	}
 
-	buf_c = buffer_acquire(dd->dma_buffer);
-
-	dma_fmt = audio_stream_get_frm_fmt(&buf_c->stream);
+	dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	sampling = get_sample_bytes(dma_fmt);
-
-	buffer_release(buf_c);
-
-	buf_c = buffer_acquire(dd->local_buffer);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		src_samples = audio_stream_get_avail_samples(&buf_c->stream);
+		src_samples = audio_stream_get_avail_samples(&dd->local_buffer->stream);
 		sink_samples = free_bytes / sampling;
 		samples = MIN(src_samples, sink_samples);
 	} else {
 		src_samples = avail_bytes / sampling;
-		sink_samples = audio_stream_get_free_samples(&buf_c->stream);
+		sink_samples = audio_stream_get_free_samples(&dd->local_buffer->stream);
 		samples = MIN(src_samples, sink_samples);
 	}
 
@@ -1010,9 +963,7 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 
 	comp_dbg(dev, "dai_common_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
 		 dev->direction, copy_bytes,
-		 samples / audio_stream_get_channels(&buf_c->stream));
-
-	buffer_release(buf_c);
+		 samples / audio_stream_get_channels(&dd->local_buffer->stream));
 
 	/* Check possibility of glitch occurrence */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -977,8 +977,9 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 			return err;
 		}
 	} else {
+		/* allocate not shared buffer */
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
-					      addr_align);
+					      addr_align, false);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "dai_common_params(): failed to alloc dma buffer");
 			return -ENOMEM;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -311,7 +311,7 @@ err:
 
 	/* assert dma_buffer_copy succeed */
 	if (ret < 0) {
-		struct comp_buffer __sparse_cache *source_c, *sink_c;
+		struct comp_buffer *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
 					dd->local_buffer : dd->dma_buffer;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1447,7 +1447,6 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_func *converter)
 {
 	uint32_t sampling = dd->sampling;
-	uint32_t dma_fmt;
 	struct dma_status stat;
 	uint32_t avail_bytes;
 	uint32_t free_bytes;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -226,7 +226,6 @@ static enum dma_cb_status
 dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 	   pcm_converter_func *converter)
 {
-	struct comp_buffer __sparse_cache *local_buf, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	int ret;
 
@@ -241,33 +240,29 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 		dma_status = DMA_CB_STATUS_END;
 	}
 
-	dma_buf = buffer_acquire(dd->dma_buffer);
-
 	/* is our pipeline handling an XRUN ? */
 	if (dd->xrun) {
 		/* make sure we only playback silence during an XRUN */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			/* fill buffer with silence */
-			buffer_zero(dma_buf);
-		buffer_release(dma_buf);
+			buffer_zero(dd->dma_buffer);
 
 		return dma_status;
 	}
 
-	local_buf = buffer_acquire(dd->local_buffer);
-
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		ret = dma_buffer_copy_to(local_buf, dma_buf,
+		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
 					 dd->process, bytes);
 	} else {
 		struct list_item *sink_list;
 
-		audio_stream_invalidate(&dma_buf->stream, bytes);
+		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 		/*
 		 * The PCM converter functions used during DMA buffer copy can never fail,
 		 * so no need to check the return value of dma_buffer_copy_from_no_consume().
 		 */
-		ret = dma_buffer_copy_from_no_consume(dma_buf, local_buf, dd->process, bytes);
+		ret = dma_buffer_copy_from_no_consume(dd->dma_buffer, dd->local_buffer,
+						      dd->process, bytes);
 #if CONFIG_IPC_MAJOR_4
 		/* Skip in case of endpoint DAI devices created by the copier */
 		if (converter) {
@@ -276,7 +271,6 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 			 * function
 			 */
 			list_for_item(sink_list, &dev->bsink_list) {
-				struct comp_buffer __sparse_cache *sink_c;
 				struct comp_dev *sink_dev;
 				struct comp_buffer *sink;
 				int j;
@@ -287,10 +281,9 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				if (sink == dd->local_buffer)
 					continue;
 
-				sink_c = buffer_acquire(sink);
-				sink_dev = sink_c->sink;
+				sink_dev = sink->sink;
 
-				j = IPC4_SINK_QUEUE_ID(sink_c->id);
+				j = IPC4_SINK_QUEUE_ID(sink->id);
 
 				if (j >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT) {
 					comp_err(dev, "Sink queue ID: %d >= max output pin count: %d\n",
@@ -306,14 +299,14 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				}
 
 				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE)
-					ret = dma_buffer_copy_from_no_consume(dma_buf, sink_c,
-									      converter[j], bytes);
-err:
-				buffer_release(sink_c);
+					ret = dma_buffer_copy_from_no_consume(dd->dma_buffer,
+									      sink, converter[j],
+									      bytes);
 			}
 		}
+err:
 #endif
-		audio_stream_consume(&dma_buf->stream, bytes);
+		audio_stream_consume(&dd->dma_buffer->stream, bytes);
 	}
 
 	/* assert dma_buffer_copy succeed */
@@ -321,9 +314,9 @@ err:
 		struct comp_buffer __sparse_cache *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					local_buf : dma_buf;
+					dd->local_buffer : dd->dma_buffer;
 		sink_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					dma_buf : local_buf;
+					dd->dma_buffer : dd->local_buffer;
 		comp_err(dev, "dai_dma_cb() dma buffer copy failed, dir %d bytes %d avail %d free %d",
 			 dev->direction, bytes,
 			 audio_stream_get_avail_samples(&source_c->stream) *
@@ -335,9 +328,6 @@ err:
 		dd->total_data_processed += bytes;
 	}
 
-	buffer_release(local_buf);
-	buffer_release(dma_buf);
-
 	return dma_status;
 }
 
@@ -346,7 +336,6 @@ static enum dma_cb_status
 dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t frames,
 			  struct comp_buffer *multi_endpoint_buffer)
 {
-	struct comp_buffer __sparse_cache *multi_buf_c, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	uint32_t i, bytes;
 
@@ -361,48 +350,41 @@ dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t fr
 		dma_status = DMA_CB_STATUS_END;
 	}
 
-	dma_buf = buffer_acquire(dd->dma_buffer);
-
 	/* is our pipeline handling an XRUN ? */
 	if (dd->xrun) {
 		/* make sure we only playback silence during an XRUN */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			/* fill buffer with silence */
-			buffer_zero(dma_buf);
-		buffer_release(dma_buf);
+			buffer_zero(dd->dma_buffer);
 
 		return dma_status;
 	}
 
-	multi_buf_c = buffer_acquire(multi_endpoint_buffer);
-
-	bytes = frames * audio_stream_frame_bytes(&dma_buf->stream);
+	bytes = frames * audio_stream_frame_bytes(&dd->dma_buffer->stream);
 	if (dev->direction == SOF_IPC_STREAM_CAPTURE)
-		audio_stream_invalidate(&dma_buf->stream, bytes);
+		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 
 	/* copy all channels one by one */
-	for (i = 0; i < audio_stream_get_channels(&dma_buf->stream); i++) {
-		uint32_t multi_buf_channel = dma_buf->chmap[i];
+	for (i = 0; i < audio_stream_get_channels(&dd->dma_buffer->stream); i++) {
+		uint32_t multi_buf_channel = dd->dma_buffer->chmap[i];
 
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-			dd->process(&multi_buf_c->stream, multi_buf_channel,
-				    &dma_buf->stream, i, frames);
+			dd->process(&multi_endpoint_buffer->stream, multi_buf_channel,
+				    &dd->dma_buffer->stream, i, frames);
 		else
-			dd->process(&dma_buf->stream, i, &multi_buf_c->stream,
+			dd->process(&dd->dma_buffer->stream, i, &multi_endpoint_buffer->stream,
 				    multi_buf_channel, frames);
 	}
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		audio_stream_writeback(&dma_buf->stream, bytes);
-		audio_stream_produce(&dma_buf->stream, bytes);
+		audio_stream_writeback(&dd->dma_buffer->stream, bytes);
+		audio_stream_produce(&dd->dma_buffer->stream, bytes);
 	} else {
-		audio_stream_consume(&dma_buf->stream, bytes);
+		audio_stream_consume(&dd->dma_buffer->stream, bytes);
 	}
 
 	/* update host position (in bytes offset) for drivers */
 	dd->total_data_processed += bytes;
-	buffer_release(multi_buf_c);
-	buffer_release(dma_buf);
 
 	return dma_status;
 }
@@ -592,14 +574,10 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
 	struct dma_block_config *prev = NULL;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo, max_block_count, buf_size;
 	int i, err = 0;
-
-	buffer_release(local_buf);
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
@@ -608,7 +586,7 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 		comp_err(dev, "dai_playback_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
 		err = -EINVAL;
-		goto out;
+		return err;
 	}
 
 	/* set up DMA configuration */
@@ -635,12 +613,12 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 					&max_block_count);
 		if (err < 0) {
 			comp_err(dev, "dai_playback_params(): could not get dma attr max block count, err = %d", err);
-			goto out;
+			return err;
 		}
 
 		if (!max_block_count) {
 			comp_err(dev, "dai_playback_params(): invalid max-block-count of zero");
-			goto out;
+			return err;
 		}
 
 		if (max_block_count < period_count) {
@@ -661,12 +639,12 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)audio_stream_get_addr(&dma_buf->stream),
+				   (uintptr_t)audio_stream_get_addr(&dd->dma_buffer->stream),
 				   fifo);
 		if (err < 0) {
 			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
-			goto out;
+			return err;
 		}
 	}
 
@@ -721,8 +699,6 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 free:
 	if (err < 0)
 		dma_sg_free(&config->elem_array);
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -734,14 +710,10 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
 	struct dma_block_config *prev = NULL;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo, max_block_count, buf_size;
 	int i, err = 0;
-
-	buffer_release(local_buf);
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(dma_fmt, local_fmt);
@@ -750,7 +722,7 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 		comp_err(dev, "dai_capture_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
 		err = -EINVAL;
-		goto out;
+		return err;
 	}
 
 	/* set up DMA configuration */
@@ -789,12 +761,12 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 					&max_block_count);
 		if (err < 0) {
 			comp_err(dev, "dai_capture_params(): could not get dma attr max block count, err = %d", err);
-			goto out;
+			return err;
 		}
 
 		if (!max_block_count) {
 			comp_err(dev, "dai_capture_params(): invalid max-block-count of zero");
-			goto out;
+			return err;
 		}
 
 		if (max_block_count < period_count) {
@@ -815,12 +787,12 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)audio_stream_get_addr(&dma_buf->stream),
+				   (uintptr_t)audio_stream_get_addr(&dd->dma_buffer->stream),
 				   fifo);
 		if (err < 0) {
 			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
-			goto out;
+			return err;
 		}
 	}
 
@@ -875,8 +847,6 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 free:
 	if (err < 0)
 		dma_sg_free(&config->elem_array);
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -885,7 +855,6 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
 	uint32_t period_bytes;
@@ -967,9 +936,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		err = buffer_set_size(buffer_c, buffer_size, addr_align);
-		buffer_release(buffer_c);
+		err = buffer_set_size(dd->dma_buffer, buffer_size, addr_align);
 
 		if (err < 0) {
 			comp_err(dev, "dai_common_params(): buffer_set_size() failed, buffer_size = %u",
@@ -992,11 +959,10 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		 * frame_fmt's (using pcm converter).
 		 */
 		hw_params.frame_fmt = dev->ipc_config.frame_fmt;
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		buffer_set_params(buffer_c, &hw_params,
+		buffer_set_params(dd->dma_buffer, &hw_params,
 				  BUFFER_UPDATE_FORCE);
+
 		dd->sampling = get_sample_bytes(hw_params.frame_fmt);
-		buffer_release(buffer_c);
 	}
 
 	dd->fast_mode = dd->ipc_config.feature_mask & BIT(IPC4_COPIER_FAST_MODE);
@@ -1064,7 +1030,6 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 
 int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
 	int ret;
 
 	dd->total_data_processed = 0;
@@ -1082,9 +1047,7 @@ int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	/* clear dma buffer to avoid pop noise */
-	buffer_c = buffer_acquire(dd->dma_buffer);
-	buffer_zero(buffer_c);
-	buffer_release(buffer_c);
+	buffer_zero(dd->dma_buffer);
 
 	/* dma reconfig not required if XRUN handling */
 	if (dd->xrun) {
@@ -1193,11 +1156,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		 * this is only supported at capture mode.
 		 */
 		if (dev->direction == SOF_IPC_STREAM_CAPTURE) {
-			struct comp_buffer __sparse_cache *buffer_c =
-				buffer_acquire(dd->dma_buffer);
-
-			buffer_zero(buffer_c);
-			buffer_release(buffer_c);
+			buffer_zero(dd->dma_buffer);
 		}
 
 		/* only start the DAI if we are not XRUN handling */
@@ -1339,17 +1298,13 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 /* report xrun occurrence */
 static void dai_report_xrun(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
-
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
-		comp_underrun(dev, buf_c, bytes);
+		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
 		comp_err(dev, "dai_report_xrun(): overrun due to no space available");
-		comp_overrun(dev, buf_c, bytes);
+		comp_overrun(dev, dd->local_buffer, bytes);
 	}
-
-	buffer_release(buf_c);
 }
 
 /* process and copy stream data from multiple DMA source buffers to sink buffer */
@@ -1357,7 +1312,6 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 				   struct comp_buffer *multi_endpoint_buffer,
 				   int num_endpoints)
 {
-	struct comp_buffer __sparse_cache *buf_c;
 	uint32_t avail_bytes = UINT32_MAX;
 	uint32_t free_bytes = UINT32_MAX;
 	uint32_t frames;
@@ -1369,9 +1323,7 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 	if (!num_endpoints || !dd || !multi_endpoint_buffer)
 		return 0;
 
-	buf_c = buffer_acquire(dd[0]->dma_buffer);
-	frame_bytes = audio_stream_frame_bytes(&buf_c->stream);
-	buffer_release(buf_c);
+	frame_bytes = audio_stream_frame_bytes(&dd[0]->dma_buffer->stream);
 
 	direction = dev->direction;
 
@@ -1401,16 +1353,14 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 		free_bytes = MIN(free_bytes, stat.free);
 	}
 
-	buf_c = buffer_acquire(multi_endpoint_buffer);
 	/* calculate minimum size to copy */
 	if (direction == SOF_IPC_STREAM_PLAYBACK) {
-		src_frames = audio_stream_get_avail_frames(&buf_c->stream);
+		src_frames = audio_stream_get_avail_frames(&multi_endpoint_buffer->stream);
 		sink_frames = free_bytes / frame_bytes;
 	} else {
 		src_frames = avail_bytes / frame_bytes;
-		sink_frames = audio_stream_get_free_frames(&buf_c->stream);
+		sink_frames = audio_stream_get_free_frames(&multi_endpoint_buffer->stream);
 	}
-	buffer_release(buf_c);
 
 	frames = MIN(src_frames, sink_frames);
 
@@ -1430,10 +1380,8 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 	}
 
 	if (direction == SOF_IPC_STREAM_PLAYBACK) {
-		buf_c = buffer_acquire(multi_endpoint_buffer);
-		frame_bytes = audio_stream_frame_bytes(&buf_c->stream);
-		buffer_stream_invalidate(buf_c, frames * frame_bytes);
-		buffer_release(buf_c);
+		frame_bytes = audio_stream_frame_bytes(&multi_endpoint_buffer->stream);
+		buffer_stream_invalidate(multi_endpoint_buffer, frames * frame_bytes);
 	}
 
 	for (i = 0; i < num_endpoints; i++) {
@@ -1449,9 +1397,7 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 		if (status == DMA_CB_STATUS_END)
 			dma_stop(dd[i]->chan->dma->z_dev, dd[i]->chan->index);
 
-		buf_c = buffer_acquire(dd[i]->dma_buffer);
-		copy_bytes = frames * audio_stream_frame_bytes(&buf_c->stream);
-		buffer_release(buf_c);
+		copy_bytes = frames * audio_stream_frame_bytes(&dd[i]->dma_buffer->stream);
 		ret = dma_reload(dd[i]->chan->dma->z_dev, dd[i]->chan->index, 0, 0, copy_bytes);
 		if (ret < 0) {
 			dai_report_xrun(dd[i], dev, copy_bytes);
@@ -1461,27 +1407,21 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 		dai_dma_position_update(dd[i], dev);
 	}
 
-	buf_c = buffer_acquire(multi_endpoint_buffer);
-	frame_bytes = audio_stream_frame_bytes(&buf_c->stream);
+	frame_bytes = audio_stream_frame_bytes(&multi_endpoint_buffer->stream);
 	if (direction == SOF_IPC_STREAM_PLAYBACK) {
-		comp_update_buffer_consume(buf_c, frames * frame_bytes);
+		comp_update_buffer_consume(multi_endpoint_buffer, frames * frame_bytes);
 	} else {
-		buffer_stream_writeback(buf_c, frames * frame_bytes);
-		comp_update_buffer_produce(buf_c, frames * frame_bytes);
+		buffer_stream_writeback(multi_endpoint_buffer, frames * frame_bytes);
+		comp_update_buffer_produce(multi_endpoint_buffer, frames * frame_bytes);
 	}
-	buffer_release(buf_c);
 
 	return 0;
 }
 
 static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer);
-	struct comp_buffer __sparse_cache *local_buf;
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t local_fmt;
-
-	buffer_release(dma_buf);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 		dd->local_buffer = list_first_item(&dev->bsource_list,
@@ -1492,9 +1432,7 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 						   struct comp_buffer,
 						   source_list);
 
-	local_buf = buffer_acquire(dd->local_buffer);
-	local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	buffer_release(local_buf);
+	local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
 
 	dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
 
@@ -1509,7 +1447,7 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_func *converter)
 {
 	uint32_t sampling = dd->sampling;
-	struct comp_buffer __sparse_cache *buf_c;
+	uint32_t dma_fmt;
 	struct dma_status stat;
 	uint32_t avail_bytes;
 	uint32_t free_bytes;
@@ -1552,11 +1490,9 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		buf_c = buffer_acquire(dd->local_buffer);
-		src_samples = audio_stream_get_avail_samples(&buf_c->stream);
+		src_samples = audio_stream_get_avail_samples(&dd->local_buffer->stream);
 		sink_samples = free_bytes / sampling;
 		samples = MIN(src_samples, sink_samples);
-		buffer_release(buf_c);
 	} else {
 		struct list_item *sink_list;
 
@@ -1567,10 +1503,8 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		 * a DAI copier and it is chosen as the dd->local buffer
 		 */
 		if (!converter) {
-			buf_c = buffer_acquire(dd->local_buffer);
-			sink_samples = audio_stream_get_free_samples(&buf_c->stream);
+			sink_samples = audio_stream_get_free_samples(&dd->local_buffer->stream);
 			samples = MIN(samples, sink_samples);
-			buffer_release(buf_c);
 		} else {
 			/*
 			 * In the case of capture DAI's with multiple sink buffers, compute the
@@ -1582,15 +1516,13 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 				struct comp_buffer *sink;
 
 				sink = container_of(sink_list, struct comp_buffer, source_list);
-				buf_c = buffer_acquire(sink);
-				sink_dev = buf_c->sink;
+				sink_dev = sink->sink;
 
 				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE) {
 					sink_samples =
-						audio_stream_get_free_samples(&buf_c->stream);
+						audio_stream_get_free_samples(&sink->stream);
 					samples = MIN(samples, sink_samples);
 				}
-				buffer_release(buf_c);
 			}
 		}
 
@@ -1792,7 +1724,6 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 #ifdef CONFIG_IPC_MAJOR_4
 int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 {
-	struct comp_buffer __sparse_cache *local_buf_c;
 	struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 
@@ -1800,12 +1731,10 @@ int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 	buf_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 
 	if (dd && dd->local_buffer) {
-		local_buf_c = buffer_acquire(dd->local_buffer);
-		if (local_buf_c->id == buf_id) {
+		if (dd->local_buffer->id == buf_id) {
 			comp_dbg(dev, "dai_zephyr_unbind: local_buffer %x unbound", buf_id);
 			dd->local_buffer = NULL;
 		}
-		buffer_release(local_buf_c);
 	}
 
 	return 0;

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -311,8 +311,8 @@ static int dcblock_copy(struct comp_dev *dev)
 }
 
 /* init and calculate the aligned setting for available frames and free frames retrieve*/
-static inline void dcblock_set_frame_alignment(struct audio_stream __sparse_cache *source,
-					       struct audio_stream __sparse_cache *sink)
+static inline void dcblock_set_frame_alignment(struct audio_stream *source,
+					       struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 1;

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -267,8 +267,8 @@ static int dcblock_trigger(struct comp_dev *dev, int cmd)
 	return comp_set_state(dev, cmd);
 }
 
-static void dcblock_process(struct comp_dev *dev, struct comp_buffer __sparse_cache *source,
-			    struct comp_buffer __sparse_cache *sink, int frames,
+static void dcblock_process(struct comp_dev *dev, struct comp_buffer *source,
+			    struct comp_buffer *sink, int frames,
 			    uint32_t source_bytes, uint32_t sink_bytes)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -36,8 +36,8 @@ static int32_t dcblock_generic(struct dcblock_state *state,
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -77,8 +77,8 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -118,8 +118,8 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -29,7 +29,7 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Setup circular for component source */
-static inline void dcblock_set_circular(const struct audio_stream __sparse_cache *source)
+static inline void dcblock_set_circular(const struct audio_stream *source)
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(audio_stream_get_addr(source));
@@ -38,8 +38,8 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -86,8 +86,8 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -134,8 +134,8 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -29,8 +29,8 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Setup circular for component sink and source */
-static inline void dcblock_set_circular(const struct audio_stream __sparse_cache *source,
-					const struct audio_stream __sparse_cache *sink)
+static inline void dcblock_set_circular(const struct audio_stream *source,
+					const struct audio_stream *sink)
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(audio_stream_get_addr(source));
@@ -43,8 +43,8 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -81,8 +81,8 @@ static void dcblock_s16_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -120,8 +120,8 @@ static void dcblock_s24_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(const struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -289,7 +289,7 @@ static void drc_params(struct processing_module *mod)
 #endif /* CONFIG_IPC_MAJOR_4 */
 
 static int drc_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -227,8 +227,8 @@ static int drc_get_config(struct processing_module *mod,
 	return comp_data_blob_get_cmd(cd->model_handler, cdata, fragment_size);
 }
 
-static void drc_set_alignment(struct audio_stream __sparse_cache *source,
-			      struct audio_stream __sparse_cache *sink)
+static void drc_set_alignment(struct audio_stream *source,
+			      struct audio_stream *sink)
 {
 	/* Currently no optimizations those would use wider loads and stores */
 	audio_stream_init_alignment_constants(1, 1, source);
@@ -243,8 +243,8 @@ static int drc_process(struct processing_module *mod,
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	int frames = input_buffers[0].size;
 	int ret;
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -272,7 +272,6 @@ static int drc_process(struct processing_module *mod,
 static void drc_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -282,14 +281,10 @@ static void drc_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(sink_c);
+	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
 
@@ -299,7 +294,6 @@ static int drc_prepare(struct processing_module *mod,
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	int channels;
 	int rate;
@@ -314,16 +308,12 @@ static int drc_prepare(struct processing_module *mod,
 	/* DRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	drc_set_alignment(&source_c->stream, &sink_c->stream);
+	drc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	channels = audio_stream_get_channels(&sink_c->stream);
-	rate = audio_stream_get_rate(&sink_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	channels = audio_stream_get_channels(&sinkb->stream);
+	rate = audio_stream_get_rate(&sinkb->stream);
 
 	/* Initialize DRC */
 	comp_info(dev, "drc_prepare(), source_format=%d", cd->source_format);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -290,7 +290,7 @@ static void drc_params(struct processing_module *mod)
 
 static int drc_prepare(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -466,8 +466,8 @@ static void drc_process_one_division(struct drc_state *state,
 }
 
 void drc_default_pass(struct processing_module *mod,
-		      const struct audio_stream __sparse_cache *source,
-		      struct audio_stream __sparse_cache *sink, uint32_t frames)
+		      const struct audio_stream *source,
+		      struct audio_stream *sink, uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -479,8 +479,8 @@ static inline void drc_pre_delay_index_inc(int *idx, int increment)
 
 #if CONFIG_FORMAT_S16LE
 static void drc_delay_input_sample_s16(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int16_t **x, int16_t **y, int samples)
 {
 	int16_t *x1;
@@ -528,8 +528,8 @@ static void drc_delay_input_sample_s16(struct drc_state *state,
 }
 
 static void drc_s16_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int16_t *x = audio_stream_get_rptr(source);
@@ -574,8 +574,8 @@ static void drc_s16_default(struct processing_module *mod,
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 static void drc_delay_input_sample_s32(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int32_t **x, int32_t **y, int samples)
 {
 	int32_t *x1;
@@ -625,8 +625,8 @@ static void drc_delay_input_sample_s32(struct drc_state *state,
 
 #if CONFIG_FORMAT_S24LE
 static void drc_delay_input_sample_s24(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int32_t **x, int32_t **y, int samples)
 {
 	int32_t *x1;
@@ -674,8 +674,8 @@ static void drc_delay_input_sample_s24(struct drc_state *state,
 }
 
 static void drc_s24_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);
@@ -722,8 +722,8 @@ static void drc_s24_default(struct processing_module *mod,
 
 #if CONFIG_FORMAT_S32LE
 static void drc_s32_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -210,8 +210,8 @@ static void eq_fir_passthrough(struct fir_state_32x16 fir[],
 			       struct output_stream_buffer *bsink,
 			       int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -509,7 +509,7 @@ static int eq_fir_process(struct processing_module *mod,
 			  int num_output_buffers)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
 	uint32_t frame_count = input_buffers[0].size;
 	int ret;
 
@@ -551,8 +551,8 @@ static int eq_fir_process(struct processing_module *mod,
 	return 0;
 }
 
-static void eq_fir_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void eq_fir_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -563,7 +563,7 @@ static void eq_fir_set_alignment(struct audio_stream __sparse_cache *source,
 
 static int eq_fir_prepare(struct processing_module *mod,
 			  struct sof_source **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -174,7 +174,6 @@ static int eq_fir_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -197,9 +196,7 @@ static int eq_fir_params(struct processing_module *mod)
 
 	component_set_nearest_period_frames(dev, comp_params.rate);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ret = buffer_set_params(sink_c, &comp_params, true);
-	buffer_release(sink_c);
+	ret = buffer_set_params(sinkb, &comp_params, true);
 	return ret;
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
@@ -570,7 +567,6 @@ static int eq_fir_prepare(struct processing_module *mod,
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	int channels;
 	enum sof_ipc_frame frame_fmt;
@@ -589,13 +585,9 @@ static int eq_fir_prepare(struct processing_module *mod,
 	/* EQ component will only ever have 1 source and 1 sink buffer. */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	eq_fir_set_alignment(&source_c->stream, &sink_c->stream);
-	channels = audio_stream_get_channels(&sink_c->stream);
-	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	eq_fir_set_alignment(&sourceb->stream, &sinkb->stream);
+	channels = audio_stream_get_channels(&sinkb->stream);
+	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
 
 	cd->eq_fir_func = eq_fir_passthrough;
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -562,7 +562,7 @@ static void eq_fir_set_alignment(struct audio_stream __sparse_cache *source,
 }
 
 static int eq_fir_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
+			  struct sof_source **sources, int num_of_sources,
 			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -23,8 +23,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int16_t *x0, *y0;
@@ -61,8 +61,8 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int32_t *x0, *y0;
@@ -99,8 +99,8 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 void eq_fir_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t *x0, *y0;
 	int32_t *x = audio_stream_get_rptr(source);

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -28,8 +28,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = audio_stream_get_wptr(sink);
@@ -72,8 +72,8 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = audio_stream_get_wptr(sink);
@@ -120,8 +120,8 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *snk = audio_stream_get_wptr(sink);

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -27,8 +27,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
@@ -84,8 +84,8 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
@@ -156,8 +156,8 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int16x4 d0 = AE_ZERO16();
 	ae_int16x4 d1 = AE_ZERO16();

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -64,8 +64,8 @@ static void eq_iir_s16_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int16_t *x0;
 	int16_t *y0;
@@ -112,8 +112,8 @@ static void eq_iir_s24_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -160,8 +160,8 @@ static void eq_iir_s32_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -209,8 +209,8 @@ static void eq_iir_s32_16_default(struct processing_module *mod,
 				  struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int16_t *y0;
@@ -257,8 +257,8 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 				  struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -303,8 +303,8 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 static void eq_iir_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 			struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -314,8 +314,8 @@ static void eq_iir_pass(struct processing_module *mod, struct input_stream_buffe
 static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 				struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int nmax;
@@ -344,8 +344,8 @@ static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stre
 static void eq_iir_s32_s24_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 				struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax;
@@ -788,8 +788,8 @@ static int eq_iir_process(struct processing_module *mod,
 			  struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	uint32_t frame_count = input_buffers[0].size;
 	int ret;
 
@@ -815,8 +815,8 @@ static int eq_iir_process(struct processing_module *mod,
  * \param[in,out] source Structure pointer of source.
  * \param[in,out] sink Structure pointer of sink.
  */
-static void eq_iir_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void eq_iir_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 	const uint32_t byte_align = 8;
 	const uint32_t frame_align_req = 2;

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -694,7 +694,6 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 				struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	uint32_t buffer_flag;
 	int ret;
 
@@ -705,8 +704,6 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 				  sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
 
 	/* we check whether we can support frame_fmt conversion (whether we have
 	 * such conversion function) due to source and sink buffer frame_fmt's.
@@ -714,13 +711,10 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 	 * pcm frame_fmt and will not make any conversion (sink and source
 	 * frame_fmt will be equal).
 	 */
-	buffer_flag = eq_iir_find_func(audio_stream_get_frm_fmt(&source_c->stream),
-				       audio_stream_get_frm_fmt(&sink_c->stream), fm_configured,
+	buffer_flag = eq_iir_find_func(audio_stream_get_frm_fmt(&sourceb->stream),
+				       audio_stream_get_frm_fmt(&sinkb->stream), fm_configured,
 				       ARRAY_SIZE(fm_configured)) ?
 				       BUFF_PARAMS_FRAME_FMT : 0;
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
 
 	ret = comp_verify_params(dev, buffer_flag, params);
 	if (ret < 0) {
@@ -838,7 +832,6 @@ static int eq_iir_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -860,9 +853,7 @@ static int eq_iir_params(struct processing_module *mod)
 
 	component_set_nearest_period_frames(dev, comp_params.rate);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ret = buffer_set_params(sink_c, &comp_params, true);
-	buffer_release(sink_c);
+	ret = buffer_set_params(sinkb, &comp_params, true);
 	return ret;
 }
 #endif
@@ -885,7 +876,6 @@ static int eq_iir_prepare(struct processing_module *mod,
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame source_format;
 	enum sof_ipc_frame sink_format;
@@ -910,16 +900,12 @@ static int eq_iir_prepare(struct processing_module *mod,
 	/* EQ component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	eq_iir_set_alignment(&source_c->stream, &sink_c->stream);
+	eq_iir_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source and sink data format */
-	channels = audio_stream_get_channels(&sink_c->stream);
-	source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	channels = audio_stream_get_channels(&sinkb->stream);
+	source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
 
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -871,7 +871,7 @@ static void eq_iir_set_passthrough_func(struct comp_data *cd,
 }
 
 static int eq_iir_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
+			  struct sof_source **sources, int num_of_sources,
 			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -872,7 +872,7 @@ static void eq_iir_set_passthrough_func(struct comp_data *cd,
 
 static int eq_iir_prepare(struct processing_module *mod,
 			  struct sof_source **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -159,7 +159,6 @@ static int ghd_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sourceb;
-	struct comp_buffer __sparse_cache *source_c;
 	int ret;
 
 	/* Detector is used only in KPB topology. It always requires channels
@@ -176,20 +175,17 @@ static int ghd_params(struct comp_dev *dev,
 	/* This detector component will only ever have 1 source */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	source_c = buffer_acquire(sourceb);
 
-	if (audio_stream_get_channels(source_c->stream) != 1) {
+	if (audio_stream_get_channels(sourceb->stream) != 1) {
 		comp_err(dev, "ghd_params(): Only single-channel supported");
 		ret = -EINVAL;
-	} else if (audio_stream_get_frm_fmt(&source_c->stream) != SOF_IPC_FRAME_S16_LE) {
+	} else if (audio_stream_get_frm_fmt(&sourceb->stream) != SOF_IPC_FRAME_S16_LE) {
 		comp_err(dev, "ghd_params(): Only S16_LE supported");
 		ret = -EINVAL;
-	} else if (source_c->stream.rate != KPB_SAMPLNG_FREQUENCY) {
+	} else if (sourceb->stream.rate != KPB_SAMPLNG_FREQUENCY) {
 		comp_err(dev, "ghd_params(): Only 16KHz supported");
 		ret = -EINVAL;
 	}
-
-	buffer_release(source_c);
 
 	return ret;
 }
@@ -383,7 +379,6 @@ static int ghd_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
 	struct audio_stream __sparse_cache *stream;
 	uint32_t bytes, tail_bytes, head_bytes = 0;
 	int ret;
@@ -399,8 +394,7 @@ static int ghd_copy(struct comp_dev *dev)
 	/* keyword components will only ever have 1 source */
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	stream = &source_c->stream;
+	stream = &sourceb->stream;
 
 	bytes = audio_stream_get_avail_bytes(stream);
 
@@ -411,7 +405,7 @@ static int ghd_copy(struct comp_dev *dev)
 		 (uint32_t)audio_stream_get_end_addr(stream));
 
 	/* copy and perform detection */
-	buffer_stream_invalidate(source_c, bytes);
+	buffer_stream_invalidate(sourceb, bytes);
 
 	tail_bytes = (char *)audio_stream_get_end_addr(stream) -
 		(char *)audio_stream_get_rptr(stream);
@@ -426,9 +420,7 @@ static int ghd_copy(struct comp_dev *dev)
 		ghd_detect(dev, stream, audio_stream_get_addr(stream), head_bytes);
 
 	/* calc new available */
-	comp_update_buffer_consume(source_c, bytes);
-
-	buffer_release(source_c);
+	comp_update_buffer_consume(sourceb, bytes);
 
 	return 0;
 }

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -379,7 +379,7 @@ static int ghd_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct audio_stream __sparse_cache *stream;
+	struct audio_stream *stream;
 	uint32_t bytes, tail_bytes, head_bytes = 0;
 	int ret;
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -105,16 +105,13 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
  */
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -168,17 +165,14 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 	uint32_t split_value;
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -232,19 +226,19 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *source;
-	struct comp_buffer __sparse_cache *sink;
+	struct comp_buffer *source;
+	struct comp_buffer *sink;
 	int ret;
 	bool update_mailbox = false;
 	bool send_ipc = false;
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		source = buffer_acquire(hd->dma_buffer);
-		sink = buffer_acquire(hd->local_buffer);
+		source = hd->dma_buffer;
+		sink = hd->local_buffer;
 		ret = dma_buffer_copy_from(source, sink, hd->process, bytes);
 	} else {
-		source = buffer_acquire(hd->local_buffer);
-		sink = buffer_acquire(hd->dma_buffer);
+		source = hd->local_buffer;
+		sink = hd->dma_buffer;
 		ret = dma_buffer_copy_to(source, sink, hd->process, bytes);
 	}
 
@@ -256,9 +250,6 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 				audio_stream_frame_bytes(&source->stream),
 			 audio_stream_get_free_samples(&sink->stream) *
 				audio_stream_frame_bytes(&sink->stream));
-
-	buffer_release(sink);
-	buffer_release(source);
 
 	if (ret < 0)
 		return;
@@ -387,27 +378,23 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 		return 0;
 	}
 
-	buffer_c = buffer_acquire(hd->local_buffer);
-
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		/* limit bytes per copy to one period for the whole pipeline
 		 * in order to avoid high load spike
 		 */
-		free_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		free_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 		copy_bytes = MIN(hd->period_bytes, MIN(avail_bytes, free_bytes));
 		if (!copy_bytes)
 			comp_info(dev, "no bytes to copy, %d free in buffer, %d available in DMA",
 				  free_bytes, avail_bytes);
 	} else {
-		avail_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
+		avail_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 		copy_bytes = MIN(avail_bytes, free_bytes);
 		if (!copy_bytes)
 			comp_info(dev, "no bytes to copy, %d avail in buffer, %d free in DMA",
 				  avail_bytes, free_bytes);
 	}
-
-	buffer_release(buffer_c);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -469,11 +456,9 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		elem_array = &hd->config.elem_array;
 	}
 
-	dma_buf_c = buffer_acquire(hd->dma_buffer);
 	err = dma_sg_alloc(elem_array, SOF_MEM_ZONE_RUNTIME, dir, buffer_count,
 			   buffer_bytes,
-			   (uintptr_t)(audio_stream_get_addr(&dma_buf_c->stream)), 0);
-	buffer_release(dma_buf_c);
+			   (uintptr_t)(audio_stream_get_addr(&hd->dma_buffer->stream)), 0);
 	if (err < 0) {
 		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
 		return err;
@@ -740,10 +725,9 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,
 						   sink_list);
-	host_buf_c = buffer_acquire(hd->local_buffer);
 
 	period_bytes = dev->frames *
-		audio_stream_frame_bytes(&host_buf_c->stream);
+		audio_stream_frame_bytes(&hd->local_buffer->stream);
 
 	if (!period_bytes) {
 		comp_err(dev, "host_params(): invalid period_bytes");
@@ -778,9 +762,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	 * but we have to write back caches after we finish anyway
 	 */
 	if (hd->dma_buffer) {
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		err = buffer_set_size(dma_buf_c, buffer_size, addr_align);
-		buffer_release(dma_buf_c);
+		err = buffer_set_size(hd->dma_buffer, buffer_size, addr_align);
 		if (err < 0) {
 			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
@@ -795,9 +777,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		buffer_set_params(dma_buf_c, params, BUFFER_UPDATE_FORCE);
-		buffer_release(dma_buf_c);
+		buffer_set_params(hd->dma_buffer, params, BUFFER_UPDATE_FORCE);
 	}
 
 	/* create SG DMA elems for local DMA buffer */
@@ -806,8 +786,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		goto out;
 
 	/* set up DMA configuration - copy in sample bytes. */
-	config->src_width = audio_stream_sample_bytes(&host_buf_c->stream);
-	config->dest_width = audio_stream_sample_bytes(&host_buf_c->stream);
+	config->src_width = audio_stream_sample_bytes(&hd->local_buffer->stream);
+	config->dest_width = audio_stream_sample_bytes(&hd->local_buffer->stream);
 	config->cyclic = 0;
 	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->is_scheduling_source = comp_is_scheduling_source(dev);
@@ -851,11 +831,10 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		host_copy_normal;
 
 	/* set processing function */
-	hd->process = pcm_get_conversion_function(audio_stream_get_frm_fmt(&host_buf_c->stream),
-						  audio_stream_get_frm_fmt(&host_buf_c->stream));
+	hd->process = pcm_get_conversion_function(audio_stream_get_frm_fmt(&hd->local_buffer->stream),
+						  audio_stream_get_frm_fmt(&hd->local_buffer->stream));
 
 out:
-	buffer_release(host_buf_c);
 
 	hd->cb_dev = dev;
 
@@ -886,11 +865,7 @@ static int host_params(struct comp_dev *dev,
 
 int host_common_prepare(struct host_data *hd)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(hd->dma_buffer);
-
-	buffer_zero(buf_c);
-	buffer_release(buf_c);
-
+	buffer_zero(hd->dma_buffer);
 	return 0;
 }
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -363,7 +363,6 @@ static void host_dma_cb(void *arg, enum notify_id type, void *data)
  */
 static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
@@ -433,7 +432,6 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
 			      uint32_t buffer_bytes)
 {
-	struct comp_buffer __sparse_cache *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
@@ -675,8 +673,6 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params, notifier_callback_t cb)
 {
 	struct dma_sg_config *config = &hd->config;
-	struct comp_buffer __sparse_cache *host_buf_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -788,7 +788,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		}
 	} else {
 		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
-					      addr_align);
+					      addr_align, false);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "host_params(): failed to alloc dma buffer");
 			err = -ENOMEM;

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -857,8 +857,9 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 	} else {
+		/* allocate not shared buffer */
 		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
-					      addr_align);
+					      addr_align, false);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "host_params(): failed to alloc dma buffer");
 			err = -ENOMEM;

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -109,18 +109,13 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
 {
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t copy_bytes;
-
-	buffer_c = buffer_acquire(buffer);
 
 	/* calculate minimum size to copy */
 	if (hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -175,19 +170,14 @@ static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t copy_bytes;
 	uint32_t split_value;
 
-	buffer_c = buffer_acquire(buffer);
-
 	/* calculate minimum size to copy */
 	if (hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -241,19 +231,19 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *source;
-	struct comp_buffer __sparse_cache *sink;
+	struct comp_buffer *source;
+	struct comp_buffer *sink;
 	int ret;
 	bool update_mailbox = false;
 	bool send_ipc = false;
 
 	if (hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK) {
-		source = buffer_acquire(hd->dma_buffer);
-		sink = buffer_acquire(hd->local_buffer);
+		source = hd->dma_buffer;
+		sink = hd->local_buffer;
 		ret = dma_buffer_copy_from(source, sink, hd->process, bytes);
 	} else {
-		source = buffer_acquire(hd->local_buffer);
-		sink = buffer_acquire(hd->dma_buffer);
+		source = hd->local_buffer;
+		sink = hd->dma_buffer;
 		ret = dma_buffer_copy_to(source, sink, hd->process, bytes);
 	}
 
@@ -265,9 +255,6 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 				audio_stream_frame_bytes(&source->stream),
 			 audio_stream_get_free_samples(&sink->stream) *
 				audio_stream_frame_bytes(&sink->stream));
-
-	buffer_release(sink);
-	buffer_release(source);
 
 	if (ret < 0)
 		return;
@@ -379,8 +366,6 @@ static void host_dma_cb(struct comp_dev *dev, size_t bytes)
 static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev *dev)
 {
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
 	struct dma_status dma_stat;
 	uint32_t avail_samples;
 	uint32_t free_samples;
@@ -397,18 +382,14 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 		return 0;
 	}
 
-	dma_buf_c = buffer_acquire(hd->dma_buffer);
-	dma_sample_bytes = get_sample_bytes(audio_stream_get_frm_fmt(&dma_buf_c->stream));
-	buffer_release(dma_buf_c);
-
-	buffer_c = buffer_acquire(buffer);
+	dma_sample_bytes = get_sample_bytes(audio_stream_get_frm_fmt(&hd->dma_buffer->stream));
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		avail_samples = (dma_stat.pending_length - hd->partial_size) / dma_sample_bytes;
-		free_samples = audio_stream_get_free_samples(&buffer_c->stream);
+		free_samples = audio_stream_get_free_samples(&buffer->stream);
 	} else {
-		avail_samples = audio_stream_get_avail_samples(&buffer_c->stream);
+		avail_samples = audio_stream_get_avail_samples(&buffer->stream);
 		free_samples = (dma_stat.free - hd->partial_size) / dma_sample_bytes;
 	}
 
@@ -424,8 +405,6 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 	if (!dma_copy_bytes)
 		comp_info(dev, "no bytes to copy, available samples: %d, free_samples: %d",
 			  avail_samples, free_samples);
-
-	buffer_release(buffer_c);
 
 	/* dma_copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -464,7 +443,6 @@ static inline bool stream_sync(struct host_data *hd, struct comp_dev *dev)
  */
 static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
 	uint32_t copy_bytes;
 	const unsigned int threshold =
 #if CONFIG_HOST_DMA_RELOAD_DELAY_ENABLE
@@ -482,7 +460,6 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 	cb(dev, copy_bytes);
 
 	hd->partial_size += copy_bytes;
-	buffer_c = buffer_acquire(hd->dma_buffer);
 
 	/*
 	 * On large buffers we don't need to reload DMA on every period. When
@@ -491,8 +468,8 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 	 * also adding a 2ms safety margin.
 	 */
 	if (!IS_ENABLED(CONFIG_HOST_DMA_RELOAD_DELAY_ENABLE) ||
-	    audio_stream_get_size(&buffer_c->stream) < hd->period_bytes << 3 ||
-	    audio_stream_get_size(&buffer_c->stream) - hd->partial_size <=
+	    audio_stream_get_size(&hd->dma_buffer->stream) < hd->period_bytes << 3 ||
+	    audio_stream_get_size(&hd->dma_buffer->stream) - hd->partial_size <=
 	    (2 + threshold) * hd->period_bytes) {
 		if (stream_sync(hd, dev)) {
 			ret = dma_reload(hd->chan->dma->z_dev, hd->chan->index, 0, 0,
@@ -504,15 +481,12 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 		}
 	}
 
-	buffer_release(buffer_c);
-
 	return ret;
 }
 
 static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
 			      uint32_t buffer_bytes, uint32_t direction)
 {
-	struct comp_buffer __sparse_cache *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
@@ -535,11 +509,9 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		elem_array = &hd->config.elem_array;
 	}
 
-	dma_buf_c = buffer_acquire(hd->dma_buffer);
 	err = dma_sg_alloc(elem_array, SOF_MEM_ZONE_RUNTIME, dir, buffer_count,
 			   buffer_bytes,
-			   (uintptr_t)audio_stream_get_addr(&dma_buf_c->stream), 0);
-	buffer_release(dma_buf_c);
+			   (uintptr_t)audio_stream_get_addr(&hd->dma_buffer->stream), 0);
 	if (err < 0) {
 		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
 		return err;
@@ -759,8 +731,6 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	struct dma_sg_elem *sg_elem;
 	struct dma_config *dma_cfg = &hd->z_config;
 	struct dma_block_config dma_block_cfg;
-	struct comp_buffer __sparse_cache *host_buf_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;
@@ -809,14 +779,13 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,
 						   sink_list);
-	host_buf_c = buffer_acquire(hd->local_buffer);
 
 	period_bytes = dev->frames * get_frame_bytes(params->frame_fmt, params->channels);
 
 	if (!period_bytes) {
 		comp_err(dev, "host_params(): invalid period_bytes");
 		err = -EINVAL;
-		goto out;
+		return err;
 	}
 
 	/* determine source and sink buffer elements */
@@ -848,13 +817,11 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	 * but we have to write back caches after we finish anywae
 	 */
 	if (hd->dma_buffer) {
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		err = buffer_set_size(dma_buf_c, buffer_size, addr_align);
-		buffer_release(dma_buf_c);
+		err = buffer_set_size(hd->dma_buffer, buffer_size, addr_align);
 		if (err < 0) {
 			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
-			goto out;
+			return err;
 		}
 	} else {
 		/* allocate not shared buffer */
@@ -863,32 +830,30 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		if (!hd->dma_buffer) {
 			comp_err(dev, "host_params(): failed to alloc dma buffer");
 			err = -ENOMEM;
-			goto out;
+			return err;
 		}
 
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		buffer_set_params(dma_buf_c, params, BUFFER_UPDATE_FORCE);
+		buffer_set_params(hd->dma_buffer, params, BUFFER_UPDATE_FORCE);
 
 		/* set processing function */
 		if (params->direction == SOF_IPC_STREAM_CAPTURE)
 			hd->process = pcm_get_conversion_function(
-				audio_stream_get_frm_fmt(&host_buf_c->stream),
-				audio_stream_get_frm_fmt(&dma_buf_c->stream));
+				audio_stream_get_frm_fmt(&hd->local_buffer->stream),
+				audio_stream_get_frm_fmt(&hd->dma_buffer->stream));
 		else
 			hd->process = pcm_get_conversion_function(
-				audio_stream_get_frm_fmt(&dma_buf_c->stream),
-				audio_stream_get_frm_fmt(&host_buf_c->stream));
+				audio_stream_get_frm_fmt(&hd->dma_buffer->stream),
+				audio_stream_get_frm_fmt(&hd->local_buffer->stream));
 
-		config->src_width = audio_stream_sample_bytes(&dma_buf_c->stream);
+		config->src_width = audio_stream_sample_bytes(&hd->dma_buffer->stream);
 		config->dest_width = config->src_width;
-		buffer_release(dma_buf_c);
 	}
 
 	/* create SG DMA elems for local DMA buffer */
 	err = create_local_elems(hd, dev, period_count, buffer_size / period_count,
 				 params->direction);
 	if (err < 0)
-		goto out;
+		return err;
 
 	/* set up DMA configuration - copy in sample bytes. */
 	config->cyclic = 0;
@@ -907,7 +872,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	if (channel < 0) {
 		comp_err(dev, "host_params(): requested channel %d is busy", hda_chan);
 		err = -ENODEV;
-		goto out;
+		return err;
 	}
 	hd->chan = &hd->dma->chan[channel];
 
@@ -961,7 +926,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		comp_err(dev, "host_params(): dma_config() failed");
 		dma_release_channel(hd->dma->z_dev, hd->chan->index);
 		hd->chan = NULL;
-		goto out;
+		return err;
 	}
 
 	err = dma_get_attribute(hd->dma->z_dev, DMA_ATTR_COPY_ALIGNMENT,
@@ -970,7 +935,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	if (err < 0) {
 		comp_err(dev, "host_params(): dma_get_attribute()");
 
-		goto out;
+		return err;
 	}
 
 	/* minimal copied data shouldn't be less than alignment */
@@ -983,8 +948,6 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	hd->copy = hd->copy_type == COMP_COPY_ONE_SHOT ? host_copy_one_shot :
 		host_copy_normal;
 
-out:
-	buffer_release(host_buf_c);
 	return err;
 }
 
@@ -1007,11 +970,7 @@ static int host_params(struct comp_dev *dev,
 
 int host_common_prepare(struct host_data *hd)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(hd->dma_buffer);
-
-	buffer_zero(buf_c);
-	buffer_release(buf_c);
-
+	buffer_zero(hd->dma_buffer);
 	return 0;
 }
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -66,8 +66,8 @@ static void igo_nr_lib_process(struct comp_data *cd)
 
 #if CONFIG_FORMAT_S16LE
 static void igo_nr_capture_s16(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);
@@ -125,8 +125,8 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S24LE
 static void igo_nr_capture_s24(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);
@@ -184,8 +184,8 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S32LE
 static void igo_nr_capture_s32(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -379,7 +379,6 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	int32_t err;
 
 	comp_info(dev, "igo_nr_params()");
@@ -395,21 +394,15 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* set source/sink_frames/rate */
-	cd->source_rate = audio_stream_get_rate(&source_c->stream);
-	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
+	cd->source_rate = audio_stream_get_rate(&sourceb->stream);
+	cd->sink_rate = audio_stream_get_rate(&sinkb->stream);
 
-	if (audio_stream_get_channels(&source_c->stream) !=
-	    audio_stream_get_channels(&sink_c->stream)) {
+	if (audio_stream_get_channels(&sourceb->stream) !=
+	    audio_stream_get_channels(&sinkb->stream)) {
 		comp_err(dev, "igo_nr_params(), mismatch source/sink stream channels");
 		cd->invalid_param = true;
 	}
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
 
 	if (!cd->sink_rate) {
 		comp_err(dev, "igo_nr_params(), zero sink rate");
@@ -701,7 +694,6 @@ static int32_t igo_nr_copy(struct comp_dev *dev)
 {
 	struct comp_copy_limits cl;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t src_frames;
 	int32_t sink_frames;
@@ -713,27 +705,21 @@ static int32_t igo_nr_copy(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* Check for changed configuration */
 	if (comp_is_new_data_blob_available(cd->model_handler))
 		igo_nr_set_igo_params(dev);
 
 	/* Get source, sink, number of frames etc. to process. */
-	comp_get_copy_limits(source_c, sink_c, &cl);
+	comp_get_copy_limits(sourceb, sinkb, &cl);
 
-	src_frames = audio_stream_get_avail_frames(&source_c->stream);
-	sink_frames = audio_stream_get_free_frames(&sink_c->stream);
+	src_frames = audio_stream_get_avail_frames(&sourceb->stream);
+	sink_frames = audio_stream_get_free_frames(&sinkb->stream);
 
 	comp_dbg(dev, "src_frames = %d, sink_frames = %d.", src_frames, sink_frames);
 
 	/* Process only when frames count is enough. */
 	if (src_frames >= IGO_FRAME_SIZE && sink_frames >= IGO_FRAME_SIZE)
-		igo_nr_process(dev, source_c, sink_c, &cl, IGO_FRAME_SIZE);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+		igo_nr_process(dev, sourceb, sinkb, &cl, IGO_FRAME_SIZE);
 
 	return 0;
 }

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -120,14 +120,14 @@ static int kpb_register_client(struct comp_data *kpb, struct kpb_client *cli);
 static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli);
 static enum task_state kpb_draining_task(void *arg);
 static int kpb_buffer_data(struct comp_dev *dev,
-			   const struct comp_buffer __sparse_cache *source, size_t size);
+			   const struct comp_buffer *source, size_t size);
 static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 					  size_t hb_size_req);
 static void kpb_clear_history_buffer(struct history_buffer *buff);
 static void kpb_free_history_buffer(struct history_buffer *buff);
 static inline bool kpb_is_sample_width_supported(uint32_t sampling_width);
-static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
-			     struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_copy_samples(struct comp_buffer *sink,
+			     struct comp_buffer *source, size_t size,
 			     size_t sample_width, uint32_t channels);
 static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width);
@@ -1048,8 +1048,8 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 }
 #endif
 #else
-static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy16(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels,  uint32_t micsel_channels, uint32_t *offsets)
 {
 	struct audio_stream *istream = &source->stream;
@@ -1080,8 +1080,8 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 	}
 }
 
-static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy32(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
 	struct audio_stream *istream = &source->stream;
@@ -1111,8 +1111,8 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 	}
 }
 #endif
-static void kpb_micselect_copy(struct comp_dev *dev, struct comp_buffer __sparse_cache *sink_c,
-			       struct comp_buffer __sparse_cache *source_c, size_t copy_bytes,
+static void kpb_micselect_copy(struct comp_dev *dev, struct comp_buffer *sink_c,
+			       struct comp_buffer *source_c, size_t copy_bytes,
 			       uint32_t channels)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
@@ -1343,7 +1343,7 @@ static int kpb_copy(struct comp_dev *dev)
  *
  */
 static int kpb_buffer_data(struct comp_dev *dev,
-			   const struct comp_buffer __sparse_cache *source, size_t size)
+			   const struct comp_buffer *source, size_t size)
 {
 	int ret = 0;
 	size_t size_to_copy = size;
@@ -2190,8 +2190,8 @@ static void kpb_copy_24b_in_32b(const struct audio_stream *source,
  *
  * \return none.
  */
-static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
-			     struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_copy_samples(struct comp_buffer *sink,
+			     struct comp_buffer *source, size_t size,
 			     size_t sample_width, uint32_t channels)
 {
 	struct audio_stream *istream = &source->stream;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -129,9 +129,9 @@ static inline bool kpb_is_sample_width_supported(uint32_t sampling_width);
 static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
 			     struct comp_buffer __sparse_cache *source, size_t size,
 			     size_t sample_width, uint32_t channels);
-static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *sink,
+static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width);
-static void kpb_buffer_samples(const struct audio_stream __sparse_cache *source,
+static void kpb_buffer_samples(const struct audio_stream *source,
 			       int offset, void *sink, size_t size,
 			       size_t sample_width);
 static void kpb_reset_history_buffer(struct history_buffer *buff);
@@ -985,8 +985,8 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 				 struct comp_buffer __sparse_cache *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint16_t ch;
 	size_t i;
 
@@ -1018,8 +1018,8 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 				 struct comp_buffer __sparse_cache *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint16_t ch;
 	size_t i;
 
@@ -1052,8 +1052,8 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 				 struct comp_buffer __sparse_cache *source, size_t size,
 				 uint32_t in_channels,  uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 
 	buffer_stream_invalidate(source, size);
 	size_t out_samples;
@@ -1084,8 +1084,8 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 				 struct comp_buffer __sparse_cache *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 
 	buffer_stream_invalidate(source, size);
 	size_t out_samples;
@@ -1853,7 +1853,7 @@ out:
 
 #ifdef KPB_HIFI3
 static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int n_samples)
 {
 	int ssize = audio_stream_sample_bytes(sink);
@@ -1901,7 +1901,7 @@ static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
 }
 #else
 static void kpb_convert_24b_to_32b(const void *source, int ioffset,
-				   struct audio_stream __sparse_cache *sink,
+				   struct audio_stream *sink,
 				   int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(sink);
@@ -1933,7 +1933,7 @@ static void kpb_convert_24b_to_32b(const void *source, int ioffset,
  *
  * \return none.
  */
-static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *sink,
+static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width)
 {
 	unsigned int samples;
@@ -1962,7 +1962,7 @@ static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *
 }
 
 #ifdef KPB_HIFI3
-static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *source, int ioffset,
+static void kpb_convert_32b_to_24b(const struct audio_stream *source, int ioffset,
 				   void *linear_sink, int ooffset, unsigned int n_samples)
 {
 	int ssize = audio_stream_sample_bytes(source);
@@ -2000,7 +2000,7 @@ static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *sou
 	}
 }
 #else
-static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *source, int ioffset,
+static void kpb_convert_32b_to_24b(const struct audio_stream *source, int ioffset,
 				   void *sink, int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(source);
@@ -2033,7 +2033,7 @@ static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *sou
  * \param[in] size Requested copy size in bytes.
  * \param[in] sample_width Sample size.
  */
-static void kpb_buffer_samples(const struct audio_stream __sparse_cache *source,
+static void kpb_buffer_samples(const struct audio_stream *source,
 			       int offset, void *sink, size_t size,
 			       size_t sample_width)
 {
@@ -2120,8 +2120,8 @@ static inline bool kpb_is_sample_width_supported(uint32_t sampling_width)
 }
 
 #ifdef KPB_HIFI3
-static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-				struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+static void kpb_copy_24b_in_32b(const struct audio_stream *source, uint32_t ioffset,
+				struct audio_stream *sink, uint32_t ooffset,
 				uint32_t n_samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
@@ -2154,8 +2154,8 @@ static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source
 	}
 }
 #else
-static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static void kpb_copy_24b_in_32b(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -2194,8 +2194,8 @@ static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
 			     struct comp_buffer __sparse_cache *source, size_t size,
 			     size_t sample_width, uint32_t channels)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	unsigned int samples;
 
 	buffer_stream_invalidate(source, size);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -330,17 +330,14 @@ static int kpb_bind(struct comp_dev *dev, void *data)
 
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink = container_of(blist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
 		int sink_buf_id;
 
-		if (!sink_c->sink) {
+		if (!sink->sink) {
 			ret = -EINVAL;
-			buffer_release(sink_c);
 			break;
 		}
 
-		sink_buf_id = sink_c->id;
-		buffer_release(sink_c);
+		sink_buf_id = sink->id;
 
 		if (sink_buf_id == buf_id) {
 			if (sink_buf_id == 0)
@@ -848,17 +845,13 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink = container_of(blist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
 		enum sof_comp_type type;
 
-		if (!sink_c->sink) {
+		if (!sink->sink) {
 			ret = -EINVAL;
-			buffer_release(sink_c);
 			break;
 		}
-
-		type = dev_comp_type(sink_c->sink);
-		buffer_release(sink_c);
+		type = dev_comp_type(sink->sink);
 
 		switch (type) {
 		case SOF_COMP_SELECTOR:
@@ -886,18 +879,15 @@ static int kpb_prepare(struct comp_dev *dev)
 		list_for_item(sink_list, &dev->bsink_list) {
 			struct comp_buffer *sink =
 				container_of(sink_list, struct comp_buffer, source_list);
-			struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
 
 			audio_stream_init_alignment_constants(byte_align, frame_align_req,
-							      &sink_c->stream);
-			sink_id = sink_c->id;
+							      &sink->stream);
+			sink_id = sink->id;
 
 			if (sink_id == 0)
-				audio_stream_set_channels(&sink_c->stream, kpb->num_of_sel_mic);
+				audio_stream_set_channels(&sink->stream, kpb->num_of_sel_mic);
 			else
-				audio_stream_set_channels(&sink_c->stream, kpb->config.channels);
-
-			buffer_release(sink_c);
+				audio_stream_set_channels(&sink->stream, kpb->config.channels);
 		}
 	}
 #endif /* CONFIG_IPC_MAJOR_4 */
@@ -1167,7 +1157,6 @@ static int kpb_copy(struct comp_dev *dev)
 	int ret = 0;
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c = NULL;
 	size_t copy_bytes = 0, produced_bytes = 0;
 	size_t sample_width = kpb->config.sampling_width;
 	struct draining_data *dd = &kpb->draining_task_data;
@@ -1185,13 +1174,11 @@ static int kpb_copy(struct comp_dev *dev)
 	source = list_first_item(&dev->bsource_list, struct comp_buffer,
 				 sink_list);
 
-	source_c = buffer_acquire(source);
-
 	/* Validate source */
-	if (!audio_stream_get_rptr(&source_c->stream)) {
+	if (!audio_stream_get_rptr(&source->stream)) {
 		comp_err(dev, "kpb_copy(): invalid source pointers.");
 		ret = -EINVAL;
-		goto out;
+		return ret;
 	}
 
 	switch (kpb->state) {
@@ -1206,29 +1193,27 @@ static int kpb_copy(struct comp_dev *dev)
 			break;
 		}
 
-		sink_c = buffer_acquire(sink);
-
 		/* Validate sink */
-		if (!audio_stream_get_wptr(&sink_c->stream)) {
+		if (!audio_stream_get_wptr(&sink->stream)) {
 			comp_err(dev, "kpb_copy(): invalid selector sink pointers.");
 			ret = -EINVAL;
 			break;
 		}
 
-		copy_bytes = audio_stream_get_copy_bytes(&source_c->stream, &sink_c->stream);
+		copy_bytes = audio_stream_get_copy_bytes(&source->stream, &sink->stream);
 		if (!copy_bytes) {
 			comp_err(dev, "kpb_copy(): nothing to copy sink->free %d source->avail %d",
-				 audio_stream_get_free_bytes(&sink_c->stream),
-				 audio_stream_get_avail_bytes(&source_c->stream));
+				 audio_stream_get_free_bytes(&sink->stream),
+				 audio_stream_get_avail_bytes(&source->stream));
 			ret = PPL_STATUS_PATH_STOP;
 			break;
 		}
 
 		if (kpb->num_of_sel_mic == 0) {
-			kpb_copy_samples(sink_c, source_c, copy_bytes, sample_width, channels);
+			kpb_copy_samples(sink, source, copy_bytes, sample_width, channels);
 		} else {
-			uint32_t avail = audio_stream_get_avail_bytes(&source_c->stream);
-			uint32_t free = audio_stream_get_free_bytes(&sink_c->stream);
+			uint32_t avail = audio_stream_get_avail_bytes(&source->stream);
+			uint32_t free = audio_stream_get_free_bytes(&sink->stream);
 
 			copy_bytes = MIN(avail, free * channels / kpb->num_of_sel_mic);
 			copy_bytes = ROUND_DOWN(copy_bytes, (sample_width >> 3) * channels);
@@ -1244,13 +1229,13 @@ static int kpb_copy(struct comp_dev *dev)
 				ret = PPL_STATUS_PATH_STOP;
 				break;
 			}
-			kpb_micselect_copy(dev, sink_c, source_c, produced_bytes, channels);
+			kpb_micselect_copy(dev, sink, source, produced_bytes, channels);
 		}
 		/* Buffer source data internally in history buffer for future
 		 * use by clients.
 		 */
 		if (copy_bytes <= kpb->hd.buffer_size) {
-			ret = kpb_buffer_data(dev, source_c, copy_bytes);
+			ret = kpb_buffer_data(dev, source, copy_bytes);
 
 			if (ret) {
 				comp_err(dev, "kpb_copy(): internal buffering failed.");
@@ -1269,11 +1254,11 @@ static int kpb_copy(struct comp_dev *dev)
 		}
 
 		if (kpb->num_of_sel_mic == 0)
-			comp_update_buffer_produce(sink_c, copy_bytes);
+			comp_update_buffer_produce(sink, copy_bytes);
 		else
-			comp_update_buffer_produce(sink_c, produced_bytes);
+			comp_update_buffer_produce(sink, produced_bytes);
 
-		comp_update_buffer_consume(source_c, copy_bytes);
+		comp_update_buffer_consume(source, copy_bytes);
 
 		break;
 	case KPB_STATE_HOST_COPY:
@@ -1286,20 +1271,18 @@ static int kpb_copy(struct comp_dev *dev)
 			break;
 		}
 
-		sink_c = buffer_acquire(sink);
-
 		/* Validate sink */
-		if (!audio_stream_get_wptr(&sink_c->stream)) {
+		if (!audio_stream_get_wptr(&sink->stream)) {
 			comp_err(dev, "kpb_copy(): invalid host sink pointers.");
 			ret = -EINVAL;
 			break;
 		}
 
-		copy_bytes = audio_stream_get_copy_bytes(&source_c->stream, &sink_c->stream);
+		copy_bytes = audio_stream_get_copy_bytes(&source->stream, &sink->stream);
 		if (!copy_bytes) {
 			comp_err(dev, "kpb_copy(): nothing to copy sink->free %d source->avail %d",
-				 audio_stream_get_free_bytes(&sink_c->stream),
-				 audio_stream_get_avail_bytes(&source_c->stream));
+				 audio_stream_get_free_bytes(&sink->stream),
+				 audio_stream_get_avail_bytes(&source->stream));
 			/* NOTE! We should stop further pipeline copy due to
 			 * no data availability however due to HW bug
 			 * (no HOST DMA IRQs) we need to call host copy
@@ -1308,10 +1291,10 @@ static int kpb_copy(struct comp_dev *dev)
 			break;
 		}
 
-		kpb_copy_samples(sink_c, source_c, copy_bytes, sample_width, channels);
+		kpb_copy_samples(sink, source, copy_bytes, sample_width, channels);
 
-		comp_update_buffer_produce(sink_c, copy_bytes);
-		comp_update_buffer_consume(source_c, copy_bytes);
+		comp_update_buffer_produce(sink, copy_bytes);
+		comp_update_buffer_consume(source, copy_bytes);
 
 		break;
 	case KPB_STATE_INIT_DRAINING:
@@ -1319,12 +1302,12 @@ static int kpb_copy(struct comp_dev *dev)
 		/* In draining and init draining we only buffer data in
 		 * the internal history buffer.
 		 */
-		avail_bytes = audio_stream_get_avail_bytes(&source_c->stream);
+		avail_bytes = audio_stream_get_avail_bytes(&source->stream);
 		copy_bytes = MIN(avail_bytes, kpb->hd.free);
 		ret = PPL_STATUS_PATH_STOP;
 		if (copy_bytes) {
-			buffer_stream_invalidate(source_c, copy_bytes);
-			ret = kpb_buffer_data(dev, source_c, copy_bytes);
+			buffer_stream_invalidate(source, copy_bytes);
+			ret = kpb_buffer_data(dev, source, copy_bytes);
 			dd->buffered_while_draining += copy_bytes;
 			kpb->hd.free -= copy_bytes;
 
@@ -1333,10 +1316,10 @@ static int kpb_copy(struct comp_dev *dev)
 				break;
 			}
 
-			comp_update_buffer_consume(source_c, copy_bytes);
+			comp_update_buffer_consume(source, copy_bytes);
 		} else {
 			comp_warn(dev, "kpb_copy(): buffering skipped (no data to copy, avail %d, free %d",
-				  audio_stream_get_avail_bytes(&source_c->stream),
+				  audio_stream_get_avail_bytes(&source->stream),
 				  kpb->hd.free);
 		}
 
@@ -1347,11 +1330,6 @@ static int kpb_copy(struct comp_dev *dev)
 		ret = -EIO;
 		break;
 	}
-
-out:
-	if (sink_c)
-		buffer_release(sink_c);
-	buffer_release(source_c);
 
 	return ret;
 }
@@ -1729,7 +1707,6 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 static enum task_state kpb_draining_task(void *arg)
 {
 	struct draining_data *draining_data = (struct draining_data *)arg;
-	struct comp_buffer __sparse_cache *sink = buffer_acquire(draining_data->sink);
 	struct history_buffer *buff = draining_data->hb;
 	size_t drain_req = draining_data->drain_req;
 	size_t sample_width = draining_data->sample_width;
@@ -1785,11 +1762,11 @@ static enum task_state kpb_draining_task(void *arg)
 
 		size_to_read = (uintptr_t)buff->end_addr - (uintptr_t)buff->r_ptr;
 
-		if (size_to_read > audio_stream_get_free_bytes(&sink->stream)) {
-			if (audio_stream_get_free_bytes(&sink->stream) >= drain_req)
+		if (size_to_read > audio_stream_get_free_bytes(&draining_data->sink->stream)) {
+			if (audio_stream_get_free_bytes(&draining_data->sink->stream) >= drain_req)
 				size_to_copy = drain_req;
 			else
-				size_to_copy = audio_stream_get_free_bytes(&sink->stream);
+				size_to_copy = audio_stream_get_free_bytes(&draining_data->sink->stream);
 		} else {
 			if (size_to_read > drain_req) {
 				size_to_copy = drain_req;
@@ -1799,7 +1776,7 @@ static enum task_state kpb_draining_task(void *arg)
 			}
 		}
 
-		kpb_drain_samples(buff->r_ptr, &sink->stream, size_to_copy,
+		kpb_drain_samples(buff->r_ptr, &draining_data->sink->stream, size_to_copy,
 				  sample_width);
 
 		buff->r_ptr = (char *)buff->r_ptr + (uint32_t)size_to_copy;
@@ -1816,14 +1793,14 @@ static enum task_state kpb_draining_task(void *arg)
 		}
 
 		if (size_to_copy) {
-			comp_update_buffer_produce(sink, size_to_copy);
-			comp_copy(sink->sink);
-		} else if (!audio_stream_get_free_bytes(&sink->stream)) {
+			comp_update_buffer_produce(draining_data->sink, size_to_copy);
+			comp_copy(draining_data->sink->sink);
+		} else if (!audio_stream_get_free_bytes(&draining_data->sink->stream)) {
 			/* There is no free space in sink buffer.
 			 * Call .copy() on sink component so it can
 			 * process its data further.
 			 */
-			comp_copy(sink->sink);
+			comp_copy(draining_data->sink->sink);
 		}
 
 		if (sync_mode_on && period_bytes >= period_bytes_limit) {
@@ -1859,13 +1836,9 @@ static enum task_state kpb_draining_task(void *arg)
 out:
 	draining_time_end = sof_cycle_get_64();
 
-	buffer_release(sink);
-
 	/* Reset host-sink copy mode back to its pre-draining value */
-	sink = buffer_acquire(kpb->host_sink);
-	comp_set_attribute(sink->sink, COMP_ATTR_COPY_TYPE,
+	comp_set_attribute(kpb->host_sink->sink, COMP_ATTR_COPY_TYPE,
 			   &kpb->draining_task_data.copy_type);
-	buffer_release(sink);
 
 	draining_time_ms = k_cyc_to_ms_near64(draining_time_end - draining_time_start);
 	if (draining_time_ms <= UINT_MAX)

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -161,8 +161,8 @@ static int mfcc_process(struct processing_module *mod,
 			struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers->data;
-	struct audio_stream __sparse_cache *sink = output_buffers->data;
+	struct audio_stream *source = input_buffers->data;
+	struct audio_stream *sink = output_buffers->data;
 	int frames = input_buffers->size;
 
 	comp_dbg(mod->dev, "mfcc_process(), start");

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -187,7 +187,7 @@ static void mfcc_set_alignment(struct audio_stream *source, struct audio_stream 
 }
 
 static int mfcc_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
+			struct sof_source **sources, int num_of_sources,
 			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct mfcc_comp_data *cd = module_get_private_data(mod);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -193,8 +193,6 @@ static int mfcc_prepare(struct processing_module *mod,
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *source_c;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame source_format;
 	enum sof_ipc_frame sink_format;
@@ -206,23 +204,21 @@ static int mfcc_prepare(struct processing_module *mod,
 	/* MFCC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
 
 	/* get source data format */
-	source_format = audio_stream_get_frm_fmt(&source_c->stream);
+	source_format = audio_stream_get_frm_fmt(&sourceb->stream);
 
 	/* set align requirements */
-	mfcc_set_alignment(&source_c->stream, &sink_c->stream);
+	mfcc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get sink data format and period bytes */
-	sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
+	sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
+	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream, dev->frames);
 	comp_info(dev, "mfcc_prepare(), source_format = %d, sink_format = %d",
 		  source_format, sink_format);
-	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
+	if (audio_stream_get_size(&sinkb->stream) < sink_period_bytes) {
 		comp_err(dev, "mfcc_prepare(): sink buffer size %d is insufficient < %d",
-			 audio_stream_get_size(&sink_c->stream), sink_period_bytes);
+			 audio_stream_get_size(&sinkb->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -231,8 +227,8 @@ static int mfcc_prepare(struct processing_module *mod,
 
 	/* Initialize MFCC, max_frames is set to dev->frames + 4 */
 	if (cd->config) {
-		ret = mfcc_setup(mod, dev->frames + 4, audio_stream_get_rate(&source_c->stream),
-				 audio_stream_get_channels(&source_c->stream));
+		ret = mfcc_setup(mod, dev->frames + 4, audio_stream_get_rate(&sourceb->stream),
+				 audio_stream_get_channels(&sourceb->stream));
 		if (ret < 0) {
 			comp_err(dev, "mfcc_prepare(), setup failed.");
 			goto err;
@@ -246,13 +242,9 @@ static int mfcc_prepare(struct processing_module *mod,
 		goto err;
 	}
 
-	buffer_release(sink_c);
-	buffer_release(source_c);
 	return 0;
 
 err:
-	buffer_release(sink_c);
-	buffer_release(source_c);
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return ret;
 }

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -188,7 +188,7 @@ static void mfcc_set_alignment(struct audio_stream *source, struct audio_stream 
 
 static int mfcc_prepare(struct processing_module *mod,
 			struct sof_source **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb;

--- a/src/audio/mfcc/mfcc_generic.c
+++ b/src/audio/mfcc/mfcc_generic.c
@@ -27,7 +27,7 @@
 void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfcc_buffer *buf,
 			  struct mfcc_pre_emph *emph, int frames, int source_channel)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream *source = bsource->data;
 	int32_t s;
 	int16_t *x0;
 	int16_t *x = audio_stream_get_rptr(source);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -218,7 +218,7 @@ static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache 
 }
 
 static int mixer_prepare(struct processing_module *mod,
-			 struct sof_source __sparse_cache **sources, int num_of_sources,
+			 struct sof_source **sources, int num_of_sources,
 			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct mixer_data *md = module_get_private_data(mod);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -82,7 +82,7 @@ static int mixer_process(struct processing_module *mod,
 {
 	struct mixer_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	const struct audio_stream __sparse_cache *sources_stream[PLATFORM_MAX_STREAMS];
+	const struct audio_stream *sources_stream[PLATFORM_MAX_STREAMS];
 	int sources_indices[PLATFORM_MAX_STREAMS];
 	int32_t i = 0, j = 0;
 	uint32_t frames = INT32_MAX;
@@ -192,7 +192,7 @@ static int mixer_reset(struct processing_module *mod)
 }
 
 /* init and calculate the aligned setting for available frames and free frames retrieve*/
-static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache *source)
+static inline void mixer_set_frame_alignment(struct audio_stream *source)
 {
 #if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
 

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -219,7 +219,7 @@ static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache 
 
 static int mixer_prepare(struct processing_module *mod,
 			 struct sof_source **sources, int num_of_sources,
-			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mixer_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/mixer/mixer_generic.c
+++ b/src/audio/mixer/mixer_generic.c
@@ -11,8 +11,8 @@
 
 #if CONFIG_FORMAT_S16LE
 /* Mix n 16 bit PCM source streams to one sink stream */
-static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int16_t *src[PLATFORM_MAX_CHANNELS];
@@ -57,8 +57,8 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE
 /* Mix n 24 bit PCM source streams to one sink stream */
-static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int32_t *src[PLATFORM_MAX_CHANNELS];
@@ -105,8 +105,8 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S32LE
 /* Mix n 32 bit PCM source streams to one sink stream */
-static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int32_t *src[PLATFORM_MAX_CHANNELS];

--- a/src/audio/mixer/mixer_hifi3.c
+++ b/src/audio/mixer/mixer_hifi3.c
@@ -13,8 +13,8 @@
 
 #if CONFIG_FORMAT_S16LE
 /* Mix n 16 bit PCM source streams to one sink stream */
-static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_int16x4 * in[PLATFORM_MAX_CHANNELS];
@@ -69,8 +69,8 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE
 /* Mix n 24 bit PCM source streams to one sink stream */
-static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_int32x2 *in[PLATFORM_MAX_CHANNELS];
@@ -114,8 +114,8 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S32LE
 /* Mix n 32 bit PCM source streams to one sink stream */
-static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_q32s * in[PLATFORM_MAX_CHANNELS];

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -167,9 +167,9 @@ static int mixout_free(struct processing_module *mod)
 }
 
 static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_data,
-			 uint16_t sink_index, struct audio_stream __sparse_cache *sink,
+			 uint16_t sink_index, struct audio_stream *sink,
 			 uint32_t start_frame, uint32_t mixed_frames,
-			 const struct audio_stream __sparse_cache *source, uint32_t frame_count)
+			 const struct audio_stream *source, uint32_t frame_count)
 {
 	const struct mixin_sink_config *sink_config;
 
@@ -197,7 +197,7 @@ static int mix_and_remap(struct comp_dev *dev, const struct mixin_data *mixin_da
 }
 
 /* mix silence into stream, i.e. set not yet mixed data in stream to zero */
-static void silence(struct audio_stream __sparse_cache *stream, uint32_t start_frame,
+static void silence(struct audio_stream *stream, uint32_t start_frame,
 		    uint32_t mixed_frames, uint32_t frame_count)
 {
 	uint32_t skip_mixed_frames;
@@ -445,7 +445,7 @@ static int mixout_process(struct processing_module *mod,
 	 * produced now.
 	 */
 	for (i = 0; i < num_input_buffers; i++) {
-		const struct audio_stream __sparse_cache *source_stream;
+		const struct audio_stream *source_stream;
 		struct comp_buffer __sparse_cache *unused_in_between_buf;
 		struct comp_dev *source;
 		int source_index;
@@ -470,7 +470,7 @@ static int mixout_process(struct processing_module *mod,
 
 	if (frames_to_produce > 0 && frames_to_produce < INT32_MAX) {
 		for (i = 0; i < num_input_buffers; i++) {
-			const struct audio_stream __sparse_cache *source_stream;
+			const struct audio_stream *source_stream;
 			struct comp_buffer __sparse_cache *unused_in_between_buf;
 			struct comp_dev *source;
 			int source_index;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -121,7 +121,7 @@ static int mixin_init(struct processing_module *mod)
 
 static int mixout_init(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_source_info *mod_source_info;
 	struct comp_dev *dev = mod->dev;
 	struct mixout_data *mo_data;
 
@@ -154,7 +154,7 @@ static int mixin_free(struct processing_module *mod)
 
 static int mixout_free(struct processing_module *mod)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_source_info *mod_source_info;
 
 	comp_dbg(mod->dev, "mixout_free()");
 
@@ -280,7 +280,7 @@ static int mixin_process(struct processing_module *mod,
 		struct comp_buffer *sink;
 		struct mixout_data *mixout_data;
 		struct processing_module *mixout_mod;
-		struct module_source_info __sparse_cache *mod_source_info;
+		struct module_source_info *mod_source_info;
 		uint32_t free_frames, pending_frames;
 
 		/* unused buffer between mixin and mixout */
@@ -353,7 +353,7 @@ static int mixin_process(struct processing_module *mod,
 		struct comp_dev *mixout;
 		struct comp_buffer *sink;
 		struct mixout_data *mixout_data;
-		struct module_source_info __sparse_cache *mod_source_info;
+		struct module_source_info *mod_source_info;
 		struct processing_module *mixout_mod;
 		uint32_t start_frame;
 		uint32_t writeback_size;
@@ -425,7 +425,7 @@ static int mixout_process(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,
 			  struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_source_info *mod_source_info;
 	struct comp_dev *dev = mod->dev;
 	struct mixout_data *md;
 	uint32_t frames_to_produce = INT32_MAX;
@@ -712,7 +712,7 @@ static int mixout_prepare(struct processing_module *mod,
 			  struct sof_source **sources, int num_of_sources,
 			  struct sof_sink **sinks, int num_of_sinks)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_source_info *mod_source_info;
 	struct comp_dev *dev = mod->dev;
 	struct mixout_data *md;
 	int ret, i;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -624,7 +624,7 @@ static int mixin_params(struct processing_module *mod)
  */
 static int mixin_prepare(struct processing_module *mod,
 			 struct sof_source **sources, int num_of_sources,
-			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mixin_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -714,7 +714,7 @@ static int mixout_params(struct processing_module *mod)
 
 static int mixout_prepare(struct processing_module *mod,
 			  struct sof_source **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct module_source_info __sparse_cache *mod_source_info;
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -623,7 +623,7 @@ static int mixin_params(struct processing_module *mod)
  * if downstream is not currently active.
  */
 static int mixin_prepare(struct processing_module *mod,
-			 struct sof_source __sparse_cache **sources, int num_of_sources,
+			 struct sof_source **sources, int num_of_sources,
 			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct mixin_data *md = module_get_private_data(mod);
@@ -713,7 +713,7 @@ static int mixout_params(struct processing_module *mod)
 }
 
 static int mixout_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
+			  struct sof_source **sources, int num_of_sources,
 			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct module_source_info __sparse_cache *mod_source_info;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -281,7 +281,6 @@ static int mixin_process(struct processing_module *mod,
 		struct mixout_data *mixout_data;
 		struct processing_module *mixout_mod;
 		struct module_source_info __sparse_cache *mod_source_info;
-		struct comp_buffer __sparse_cache *sink_c;
 		uint32_t free_frames, pending_frames;
 
 		/* unused buffer between mixin and mixout */
@@ -306,20 +305,17 @@ static int mixin_process(struct processing_module *mod,
 			return -EINVAL;
 		}
 
-		sink_c = buffer_acquire(sink);
-
 		/* Normally this should never happen as we checked above
 		 * that mixout is in active state and so its sink buffer
 		 * should be already initialized in mixout .params().
 		 */
-		if (!sink_c->hw_params_configured) {
+		if (!sink->hw_params_configured) {
 			comp_err(dev, "Uninitialized mixout sink buffer!");
-			buffer_release(sink_c);
 			module_source_info_release(mod_source_info);
 			return -EINVAL;
 		}
 
-		free_frames = audio_stream_get_free_frames(&sink_c->stream);
+		free_frames = audio_stream_get_free_frames(&sink->stream);
 
 		/* mixout sink buffer may still have not yet produced data -- data
 		 * consumed and written there by mixin on previous mixin_process() run.
@@ -329,7 +325,6 @@ static int mixin_process(struct processing_module *mod,
 		assert(free_frames >= pending_frames);
 		sinks_free_frames = MIN(sinks_free_frames, free_frames - pending_frames);
 
-		buffer_release(sink_c);
 		module_source_info_release(mod_source_info);
 	}
 
@@ -363,7 +358,6 @@ static int mixin_process(struct processing_module *mod,
 		struct module_source_info __sparse_cache *mod_source_info;
 		struct processing_module *mixout_mod;
 		uint32_t start_frame;
-		struct comp_buffer __sparse_cache *sink_c;
 		uint32_t writeback_size;
 
 		mixout = active_mixouts[i];
@@ -385,25 +379,22 @@ static int mixin_process(struct processing_module *mod,
 		 */
 		start_frame = mixout_data->pending_frames[source_index];
 
-		sink_c = buffer_acquire(sink);
-
 		/* if source does not produce any data but mixin is in active state -- generate
 		 * silence instead of that source data
 		 */
 		if (source_avail_frames == 0) {
 			/* generate silence */
-			silence(&sink_c->stream, start_frame, mixout_data->mixed_frames,
+			silence(&sink->stream, start_frame, mixout_data->mixed_frames,
 				frames_to_copy);
 		} else {
 			/* basically, if sink buffer has no data -- copy source data there, if
 			 * sink buffer has some data (written by another mixin) mix that data
 			 * with source data.
 			 */
-			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink_c->stream,
+			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink->stream,
 					    start_frame, mixout_data->mixed_frames,
 					    input_buffers[0].data, frames_to_copy);
 			if (ret < 0) {
-				buffer_release(sink_c);
 				module_source_info_release(mod_source_info);
 				return ret;
 			}
@@ -413,11 +404,10 @@ static int mixin_process(struct processing_module *mod,
 		 * of frames_to_copy size (converted to bytes, of course). However, seems
 		 * there is no appropreate API. Anyway, start_frame would be 0 most of the time.
 		 */
-		writeback_size = audio_stream_period_bytes(&sink_c->stream,
+		writeback_size = audio_stream_period_bytes(&sink->stream,
 							   frames_to_copy + start_frame);
 		if (writeback_size > 0)
-			buffer_stream_writeback(sink_c, writeback_size);
-		buffer_release(sink_c);
+			buffer_stream_writeback(sink, writeback_size);
 
 		mixout_data->pending_frames[source_index] += frames_to_copy;
 
@@ -547,15 +537,12 @@ static int mixout_reset(struct processing_module *mod)
 	if (dev->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK) {
 		list_for_item(blist, &dev->bsource_list) {
 			struct comp_buffer *source;
-			struct comp_buffer __sparse_cache *source_c;
 			bool stop;
 
 			/* FIXME: this is racy and implicitly protected by serialised IPCs */
 			source = container_of(blist, struct comp_buffer, sink_list);
-			source_c = buffer_acquire(source);
-			stop = (dev->pipeline == source_c->source->pipeline &&
-					source_c->source->state > COMP_STATE_PAUSED);
-			buffer_release(source_c);
+			stop = (dev->pipeline == source->source->pipeline &&
+					source->source->state > COMP_STATE_PAUSED);
 
 			if (stop)
 				/* should not reset the downstream components */
@@ -584,28 +571,25 @@ static int mixin_params(struct processing_module *mod)
 	 */
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink;
-		struct comp_buffer __sparse_cache *sink_c;
 		enum sof_ipc_frame frame_fmt, valid_fmt;
 		uint16_t sink_id;
 
 		sink = buffer_from_list(blist, PPL_DIR_DOWNSTREAM);
-		sink_c = buffer_acquire(sink);
 
-		audio_stream_set_channels(&sink_c->stream,
+		audio_stream_set_channels(&sink->stream,
 					  mod->priv.cfg.base_cfg.audio_fmt.channels_count);
 
 		/* Applying channel remapping may produce sink stream with channel count
 		 * different from source channel count.
 		 */
-		sink_id = IPC4_SRC_QUEUE_ID(sink_c->id);
+		sink_id = IPC4_SRC_QUEUE_ID(sink->id);
 		if (sink_id >= MIXIN_MAX_SINKS) {
 			comp_err(dev, "Sink index out of range: %u, max sink count: %u",
 				 (uint32_t)sink_id, MIXIN_MAX_SINKS);
-			buffer_release(sink_c);
 			return -EINVAL;
 		}
 		if (md->sink_config[sink_id].mixer_mode == IPC4_MIXER_CHANNEL_REMAPPING_MODE)
-			audio_stream_set_channels(&sink_c->stream,
+			audio_stream_set_channels(&sink->stream,
 						  md->sink_config[sink_id].output_channel_count);
 
 		/* comp_verify_params() does not modify valid_sample_fmt (a BUG?),
@@ -616,10 +600,8 @@ static int mixin_params(struct processing_module *mod)
 					    &frame_fmt, &valid_fmt,
 					    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-		audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
-		audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
-
-		buffer_release(sink_c);
+		audio_stream_set_frm_fmt(&sink->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
 	}
 
 	/* use BUFF_PARAMS_CHANNELS to skip updating channel count */
@@ -647,7 +629,6 @@ static int mixin_prepare(struct processing_module *mod,
 	struct mixin_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	enum sof_ipc_frame fmt;
 	int ret;
 
@@ -658,9 +639,7 @@ static int mixin_prepare(struct processing_module *mod,
 		return ret;
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
-	fmt = audio_stream_get_valid_fmt(&sink_c->stream);
-	buffer_release(sink_c);
+	fmt = audio_stream_get_valid_fmt(&sink->stream);
 
 	/* currently inactive so setup mixer */
 	switch (fmt) {
@@ -687,7 +666,6 @@ static int mixout_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt, valid_fmt;
 	uint32_t sink_period_bytes, sink_stream_size;
@@ -704,7 +682,6 @@ static int mixout_params(struct processing_module *mod)
 	}
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
 
 	/* comp_verify_params() does not modify valid_sample_fmt (a BUG?), let's do this here */
 	audio_stream_fmt_conversion(mod->priv.cfg.base_cfg.audio_fmt.depth,
@@ -712,15 +689,14 @@ static int mixout_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
-	audio_stream_set_channels(&sink_c->stream, params->channels);
+	audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
+	audio_stream_set_channels(&sink->stream, params->channels);
 
-	sink_stream_size = audio_stream_get_size(&sink_c->stream);
+	sink_stream_size = audio_stream_get_size(&sink->stream);
 
 	/* calculate period size based on config */
-	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
+	sink_period_bytes = audio_stream_period_bytes(&sink->stream,
 						      dev->frames);
-	buffer_release(sink_c);
 
 	if (sink_period_bytes == 0) {
 		comp_err(dev, "mixout_params(): period_bytes = 0");

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -274,7 +274,7 @@ static int mixin_process(struct processing_module *mod,
 	 * and frames free in each connected mixout sink buffer.
 	 */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *unused_in_between_buf_c;
+		struct comp_buffer *unused_in_between_buf_c;
 		struct comp_dev *mixout;
 		uint16_t sink_id;
 		struct comp_buffer *sink;
@@ -284,9 +284,8 @@ static int mixin_process(struct processing_module *mod,
 		uint32_t free_frames, pending_frames;
 
 		/* unused buffer between mixin and mixout */
-		unused_in_between_buf_c = attr_container_of(output_buffers[i].data,
-							    struct comp_buffer __sparse_cache,
-							    stream, __sparse_cache);
+		unused_in_between_buf_c = container_of(output_buffers[i].data,
+						       struct comp_buffer, stream);
 		mixout = unused_in_between_buf_c->sink;
 		sink_id = IPC4_SRC_QUEUE_ID(unused_in_between_buf_c->id);
 
@@ -329,16 +328,15 @@ static int mixin_process(struct processing_module *mod,
 	}
 
 	if (source_avail_frames > 0) {
-		struct comp_buffer __sparse_cache *source_c;
+		struct comp_buffer *source_c;
 
 		frames_to_copy = MIN(source_avail_frames, sinks_free_frames);
 		bytes_to_consume_from_source_buf =
 			audio_stream_period_bytes(input_buffers[0].data, frames_to_copy);
 		if (bytes_to_consume_from_source_buf > 0) {
 			input_buffers[0].consumed = bytes_to_consume_from_source_buf;
-			source_c = attr_container_of(input_buffers[0].data,
-						     struct comp_buffer __sparse_cache,
-						     stream, __sparse_cache);
+			source_c = container_of(input_buffers[0].data, struct comp_buffer,
+						stream);
 			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
 		}
 	} else {
@@ -446,14 +444,13 @@ static int mixout_process(struct processing_module *mod,
 	 */
 	for (i = 0; i < num_input_buffers; i++) {
 		const struct audio_stream *source_stream;
-		struct comp_buffer __sparse_cache *unused_in_between_buf;
+		struct comp_buffer *unused_in_between_buf;
 		struct comp_dev *source;
 		int source_index;
 
 		source_stream = input_buffers[i].data;
-		unused_in_between_buf = attr_container_of(source_stream,
-							  struct comp_buffer __sparse_cache,
-							  stream, __sparse_cache);
+		unused_in_between_buf = container_of(source_stream, struct comp_buffer,
+						     stream);
 
 		source = unused_in_between_buf->source;
 
@@ -471,15 +468,14 @@ static int mixout_process(struct processing_module *mod,
 	if (frames_to_produce > 0 && frames_to_produce < INT32_MAX) {
 		for (i = 0; i < num_input_buffers; i++) {
 			const struct audio_stream *source_stream;
-			struct comp_buffer __sparse_cache *unused_in_between_buf;
+			struct comp_buffer *unused_in_between_buf;
 			struct comp_dev *source;
 			int source_index;
 			uint32_t pending_frames;
 
 			source_stream = input_buffers[i].data;
-			unused_in_between_buf = attr_container_of(source_stream,
-								  struct comp_buffer __sparse_cache,
-								  stream, __sparse_cache);
+			unused_in_between_buf = container_of(source_stream,
+							     struct comp_buffer, stream);
 
 			source = unused_in_between_buf->source;
 

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -17,9 +17,9 @@
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s16(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -61,7 +61,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s16(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int32_t skip_mixed_frames, n, left_frames, i, channel_count, frames, samples;
@@ -101,9 +101,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s24(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -153,9 +153,9 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s32(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -198,7 +198,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s32(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int32_t skip_mixed_frames, left_frames, n, channel_count, i, frames, samples;

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -16,9 +16,9 @@
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s16(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -104,7 +104,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s16(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int skip_mixed_frames, left_frames;
@@ -140,9 +140,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s24(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -230,9 +230,9 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s32(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -315,7 +315,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s32(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int skip_mixed_frames, left_frames;

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -634,7 +634,7 @@ static int cadence_codec_init_process(struct processing_module *mod)
 
 static int cadence_codec_prepare(struct processing_module *mod,
 				 struct sof_source **sources, int num_of_sources,
-				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				 struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret = 0, mem_tabs_size;
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -633,7 +633,7 @@ static int cadence_codec_init_process(struct processing_module *mod)
 }
 
 static int cadence_codec_prepare(struct processing_module *mod,
-				 struct sof_source __sparse_cache **sources, int num_of_sources,
+				 struct sof_source **sources, int num_of_sources,
 				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	int ret = 0, mem_tabs_size;

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -716,7 +716,6 @@ cadence_codec_process(struct processing_module *mod,
 		      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct comp_buffer *local_buff;
-	struct comp_buffer __sparse_cache *buffer_c;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;
@@ -747,9 +746,7 @@ cadence_codec_process(struct processing_module *mod,
 
 	/* do not proceed with processing if not enough free space left in the local buffer */
 	local_buff = list_first_item(&mod->sink_buffer_list, struct comp_buffer, sink_list);
-	buffer_c = buffer_acquire(local_buff);
-	free_bytes = audio_stream_get_free(&buffer_c->stream);
-	buffer_release(buffer_c);
+	free_bytes = audio_stream_get_free(&local_buff->stream);
 	if (free_bytes < output_bytes)
 		return -ENOSPC;
 

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -179,7 +179,7 @@ static int dts_codec_init(struct processing_module *mod)
 }
 
 static int dts_codec_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
+			     struct sof_source **sources, int num_of_sources,
 			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	int ret;

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -78,7 +78,6 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 {
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	struct comp_buffer __sparse_cache *source_c;
 	const struct audio_stream __sparse_cache *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;
@@ -89,15 +88,11 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	if (!source)
 		return -EINVAL;
 
-	source_c = buffer_acquire(source);
-
-	stream = &source_c->stream;
+	stream = &source->stream;
 	buffer_fmt = audio_stream_get_buffer_fmt(stream);
 	frame_fmt = audio_stream_get_frm_fmt(stream);
 	rate = audio_stream_get_rate(stream);
 	channels = audio_stream_get_channels(stream);
-
-	buffer_release(source_c);
 
 	switch (buffer_fmt) {
 	case SOF_IPC_BUFFER_INTERLEAVED:

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -78,7 +78,7 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 {
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	const struct audio_stream __sparse_cache *stream;
+	const struct audio_stream *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;
 	unsigned int buffer_fmt, frame_fmt, rate, channels;

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -180,7 +180,7 @@ static int dts_codec_init(struct processing_module *mod)
 
 static int dts_codec_prepare(struct processing_module *mod,
 			     struct sof_source **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -197,7 +197,7 @@ static int validate_config(struct module_config *cfg)
 
 int module_prepare(struct processing_module *mod,
 		   struct sof_source __sparse_cache **sources, int num_of_sources,
-		   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		   struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct module_data *md = &mod->priv;
@@ -284,7 +284,7 @@ int module_process_legacy(struct processing_module *mod,
 
 int module_process_sink_src(struct processing_module *mod,
 			    struct sof_source __sparse_cache **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			    struct sof_sink **sinks, int num_of_sinks)
 
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -196,7 +196,7 @@ static int validate_config(struct module_config *cfg)
 }
 
 int module_prepare(struct processing_module *mod,
-		   struct sof_source __sparse_cache **sources, int num_of_sources,
+		   struct sof_source **sources, int num_of_sources,
 		   struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
@@ -283,7 +283,7 @@ int module_process_legacy(struct processing_module *mod,
 }
 
 int module_process_sink_src(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
+			    struct sof_source **sources, int num_of_sources,
 			    struct sof_sink **sinks, int num_of_sinks)
 
 {

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -156,7 +156,7 @@ static int modules_init(struct processing_module *mod)
  */
 static int modules_prepare(struct processing_module *mod,
 			   struct sof_source **sources, int num_of_sources,
-			   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			   struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	int ret = 0;

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -155,7 +155,7 @@ static int modules_init(struct processing_module *mod)
  *          There is one assumption - all IADK modules utilize IPC4 protocol.
  */
 static int modules_prepare(struct processing_module *mod,
-			   struct sof_source __sparse_cache **sources, int num_of_sources,
+			   struct sof_source **sources, int num_of_sources,
 			   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -21,7 +21,7 @@ static int passthrough_codec_init(struct processing_module *mod)
 }
 
 static int passthrough_codec_prepare(struct processing_module *mod,
-				     struct sof_source __sparse_cache **sources, int num_of_sources,
+				     struct sof_source **sources, int num_of_sources,
 				     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -22,7 +22,7 @@ static int passthrough_codec_init(struct processing_module *mod)
 
 static int passthrough_codec_prepare(struct processing_module *mod,
 				     struct sof_source **sources, int num_of_sources,
-				     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -674,7 +674,7 @@ static int waves_codec_init(struct processing_module *mod)
 }
 
 static int waves_codec_prepare(struct processing_module *mod,
-			       struct sof_source __sparse_cache **sources, int num_of_sources,
+			       struct sof_source **sources, int num_of_sources,
 			       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -220,8 +220,8 @@ static int waves_effect_check(struct comp_dev *dev)
 						    source_list);
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	const struct audio_stream __sparse_cache *src_fmt = &source->stream;
-	const struct audio_stream __sparse_cache *snk_fmt = &sink->stream;
+	const struct audio_stream *src_fmt = &source->stream;
+	const struct audio_stream *snk_fmt = &sink->stream;
 	int ret = 0;
 
 	/* Init sink & source buffers */
@@ -298,7 +298,7 @@ static int waves_effect_init(struct processing_module *mod)
 						     sink_list);
 	struct module_data *codec = &mod->priv;
 	struct waves_codec_data *waves_codec = codec->private;
-	const struct audio_stream __sparse_cache *src_fmt = &source->stream;
+	const struct audio_stream *src_fmt = &source->stream;
 	MaxxStatus_t status;
 	MaxxBuffer_Format_t sample_format;
 	MaxxBuffer_Layout_t buffer_format;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -675,7 +675,7 @@ static int waves_codec_init(struct processing_module *mod)
 
 static int waves_codec_prepare(struct processing_module *mod,
 			       struct sof_source **sources, int num_of_sources,
-			       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	int ret;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -175,7 +175,7 @@ err:
 
 static int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
-	struct sof_sink __sparse_cache *audio_sink[PLATFORM_MAX_STREAMS];
+	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
 	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
@@ -973,7 +973,7 @@ out:
 
 static int module_adapter_sink_source_copy(struct comp_dev *dev)
 {
-	struct sof_sink __sparse_cache *audio_sink[PLATFORM_MAX_STREAMS];
+	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
 	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -448,8 +448,9 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* allocate buffer for all sinks */
 	if (list_is_empty(&mod->sink_buffer_list)) {
 		for (i = 0; i < mod->num_output_buffers; i++) {
+			/* allocate not shared buffer */
 			struct comp_buffer *buffer = buffer_alloc(buff_size, SOF_MEM_CAPS_RAM,
-								  0, PLATFORM_DCACHE_ALIGN);
+								  0, PLATFORM_DCACHE_ALIGN, false);
 			uint32_t flags;
 
 			if (!buffer) {

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1630,7 +1630,7 @@ static bool module_adapter_multi_sink_source_check(struct comp_dev *dev)
 
 int module_adapter_bind(struct comp_dev *dev, void *data)
 {
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct module_source_info *mod_source_info;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *source_dev;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -545,7 +545,7 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
  * @bytes: number of bytes available in the source buffer
  */
 static void
-ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
+ca_copy_from_source_to_module(const struct audio_stream *source,
 			      void __sparse_cache *buff, uint32_t buff_size, size_t bytes)
 {
 	/* head_size - available data until end of source buffer */
@@ -573,7 +573,7 @@ ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
  * @bytes: number of bytes available in the module output buffer
  */
 static void
-ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
+ca_copy_from_module_to_sink(const struct audio_stream *sink,
 			    void __sparse_cache *buff, size_t bytes)
 {
 	/* head_size - free space until end of sink buffer */

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -418,8 +418,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	i = 0;
 	list_for_item(blist, &dev->bsink_list) {
 		mod->output_buffers[i].data =
-			 (void *)rballoc(0, SOF_MEM_CAPS_RAM,
-								      md->mpd.out_buff_size);
+			 (void *)rballoc(0, SOF_MEM_CAPS_RAM, md->mpd.out_buff_size);
 		if (!mod->output_buffers[i].data) {
 			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc output buffer data");
 			ret = -ENOMEM;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -176,7 +176,7 @@ err:
 static int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
 	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
-	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
+	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_of_sources = 0;
@@ -974,7 +974,7 @@ out:
 static int module_adapter_sink_source_copy(struct comp_dev *dev)
 {
 	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
-	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
+	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_of_sources = 0;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1686,7 +1686,7 @@ int module_adapter_bind(struct comp_dev *dev, void *data)
 
 int module_adapter_unbind(struct comp_dev *dev, void *data)
 {
-	struct module_source_info *mod_source_info;
+	struct module_source_info __sparse_cache *mod_source_info;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *source_dev;

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -11,8 +11,8 @@
 #include <sof/math/iir_df2t.h>
 
 static void multiband_drc_default_pass(const struct processing_module *mod,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, audio_stream_get_channels(source) * frames);

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -203,8 +203,8 @@ static void multiband_drc_process_deemp(struct multiband_drc_state *state,
   */
 #if CONFIG_FORMAT_S16LE
 static void multiband_drc_s16_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
@@ -270,8 +270,8 @@ static void multiband_drc_s16_default(const struct processing_module *mod,
 
 #if CONFIG_FORMAT_S24LE
 static void multiband_drc_s24_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
@@ -337,8 +337,8 @@ static void multiband_drc_s24_default(const struct processing_module *mod,
 
 #if CONFIG_FORMAT_S32LE
 static void multiband_drc_s32_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -274,7 +274,6 @@ static void set_mux_params(struct processing_module *mod)
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink, *source;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct list_item *source_list;
 	int j;
 	const uint32_t byte_align = 1;
@@ -298,15 +297,13 @@ static void set_mux_params(struct processing_module *mod)
 	/* update sink format */
 	if (!list_is_empty(&dev->bsink_list)) {
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 		audio_stream_init_alignment_constants(byte_align, frame_align_req,
-						      &sink_c->stream);
+						      &sink->stream);
 
-		if (!sink_c->hw_params_configured) {
-			ipc4_update_buffer_format(sink_c, &cd->md.output_format);
-			params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
+		if (!sink->hw_params_configured) {
+			ipc4_update_buffer_format(sink, &cd->md.output_format);
+			params->frame_fmt = audio_stream_get_frm_fmt(&sink->stream);
 		}
-		buffer_release(sink_c);
 	}
 
 	/* update each source format */
@@ -316,18 +313,16 @@ static void set_mux_params(struct processing_module *mod)
 		list_for_item(source_list, &dev->bsource_list)
 		{
 			source = container_of(source_list, struct comp_buffer, sink_list);
-			source_c = buffer_acquire(source);
 			audio_stream_init_alignment_constants(byte_align, frame_align_req,
-							      &source_c->stream);
-			j = source_c->id;
-			cd->config.streams[j].pipeline_id = source_c->pipeline_id;
+							      &source->stream);
+			j = source->id;
+			cd->config.streams[j].pipeline_id = source->pipeline_id;
 			if (j == BASE_CFG_QUEUED_ID)
 				audio_fmt = &cd->md.base_cfg.audio_fmt;
 			else
 				audio_fmt = &cd->md.reference_format;
 
-			ipc4_update_buffer_format(source_c, audio_fmt);
-			buffer_release(source_c);
+			ipc4_update_buffer_format(source, audio_fmt);
 		}
 	}
 
@@ -429,7 +424,6 @@ static int demux_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct list_item *clist;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct audio_stream __sparse_cache *sinks_stream[MUX_MAX_STREAMS] = { NULL };
 	struct mux_look_up *look_ups[MUX_MAX_STREAMS] = { NULL };
 	int frames;
@@ -442,20 +436,16 @@ static int demux_process(struct processing_module *mod,
 	/* align sink streams with their respective configurations */
 	list_for_item(clist, &dev->bsink_list) {
 		sink = container_of(clist, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		if (sink_c->sink->state == dev->state) {
-			i = get_stream_index(dev, cd, sink_c->pipeline_id);
+		if (sink->sink->state == dev->state) {
+			i = get_stream_index(dev, cd, sink->pipeline_id);
 			/* return if index wrong */
 			if (i < 0) {
-				buffer_release(sink_c);
 				return i;
 			}
 
-			look_ups[i] = get_lookup_table(dev, cd, sink_c->pipeline_id);
-			sinks_stream[i] = &sink_c->stream;
+			look_ups[i] = get_lookup_table(dev, cd, sink->pipeline_id);
+			sinks_stream[i] = &sink->stream;
 		}
-
-		buffer_release(sink_c);
 	}
 
 	/* if there are no sinks active, then sinks[] is also empty */
@@ -487,7 +477,6 @@ static int mux_process(struct processing_module *mod,
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
 	struct list_item *clist;
 	const struct audio_stream __sparse_cache *sources_stream[MUX_MAX_STREAMS] = { NULL };
 	int frames = 0;
@@ -501,23 +490,20 @@ static int mux_process(struct processing_module *mod,
 	j = 0;
 	list_for_item(clist, &dev->bsource_list) {
 		source = container_of(clist, struct comp_buffer, sink_list);
-		source_c = buffer_acquire(source);
-		if (source_c->source->state == dev->state) {
+		if (source->source->state == dev->state) {
 			if (frames)
 				frames = MIN(frames, input_buffers[j].size);
 			else
 				frames = input_buffers[j].size;
 
-			i = get_stream_index(dev, cd, source_c->pipeline_id);
+			i = get_stream_index(dev, cd, source->pipeline_id);
 			/* return if index wrong */
 			if (i < 0) {
-				buffer_release(source_c);
 				return i;
 			}
 
-			sources_stream[i] = &source_c->stream;
+			sources_stream[i] = &source->stream;
 		}
-		buffer_release(source_c);
 		j++;
 	}
 
@@ -536,11 +522,8 @@ static int mux_process(struct processing_module *mod,
 	j = 0;
 	list_for_item(clist, &dev->bsource_list) {
 		source = container_of(clist, struct comp_buffer, sink_list);
-		source_c = buffer_acquire(source);
-		if (source_c->source->state == dev->state)
+		if (source->source->state == dev->state)
 			mod->input_buffers[j].consumed = source_bytes;
-
-		buffer_release(source_c);
 		j++;
 	}
 	mod->output_buffers[0].size = sink_bytes;
@@ -560,10 +543,7 @@ static int mux_reset(struct processing_module *mod)
 		list_for_item(blist, &dev->bsource_list) {
 			struct comp_buffer *source = container_of(blist, struct comp_buffer,
 								  sink_list);
-			struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
-			int state = source_c->source->state;
-
-			buffer_release(source_c);
+			int state = source->source->state;
 
 			/* only mux the sources with the same state with mux */
 			if (state > COMP_STATE_READY)
@@ -586,8 +566,6 @@ static int mux_prepare(struct processing_module *mod,
 	struct list_item *blist;
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *source_c;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct sof_mux_config *config;
 	size_t blob_size;
 	int state;
@@ -628,10 +606,8 @@ static int mux_prepare(struct processing_module *mod,
 	/* check each mux source state, set source align to 1 byte, 1 frame */
 	list_for_item(blist, &dev->bsource_list) {
 		source = container_of(blist, struct comp_buffer, sink_list);
-		source_c = buffer_acquire(source);
-		state = source_c->source->state;
-		audio_stream_init_alignment_constants(1, 1, &source_c->stream);
-		buffer_release(source_c);
+		state = source->source->state;
+		audio_stream_init_alignment_constants(1, 1, &source->stream);
 
 		/* only prepare downstream if we have no active sources */
 		if (state == COMP_STATE_PAUSED || state == COMP_STATE_ACTIVE)
@@ -641,9 +617,7 @@ static int mux_prepare(struct processing_module *mod,
 	/* set sink align to 1 byte, 1 frame */
 	list_for_item(blist, &dev->bsink_list) {
 		sink = container_of(blist, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		audio_stream_init_alignment_constants(1, 1, &sink_c->stream);
-		buffer_release(sink_c);
+		audio_stream_init_alignment_constants(1, 1, &sink->stream);
 	}
 
 	/* prepare downstream */

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -559,7 +559,7 @@ static int mux_reset(struct processing_module *mod)
 
 static int mux_prepare(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -558,7 +558,7 @@ static int mux_reset(struct processing_module *mod)
 }
 
 static int mux_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -370,10 +370,10 @@ static struct mux_look_up *get_lookup_table(struct comp_dev *dev, struct comp_da
 }
 
 static void mux_prepare_active_look_up(struct comp_data *cd,
-				       struct audio_stream __sparse_cache *sink,
-				       const struct audio_stream __sparse_cache **sources)
+				       struct audio_stream *sink,
+				       const struct audio_stream **sources)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	int elem;
 	int active_elem = 0;
 
@@ -395,8 +395,8 @@ static void mux_prepare_active_look_up(struct comp_data *cd,
 }
 
 static void demux_prepare_active_look_up(struct comp_data *cd,
-					 struct audio_stream __sparse_cache *sink,
-					 const struct audio_stream __sparse_cache *source,
+					 struct audio_stream *sink,
+					 const struct audio_stream *source,
 					 struct mux_look_up *look_up)
 {
 	int elem;
@@ -424,7 +424,7 @@ static int demux_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct list_item *clist;
 	struct comp_buffer *sink;
-	struct audio_stream __sparse_cache *sinks_stream[MUX_MAX_STREAMS] = { NULL };
+	struct audio_stream *sinks_stream[MUX_MAX_STREAMS] = { NULL };
 	struct mux_look_up *look_ups[MUX_MAX_STREAMS] = { NULL };
 	int frames;
 	int sink_bytes;
@@ -478,7 +478,7 @@ static int mux_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source;
 	struct list_item *clist;
-	const struct audio_stream __sparse_cache *sources_stream[MUX_MAX_STREAMS] = { NULL };
+	const struct audio_stream *sources_stream[MUX_MAX_STREAMS] = { NULL };
 	int frames = 0;
 	int sink_bytes;
 	int source_bytes;

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -19,11 +19,11 @@
 
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
-static void mux_check_for_wrap(struct audio_stream __sparse_cache *sink,
-			       const struct audio_stream __sparse_cache **sources,
+static void mux_check_for_wrap(struct audio_stream *sink,
+			       const struct audio_stream **sources,
 			       struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* check sources and destinations for wrap */
@@ -36,8 +36,8 @@ static void mux_check_for_wrap(struct audio_stream __sparse_cache *sink,
 	}
 }
 
-static void demux_check_for_wrap(struct audio_stream __sparse_cache *sink,
-				 const struct audio_stream __sparse_cache *source,
+static void demux_check_for_wrap(struct audio_stream *sink,
+				 const struct audio_stream *source,
 				 struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -53,7 +53,7 @@ static void demux_check_for_wrap(struct audio_stream __sparse_cache *sink,
 
 #if CONFIG_FORMAT_S16LE
 
-static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream __sparse_cache *sink,
+static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 						   const struct audio_stream
 						   __sparse_cache *source,
 						   struct mux_look_up *lookup)
@@ -79,12 +79,12 @@ static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream __sparse_
 	return min_frames;
 }
 
-static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream __sparse_cache *sink,
+static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 						 const struct audio_stream
 						 __sparse_cache **sources,
 						 struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t frames;
 	uint32_t min_frames;
 	uint32_t elem;
@@ -111,11 +111,11 @@ static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream __sparse_ca
 	return min_frames;
 }
 
-static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *sink,
-					  const struct audio_stream __sparse_cache **sources,
+static void mux_init_look_up_pointers_s16(struct audio_stream *sink,
+					  const struct audio_stream **sources,
 					  struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* init pointers */
@@ -132,8 +132,8 @@ static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *si
 	}
 }
 
-static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *sink,
-					    const struct audio_stream __sparse_cache *source,
+static void demux_init_look_up_pointers_s16(struct audio_stream *sink,
+					    const struct audio_stream *source,
 					    struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -162,8 +162,8 @@ static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void demux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache *source, uint32_t frames,
+static void demux_s16le(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream *source, uint32_t frames,
 			struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -215,8 +215,8 @@ static void demux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void mux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t frames,
+static void mux_s16le(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -259,12 +259,12 @@ static void mux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 
-static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream __sparse_cache *sink,
+static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 						 const struct audio_stream
 						 __sparse_cache **sources,
 						 struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t frames;
 	uint32_t min_frames;
 	uint32_t elem;
@@ -289,7 +289,7 @@ static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream __sparse_ca
 	return min_frames;
 }
 
-static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream __sparse_cache *sink,
+static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 						   const struct audio_stream
 						   __sparse_cache *source,
 						   struct mux_look_up *lookup)
@@ -313,11 +313,11 @@ static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream __sparse_
 	return min_frames;
 }
 
-static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *sink,
-					  const struct audio_stream __sparse_cache **sources,
+static void mux_init_look_up_pointers_s32(struct audio_stream *sink,
+					  const struct audio_stream **sources,
 					  struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* init pointers */
@@ -334,8 +334,8 @@ static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *si
 	}
 }
 
-static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *sink,
-					    const struct audio_stream __sparse_cache *source,
+static void demux_init_look_up_pointers_s32(struct audio_stream *sink,
+					    const struct audio_stream *source,
 					    struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -364,8 +364,8 @@ static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void demux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache *source, uint32_t frames,
+static void demux_s32le(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream *source, uint32_t frames,
 			struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -417,8 +417,8 @@ static void demux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void mux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t frames,
+static void mux_s32le(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_look_up *lookup)
 {
 	uint32_t i;

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -54,8 +54,7 @@ static void demux_check_for_wrap(struct audio_stream *sink,
 #if CONFIG_FORMAT_S16LE
 
 static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
-						   const struct audio_stream
-						   __sparse_cache *source,
+						   const struct audio_stream *source,
 						   struct mux_look_up *lookup)
 {
 	uint32_t frames;
@@ -80,8 +79,7 @@ static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 }
 
 static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream *sink,
-						 const struct audio_stream
-						 __sparse_cache **sources,
+						 const struct audio_stream **sources,
 						 struct mux_look_up *lookup)
 {
 	const struct audio_stream *source;
@@ -260,8 +258,7 @@ static void mux_s16le(struct comp_dev *dev, struct audio_stream *sink,
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 
 static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
-						 const struct audio_stream
-						 __sparse_cache **sources,
+						 const struct audio_stream **sources,
 						 struct mux_look_up *lookup)
 {
 	const struct audio_stream *source;
@@ -290,8 +287,7 @@ static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 }
 
 static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream *sink,
-						   const struct audio_stream
-						   __sparse_cache *source,
+						   const struct audio_stream *source,
 						   struct mux_look_up *lookup)
 {
 	uint32_t frames;

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -534,8 +534,7 @@ mux_func mux_get_processing_function(struct processing_module *mod)
 				source_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sinkb);
-		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sink_c->stream);
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sinkb->stream);
 
 
 		if (fmt == mux_func_map[i].frame_format)
@@ -558,10 +557,7 @@ demux_func demux_get_processing_function(struct processing_module *mod)
 				sink_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer __sparse_cache *source_c = buffer_acquire(sourceb);
-		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_c->stream);
-
-		buffer_release(source_c);
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sourceb->stream);
 
 		if (fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].demux_proc_func;

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -15,8 +15,8 @@
 #include <sof/audio/pcm_converter.h>
 #include <rtos/panic.h>
 
-int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-			  struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
+			  struct audio_stream *sink, uint32_t ooffset,
 			  uint32_t samples, pcm_converter_lin_func converter)
 {
 	const int s_size_in = audio_stream_sample_bytes(source);

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -34,8 +34,8 @@
 #define BYTES_TO_S32_SAMPLES	2
 
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
-static int pcm_convert_u8_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_u8_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
@@ -63,8 +63,8 @@ static int pcm_convert_u8_to_s32(const struct audio_stream __sparse_cache *sourc
 	return samples;
 }
 
-static int pcm_convert_s32_to_u8(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_u8(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -95,8 +95,8 @@ static int pcm_convert_s32_to_u8(const struct audio_stream __sparse_cache *sourc
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 
-static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -124,8 +124,8 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -157,8 +157,8 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -186,8 +186,8 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -219,8 +219,8 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -248,8 +248,8 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -277,8 +277,8 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *source,
-				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
+				     uint32_t ioffset, struct audio_stream *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -442,16 +442,16 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int16(_pcm_convert_f_to_i(src[i], 15));
 }
 
-static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s16_to_f_lin);
 }
 
-static int pcm_convert_f_to_s16(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s16(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -486,16 +486,16 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int24(_pcm_convert_f_to_i(src[i], 23));
 }
 
-static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s24_to_f_lin);
 }
 
-static int pcm_convert_f_to_s24(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s24(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -530,16 +530,16 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
 		dst[i] = _pcm_convert_f_to_i(src[i], 31);
 }
 
-static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s32_to_f_lin);
 }
 
-static int pcm_convert_f_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -599,8 +599,8 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -628,8 +628,8 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -658,8 +658,8 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -687,8 +687,8 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -717,8 +717,8 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -746,8 +746,8 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -777,8 +777,8 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
@@ -807,8 +807,8 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -841,8 +841,8 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 }
 
 /* 2x24bit samples are packed into 3x16bit samples for hda link dma */
-static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream __sparse_cache *source,
-						   uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *source,
+						   uint32_t ioffset, struct audio_stream *sink,
 						   uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -36,8 +36,8 @@
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	ae_int16x4 sample = AE_ZERO16();
@@ -110,8 +110,8 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	ae_int16x4 sample = AE_ZERO16();
@@ -181,8 +181,8 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -237,8 +237,8 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -303,8 +303,8 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -368,8 +368,8 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -413,8 +413,8 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *source,
-				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
+				     uint32_t ioffset, struct audio_stream *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -541,8 +541,8 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -556,8 +556,8 @@ static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s16(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s16(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -642,8 +642,8 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -657,8 +657,8 @@ static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s24(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s24(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -739,8 +739,8 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -754,8 +754,8 @@ static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -810,9 +810,9 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -860,9 +860,9 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -919,9 +919,9 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -962,9 +962,9 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1007,9 +1007,9 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1062,9 +1062,9 @@ static ae_int32x2 pcm_shift_s24_c32_to_s16(ae_int32x2 sample)
 	return sample;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1109,9 +1109,9 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
@@ -1156,9 +1156,9 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -176,10 +176,6 @@ static void buffer_set_comp(struct comp_buffer *buffer, struct comp_dev *comp,
 		buffer_c->sink = comp;
 
 	buffer_release(buffer_c);
-
-	/* The buffer might be marked as shared later, write back the cache */
-	if (!buffer->c.shared)
-		dcache_writeback_invalidate_region(uncache_to_cache(buffer), sizeof(*buffer));
 }
 
 int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -168,14 +168,10 @@ free:
 static void buffer_set_comp(struct comp_buffer *buffer, struct comp_dev *comp,
 			    int dir)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
-
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
-		buffer_c->source = comp;
+		buffer->source = comp;
 	else
-		buffer_c->sink = comp;
-
-	buffer_release(buffer_c);
+		buffer->sink = comp;
 }
 
 int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
@@ -410,7 +406,6 @@ int pipeline_for_each_comp(struct comp_dev *current,
 	/* run this operation further */
 	list_for_item(clist, buffer_list) {
 		struct comp_buffer *buffer = buffer_from_list(clist, dir);
-		struct comp_buffer __sparse_cache *buffer_c;
 		struct comp_dev *buffer_comp;
 		int err = 0;
 
@@ -434,27 +429,21 @@ int pipeline_for_each_comp(struct comp_dev *current,
 
 		buffer_comp = buffer_get_comp(buffer, dir);
 
-		buffer_c = buffer_acquire(buffer);
-
 		/* execute operation on buffer */
 		if (ctx->buff_func)
-			ctx->buff_func(buffer_c, ctx->buff_data);
+			ctx->buff_func(buffer, ctx->buff_data);
 
 		/* don't go further if this component is not connected */
 		if (buffer_comp &&
 		    (!ctx->skip_incomplete || buffer_comp->pipeline) &&
 		    ctx->comp_func) {
-			buffer_c->walking = true;
-			buffer_release(buffer_c);
+			buffer->walking = true;
 
 			err = ctx->comp_func(buffer_comp, buffer,
 					     ctx, dir);
 
-			buffer_c = buffer_acquire(buffer);
-			buffer_c->walking = false;
+			buffer->walking = false;
 		}
-
-		buffer_release(buffer_c);
 
 		if (err < 0 || err == PPL_STATUS_PATH_STOP)
 			return err;

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -30,7 +30,6 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 				    int dir)
 {
 	struct pipeline_data *ppl_data = ctx->comp_data;
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(calling_buf);
 	int err = 0;
 
 	pipe_dbg(current->pipeline, "pipeline_comp_params_neg(), current->comp.id = %u, dir = %u",
@@ -48,12 +47,12 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 		 * a component who has different channels input/output buffers
 		 * should explicitly configure the channels of the branched buffers.
 		 */
-		err = buffer_set_params(buf_c, &ppl_data->params->params,
+		err = buffer_set_params(calling_buf, &ppl_data->params->params,
 					BUFFER_UPDATE_FORCE);
 		break;
 	default:
 		/* return 0 if params matches */
-		if (!buffer_params_match(buf_c,
+		if (!buffer_params_match(calling_buf,
 					 &ppl_data->params->params,
 					 BUFF_PARAMS_FRAME_FMT |
 					 BUFF_PARAMS_RATE)) {
@@ -66,8 +65,6 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 			err = -EINVAL;
 		}
 	}
-
-	buffer_release(buf_c);
 	return err;
 }
 
@@ -188,11 +185,8 @@ static int pipeline_comp_hw_params_buf(struct comp_dev *current,
 		return ret;
 	/* set buffer parameters */
 	if (calling_buf) {
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(calling_buf);
-
-		ret = buffer_set_params(buf_c, &ppl_data->params->params,
+		ret = buffer_set_params(calling_buf, &ppl_data->params->params,
 					BUFFER_UPDATE_IF_UNSET);
-		buffer_release(buf_c);
 		if (ret < 0)
 			pipe_err(current->pipeline,
 				 "pipeline_comp_hw_params(): buffer_set_params(): %d", ret);

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -128,7 +128,7 @@ static int pipeline_comp_params(struct comp_dev *current,
 }
 
 /* save params changes made by component */
-static void pipeline_update_buffer_pcm_params(struct comp_buffer __sparse_cache *buffer,
+static void pipeline_update_buffer_pcm_params(struct comp_buffer *buffer,
 					      void *data)
 {
 	struct sof_ipc_stream_params *params = data;

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -716,7 +716,7 @@ static int rtnr_trigger(struct comp_dev *dev, int cmd)
 }
 
 static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
-				      struct audio_stream __sparse_cache *src)
+				      struct audio_stream *src)
 {
 
 	dst->size = audio_stream_get_size(src);
@@ -728,7 +728,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->end_addr = audio_stream_get_end_addr(src);
 }
 
-static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
+static void rtnr_copy_to_sof_stream(struct audio_stream *dst,
 				    struct audio_stream_rtnr *src)
 {
 	audio_stream_set_size(dst, src->size);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -325,7 +325,6 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	int ret;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	bool channels_valid;
 
 	comp_info(dev, "rtnr_params()");
@@ -341,21 +340,17 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 							source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* set source/sink_frames/rate */
-	cd->source_rate = audio_stream_get_rate(&source_c->stream);
-	cd->sink_rate = audio_stream_get_rate(&sink_c->stream);
-	cd->sources_stream[0].rate = audio_stream_get_rate(&source_c->stream);
-	cd->sink_stream.rate = audio_stream_get_rate(&sink_c->stream);
-	channels_valid = audio_stream_get_channels(&source_c->stream) ==
-		audio_stream_get_channels(&sink_c->stream);
+	cd->source_rate = audio_stream_get_rate(&sourceb->stream);
+	cd->sink_rate = audio_stream_get_rate(&sinkb->stream);
+	cd->sources_stream[0].rate = audio_stream_get_rate(&sourceb->stream);
+	cd->sink_stream.rate = audio_stream_get_rate(&sinkb->stream);
+	channels_valid = audio_stream_get_channels(&sourceb->stream) ==
+		audio_stream_get_channels(&sinkb->stream);
 
 	if (!cd->sink_rate) {
 		comp_err(dev, "rtnr_nr_params(), zero sink rate");
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* Currently support 16kHz sample rate only. */
@@ -369,29 +364,23 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	default:
 		comp_err(dev, "rtnr_nr_params(), invalid sample rate(%d kHz)",
 			 cd->source_rate);
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	if (!channels_valid) {
 		comp_err(dev, "rtnr_params(), source/sink stream must have same channels");
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* set source/sink stream channels */
-	cd->sources_stream[0].channels = audio_stream_get_channels(&source_c->stream);
-	cd->sink_stream.channels = audio_stream_get_channels(&sink_c->stream);
+	cd->sources_stream[0].channels = audio_stream_get_channels(&sourceb->stream);
+	cd->sink_stream.channels = audio_stream_get_channels(&sinkb->stream);
 
 	/* set source/sink stream overrun/underrun permitted */
-	cd->sources_stream[0].overrun_permitted = audio_stream_get_overrun(&source_c->stream);
-	cd->sink_stream.overrun_permitted = audio_stream_get_overrun(&sink_c->stream);
-	cd->sources_stream[0].underrun_permitted = audio_stream_get_underrun(&source_c->stream);
-	cd->sink_stream.underrun_permitted = audio_stream_get_underrun(&sink_c->stream);
-
-out:
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	cd->sources_stream[0].overrun_permitted = audio_stream_get_overrun(&sourceb->stream);
+	cd->sink_stream.overrun_permitted = audio_stream_get_overrun(&sinkb->stream);
+	cd->sources_stream[0].underrun_permitted = audio_stream_get_underrun(&sourceb->stream);
+	cd->sink_stream.underrun_permitted = audio_stream_get_underrun(&sinkb->stream);
 
 	return ret;
 }
@@ -874,10 +863,8 @@ static int rtnr_prepare(struct comp_dev *dev)
 
 	/* Get sink data format */
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	cd->sink_stream.frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
-	buffer_release(sink_c);
+	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
+	cd->sink_stream.frame_fmt = audio_stream_get_frm_fmt(&sinkb->stream);
 
 	/* Check source and sink PCM format and get processing function */
 	comp_info(dev, "rtnr_prepare(), sink_format=%d", cd->sink_format);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -821,7 +821,7 @@ static int selector_process(struct processing_module *mod,
  * \return Error code.
  */
 static int selector_prepare(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
+			    struct sof_source **sources, int num_of_sources,
 			    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -822,7 +822,7 @@ static int selector_process(struct processing_module *mod,
  */
 static int selector_prepare(struct processing_module *mod,
 			    struct sof_source **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			    struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct module_data *md = &mod->priv;

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -110,12 +110,12 @@ static int selector_verify_params(struct comp_dev *dev,
 		 * pipeline_comp_hw_params()
 		 */
 		in_channels = cd->config.in_channels_count ?
-			cd->config.in_channels_count : audio_stream_get_channels(&buffer_c->stream);
+			cd->config.in_channels_count : audio_stream_get_channels(&buffer->stream);
 		params->channels = in_channels;
 	}
 
 	/* Set buffer params */
-	buffer_set_params(buffer_c, params, BUFFER_UPDATE_FORCE);
+	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
 	/* set component period frames */
 	component_set_nearest_period_frames(dev, audio_stream_get_rate(&sinkb->stream));

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -32,8 +32,8 @@ LOG_MODULE_DECLARE(selector, CONFIG_SOF_LOG_LEVEL);
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int16_t *src = audio_stream_get_rptr(source);
@@ -72,8 +72,8 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = audio_stream_get_wptr(sink);
@@ -104,8 +104,8 @@ static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t *src = audio_stream_get_rptr(source);
@@ -144,8 +144,8 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = audio_stream_get_wptr(sink);
@@ -206,8 +206,8 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *dest = audio_stream_get_wptr(sink);
 	int nmax;
@@ -277,8 +277,8 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dest = audio_stream_get_wptr(sink);
 	int nmax;

--- a/src/audio/sink_api_helper.c
+++ b/src/audio/sink_api_helper.c
@@ -7,19 +7,19 @@
 #include <sof/audio/sink_api_implementation.h>
 #include <sof/audio/audio_stream.h>
 
-void sink_init(struct sof_sink __sparse_cache *sink, const struct sink_ops *ops,
+void sink_init(struct sof_sink *sink, const struct sink_ops *ops,
 	       struct sof_audio_stream_params *audio_stream_params)
 {
 	sink->ops = ops;
 	sink->audio_stream_params = audio_stream_params;
 }
 
-size_t sink_get_free_size(struct sof_sink __sparse_cache *sink)
+size_t sink_get_free_size(struct sof_sink *sink)
 {
 	return sink->ops->get_free_size(sink);
 }
 
-int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+int sink_get_buffer(struct sof_sink *sink, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
 	int ret;
@@ -35,7 +35,7 @@ int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
 	return ret;
 }
 
-int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
+int sink_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
 	int ret;
 
@@ -56,47 +56,47 @@ int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
 	return ret;
 }
 
-size_t sink_get_num_of_processed_bytes(struct sof_sink __sparse_cache *sink)
+size_t sink_get_num_of_processed_bytes(struct sof_sink *sink)
 {
 	return sink->num_of_bytes_processed;
 }
 
-void sink_reset_num_of_processed_bytes(struct sof_sink __sparse_cache *sink)
+void sink_reset_num_of_processed_bytes(struct sof_sink *sink)
 {
 	sink->num_of_bytes_processed = 0;
 }
 
-enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink __sparse_cache *sink)
+enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->frame_fmt;
 }
 
-enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink __sparse_cache *sink)
+enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->valid_sample_fmt;
 }
 
-uint32_t sink_get_rate(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_rate(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->rate;
 }
 
-uint32_t sink_get_channels(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_channels(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->channels;
 }
 
-uint32_t sink_get_buffer_fmt(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_buffer_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->buffer_fmt;
 }
 
-bool sink_get_overrun(struct sof_sink __sparse_cache *sink)
+bool sink_get_overrun(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->overrun_permitted;
 }
 
-int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame frame_fmt)
+int sink_set_frm_fmt(struct sof_sink *sink, enum sof_ipc_frame frame_fmt)
 {
 	sink->audio_stream_params->frame_fmt = frame_fmt;
 
@@ -106,7 +106,7 @@ int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame fr
 	return 0;
 }
 
-int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink,
+int sink_set_valid_fmt(struct sof_sink *sink,
 		       enum sof_ipc_frame valid_sample_fmt)
 {
 	sink->audio_stream_params->valid_sample_fmt = valid_sample_fmt;
@@ -115,7 +115,7 @@ int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate)
+int sink_set_rate(struct sof_sink *sink, unsigned int rate)
 {
 	sink->audio_stream_params->rate = rate;
 	if (sink->ops->on_audio_format_set)
@@ -123,7 +123,7 @@ int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate)
 	return 0;
 }
 
-int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channels)
+int sink_set_channels(struct sof_sink *sink, unsigned int channels)
 {
 	sink->audio_stream_params->channels = channels;
 	if (sink->ops->on_audio_format_set)
@@ -131,7 +131,7 @@ int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channel
 	return 0;
 }
 
-int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fmt)
+int sink_set_buffer_fmt(struct sof_sink *sink, uint32_t buffer_fmt)
 {
 	sink->audio_stream_params->buffer_fmt = buffer_fmt;
 	if (sink->ops->on_audio_format_set)
@@ -139,7 +139,7 @@ int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fm
 	return 0;
 }
 
-int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitted)
+int sink_set_overrun(struct sof_sink *sink, bool overrun_permitted)
 {
 	sink->audio_stream_params->overrun_permitted = overrun_permitted;
 	if (sink->ops->on_audio_format_set)
@@ -147,19 +147,19 @@ int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitte
 	return 0;
 }
 
-size_t sink_get_frame_bytes(struct sof_sink __sparse_cache *sink)
+size_t sink_get_frame_bytes(struct sof_sink *sink)
 {
 	return get_frame_bytes(sink_get_frm_fmt(sink),
 				sink_get_channels(sink));
 }
 
-size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink)
+size_t sink_get_free_frames(struct sof_sink *sink)
 {
 	return sink_get_free_size(sink) /
 			sink_get_frame_bytes(sink);
 }
 
-int sink_set_params(struct sof_sink __sparse_cache *sink,
+int sink_set_params(struct sof_sink *sink,
 		    struct sof_ipc_stream_params *params, bool force_update)
 {
 	if (sink->ops->audio_set_ipc_params)
@@ -167,7 +167,7 @@ int sink_set_params(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+int sink_set_alignment_constants(struct sof_sink *sink,
 				 const uint32_t byte_align,
 				 const uint32_t frame_align_req)
 {
@@ -176,12 +176,12 @@ int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs)
+void sink_set_obs(struct sof_sink *sink, size_t obs)
 {
 	sink->obs = obs;
 }
 
-size_t sink_get_obs(struct sof_sink __sparse_cache *sink)
+size_t sink_get_obs(struct sof_sink *sink)
 {
 	return sink->obs;
 }

--- a/src/audio/sink_source_utils.c
+++ b/src/audio/sink_source_utils.c
@@ -12,7 +12,7 @@
 #include <sof/math/numbers.h>
 #include <limits.h>
 
-int source_to_sink_copy(struct sof_source __sparse_cache *source,
+int source_to_sink_copy(struct sof_source *source,
 			struct sof_sink __sparse_cache *sink, bool free, size_t size)
 {
 	uint8_t *src_ptr;

--- a/src/audio/sink_source_utils.c
+++ b/src/audio/sink_source_utils.c
@@ -13,7 +13,7 @@
 #include <limits.h>
 
 int source_to_sink_copy(struct sof_source *source,
-			struct sof_sink __sparse_cache *sink, bool free, size_t size)
+			struct sof_sink *sink, bool free, size_t size)
 {
 	uint8_t *src_ptr;
 	uint8_t *src_begin;

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -26,8 +26,8 @@ DECLARE_TR_CTX(maxim_dsm_comp_tr, SOF_UUID(maxim_dsm_comp_uuid),
 #define SOF_SMART_AMP_MODEL 1
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink, uint32_t frames,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink, uint32_t frames,
 			     int8_t *chan_map, bool is_feedback);
 
 struct smart_amp_data {
@@ -532,8 +532,8 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 }
 
 static int smart_amp_process(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink,
 			     uint32_t frames, int8_t *chan_map,
 			     bool is_feedback)
 {

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -518,9 +518,7 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
 		if (sad->feedback_buf) {
-			struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
-			buffer_zero(buf);
-			buffer_release(buf);
+			buffer_zero(sad->feedback_buf);
 		}
 		break;
 	case COMP_TRIGGER_PAUSE:
@@ -558,10 +556,7 @@ static int smart_amp_process(struct comp_dev *dev,
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
-	enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_buf->stream);
-
-	buffer_release(source_buf);
+	enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sad->source_buf->stream);
 
 	switch (fmt) {
 	case SOF_IPC_FRAME_S16_LE:
@@ -577,8 +572,6 @@ static smart_amp_proc get_smart_amp_process(struct comp_dev *dev)
 static int smart_amp_copy(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
-	struct comp_buffer __sparse_cache *sink_buf = buffer_acquire(sad->sink_buf);
 	uint32_t avail_passthrough_frames;
 	uint32_t avail_feedback_frames;
 	uint32_t avail_frames;
@@ -589,56 +582,49 @@ static int smart_amp_copy(struct comp_dev *dev)
 	comp_dbg(dev, "smart_amp_copy()");
 
 	/* available bytes and samples calculation */
-	avail_passthrough_frames = audio_stream_avail_frames(&source_buf->stream,
-							     &sink_buf->stream);
+	avail_passthrough_frames = audio_stream_avail_frames(&sad->source_buf->stream,
+							     &sad->sink_buf->stream);
 
 	avail_frames = avail_passthrough_frames;
 
 	if (sad->feedback_buf) {
-		struct comp_buffer __sparse_cache *feedback_buf = buffer_acquire(sad->feedback_buf);
-
-		if (comp_get_state(dev, feedback_buf->source) == dev->state) {
+		if (comp_get_state(dev, sad->feedback_buf->source) == dev->state) {
 			/* feedback */
 			avail_feedback_frames =
-				audio_stream_get_avail_frames(&feedback_buf->stream);
+				audio_stream_get_avail_frames(&sad->feedback_buf->stream);
 
 			avail_feedback_frames = MIN(avail_passthrough_frames,
 						    avail_feedback_frames);
 
 			feedback_bytes = avail_feedback_frames *
-				audio_stream_frame_bytes(&feedback_buf->stream);
+				audio_stream_frame_bytes(&sad->feedback_buf->stream);
 
 			comp_dbg(dev, "smart_amp_copy(): processing %d feedback frames (avail_passthrough_frames: %d)",
 				 avail_feedback_frames, avail_passthrough_frames);
 
 			/* perform buffer writeback after source_buf process */
-			buffer_stream_invalidate(feedback_buf, feedback_bytes);
-			sad->process(dev, &feedback_buf->stream,
-				     &sink_buf->stream, avail_feedback_frames,
+			buffer_stream_invalidate(sad->feedback_buf, feedback_bytes);
+			sad->process(dev, &sad->feedback_buf->stream,
+				     &sad->sink_buf->stream, avail_feedback_frames,
 				     sad->config.feedback_ch_map, true);
 
-			comp_update_buffer_consume(feedback_buf, feedback_bytes);
+			comp_update_buffer_consume(sad->feedback_buf, feedback_bytes);
 		}
-
-		buffer_release(feedback_buf);
 	}
 
 	/* bytes calculation */
-	source_bytes = avail_frames * audio_stream_frame_bytes(&source_buf->stream);
-	sink_bytes = avail_frames * audio_stream_frame_bytes(&sink_buf->stream);
+	source_bytes = avail_frames * audio_stream_frame_bytes(&sad->source_buf->stream);
+	sink_bytes = avail_frames * audio_stream_frame_bytes(&sad->sink_buf->stream);
 
 	/* process data */
-	buffer_stream_invalidate(source_buf, source_bytes);
-	sad->process(dev, &source_buf->stream, &sink_buf->stream,
+	buffer_stream_invalidate(sad->source_buf, source_bytes);
+	sad->process(dev, &sad->source_buf->stream, &sad->sink_buf->stream,
 		     avail_frames, sad->config.source_ch_map, false);
-	buffer_stream_writeback(sink_buf, sink_bytes);
+	buffer_stream_writeback(sad->sink_buf, sink_bytes);
 
 	/* source/sink buffer pointers update */
-	comp_update_buffer_consume(source_buf, source_bytes);
-	comp_update_buffer_produce(sink_buf, sink_bytes);
-
-	buffer_release(sink_buf);
-	buffer_release(source_buf);
+	comp_update_buffer_consume(sad->source_buf, source_bytes);
+	comp_update_buffer_produce(sad->sink_buf, sink_bytes);
 
 	return 0;
 }
@@ -661,7 +647,6 @@ static int smart_amp_reset(struct comp_dev *dev)
 static int smart_amp_prepare(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_c, *buf_c;
 	struct list_item *blist;
 	int ret;
 	int bitwidth;
@@ -676,45 +661,37 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer *source_buffer = container_of(blist, struct comp_buffer,
 								 sink_list);
-		source_c = buffer_acquire(source_buffer);
 
-		if (source_c->source->ipc_config.type == SOF_COMP_DEMUX) {
+		if (source_buffer->source->ipc_config.type == SOF_COMP_DEMUX) {
 			sad->feedback_buf = source_buffer;
 		} else {
 			sad->source_buf = source_buffer;
-			sad->in_channels = audio_stream_get_channels(&source_c->stream);
+			sad->in_channels = audio_stream_get_channels(&source_buffer->stream);
 		}
-
-		buffer_release(source_c);
 	}
 
 	sad->sink_buf = list_first_item(&dev->bsink_list, struct comp_buffer,
 					source_list);
 
-	buf_c = buffer_acquire(sad->sink_buf);
-	sad->out_channels = audio_stream_get_channels(&buf_c->stream);
-	buffer_release(buf_c);
-
-	source_c = buffer_acquire(sad->source_buf);
+	sad->out_channels = audio_stream_get_channels(&sad->sink_buf->stream);
 
 	if (sad->feedback_buf) {
-		buf_c = buffer_acquire(sad->feedback_buf);
+		audio_stream_set_channels(&sad->feedback_buf->stream,
+					  sad->config.feedback_channels);
+		audio_stream_set_rate(&sad->feedback_buf->stream,
+				      audio_stream_get_rate(&sad->source_buf->stream));
 
-		audio_stream_set_channels(&buf_c->stream, sad->config.feedback_channels);
-		audio_stream_set_rate(&buf_c->stream, audio_stream_get_rate(&source_c->stream));
-		buffer_release(buf_c);
-
-		ret = smart_amp_check_audio_fmt(audio_stream_get_rate(&source_c->stream),
-						audio_stream_get_channels(&source_c->stream));
+		ret = smart_amp_check_audio_fmt(audio_stream_get_rate(&sad->source_buf->stream),
+						audio_stream_get_channels(&sad->source_buf->stream));
 		if (ret) {
 			comp_err(dev, "[DSM] Format not supported, sample rate: %d, ch: %d",
-				 audio_stream_get_rate(&source_c->stream),
-				 audio_stream_get_channels(&source_c->stream));
+				 audio_stream_get_rate(&sad->source_buf->stream),
+				 audio_stream_get_channels(&sad->source_buf->stream));
 			goto error;
 		}
 	}
 
-	switch (audio_stream_get_frm_fmt(&source_c->stream)) {
+	switch (audio_stream_get_frm_fmt(&sad->source_buf->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
 		bitwidth = 16;
 		break;
@@ -726,7 +703,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		break;
 	default:
 		comp_err(dev, "[DSM] smart_amp_process() error: not supported frame format %d",
-			 audio_stream_get_frm_fmt(&source_c->stream));
+			 audio_stream_get_frm_fmt(&sad->source_buf->stream));
 		goto error;
 	}
 
@@ -751,8 +728,6 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	}
 
 error:
-	buffer_release(source_c);
-
 	smart_amp_flush(sad->mod_handle, dev);
 	return ret;
 }

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -24,9 +24,9 @@ static void smart_amp_fb_generic(int32_t x)
 
 #if CONFIG_FORMAT_S16LE
 static void smart_amp_s16_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int16_t *x;
@@ -52,9 +52,9 @@ static void smart_amp_s16_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void smart_amp_s24_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -80,9 +80,9 @@ static void smart_amp_s24_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void smart_amp_s32_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -106,9 +106,9 @@ static void smart_amp_s32_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S16LE
 static void smart_amp_s16_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int16_t *x;
@@ -130,9 +130,9 @@ static void smart_amp_s16_fb_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void smart_amp_s24_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -154,9 +154,9 @@ static void smart_amp_s24_fb_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void smart_amp_s32_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -579,7 +579,7 @@ int smart_amp_check_audio_fmt(int sample_rate, int ch_num)
 }
 
 static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
-				const struct audio_stream __sparse_cache *stream,
+				const struct audio_stream *stream,
 				int8_t *chan_map, uint32_t num_ch)
 {
 	int idx, ch;
@@ -629,7 +629,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 }
 
 static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
-				const struct audio_stream __sparse_cache *stream,
+				const struct audio_stream *stream,
 				int8_t *chan_map, uint32_t num_ch_in,
 				uint32_t num_ch_out)
 {
@@ -681,8 +681,8 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 }
 
 int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch_in, uint32_t num_ch_out)
 {
@@ -741,8 +741,8 @@ err:
 }
 
 int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch)
 {

--- a/src/audio/source_api_helper.c
+++ b/src/audio/source_api_helper.c
@@ -7,7 +7,7 @@
 #include <sof/audio/source_api_implementation.h>
 #include <sof/audio/audio_stream.h>
 
-void source_init(struct sof_source __sparse_cache *source, const struct source_ops *ops,
+void source_init(struct sof_source *source, const struct source_ops *ops,
 		 struct sof_audio_stream_params *audio_stream_params)
 {
 	source->ops = ops;
@@ -15,12 +15,12 @@ void source_init(struct sof_source __sparse_cache *source, const struct source_o
 	source->audio_stream_params = audio_stream_params;
 }
 
-size_t source_get_data_available(struct sof_source __sparse_cache *source)
+size_t source_get_data_available(struct sof_source *source)
 {
 	return source->ops->get_data_available(source);
 }
 
-int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+int source_get_data(struct sof_source *source, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
 	int ret;
@@ -35,7 +35,7 @@ int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
 	return ret;
 }
 
-int source_release_data(struct sof_source __sparse_cache *source, size_t free_size)
+int source_release_data(struct sof_source *source, size_t free_size)
 {
 	int ret;
 
@@ -56,47 +56,47 @@ int source_release_data(struct sof_source __sparse_cache *source, size_t free_si
 	return ret;
 }
 
-size_t source_get_num_of_processed_bytes(struct sof_source __sparse_cache *source)
+size_t source_get_num_of_processed_bytes(struct sof_source *source)
 {
 	return source->num_of_bytes_processed;
 }
 
-void source_reset_num_of_processed_bytes(struct sof_source __sparse_cache *source)
+void source_reset_num_of_processed_bytes(struct sof_source *source)
 {
 	source->num_of_bytes_processed = 0;
 }
 
-enum sof_ipc_frame source_get_frm_fmt(struct sof_source __sparse_cache *source)
+enum sof_ipc_frame source_get_frm_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->frame_fmt;
 }
 
-enum sof_ipc_frame source_get_valid_fmt(struct sof_source __sparse_cache *source)
+enum sof_ipc_frame source_get_valid_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->valid_sample_fmt;
 }
 
-unsigned int source_get_rate(struct sof_source __sparse_cache *source)
+unsigned int source_get_rate(struct sof_source *source)
 {
 	return source->audio_stream_params->rate;
 }
 
-unsigned int source_get_channels(struct sof_source __sparse_cache *source)
+unsigned int source_get_channels(struct sof_source *source)
 {
 	return source->audio_stream_params->channels;
 }
 
-uint32_t source_get_buffer_fmt(struct sof_source __sparse_cache *source)
+uint32_t source_get_buffer_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->buffer_fmt;
 }
 
-bool source_get_underrun(struct sof_source __sparse_cache *source)
+bool source_get_underrun(struct sof_source *source)
 {
 	return source->audio_stream_params->underrun_permitted;
 }
 
-int source_set_valid_fmt(struct sof_source __sparse_cache *source,
+int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt)
 {
 	source->audio_stream_params->valid_sample_fmt = valid_sample_fmt;
@@ -105,7 +105,7 @@ int source_set_valid_fmt(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate)
+int source_set_rate(struct sof_source *source, unsigned int rate)
 {
 	source->audio_stream_params->rate = rate;
 	if (source->ops->on_audio_format_set)
@@ -113,7 +113,7 @@ int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate)
 	return 0;
 }
 
-int source_set_channels(struct sof_source __sparse_cache *source, unsigned int channels)
+int source_set_channels(struct sof_source *source, unsigned int channels)
 {
 	source->audio_stream_params->channels = channels;
 	if (source->ops->on_audio_format_set)
@@ -121,7 +121,7 @@ int source_set_channels(struct sof_source __sparse_cache *source, unsigned int c
 	return 0;
 }
 
-int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buffer_fmt)
+int source_set_buffer_fmt(struct sof_source *source, uint32_t buffer_fmt)
 {
 	source->audio_stream_params->buffer_fmt = buffer_fmt;
 	if (source->ops->on_audio_format_set)
@@ -129,7 +129,7 @@ int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buf
 	return 0;
 }
 
-int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_permitted)
+int source_set_underrun(struct sof_source *source, bool underrun_permitted)
 {
 	source->audio_stream_params->underrun_permitted = underrun_permitted;
 	if (source->ops->on_audio_format_set)
@@ -137,19 +137,19 @@ int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_
 	return 0;
 }
 
-size_t source_get_frame_bytes(struct sof_source __sparse_cache *source)
+size_t source_get_frame_bytes(struct sof_source *source)
 {
 	return get_frame_bytes(source_get_frm_fmt(source),
 				source_get_channels(source));
 }
 
-size_t source_get_data_frames_available(struct sof_source __sparse_cache *source)
+size_t source_get_data_frames_available(struct sof_source *source)
 {
 	return source_get_data_available(source) /
 			source_get_frame_bytes(source);
 }
 
-int source_set_params(struct sof_source __sparse_cache *source,
+int source_set_params(struct sof_source *source,
 		      struct sof_ipc_stream_params *params, bool force_update)
 {
 	if (source->ops->audio_set_ipc_params)
@@ -157,7 +157,7 @@ int source_set_params(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-int source_set_alignment_constants(struct sof_source __sparse_cache *source,
+int source_set_alignment_constants(struct sof_source *source,
 				   const uint32_t byte_align,
 				   const uint32_t frame_align_req)
 {
@@ -166,12 +166,12 @@ int source_set_alignment_constants(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs)
+void source_set_ibs(struct sof_source *source, size_t ibs)
 {
 	source->ibs = ibs;
 }
 
-size_t source_get_ibs(struct sof_source __sparse_cache *source)
+size_t source_get_ibs(struct sof_source *source)
 {
 	return source->ibs;
 }

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -101,7 +101,7 @@ struct comp_data {
 	int sink_frames;
 	int sample_container_bytes;
 	int channels_count;
-	int (*src_func)(struct comp_data *cd, struct sof_source __sparse_cache *source,
+	int (*src_func)(struct comp_data *cd, struct sof_source *source,
 			struct sof_sink __sparse_cache *sink);
 	void (*polyphase_func)(struct src_stage_prm *s);
 };
@@ -335,7 +335,7 @@ int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
 }
 
 /* Fallback function */
-static int src_fallback(struct comp_data *cd, struct sof_source __sparse_cache *source,
+static int src_fallback(struct comp_data *cd, struct sof_source *source,
 			struct sof_sink __sparse_cache *sink)
 {
 	return 0;
@@ -343,7 +343,7 @@ static int src_fallback(struct comp_data *cd, struct sof_source __sparse_cache *
 
 /* Normal 2 stage SRC */
 static int src_2s(struct comp_data *cd,
-		  struct sof_source __sparse_cache *source, struct sof_sink __sparse_cache *sink)
+		  struct sof_source *source, struct sof_sink __sparse_cache *sink)
 {
 	struct src_stage_prm s1;
 	struct src_stage_prm s2;
@@ -443,7 +443,7 @@ static int src_2s(struct comp_data *cd,
 }
 
 /* 1 stage SRC for simple conversions */
-static int src_1s(struct comp_data *cd, struct sof_source __sparse_cache *source,
+static int src_1s(struct comp_data *cd, struct sof_source *source,
 		  struct sof_sink __sparse_cache *sink)
 {
 	struct src_stage_prm s1;
@@ -482,7 +482,7 @@ static int src_1s(struct comp_data *cd, struct sof_source __sparse_cache *source
 }
 
 /* A fast copy function for same in and out rate */
-static int src_copy_sxx(struct comp_data *cd, struct sof_source __sparse_cache *source,
+static int src_copy_sxx(struct comp_data *cd, struct sof_source *source,
 			struct sof_sink __sparse_cache *sink)
 {
 	int frames = cd->param.blk_in;
@@ -624,7 +624,7 @@ static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_c
 #error "No or invalid IPC MAJOR version selected."
 #endif /* CONFIG_IPC_MAJOR_4 */
 
-static void src_set_alignment(struct sof_source __sparse_cache *source,
+static void src_set_alignment(struct sof_source *source,
 			      struct sof_sink __sparse_cache *sink)
 {
 	const uint32_t byte_align = 1;
@@ -672,7 +672,7 @@ static int src_verify_params(struct processing_module *mod)
 }
 
 static bool src_get_copy_limits(struct comp_data *cd,
-				struct sof_source __sparse_cache *source,
+				struct sof_source *source,
 				struct sof_sink __sparse_cache *sink)
 {
 	struct src_param *sp;
@@ -716,7 +716,7 @@ static bool src_get_copy_limits(struct comp_data *cd,
 }
 
 static int src_params_general(struct processing_module *mod,
-			      struct sof_source __sparse_cache *source,
+			      struct sof_source *source,
 			      struct sof_sink __sparse_cache *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
@@ -826,7 +826,7 @@ static int src_params_general(struct processing_module *mod,
 }
 
 static int src_prepare_general(struct processing_module *mod,
-			       struct sof_source __sparse_cache *source,
+			       struct sof_source *source,
 			       struct sof_sink __sparse_cache *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
@@ -983,7 +983,7 @@ static int src_init(struct processing_module *mod)
 }
 
 static int src_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	int ret;
@@ -1002,7 +1002,7 @@ static int src_prepare(struct processing_module *mod,
 
 
 static bool src_is_ready_to_process(struct processing_module *mod,
-				    struct sof_source __sparse_cache **sources, int num_of_sources,
+				    struct sof_source **sources, int num_of_sources,
 				    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
@@ -1011,7 +1011,7 @@ static bool src_is_ready_to_process(struct processing_module *mod,
 }
 
 static int src_process(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -102,7 +102,7 @@ struct comp_data {
 	int sample_container_bytes;
 	int channels_count;
 	int (*src_func)(struct comp_data *cd, struct sof_source *source,
-			struct sof_sink __sparse_cache *sink);
+			struct sof_sink *sink);
 	void (*polyphase_func)(struct src_stage_prm *s);
 };
 
@@ -336,14 +336,14 @@ int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
 
 /* Fallback function */
 static int src_fallback(struct comp_data *cd, struct sof_source *source,
-			struct sof_sink __sparse_cache *sink)
+			struct sof_sink *sink)
 {
 	return 0;
 }
 
 /* Normal 2 stage SRC */
 static int src_2s(struct comp_data *cd,
-		  struct sof_source *source, struct sof_sink __sparse_cache *sink)
+		  struct sof_source *source, struct sof_sink *sink)
 {
 	struct src_stage_prm s1;
 	struct src_stage_prm s2;
@@ -444,7 +444,7 @@ static int src_2s(struct comp_data *cd,
 
 /* 1 stage SRC for simple conversions */
 static int src_1s(struct comp_data *cd, struct sof_source *source,
-		  struct sof_sink __sparse_cache *sink)
+		  struct sof_sink *sink)
 {
 	struct src_stage_prm s1;
 	int ret;
@@ -483,7 +483,7 @@ static int src_1s(struct comp_data *cd, struct sof_source *source,
 
 /* A fast copy function for same in and out rate */
 static int src_copy_sxx(struct comp_data *cd, struct sof_source *source,
-			struct sof_sink __sparse_cache *sink)
+			struct sof_sink *sink)
 {
 	int frames = cd->param.blk_in;
 
@@ -531,7 +531,7 @@ static int src_stream_pcm_sink_rate_check(struct ipc4_config_src cfg,
  * set up param then verify param. BTW for IPC3 path, the param is sent by
  * host driver.
  */
-static int src_set_params(struct processing_module *mod, struct sof_sink __sparse_cache *sink)
+static int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 {
 	struct sof_ipc_stream_params src_params;
 	struct sof_ipc_stream_params *params = mod->stream_params;
@@ -561,7 +561,7 @@ static int src_set_params(struct processing_module *mod, struct sof_sink __spars
 	return ret;
 }
 
-static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_cache  *sink)
+static void src_set_sink_params(struct comp_dev *dev, struct sof_sink  *sink)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_data *cd = module_get_private_data(mod);
@@ -610,12 +610,12 @@ static int src_stream_pcm_source_rate_check(struct ipc_config_src cfg,
 	return 0;
 }
 
-static int src_set_params(struct processing_module *mod, struct sof_sink __sparse_cache *sink)
+static int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 {
 	return 0;
 }
 
-static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_cache *sink)
+static void src_set_sink_params(struct comp_dev *dev, struct sof_sink *sink)
 {
 	/* empty */
 }
@@ -625,7 +625,7 @@ static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_c
 #endif /* CONFIG_IPC_MAJOR_4 */
 
 static void src_set_alignment(struct sof_source *source,
-			      struct sof_sink __sparse_cache *sink)
+			      struct sof_sink *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 1;
@@ -673,7 +673,7 @@ static int src_verify_params(struct processing_module *mod)
 
 static bool src_get_copy_limits(struct comp_data *cd,
 				struct sof_source *source,
-				struct sof_sink __sparse_cache *sink)
+				struct sof_sink *sink)
 {
 	struct src_param *sp;
 	struct src_stage *s1;
@@ -717,7 +717,7 @@ static bool src_get_copy_limits(struct comp_data *cd,
 
 static int src_params_general(struct processing_module *mod,
 			      struct sof_source *source,
-			      struct sof_sink __sparse_cache *sink)
+			      struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -827,7 +827,7 @@ static int src_params_general(struct processing_module *mod,
 
 static int src_prepare_general(struct processing_module *mod,
 			       struct sof_source *source,
-			       struct sof_sink __sparse_cache *sink)
+			       struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -984,7 +984,7 @@ static int src_init(struct processing_module *mod)
 
 static int src_prepare(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 
@@ -1003,7 +1003,7 @@ static int src_prepare(struct processing_module *mod,
 
 static bool src_is_ready_to_process(struct processing_module *mod,
 				    struct sof_source **sources, int num_of_sources,
-				    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				    struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 
@@ -1012,7 +1012,7 @@ static bool src_is_ready_to_process(struct processing_module *mod,
 
 static int src_process(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -726,7 +726,7 @@ static void tdfb_set_alignment(struct audio_stream __sparse_cache *source,
 }
 
 static int tdfb_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
+			struct sof_source **sources, int num_of_sources,
 			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct tdfb_comp_data *cd = module_get_private_data(mod);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -660,8 +660,8 @@ static int tdfb_process(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	int frame_count = input_buffers[0].size;
 	int ret;
 
@@ -715,8 +715,8 @@ static int tdfb_process(struct processing_module *mod,
 	return 0;
 }
 
-static void tdfb_set_alignment(struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink)
+static void tdfb_set_alignment(struct audio_stream *source,
+			       struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -731,7 +731,6 @@ static int tdfb_prepare(struct processing_module *mod,
 {
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt;
 	int source_channels;
@@ -744,16 +743,12 @@ static int tdfb_prepare(struct processing_module *mod,
 	/* Find source and sink buffers */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	tdfb_set_alignment(&source_c->stream, &sink_c->stream);
+	tdfb_set_alignment(&sourceb->stream, &sinkb->stream);
 
-	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	source_channels = audio_stream_get_channels(&source_c->stream);
-	sink_channels = audio_stream_get_channels(&sink_c->stream);
-	rate = audio_stream_get_rate(&source_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
+	source_channels = audio_stream_get_channels(&sourceb->stream);
+	sink_channels = audio_stream_get_channels(&sinkb->stream);
+	rate = audio_stream_get_rate(&sourceb->stream);
 
 	/* Initialize filter */
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -727,7 +727,7 @@ static void tdfb_set_alignment(struct audio_stream __sparse_cache *source,
 
 static int tdfb_prepare(struct processing_module *mod,
 			struct sof_source **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -58,8 +58,8 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -104,8 +104,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -150,8 +150,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -19,8 +19,8 @@
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int16x4 d;
@@ -108,8 +108,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;
@@ -197,8 +197,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -58,8 +58,8 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -104,8 +104,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -150,8 +150,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -429,7 +429,6 @@ static int tone_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
@@ -444,18 +443,12 @@ static int tone_params(struct comp_dev *dev,
 	if (dev->ipc_config.frame_fmt != SOF_IPC_FRAME_S32_LE)
 		return -EINVAL;
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
-	audio_stream_set_frm_fmt(&source_c->stream, dev->ipc_config.frame_fmt);
-	audio_stream_set_frm_fmt(&sink_c->stream, dev->ipc_config.frame_fmt);
+	audio_stream_set_frm_fmt(&sourceb->stream, dev->ipc_config.frame_fmt);
+	audio_stream_set_frm_fmt(&sinkb->stream, dev->ipc_config.frame_fmt);
 
 	/* calculate period size based on config */
 	cd->period_bytes = dev->frames *
-			   audio_stream_frame_bytes(&source_c->stream);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+			   audio_stream_frame_bytes(&sourceb->stream);
 
 	return 0;
 }
@@ -634,7 +627,6 @@ static int tone_trigger(struct comp_dev *dev, int cmd)
 static int tone_copy(struct comp_dev *dev)
 {
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t free;
 	int ret = 0;
@@ -645,24 +637,21 @@ static int tone_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	sink_c = buffer_acquire(sink);
-	free = audio_stream_get_free_bytes(&sink_c->stream);
+	free = audio_stream_get_free_bytes(&sink->stream);
 
 	/* Test that sink has enough free frames. Then run once to maintain
 	 * low latency and steady load for tones.
 	 */
 	if (free >= cd->period_bytes) {
 		/* create tone */
-		cd->tone_func(dev, &sink_c->stream, dev->frames);
-		buffer_stream_writeback(sink_c, cd->period_bytes);
+		cd->tone_func(dev, &sink->stream, dev->frames);
+		buffer_stream_writeback(sink, cd->period_bytes);
 
 		/* calc new free and available */
-		comp_update_buffer_produce(sink_c, cd->period_bytes);
+		comp_update_buffer_produce(sink, cd->period_bytes);
 
 		ret = dev->frames;
 	}
-
-	buffer_release(sink_c);
 
 	return ret;
 }

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -95,7 +95,7 @@ struct comp_data {
 	uint32_t frame_bytes;
 	uint32_t rate;
 	struct tone_state sg[PLATFORM_MAX_CHANNELS];
-	void (*tone_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+	void (*tone_func)(struct comp_dev *dev, struct audio_stream *sink,
 			  uint32_t frames);
 };
 
@@ -113,7 +113,7 @@ static inline void tone_circ_inc_wrap(int32_t **ptr, int32_t *end, size_t size)
 		*ptr = (int32_t *)((size_t)*ptr - size);
 }
 
-static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+static void tone_s32_default(struct comp_dev *dev, struct audio_stream *sink,
 			     uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -400,7 +400,7 @@ err:
 
 /* just stubs for now. Remove these after making these ops optional in the module adapter */
 static int up_down_mixer_prepare(struct processing_module *mod,
-				 struct sof_source __sparse_cache **sources, int num_of_sources,
+				 struct sof_source **sources, int num_of_sources,
 				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct up_down_mixer_data *cd = module_get_private_data(mod);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -401,7 +401,7 @@ err:
 /* just stubs for now. Remove these after making these ops optional in the module adapter */
 static int up_down_mixer_prepare(struct processing_module *mod,
 				 struct sof_source **sources, int num_of_sources,
-				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct up_down_mixer_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -638,7 +638,6 @@ static int volume_prepare(struct processing_module *mod,
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
 	uint32_t sink_period_bytes;
 	int ret;
 	int i;
@@ -653,20 +652,15 @@ static int volume_prepare(struct processing_module *mod,
 	sourceb = list_first_item(&dev->bsource_list,
 				  struct comp_buffer, sink_list);
 
-	sink_c = buffer_acquire(sinkb);
-	source_c = buffer_acquire(sourceb);
-
-	volume_set_alignment(&source_c->stream, &sink_c->stream);
-
-	buffer_release(source_c);
+	volume_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get sink period bytes */
-	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
+	sink_period_bytes = audio_stream_period_bytes(&sinkb->stream,
 						      dev->frames);
 
-	if (audio_stream_get_size(&sink_c->stream) < sink_period_bytes) {
+	if (audio_stream_get_size(&sinkb->stream) < sink_period_bytes) {
 		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d",
-			 audio_stream_get_size(&sink_c->stream), sink_period_bytes);
+			 audio_stream_get_size(&sinkb->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -680,7 +674,7 @@ static int volume_prepare(struct processing_module *mod,
 		goto err;
 	}
 
-	cd->zc_get = vol_get_zc_function(dev, sink_c);
+	cd->zc_get = vol_get_zc_function(dev, sinkb);
 	if (!cd->zc_get) {
 		comp_err(dev, "volume_prepare(): invalid cd->zc_get");
 		ret = -EINVAL;
@@ -695,16 +689,14 @@ static int volume_prepare(struct processing_module *mod,
 	 */
 	cd->ramp_finished = false;
 
-	cd->channels = audio_stream_get_channels(&sink_c->stream);
+	cd->channels = audio_stream_get_channels(&sinkb->stream);
 	if (cd->channels > SOF_IPC_MAX_CHANNELS) {
 		ret = -EINVAL;
 		goto err;
 	}
 
 	cd->sample_rate_inv = (int32_t)(1000LL * INT32_MAX /
-					audio_stream_get_rate(&sink_c->stream));
-
-	buffer_release(sink_c);
+					audio_stream_get_rate(&sinkb->stream));
 
 	for (i = 0; i < cd->channels; i++) {
 		cd->volume[i] = cd->vol_min;
@@ -725,7 +717,6 @@ static int volume_prepare(struct processing_module *mod,
 	return 0;
 
 err:
-	buffer_release(sink_c);
 	comp_set_state(dev, COMP_TRIGGER_RESET);
 	return ret;
 }

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -575,7 +575,7 @@ static int volume_process(struct processing_module *mod,
  * \param[in,out] dev Volume base component device.
  */
 static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
-				       struct comp_buffer __sparse_cache *sinkb)
+				       struct comp_buffer *sinkb)
 {
 	int i;
 
@@ -631,8 +631,8 @@ static void volume_set_alignment(struct audio_stream *source,
  * to also do some type of conversion here.
  */
 static int volume_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_source **sources, int num_of_sources,
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct module_data *md = &mod->priv;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -57,7 +57,7 @@ LOG_MODULE_REGISTER(volume, CONFIG_SOF_LOG_LEVEL);
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s16(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	uint32_t curr_frames = frames;
@@ -105,7 +105,7 @@ static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s24(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	int64_t sum;
@@ -153,7 +153,7 @@ static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s32(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s32(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	int64_t sum;
@@ -593,8 +593,8 @@ static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
  * \param[in,out] source Structure pointer of source.
  * \param[in,out] sink Structure pointer of sink.
  */
-static void volume_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void volume_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 #if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
 

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -134,7 +134,7 @@ typedef void (*vol_scale_func)(struct processing_module *mod, struct input_strea
 /**
  * \brief volume interface for function getting nearest zero crossing frame
  */
-typedef uint32_t (*vol_zc_func)(const struct audio_stream __sparse_cache *source,
+typedef uint32_t (*vol_zc_func)(const struct audio_stream *source,
 				uint32_t frames, int64_t *prev_sum);
 
 /**

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -110,8 +110,8 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x;
 	int32_t *y;
 	int nmax, n;
@@ -153,8 +153,8 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -205,8 +205,8 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x;
 	int32_t *y;
 	int nmax, n;
@@ -247,8 +247,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int16_t *x, *x0;
 	int16_t *y, *y0;
@@ -296,8 +296,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x;
 	int16_t *y;
 	int nmax, n;

--- a/src/audio/volume/volume_generic_with_peakvol.c
+++ b/src/audio/volume/volume_generic_with_peakvol.c
@@ -57,8 +57,8 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -112,8 +112,8 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
@@ -166,8 +166,8 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -224,8 +224,8 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
@@ -280,8 +280,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int16_t *x, *x0;
 	int16_t *y, *y0;
@@ -336,8 +336,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -147,8 +147,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -198,8 +198,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -289,8 +289,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -339,8 +339,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -436,8 +436,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/volume/volume_hifi3_with_peakvol.c
@@ -41,8 +41,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -116,8 +116,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int channel, n, i, m;
 	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
@@ -176,8 +176,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -252,8 +252,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, channel, m;
 	const int channels_count = audio_stream_get_channels(sink);
@@ -312,8 +312,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
 	ae_f16x4 in_sample = AE_ZERO16();
@@ -394,8 +394,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, channel, m;
 	ae_f16 *in;

--- a/src/audio/volume/volume_hifi4.c
+++ b/src/audio/volume/volume_hifi4.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -147,8 +147,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -198,8 +198,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -289,8 +289,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -338,8 +338,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -435,8 +435,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -54,8 +54,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -150,8 +150,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 
 	int i, n, m;
@@ -217,8 +217,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -321,8 +321,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -385,8 +385,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -501,8 +501,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -37,7 +37,6 @@ LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
 void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_or_sink)
 {
 	struct comp_buffer *bufferb;
-	struct comp_buffer __sparse_cache *buffer_c;
 
 	if (source_or_sink)
 		bufferb = list_first_item(&dev->bsource_list,
@@ -46,10 +45,7 @@ void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_o
 		bufferb = list_first_item(&dev->bsink_list,
 					  struct comp_buffer, source_list);
 
-	buffer_c = buffer_acquire(bufferb);
-	cd->scale_vol = vol_get_processing_function(dev, buffer_c, cd);
-
-	buffer_release(buffer_c);
+	cd->scale_vol = vol_get_processing_function(dev, bufferb, cd);
 }
 
 /**

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -366,7 +366,6 @@ int volume_get_config(struct processing_module *mod,
 static int volume_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -378,14 +377,10 @@ static int volume_params(struct processing_module *mod)
 
 	/* volume component will only ever have 1 sink buffer */
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(sink_c);
+	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	return 0;
 }

--- a/src/include/ipc4/base-config.h
+++ b/src/include/ipc4/base-config.h
@@ -242,7 +242,7 @@ struct sof_ipc_stream_params;
 void ipc4_base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *base_cfg,
 					   struct sof_ipc_stream_params *params);
 struct comp_buffer;
-void ipc4_update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
+void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 			       const struct ipc4_audio_format *fmt);
 
 #endif

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -272,7 +272,7 @@ struct copier_data {
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
-		      struct comp_buffer __sparse_cache *sink, int frame);
+		      struct comp_buffer *sink, int frame);
 
 pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 				      const struct ipc4_audio_format *out_fmt,

--- a/src/include/ipc4/mixin_mixout.h
+++ b/src/include/ipc4/mixin_mixout.h
@@ -105,15 +105,15 @@ struct ipc4_mixer_mode_config {
 /**
  * \brief normal mode mixin_mixout processing function interface
  */
-typedef void (*normal_mix_func)(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+typedef void (*normal_mix_func)(struct audio_stream *sink, int32_t start_frame,
 				int32_t mixed_frames,
-				const struct audio_stream __sparse_cache *source,
+				const struct audio_stream *source,
 				int32_t frame_count, uint16_t gain);
 
 /**
  * \brief mixin_mixout mute processing function interface
  */
-typedef void (*mute_func) (struct audio_stream __sparse_cache *stream, int32_t channel_index,
+typedef void (*mute_func) (struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count);
 
 /**

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -48,14 +48,14 @@
  * \brief aria get data function interface
  */
 typedef void (*aria_get_data_func)(struct processing_module *mod,
-				   struct audio_stream __sparse_cache *sink, int frames);
+				   struct audio_stream *sink, int frames);
 
 struct aria_data;
 /**
  * \brief Aria gain processing function
  */
 void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-			 struct audio_stream __sparse_cache *source, int frames);
+			 struct audio_stream *source, int frames);
 
 aria_get_data_func aria_algo_get_data_func(struct processing_module *mod);
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -104,148 +104,146 @@ struct audio_stream {
 	struct sof_audio_stream_params runtime_stream_params;
 };
 
-static inline void *audio_stream_get_rptr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_rptr(const struct audio_stream *buf)
 {
 	return buf->r_ptr;
 }
 
-static inline void *audio_stream_get_wptr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_wptr(const struct audio_stream *buf)
 {
 	return buf->w_ptr;
 }
 
-static inline void *audio_stream_get_end_addr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_end_addr(const struct audio_stream *buf)
 {
 	return buf->end_addr;
 }
 
-static inline void *audio_stream_get_addr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_addr(const struct audio_stream *buf)
 {
 	return buf->addr;
 }
 
-static inline uint32_t audio_stream_get_size(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_size(const struct audio_stream *buf)
 {
 	return buf->size;
 }
 
-static inline uint32_t audio_stream_get_avail(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_avail(const struct audio_stream *buf)
 {
 	return buf->avail;
 }
 
-static inline uint32_t audio_stream_get_free(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_free(const struct audio_stream *buf)
 {
 	return buf->free;
 }
 
-static inline enum sof_ipc_frame audio_stream_get_frm_fmt(
-	const struct audio_stream __sparse_cache *buf)
+static inline enum sof_ipc_frame audio_stream_get_frm_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.frame_fmt;
 }
 
-static inline enum sof_ipc_frame audio_stream_get_valid_fmt(
-	const struct audio_stream __sparse_cache *buf)
+static inline enum sof_ipc_frame audio_stream_get_valid_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.valid_sample_fmt;
 }
 
-static inline uint32_t audio_stream_get_rate(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_rate(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.rate;
 }
 
-static inline uint32_t audio_stream_get_channels(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_channels(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.channels;
 }
 
-static inline bool audio_stream_get_underrun(const struct audio_stream __sparse_cache *buf)
+static inline bool audio_stream_get_underrun(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.underrun_permitted;
 }
 
-static inline uint32_t audio_stream_get_buffer_fmt(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_buffer_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.buffer_fmt;
 }
 
-static inline bool audio_stream_get_overrun(const struct audio_stream __sparse_cache *buf)
+static inline bool audio_stream_get_overrun(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.overrun_permitted;
 }
 
-static inline void audio_stream_set_rptr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_rptr(struct audio_stream *buf, void *val)
 {
 	buf->r_ptr = val;
 }
 
-static inline void audio_stream_set_wptr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_wptr(struct audio_stream *buf, void *val)
 {
 	buf->w_ptr = val;
 }
 
-static inline void audio_stream_set_end_addr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_end_addr(struct audio_stream *buf, void *val)
 {
 	buf->end_addr = val;
 }
 
-static inline void audio_stream_set_addr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_addr(struct audio_stream *buf, void *val)
 {
 	buf->addr = val;
 }
 
-static inline void audio_stream_set_size(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_size(struct audio_stream *buf, uint32_t val)
 {
 	buf->size = val;
 }
 
-static inline void audio_stream_set_avail(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_avail(struct audio_stream *buf, uint32_t val)
 {
 	buf->avail = val;
 }
 
-static inline void audio_stream_set_free(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_free(struct audio_stream *buf, uint32_t val)
 {
 	buf->free = val;
 }
 
-static inline void audio_stream_set_frm_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_frm_fmt(struct audio_stream *buf,
 					    enum sof_ipc_frame val)
 {
 	buf->runtime_stream_params.frame_fmt = val;
 }
 
-static inline void audio_stream_set_valid_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_valid_fmt(struct audio_stream *buf,
 					      enum sof_ipc_frame val)
 {
 	buf->runtime_stream_params.valid_sample_fmt = val;
 }
 
-static inline void audio_stream_set_rate(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_rate(struct audio_stream *buf, uint32_t val)
 {
 	buf->runtime_stream_params.rate = val;
 }
 
-static inline void audio_stream_set_channels(struct audio_stream __sparse_cache *buf, uint16_t val)
+static inline void audio_stream_set_channels(struct audio_stream *buf, uint16_t val)
 {
 	buf->runtime_stream_params.channels = val;
 }
 
-static inline void audio_stream_set_underrun(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_underrun(struct audio_stream *buf,
 					     bool underrun_permitted)
 {
 	buf->runtime_stream_params.underrun_permitted = underrun_permitted;
 }
 
-static inline void audio_stream_set_overrun(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_overrun(struct audio_stream *buf,
 					    bool overrun_permitted)
 {
 	buf->runtime_stream_params.overrun_permitted = overrun_permitted;
 }
 
-static inline void audio_stream_set_buffer_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_buffer_fmt(struct audio_stream *buf,
 					       uint32_t buffer_fmt)
 {
 	buf->runtime_stream_params.buffer_fmt = buffer_fmt;
@@ -356,7 +354,7 @@ static inline void audio_stream_set_buffer_fmt(struct audio_stream __sparse_cach
  * @param params Parameters (frame format, rate, number of channels).
  * @return 0 if succeeded, error code otherwise.
  */
-static inline int audio_stream_set_params(struct audio_stream __sparse_cache *buffer,
+static inline int audio_stream_set_params(struct audio_stream *buffer,
 					  struct sof_ipc_stream_params *params)
 {
 	if (!params)
@@ -374,7 +372,7 @@ static inline int audio_stream_set_params(struct audio_stream __sparse_cache *bu
  * @param buf Component buffer.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_frame_bytes(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
 {
 	return get_frame_bytes(buf->runtime_stream_params.frame_fmt,
 			       buf->runtime_stream_params.channels);
@@ -385,7 +383,7 @@ static inline uint32_t audio_stream_frame_bytes(const struct audio_stream __spar
  * @param buf Component buffer.
  * @return Size of sample in bytes.
  */
-static inline uint32_t audio_stream_sample_bytes(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
 {
 	return get_sample_bytes(buf->runtime_stream_params.frame_fmt);
 }
@@ -423,7 +421,7 @@ static inline uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
  */
 static inline void audio_stream_init_alignment_constants(const uint32_t byte_align,
 							 const uint32_t frame_align_req,
-							 struct audio_stream __sparse_cache *stream)
+							 struct audio_stream *stream)
 {
 	uint32_t process_size;
 	uint32_t frame_size = audio_stream_frame_bytes(stream);
@@ -441,8 +439,7 @@ static inline void audio_stream_init_alignment_constants(const uint32_t byte_ali
  * @param frames Number of processing frames.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_period_bytes(const struct audio_stream __sparse_cache *buf,
-						 uint32_t frames)
+static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf, uint32_t frames)
 {
 	return frames * audio_stream_frame_bytes(buf);
 }
@@ -454,8 +451,7 @@ static inline uint32_t audio_stream_period_bytes(const struct audio_stream __spa
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_wrap(const struct audio_stream __sparse_cache *buffer,
-				      void *ptr)
+static inline void *audio_stream_wrap(const struct audio_stream *buffer, void *ptr)
 {
 	if (ptr >= buffer->end_addr)
 		ptr = (char *)buffer->addr +
@@ -492,8 +488,7 @@ static inline void *cir_buf_wrap(void *ptr, void *buf_addr, void *buf_end)
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_rewind_wrap(const struct audio_stream __sparse_cache *buffer,
-					     void *ptr)
+static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer, void *ptr)
 {
 	if (ptr < buffer->addr)
 		ptr = (char *)buffer->end_addr - ((char *)buffer->addr - (char *)ptr);
@@ -509,7 +504,7 @@ static inline void *audio_stream_rewind_wrap(const struct audio_stream __sparse_
  * @return amount of data available for processing in bytes
  */
 static inline uint32_t
-audio_stream_get_avail_bytes(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_bytes(const struct audio_stream *stream)
 {
 	/*
 	 * In case of underrun-permitted stream, report buffer full instead of
@@ -529,7 +524,7 @@ audio_stream_get_avail_bytes(const struct audio_stream __sparse_cache *stream)
  * @return amount of data available for processing in samples
  */
 static inline uint32_t
-audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_samples(const struct audio_stream *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -541,7 +536,7 @@ audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
  * @return amount of data available for processing in frames
  */
 static inline uint32_t
-audio_stream_get_avail_frames(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_frames(const struct audio_stream *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -553,7 +548,7 @@ audio_stream_get_avail_frames(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in bytes
  */
 static inline uint32_t
-audio_stream_get_free_bytes(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_bytes(const struct audio_stream *stream)
 {
 	/*
 	 * In case of overrun-permitted stream, report buffer empty instead of
@@ -573,7 +568,7 @@ audio_stream_get_free_bytes(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in samples
  */
 static inline uint32_t
-audio_stream_get_free_samples(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_samples(const struct audio_stream *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -585,7 +580,7 @@ audio_stream_get_free_samples(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in frames
  */
 static inline uint32_t
-audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_frames(const struct audio_stream *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -601,8 +596,8 @@ audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
  *  @return 1 if there is not enough free space in sink.
  *  @return -1 if there is not enough data in source.
  */
-static inline int audio_stream_can_copy_bytes(const struct audio_stream __sparse_cache *source,
-					      const struct audio_stream __sparse_cache *sink,
+static inline int audio_stream_can_copy_bytes(const struct audio_stream *source,
+					      const struct audio_stream *sink,
 					      uint32_t bytes)
 {
 	/* check for underrun */
@@ -626,8 +621,8 @@ static inline int audio_stream_can_copy_bytes(const struct audio_stream __sparse
  * @return Number of bytes.
  */
 static inline uint32_t
-audio_stream_get_copy_bytes(const struct audio_stream __sparse_cache *source,
-			    const struct audio_stream __sparse_cache *sink)
+audio_stream_get_copy_bytes(const struct audio_stream *source,
+			    const struct audio_stream *sink)
 {
 	uint32_t avail = audio_stream_get_avail_bytes(source);
 	uint32_t free = audio_stream_get_free_bytes(sink);
@@ -647,8 +642,8 @@ audio_stream_get_copy_bytes(const struct audio_stream __sparse_cache *source,
  * @return Number of frames.
  */
 static inline uint32_t
-audio_stream_avail_frames(const struct audio_stream __sparse_cache *source,
-			  const struct audio_stream __sparse_cache *sink)
+audio_stream_avail_frames(const struct audio_stream *source,
+			  const struct audio_stream *sink)
 {
 	uint32_t src_frames = audio_stream_get_avail_frames(source);
 	uint32_t sink_frames = audio_stream_get_free_frames(sink);
@@ -665,8 +660,8 @@ audio_stream_avail_frames(const struct audio_stream __sparse_cache *source,
  * @return Number of frames.
  */
 static inline uint32_t
-audio_stream_avail_frames_aligned(const struct audio_stream __sparse_cache *source,
-				  const struct audio_stream __sparse_cache *sink)
+audio_stream_avail_frames_aligned(const struct audio_stream *source,
+				  const struct audio_stream *sink)
 {
 	uint32_t src_frames = (audio_stream_get_avail_bytes(source) >>
 			source->runtime_stream_params.align_shift_idx) *
@@ -683,8 +678,7 @@ audio_stream_avail_frames_aligned(const struct audio_stream __sparse_cache *sour
  * @param buffer Buffer to update.
  * @param bytes Number of written bytes.
  */
-static inline void audio_stream_produce(struct audio_stream __sparse_cache *buffer,
-					uint32_t bytes)
+static inline void audio_stream_produce(struct audio_stream *buffer, uint32_t bytes)
 {
 	buffer->w_ptr = audio_stream_wrap(buffer,
 					  (char *)buffer->w_ptr + bytes);
@@ -711,8 +705,7 @@ static inline void audio_stream_produce(struct audio_stream __sparse_cache *buff
  * @param buffer Buffer to update.
  * @param bytes Number of read bytes.
  */
-static inline void audio_stream_consume(struct audio_stream __sparse_cache *buffer,
-					uint32_t bytes)
+static inline void audio_stream_consume(struct audio_stream *buffer, uint32_t bytes)
 {
 	buffer->r_ptr = audio_stream_wrap(buffer,
 					  (char *)buffer->r_ptr + bytes);
@@ -734,7 +727,7 @@ static inline void audio_stream_consume(struct audio_stream __sparse_cache *buff
  * Resets the buffer.
  * @param buffer Buffer to reset.
  */
-static inline void audio_stream_reset(struct audio_stream __sparse_cache *buffer)
+static inline void audio_stream_reset(struct audio_stream *buffer)
 {
 	/* reset read and write pointer to buffer bas */
 	buffer->w_ptr = buffer->addr;
@@ -753,8 +746,7 @@ static inline void audio_stream_reset(struct audio_stream __sparse_cache *buffer
  * @param buff_addr Address of the memory block to assign.
  * @param size Size of the memory block in bytes.
  */
-void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
-		       void *buff_addr, uint32_t size);
+void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint32_t size);
 
 /**
  * Invalidates (in DSP d-cache) the buffer in range [r_ptr, r_ptr+bytes],
@@ -762,8 +754,7 @@ void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to invalidate.
  */
-static inline void audio_stream_invalidate(struct audio_stream __sparse_cache *buffer,
-					   uint32_t bytes)
+static inline void audio_stream_invalidate(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -786,8 +777,7 @@ static inline void audio_stream_invalidate(struct audio_stream __sparse_cache *b
  * @param buffer Buffer.
  * @param bytes Size of the fragment to write back.
  */
-static inline void audio_stream_writeback(struct audio_stream __sparse_cache *buffer,
-					  uint32_t bytes)
+static inline void audio_stream_writeback(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -811,8 +801,7 @@ static inline void audio_stream_writeback(struct audio_stream __sparse_cache *bu
  * @return Number of data samples to buffer wrap.
  */
 static inline int
-audio_stream_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
-				const void *ptr)
+audio_stream_bytes_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	assert((intptr_t)source->end_addr >= (intptr_t)ptr);
 	return (intptr_t)source->end_addr - (intptr_t)ptr;
@@ -827,8 +816,7 @@ audio_stream_bytes_without_wrap(const struct audio_stream __sparse_cache *source
  *	   need to add size of sample to returned bytes count.
  */
 static inline int
-audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
-				       const void *ptr)
+audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	assert((intptr_t)ptr >= (intptr_t)source->addr);
 	int to_begin = (intptr_t)ptr - (intptr_t)source->addr;
@@ -843,8 +831,7 @@ audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache 
  * @return Previous position of the write pointer.
  */
 static inline uint32_t
-*audio_stream_rewind_wptr_by_bytes(const struct audio_stream __sparse_cache *source,
-				       const uint32_t bytes)
+*audio_stream_rewind_wptr_by_bytes(const struct audio_stream *source, const uint32_t bytes)
 {
 	void *wptr = audio_stream_get_wptr(source);
 	int to_begin = audio_stream_rewind_bytes_without_wrap(source, wptr);
@@ -866,8 +853,7 @@ static inline uint32_t
  * @return Number of data s16 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s16(const struct audio_stream __sparse_cache *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s16(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int16_t *)source->end_addr - (int16_t *)ptr;
 
@@ -883,8 +869,7 @@ audio_stream_samples_without_wrap_s16(const struct audio_stream __sparse_cache *
  * @return Number of data s24 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s24(const struct audio_stream __sparse_cache *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s24(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -900,8 +885,7 @@ audio_stream_samples_without_wrap_s24(const struct audio_stream __sparse_cache *
  * @return Number of data s32 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s32(const struct audio_stream __sparse_cache *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s32(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -947,8 +931,7 @@ static inline int cir_buf_samples_without_wrap_s32(void *ptr, void *buf_end)
  * @return Number of data frames to buffer wrap.
  */
 static inline uint32_t
-audio_stream_frames_without_wrap(const struct audio_stream __sparse_cache *source,
-				 const void *ptr)
+audio_stream_frames_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	uint32_t bytes = audio_stream_bytes_without_wrap(source, ptr);
 	uint32_t frame_bytes = audio_stream_frame_bytes(source);
@@ -965,8 +948,8 @@ audio_stream_frames_without_wrap(const struct audio_stream __sparse_cache *sourc
  * @param samples Number of samples to copy.
  * @return number of processed samples.
  */
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples);
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples);
 
 /**
  * Copies data from one circular buffer to another circular buffer.
@@ -990,7 +973,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
  * @param samples Number of samples to copy.
  */
 void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int samples);
 
 /**
@@ -1001,7 +984,7 @@ void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *source, int ioffset,
+void audio_stream_copy_to_linear(const struct audio_stream *source, int ioffset,
 				 void *linear_sink, int ooffset, unsigned int samples);
 
 /**
@@ -1011,8 +994,7 @@ void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *sourc
  * @return 0 if there is enough free space in buffer.
  * @return 1 if there is not enough free space in buffer.
  */
-static inline int audio_stream_set_zero(struct audio_stream __sparse_cache *buffer,
-					uint32_t bytes)
+static inline int audio_stream_set_zero(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -1071,13 +1053,13 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
  * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
 static inline struct sof_source *
-audio_stream_get_source(struct audio_stream __sparse_cache *audio_stream)
+audio_stream_get_source(struct audio_stream *audio_stream)
 {
 	return &audio_stream->source_api;
 }
 
 static inline struct sof_sink *
-audio_stream_get_sink(struct audio_stream __sparse_cache *audio_stream)
+audio_stream_get_sink(struct audio_stream *audio_stream)
 {
 	return &audio_stream->sink_api;
 }

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1050,7 +1050,6 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 }
 
 /** get a handler to source API
- * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
 static inline struct sof_source *
 audio_stream_get_source(struct audio_stream *audio_stream)

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1076,7 +1076,7 @@ audio_stream_get_source(struct audio_stream __sparse_cache *audio_stream)
 	return &audio_stream->source_api;
 }
 
-static inline struct sof_sink __sparse_cache *
+static inline struct sof_sink *
 audio_stream_get_sink(struct audio_stream __sparse_cache *audio_stream)
 {
 	return &audio_stream->sink_api;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1070,7 +1070,7 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 /** get a handler to source API
  * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
-static inline struct sof_source __sparse_cache *
+static inline struct sof_source *
 audio_stream_get_source(struct audio_stream __sparse_cache *audio_stream)
 {
 	return &audio_stream->source_api;

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -249,10 +249,8 @@ void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir);
 
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
-	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer_c->sink :
-		buffer_c->source;
-	buffer_release(buffer_c);
+	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer->sink :
+		buffer->source;
 	return comp;
 }
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -219,17 +219,6 @@ static inline void buffer_stream_writeback(struct comp_buffer *buffer,
 	if (buffer->is_shared)
 		audio_stream_writeback(&buffer->stream, bytes);
 }
-/* stubs for acquire/release for compilation, to be removed at last step */
-__must_check static inline struct comp_buffer __sparse_cache *buffer_acquire(
-	struct comp_buffer *buffer)
-{
-	return (struct comp_buffer __sparse_cache *)buffer;
-}
-
-static inline void buffer_release(struct comp_buffer __sparse_cache *buffer)
-{
-	(void)buffer;
-}
 
 /*
  * Attach a new buffer at the beginning of the list. Note, that "head" must

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -161,7 +161,7 @@ struct comp_buffer {
 
 /* Only to be used for synchronous same-core notifications! */
 struct buffer_cb_transact {
-	struct comp_buffer __sparse_cache *buffer;
+	struct comp_buffer *buffer;
 	uint32_t transaction_amount;
 	void *transaction_begin_address;
 };
@@ -190,30 +190,30 @@ struct buffer_cb_free {
 struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align,
 				 bool is_shared);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared);
-int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment);
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment);
 void buffer_free(struct comp_buffer *buffer);
-void buffer_zero(struct comp_buffer __sparse_cache *buffer);
+void buffer_zero(struct comp_buffer *buffer);
 
 /* called by a component after producing data into this buffer */
-void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
+void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
 
 /* called by a component after consuming data from this buffer */
-void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
+void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
-int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
+int buffer_set_params(struct comp_buffer *buffer,
 		      struct sof_ipc_stream_params *params, bool force_update);
 
-bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
+bool buffer_params_match(struct comp_buffer *buffer,
 			 struct sof_ipc_stream_params *params, uint32_t flag);
 
-static inline void buffer_stream_invalidate(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_stream_invalidate(struct comp_buffer *buffer,
 					    uint32_t bytes)
 {
 	if (buffer->is_shared)
 		audio_stream_invalidate(&buffer->stream, bytes);
 }
 
-static inline void buffer_stream_writeback(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_stream_writeback(struct comp_buffer *buffer,
 					   uint32_t bytes)
 {
 	if (buffer->is_shared)
@@ -254,7 +254,7 @@ static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int d
 	return comp;
 }
 
-static inline void buffer_reset_pos(struct comp_buffer __sparse_cache *buffer, void *data)
+static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)
 {
 	/* reset rw pointers and avail/free bytes counters */
 	audio_stream_reset(&buffer->stream);
@@ -264,7 +264,7 @@ static inline void buffer_reset_pos(struct comp_buffer __sparse_cache *buffer, v
 }
 
 /* Run-time buffer re-configuration calls this too, so it must use cached access */
-static inline void buffer_init(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_init(struct comp_buffer *buffer,
 			       uint32_t size, uint32_t caps)
 {
 	buffer->caps = caps;
@@ -273,7 +273,7 @@ static inline void buffer_init(struct comp_buffer __sparse_cache *buffer,
 	audio_stream_init(&buffer->stream, buffer->stream.addr, size);
 }
 
-static inline void buffer_reset_params(struct comp_buffer __sparse_cache *buffer, void *data)
+static inline void buffer_reset_params(struct comp_buffer *buffer, void *data)
 {
 	buffer->hw_params_configured = false;
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -133,8 +133,6 @@ extern struct tr_ctx buffer_tr;
  * 5) write back cached data and release lock using uncache pointer.
  */
 struct comp_buffer {
-	struct coherent c;
-
 	/* data buffer */
 	struct audio_stream stream;
 
@@ -144,6 +142,7 @@ struct comp_buffer {
 	uint32_t caps;
 	uint32_t core;
 	struct tr_ctx tctx;			/* trace settings */
+	bool is_shared;			/* buffer structure is shared between 2 cores */
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */
@@ -188,8 +187,9 @@ struct buffer_cb_free {
 	} while (0)
 
 /* pipeline buffer creation and destruction */
-struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align);
-struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc);
+struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align,
+				 bool is_shared);
+struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared);
 int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment);
 void buffer_free(struct comp_buffer *buffer);
 void buffer_zero(struct comp_buffer __sparse_cache *buffer);
@@ -209,32 +209,26 @@ bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
 static inline void buffer_stream_invalidate(struct comp_buffer __sparse_cache *buffer,
 					    uint32_t bytes)
 {
-	if (!is_coherent_shared(buffer, c))
-		return;
-
-	audio_stream_invalidate(&buffer->stream, bytes);
+	if (buffer->is_shared)
+		audio_stream_invalidate(&buffer->stream, bytes);
 }
 
 static inline void buffer_stream_writeback(struct comp_buffer __sparse_cache *buffer,
 					   uint32_t bytes)
 {
-	if (!is_coherent_shared(buffer, c))
-		return;
-
-	audio_stream_writeback(&buffer->stream, bytes);
+	if (buffer->is_shared)
+		audio_stream_writeback(&buffer->stream, bytes);
 }
-
+/* stubs for acquire/release for compilation, to be removed at last step */
 __must_check static inline struct comp_buffer __sparse_cache *buffer_acquire(
 	struct comp_buffer *buffer)
 {
-	struct coherent __sparse_cache *c = coherent_acquire_thread(&buffer->c, sizeof(*buffer));
-
-	return attr_container_of(c, struct comp_buffer __sparse_cache, c, __sparse_cache);
+	return (struct comp_buffer __sparse_cache *)buffer;
 }
 
 static inline void buffer_release(struct comp_buffer __sparse_cache *buffer)
 {
-	coherent_release_thread(&buffer->c, sizeof(*buffer));
+	(void)buffer;
 }
 
 /*

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -894,15 +894,7 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 				    struct comp_buffer *sink,
 				    struct comp_copy_limits *cl)
 {
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
-
-	source_c = buffer_acquire(source);
-	sink_c = buffer_acquire(sink);
-
-	comp_get_copy_limits(source_c, sink_c, cl);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	comp_get_copy_limits(source, sink, cl);
 }
 
 /**
@@ -919,15 +911,7 @@ void comp_get_copy_limits_with_lock_frame_aligned(struct comp_buffer *source,
 						  struct comp_buffer *sink,
 						  struct comp_copy_limits *cl)
 {
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
-
-	source_c = buffer_acquire(source);
-	sink_c = buffer_acquire(sink);
-
-	comp_get_copy_limits_frame_aligned(source_c, sink_c, cl);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	comp_get_copy_limits_frame_aligned(source, sink, cl);
 }
 
 /**

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -817,7 +817,7 @@ static inline void component_set_nearest_period_frames(struct comp_dev *current,
  * @param copy_bytes Requested size of data to be available.
  */
 static inline void comp_underrun(struct comp_dev *dev,
-				 struct comp_buffer __sparse_cache *source,
+				 struct comp_buffer *source,
 				 uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -839,7 +839,7 @@ static inline void comp_underrun(struct comp_dev *dev,
  * @param sink Sink buffer.
  * @param copy_bytes Requested size of free space to be available.
  */
-static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer __sparse_cache *sink,
+static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 				uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -864,8 +864,8 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer __spars
  * @param[in] sink Sink buffer.
  * @param[out] cl Current copy limits.
  */
-void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
-			  struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits(struct comp_buffer *source,
+			  struct comp_buffer *sink,
 			  struct comp_copy_limits *cl);
 
 /**
@@ -877,8 +877,8 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
  * @param[in] sink Buffer of sink.
  * @param[out] cl Current copy limits.
  */
-void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache *source,
-					const struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
+					const struct comp_buffer *sink,
 					struct comp_copy_limits *cl);
 
 /**

--- a/src/include/sof/audio/dcblock/dcblock.h
+++ b/src/include/sof/audio/dcblock/dcblock.h
@@ -40,8 +40,8 @@ struct dcblock_state {
  * DC Blocking Filter.
  */
 typedef void (*dcblock_func)(const struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink,
 			     uint32_t frames);
 
 /* DC Blocking Filter component private data */

--- a/src/include/sof/audio/drc/drc.h
+++ b/src/include/sof/audio/drc/drc.h
@@ -60,8 +60,8 @@ struct drc_state {
 };
 
 typedef void (*drc_func)(struct processing_module *mod,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 uint32_t frames);
 
 /* DRC component private data */
@@ -83,8 +83,8 @@ extern const struct drc_proc_fnmap drc_proc_fnmap[];
 extern const size_t drc_proc_fncount;
 
 void drc_default_pass(struct processing_module *mod,
-		      const struct audio_stream __sparse_cache *source,
-		      struct audio_stream __sparse_cache *sink, uint32_t frames);
+		      const struct audio_stream *source,
+		      struct audio_stream *sink, uint32_t frames);
 /**
  * \brief Returns DRC processing function.
  */

--- a/src/include/sof/audio/igo_nr/igo_nr_comp.h
+++ b/src/include/sof/audio/igo_nr/igo_nr_comp.h
@@ -41,8 +41,8 @@ struct comp_data {
 	int32_t sink_frames_max;	/* Max # of frames to process at sink */
 	int32_t frames;		/* IO buffer length */
 	void (*igo_nr_func)(struct comp_data *cd,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    int32_t frames);
 };
 

--- a/src/include/sof/audio/mixer.h
+++ b/src/include/sof/audio/mixer.h
@@ -34,16 +34,16 @@ void sys_comp_module_mixer_interface_init(void);
 
 /* mixer component private data */
 struct mixer_data {
-	void (*mix_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			 const struct audio_stream __sparse_cache **sources, uint32_t count,
+	void (*mix_func)(struct comp_dev *dev, struct audio_stream *sink,
+			 const struct audio_stream **sources, uint32_t count,
 			 uint32_t frames);
 };
 
 /**
  * \brief mixer processing function interface
  */
-typedef void (*mixer_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			   const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+typedef void (*mixer_func)(struct comp_dev *dev, struct audio_stream *sink,
+			   const struct audio_stream **sources, uint32_t num_sources,
 			   uint32_t frames);
 
 /** \brief Volume processing functions map. */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -343,7 +343,7 @@ static inline void module_source_info_release(struct module_source_info __sparse
 
 /* when source argument is NULL, this function returns the first unused entry */
 static inline
-int find_module_source_index(struct module_source_info __sparse_cache *msi,
+int find_module_source_index(struct module_source_info *msi,
 			     const struct comp_dev *source)
 {
 	int i;

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -246,13 +246,13 @@ int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod,
 		   struct sof_source **sources, int num_of_sources,
-		   struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		   struct sof_sink **sinks, int num_of_sinks);
 
 static inline
 bool module_is_ready_to_process(struct processing_module *mod,
 				struct sof_source **sources,
 				int num_of_sources,
-				struct sof_sink __sparse_cache **sinks,
+				struct sof_sink **sinks,
 				int num_of_sinks)
 {
 	struct module_data *md = &mod->priv;
@@ -273,7 +273,7 @@ bool module_is_ready_to_process(struct processing_module *mod,
 
 int module_process_sink_src(struct processing_module *mod,
 			    struct sof_source **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+			    struct sof_sink **sinks, int num_of_sinks);
 int module_process_legacy(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,
 			  struct output_stream_buffer *output_buffers,

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -319,8 +319,8 @@ static inline void module_update_buffer_position(struct input_stream_buffer *inp
 						 struct output_stream_buffer *output_buffers,
 						 uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = input_buffers->data;
-	struct audio_stream __sparse_cache *sink = output_buffers->data;
+	struct audio_stream *source = input_buffers->data;
+	struct audio_stream *sink = output_buffers->data;
 
 	input_buffers->consumed += audio_stream_frame_bytes(source) * frames;
 	output_buffers->size += audio_stream_frame_bytes(sink) * frames;

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -327,13 +327,13 @@ static inline void module_update_buffer_position(struct input_stream_buffer *inp
 }
 
 __must_check static inline
-struct module_source_info __sparse_cache *module_source_info_acquire(struct module_source_info *msi)
+struct module_source_info *module_source_info_acquire(struct module_source_info *msi)
 {
-	struct coherent __sparse_cache *c;
+	struct coherent *c;
 
 	c = coherent_acquire_thread(&msi->c, sizeof(*msi));
 
-	return attr_container_of(c, struct module_source_info __sparse_cache, c, __sparse_cache);
+	return container_of(c, struct module_source_info, c);
 }
 
 static inline void module_source_info_release(struct module_source_info __sparse_cache *msi)

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -245,12 +245,12 @@ void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint3
 int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod,
-		   struct sof_source __sparse_cache **sources, int num_of_sources,
+		   struct sof_source **sources, int num_of_sources,
 		   struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 
 static inline
 bool module_is_ready_to_process(struct processing_module *mod,
-				struct sof_source __sparse_cache **sources,
+				struct sof_source **sources,
 				int num_of_sources,
 				struct sof_sink __sparse_cache **sinks,
 				int num_of_sinks)
@@ -272,7 +272,7 @@ bool module_is_ready_to_process(struct processing_module *mod,
 }
 
 int module_process_sink_src(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
+			    struct sof_source **sources, int num_of_sources,
 			    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 int module_process_legacy(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -336,7 +336,7 @@ struct module_source_info *module_source_info_acquire(struct module_source_info 
 	return container_of(c, struct module_source_info, c);
 }
 
-static inline void module_source_info_release(struct module_source_info __sparse_cache *msi)
+static inline void module_source_info_release(struct module_source_info *msi)
 {
 	coherent_release_thread(&msi->c, sizeof(*msi));
 }

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -158,7 +158,7 @@ struct module_interface {
 	 * component preparation in .prepare()
 	 */
 	int (*prepare)(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 
 	/**
@@ -177,7 +177,7 @@ struct module_interface {
 	 * the module
 	 */
 	bool (*is_ready_to_process)(struct processing_module *mod,
-				    struct sof_source __sparse_cache **sources, int num_of_sources,
+				    struct sof_source **sources, int num_of_sources,
 				    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 
 	/**
@@ -200,7 +200,7 @@ struct module_interface {
 	 *	- sinks are handlers to sink API struct sink*[]
 	 */
 	int (*process)(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
+		       struct sof_source **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 
 	/**

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -50,7 +50,7 @@ enum module_processing_mode {
  * \brief Input stream buffer
  */
 struct input_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
+	void *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 	uint32_t consumed; /* number of bytes consumed by the module */
 
@@ -63,7 +63,7 @@ struct input_stream_buffer {
  * \brief Output stream buffer
  */
 struct output_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
+	void *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 };
 

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -159,7 +159,7 @@ struct module_interface {
 	 */
 	int (*prepare)(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		       struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * (optional) return true if the module is ready to process
@@ -178,7 +178,7 @@ struct module_interface {
 	 */
 	bool (*is_ready_to_process)(struct processing_module *mod,
 				    struct sof_source **sources, int num_of_sources,
-				    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+				    struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * Module specific processing procedure
@@ -201,7 +201,7 @@ struct module_interface {
 	 */
 	int (*process)(struct processing_module *mod,
 		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		       struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * process_audio_stream (depreciated)

--- a/src/include/sof/audio/multiband_drc/multiband_drc.h
+++ b/src/include/sof/audio/multiband_drc/multiband_drc.h
@@ -28,8 +28,8 @@ struct multiband_drc_state {
 };
 
 typedef void (*multiband_drc_func)(const struct processing_module *mod,
-				   const struct audio_stream __sparse_cache *source,
-				   struct audio_stream __sparse_cache *sink,
+				   const struct audio_stream *source,
+				   struct audio_stream *sink,
 				   uint32_t frames);
 
 /* Multiband DRC component private data */

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -65,11 +65,11 @@ struct mux_stream_data {
 	uint8_t reserved2[3]; // padding to ensure proper alignment of following instances
 } __attribute__((packed, aligned(4)));
 
-typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames,
+typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames,
 			  struct mux_look_up *look_up);
-typedef void(*mux_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache **sources, uint32_t frames,
+typedef void(*mux_func)(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream **sources, uint32_t frames,
 			struct mux_look_up *look_up);
 
 /**

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -45,8 +45,8 @@ struct audio_stream;
  * \param samples number of samples to convert
  * \return error code or number of processed samples.
  */
-typedef int (*pcm_converter_func)(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+typedef int (*pcm_converter_func)(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples);
 
 /**
@@ -163,8 +163,8 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
  * \param converter core conversion function working on linear memory regions
  * \return error code or number of processed samples
  */
-int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-			  struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
+			  struct audio_stream *sink, uint32_t ooffset,
 			  uint32_t samples, pcm_converter_lin_func converter);
 
 #endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -100,7 +100,7 @@ struct pipeline_walk_context {
 	int (*comp_func)(struct comp_dev *cd, struct comp_buffer *buffer,
 			 struct pipeline_walk_context *ctx, int dir);
 	void *comp_data;
-	void (*buff_func)(struct comp_buffer __sparse_cache *buffer, void *data);
+	void (*buff_func)(struct comp_buffer *buffer, void *data);
 	void *buff_data;
 	struct comp_buffer *incoming;
 	/**< pipelines to be scheduled after trigger walk */

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -100,8 +100,8 @@ struct sof_selector_avs_ipc4_config {
 };
 
 #else
-typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			 const struct audio_stream __sparse_cache *source, uint32_t frames);
+typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream *sink,
+			 const struct audio_stream *source, uint32_t frames);
 #endif
 
 /** \brief Selector component private data. */

--- a/src/include/sof/audio/sink_api.h
+++ b/src/include/sof/audio/sink_api.h
@@ -54,13 +54,13 @@ struct sof_ipc_stream_params;
  * Retrieves size of free space available in sink (in bytes)
  * return number of free bytes in buffer available to immediate filling
  */
-size_t sink_get_free_size(struct sof_sink __sparse_cache *sink);
+size_t sink_get_free_size(struct sof_sink *sink);
 
 /**
  * Retrieves size of free space available in sink (in frames)
  * return number of free bytes in buffer available to immediate filling
  */
-size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink);
+size_t sink_get_free_frames(struct sof_sink *sink);
 
 /**
  * Get a circular buffer to operate on (to write).
@@ -81,7 +81,7 @@ size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink);
  * @retval -ENODATA if req_size is bigger than free space
  *
  */
-int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+int sink_get_buffer(struct sof_sink *sink, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 /**
@@ -96,7 +96,7 @@ int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
  *	  commit_buffer with commit_size==MAXINT
  * @return proper error code (0  on success)
  */
-int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size);
+int sink_commit_buffer(struct sof_sink *sink, size_t commit_size);
 
 /**
  * Get total number of bytes processed by the sink (meaning - committed by sink_commit_buffer())
@@ -104,33 +104,33 @@ int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
  * @param sink a handler to sink
  * @return total number of processed data
  */
-size_t sink_get_num_of_processed_bytes(struct sof_sink __sparse_cache *sink);
+size_t sink_get_num_of_processed_bytes(struct sof_sink *sink);
 
 /**
  * sets counter of total number of bytes processed  to zero
  */
-void sink_reset_num_of_processed_bytes(struct sof_sink __sparse_cache *sink);
+void sink_reset_num_of_processed_bytes(struct sof_sink *sink);
 
 /** get size of a single audio frame (in bytes) */
-size_t sink_get_frame_bytes(struct sof_sink __sparse_cache *sink);
+size_t sink_get_frame_bytes(struct sof_sink *sink);
 
 /** set of functions for retrieve audio parameters */
-enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink __sparse_cache *sink);
-enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_rate(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_channels(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_buffer_fmt(struct sof_sink __sparse_cache *sink);
-bool sink_get_overrun(struct sof_sink __sparse_cache *sink);
+enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink *sink);
+enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink *sink);
+uint32_t sink_get_rate(struct sof_sink *sink);
+uint32_t sink_get_channels(struct sof_sink *sink);
+uint32_t sink_get_buffer_fmt(struct sof_sink *sink);
+bool sink_get_overrun(struct sof_sink *sink);
 
 /** set of functions for setting audio parameters */
-int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame frame_fmt);
-int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame valid_sample_fmt);
-int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate);
-int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channels);
-int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitted);
-int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fmt);
-void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs);
-size_t sink_get_obs(struct sof_sink __sparse_cache *sink);
+int sink_set_frm_fmt(struct sof_sink *sink, enum sof_ipc_frame frame_fmt);
+int sink_set_valid_fmt(struct sof_sink *sink, enum sof_ipc_frame valid_sample_fmt);
+int sink_set_rate(struct sof_sink *sink, unsigned int rate);
+int sink_set_channels(struct sof_sink *sink, unsigned int channels);
+int sink_set_overrun(struct sof_sink *sink, bool overrun_permitted);
+int sink_set_buffer_fmt(struct sof_sink *sink, uint32_t buffer_fmt);
+void sink_set_obs(struct sof_sink *sink, size_t obs);
+size_t sink_get_obs(struct sof_sink *sink);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params
@@ -140,7 +140,7 @@ size_t sink_get_obs(struct sof_sink __sparse_cache *sink);
  * @param force_update tells the implementation that the params should override actual settings
  * @return 0 if success
  */
-int sink_set_params(struct sof_sink __sparse_cache *sink,
+int sink_set_params(struct sof_sink *sink,
 		    struct sof_ipc_stream_params *params, bool force_update);
 
 /**
@@ -158,7 +158,7 @@ int sink_set_params(struct sof_sink __sparse_cache *sink,
  *
  * @return 0 if success
  */
-int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+int sink_set_alignment_constants(struct sof_sink *sink,
 				 const uint32_t byte_align,
 				 const uint32_t frame_align_req);
 

--- a/src/include/sof/audio/sink_api_implementation.h
+++ b/src/include/sof/audio/sink_api_implementation.h
@@ -27,18 +27,18 @@ struct sink_ops {
 	/**
 	 * see comment of sink_get_free_size()
 	 */
-	size_t (*get_free_size)(struct sof_sink __sparse_cache *sink);
+	size_t (*get_free_size)(struct sof_sink *sink);
 
 	/**
 	 * see comment of sink_get_buffer()
 	 */
-	int (*get_buffer)(struct sof_sink __sparse_cache *sink, size_t req_size,
+	int (*get_buffer)(struct sof_sink *sink, size_t req_size,
 			  void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 	/**
 	 * see comment of sink_commit_buffer()
 	 */
-	int (*commit_buffer)(struct sof_sink __sparse_cache *sink, size_t commit_size);
+	int (*commit_buffer)(struct sof_sink *sink, size_t commit_size);
 
 	/**
 	 * OPTIONAL: Notification to the sink implementation about changes in audio format
@@ -49,20 +49,20 @@ struct sink_ops {
 	 *
 	 * @retval 0 if success, negative if new parameters are not supported
 	 */
-	int (*on_audio_format_set)(struct sof_sink __sparse_cache *sink);
+	int (*on_audio_format_set)(struct sof_sink *sink);
 
 	/**
 	 * OPTIONAL
 	 * see sink_set_params comments
 	 */
-	int (*audio_set_ipc_params)(struct sof_sink __sparse_cache *sink,
+	int (*audio_set_ipc_params)(struct sof_sink *sink,
 				    struct sof_ipc_stream_params *params, bool force_update);
 
 	/**
 	 * OPTIONAL
 	 * see comment for sink_set_alignment_constants
 	 */
-	int (*set_alignment_constants)(struct sof_sink __sparse_cache *sink,
+	int (*set_alignment_constants)(struct sof_sink *sink,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
 };
@@ -86,7 +86,7 @@ struct sof_sink {
  *	  the implementation must ensure coherent access to the parameteres
  *	  in case of i.e. cross core shared queue, it must be located in non-cached memory
  */
-void sink_init(struct sof_sink __sparse_cache *sink, const struct sink_ops *ops,
+void sink_init(struct sof_sink *sink, const struct sink_ops *ops,
 	       struct sof_audio_stream_params *audio_stream_params);
 
 #endif /* __SOF_SINK_API_IMPLEMENTATION_H__ */

--- a/src/include/sof/audio/sink_source_utils.h
+++ b/src/include/sof/audio/sink_source_utils.h
@@ -19,7 +19,7 @@
  *	       if false, data will remain in the source
  * @param size number of bytes to be copied
  */
-int source_to_sink_copy(struct sof_source __sparse_cache *source,
+int source_to_sink_copy(struct sof_source *source,
 			struct sof_sink __sparse_cache *sink, bool free, size_t size);
 
 #endif /* SINK_SOURCE_UTILS_H */

--- a/src/include/sof/audio/sink_source_utils.h
+++ b/src/include/sof/audio/sink_source_utils.h
@@ -20,6 +20,6 @@
  * @param size number of bytes to be copied
  */
 int source_to_sink_copy(struct sof_source *source,
-			struct sof_sink __sparse_cache *sink, bool free, size_t size);
+			struct sof_sink *sink, bool free, size_t size);
 
 #endif /* SINK_SOURCE_UTILS_H */

--- a/src/include/sof/audio/smart_amp/smart_amp.h
+++ b/src/include/sof/audio/smart_amp/smart_amp.h
@@ -136,9 +136,9 @@ struct smart_amp_mod_struct_t {
 };
 
 typedef void (*smart_amp_func)(const struct comp_dev *dev,
-			       const struct audio_stream __sparse_cache *source,
-			       const struct audio_stream __sparse_cache *sink,
-			       const struct audio_stream __sparse_cache *feedback,
+			       const struct audio_stream *source,
+			       const struct audio_stream *sink,
+			       const struct audio_stream *feedback,
 			       uint32_t frames);
 struct smart_amp_func_map {
 	uint16_t frame_fmt;
@@ -151,14 +151,14 @@ int smart_amp_init(struct smart_amp_mod_struct_t *hspk, struct comp_dev *dev);
 int smart_amp_flush(struct smart_amp_mod_struct_t *hspk, struct comp_dev *dev);
 /* Feed forward processing function */
 int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch_in, uint32_t num_ch_out);
 /* Feedback processing function */
 int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch);
 /* memory usage calculation for the component */

--- a/src/include/sof/audio/source_api.h
+++ b/src/include/sof/audio/source_api.h
@@ -54,13 +54,13 @@ struct sof_ipc_stream_params;
  * Retrieves size of available data (in bytes)
  * return number of bytes that are available for immediate use
  */
-size_t source_get_data_available(struct sof_source __sparse_cache *source);
+size_t source_get_data_available(struct sof_source *source);
 
 /**
  * Retrieves size of available data (in frames)
  * return number of bytes that are available for immediate use
  */
-size_t source_get_data_frames_available(struct sof_source __sparse_cache *source);
+size_t source_get_data_frames_available(struct sof_source *source);
 
 /**
  * Retrieves a fragment of circular data to be used by the caller (to read)
@@ -93,7 +93,7 @@ size_t source_get_data_frames_available(struct sof_source __sparse_cache *source
  *
  * @retval -ENODATA if req_size is bigger than available data
  */
-int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+int source_get_data(struct sof_source *source, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 /**
@@ -110,38 +110,38 @@ int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
  *
  * @return proper error code (0  on success)
  */
-int source_release_data(struct sof_source __sparse_cache *source, size_t free_size);
+int source_release_data(struct sof_source *source, size_t free_size);
 
 /**
  * Get total number of bytes processed by the source (meaning - freed by source_release_data())
  */
-size_t source_get_num_of_processed_bytes(struct sof_source __sparse_cache *source);
+size_t source_get_num_of_processed_bytes(struct sof_source *source);
 
 /**
  * sets counter of total number of bytes processed  to zero
  */
-void source_reset_num_of_processed_bytes(struct sof_source __sparse_cache *source);
+void source_reset_num_of_processed_bytes(struct sof_source *source);
 
 /** get size of a single audio frame (in bytes) */
-size_t source_get_frame_bytes(struct sof_source __sparse_cache *source);
+size_t source_get_frame_bytes(struct sof_source *source);
 
 /** set of functions for retrieve audio parameters */
-enum sof_ipc_frame source_get_frm_fmt(struct sof_source __sparse_cache *source);
-enum sof_ipc_frame source_get_valid_fmt(struct sof_source __sparse_cache *source);
-unsigned int source_get_rate(struct sof_source __sparse_cache *source);
-unsigned int source_get_channels(struct sof_source __sparse_cache *source);
-uint32_t source_get_buffer_fmt(struct sof_source __sparse_cache *source);
-bool source_get_underrun(struct sof_source __sparse_cache *source);
+enum sof_ipc_frame source_get_frm_fmt(struct sof_source *source);
+enum sof_ipc_frame source_get_valid_fmt(struct sof_source *source);
+unsigned int source_get_rate(struct sof_source *source);
+unsigned int source_get_channels(struct sof_source *source);
+uint32_t source_get_buffer_fmt(struct sof_source *source);
+bool source_get_underrun(struct sof_source *source);
 
 /** set of functions for setting audio parameters */
-int source_set_valid_fmt(struct sof_source __sparse_cache *source,
+int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt);
-int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate);
-int source_set_channels(struct sof_source __sparse_cache *source, unsigned int channels);
-int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_permitted);
-int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buffer_fmt);
-void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs);
-size_t source_get_ibs(struct sof_source __sparse_cache *source);
+int source_set_rate(struct sof_source *source, unsigned int rate);
+int source_set_channels(struct sof_source *source, unsigned int channels);
+int source_set_underrun(struct sof_source *source, bool underrun_permitted);
+int source_set_buffer_fmt(struct sof_source *source, uint32_t buffer_fmt);
+void source_set_ibs(struct sof_source *source, size_t ibs);
+size_t source_get_ibs(struct sof_source *source);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params
@@ -151,7 +151,7 @@ size_t source_get_ibs(struct sof_source __sparse_cache *source);
  * @param force_update tells the implementation that the params should override actual settings
  * @return 0 if success
  */
-int source_set_params(struct sof_source __sparse_cache *source,
+int source_set_params(struct sof_source *source,
 		      struct sof_ipc_stream_params *params, bool force_update);
 
 /**
@@ -169,7 +169,7 @@ int source_set_params(struct sof_source __sparse_cache *source,
  *
  * @return 0 if success
  */
-int source_set_alignment_constants(struct sof_source __sparse_cache *source,
+int source_set_alignment_constants(struct sof_source *source,
 				   const uint32_t byte_align,
 				   const uint32_t frame_align_req);
 

--- a/src/include/sof/audio/source_api_implementation.h
+++ b/src/include/sof/audio/source_api_implementation.h
@@ -27,18 +27,18 @@ struct source_ops {
 	/**
 	 * see comment of source_get_data_available()
 	 */
-	size_t (*get_data_available)(struct sof_source __sparse_cache *source);
+	size_t (*get_data_available)(struct sof_source *source);
 
 	/**
 	 * see comment of source_get_data_available()
 	 */
-	int (*get_data)(struct sof_source __sparse_cache *source, size_t req_size,
+	int (*get_data)(struct sof_source *source, size_t req_size,
 			void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 	/**
 	 * see comment of source_release_data()
 	 */
-	int (*release_data)(struct sof_source __sparse_cache *source, size_t free_size);
+	int (*release_data)(struct sof_source *source, size_t free_size);
 
 	/**
 	 * OPTIONAL: Notification to the source implementation about changes in audio format
@@ -49,20 +49,20 @@ struct source_ops {
 	 *
 	 * @retval 0 if success, negative if new parameteres are not supported
 	 */
-	int (*on_audio_format_set)(struct sof_source __sparse_cache *source);
+	int (*on_audio_format_set)(struct sof_source *source);
 
 	/**
 	 * OPTIONAL
 	 * see source_set_params comments
 	 */
-	int (*audio_set_ipc_params)(struct sof_source __sparse_cache *source,
+	int (*audio_set_ipc_params)(struct sof_source *source,
 				    struct sof_ipc_stream_params *params, bool force_update);
 
 	/**
 	 * OPTIONAL
 	 * see comment for source_set_alignment_constants
 	 */
-	int (*set_alignment_constants)(struct sof_source __sparse_cache *source,
+	int (*set_alignment_constants)(struct sof_source *source,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
 };
@@ -86,7 +86,7 @@ struct sof_source {
  *	  the implementation must ensure coherent access to the parameteres
  *	  in case of i.e. cross core shared queue, it must be located in non-cached memory
  */
-void source_init(struct sof_source __sparse_cache *source, const struct source_ops *ops,
+void source_init(struct sof_source *source, const struct source_ops *ops,
 		 struct sof_audio_stream_params *audio_stream_params);
 
 #endif /* __SOF_SOURCE_API_IMPLEMENTATION_H__ */

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -307,7 +307,7 @@ static inline void __coherent_shared_thread(struct coherent *c, const size_t siz
 /*
  * Coherent devices only require locking to manage shared access.
  */
-__must_check static inline struct coherent __sparse_cache *coherent_acquire(struct coherent *c,
+__must_check static inline struct coherent *coherent_acquire(struct coherent *c,
 								     const size_t size)
 {
 	if (c->shared) {
@@ -319,7 +319,7 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire(stru
 		dcache_invalidate_region(cc, size);
 	}
 
-	return (__sparse_force struct coherent __sparse_cache *)c;
+	return c;
 }
 
 static inline void coherent_release(struct coherent __sparse_cache *c,

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -384,10 +384,10 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire_thre
 		dcache_invalidate_region(cc, size);
 	}
 
-	return (__sparse_force struct coherent __sparse_cache *)c;
+	return c;
 }
 
-static inline void coherent_release_thread(struct coherent __sparse_cache *c,
+static inline void coherent_release_thread(struct coherent *c,
 					   const size_t size)
 {
 	if (c->shared) {

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -202,10 +202,10 @@ static inline void __coherent_shared(struct coherent *c, const size_t size)
 
 #ifdef __ZEPHYR__
 
-__must_check static inline struct coherent __sparse_cache *coherent_acquire_thread(
+__must_check static inline struct coherent *coherent_acquire_thread(
 	struct coherent *c, const size_t size)
 {
-	struct coherent __sparse_cache *cc = uncache_to_cache(c);
+	struct coherent *cc = uncache_to_cache(c);
 
 	/* assert if someone passes a cache/local address in here. */
 	ADDR_IS_COHERENT(c);
@@ -226,7 +226,7 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire_thre
 	return cc;
 }
 
-static inline void coherent_release_thread(struct coherent __sparse_cache *c,
+static inline void coherent_release_thread(struct coherent *c,
 					   const size_t size)
 {
 	/* assert if someone passes a coherent address in here. */

--- a/src/include/sof/coherent.h
+++ b/src/include/sof/coherent.h
@@ -202,10 +202,10 @@ static inline void __coherent_shared(struct coherent *c, const size_t size)
 
 #ifdef __ZEPHYR__
 
-__must_check static inline struct coherent *coherent_acquire_thread(
+__must_check static inline struct coherent __sparse_cache *coherent_acquire_thread(
 	struct coherent *c, const size_t size)
 {
-	struct coherent *cc = uncache_to_cache(c);
+	struct coherent __sparse_cache *cc = uncache_to_cache(c);
 
 	/* assert if someone passes a cache/local address in here. */
 	ADDR_IS_COHERENT(c);
@@ -226,7 +226,7 @@ __must_check static inline struct coherent *coherent_acquire_thread(
 	return cc;
 }
 
-static inline void coherent_release_thread(struct coherent *c,
+static inline void coherent_release_thread(struct coherent __sparse_cache *c,
 					   const size_t size)
 {
 	/* assert if someone passes a coherent address in here. */
@@ -384,10 +384,10 @@ __must_check static inline struct coherent __sparse_cache *coherent_acquire_thre
 		dcache_invalidate_region(cc, size);
 	}
 
-	return c;
+	return (__sparse_force struct coherent __sparse_cache *)c;
 }
 
-static inline void coherent_release_thread(struct coherent *c,
+static inline void coherent_release_thread(struct coherent __sparse_cache *c,
 					   const size_t size)
 {
 	if (c->shared) {

--- a/src/include/sof/math/fir_hifi3.h
+++ b/src/include/sof/math/fir_hifi3.h
@@ -48,7 +48,7 @@ static inline void fir_core_setup_circular(struct fir_state_32x16 *fir)
 }
 
 /* Setup circular for component buffer */
-static inline void fir_comp_setup_circular(const struct audio_stream __sparse_cache *buffer)
+static inline void fir_comp_setup_circular(const struct audio_stream *buffer)
 {
 	AE_SETCBEGIN0(audio_stream_get_addr(buffer));
 	AE_SETCEND0(audio_stream_get_end_addr(buffer));

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -36,7 +36,7 @@
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
 /* create a new component in the pipeline */
-struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
+struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared)
 {
 	struct comp_buffer *buffer;
 
@@ -44,7 +44,8 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc)
 		desc->size, desc->comp.pipeline_id, desc->comp.id, desc->flags);
 
 	/* allocate buffer */
-	buffer = buffer_alloc(desc->size, desc->caps, desc->flags, PLATFORM_DCACHE_ALIGN);
+	buffer = buffer_alloc(desc->size, desc->caps, desc->flags, PLATFORM_DCACHE_ALIGN,
+			      is_shared);
 	if (buffer) {
 		buffer->id = desc->comp.id;
 		buffer->pipeline_id = desc->comp.pipeline_id;
@@ -173,13 +174,9 @@ int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
 			struct comp_buffer *buffer, uint32_t dir)
 {
 	/* check if it's a connection between cores */
-	if (buffer->core != comp_core) {
-		/* set the buffer as a coherent object */
-		coherent_shared_thread(buffer, c);
-
+	if (buffer->core != comp_core)
 		if (!comp->is_shared)
 			comp_make_shared(comp);
-	}
 
 	return pipeline_connect(comp, buffer, dir);
 }

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -104,7 +104,6 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	struct list_item *clist;
 	struct comp_buffer *sinkb;
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
 	int dir = dev->direction;
 
 	if (!params) {
@@ -128,22 +127,18 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					      struct comp_buffer,
 					      source_list);
 
-		buf_c = buffer_acquire(buf);
-
 		/* update specific pcm parameter with buffer parameter if
 		 * specific flag is set.
 		 */
-		comp_update_params(flag, params, buf_c);
+		comp_update_params(flag, params, buf);
 
 		/* overwrite buffer parameters with modified pcm
 		 * parameters
 		 */
-		buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);
+		buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
 
 		/* set component period frames */
-		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
-
-		buffer_release(buf_c);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf->stream));
 	} else {
 		/* for other components we iterate over all downstream buffers
 		 * (for playback) or upstream buffers (for capture).
@@ -152,19 +147,15 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 
 		list_for_item(clist, buffer_list) {
 			buf = buffer_from_list(clist, dir);
-			buf_c = buffer_acquire(buf);
-			comp_update_params(flag, params, buf_c);
-			buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);
-			buffer_release(buf_c);
+			comp_update_params(flag, params, buf);
+			buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
 		}
 
 		/* fetch sink buffer in order to calculate period frames */
 		sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 					source_list);
 
-		buf_c = buffer_acquire(sinkb);
-		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
-		buffer_release(buf_c);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&sinkb->stream));
 	}
 
 	return 0;
@@ -287,10 +278,8 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	irq_local_disable(flags);
 	list_for_item_safe(clist, tmp, &icd->cd->bsource_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, sink_list);
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
 
-		buffer_c->sink = NULL;
-		buffer_release(buffer_c);
+		buffer->sink = NULL;
 		/* Also if it isn't shared - we are about to modify uncached data */
 		dcache_writeback_invalidate_region(uncache_to_cache(buffer),
 						   sizeof(*buffer));
@@ -300,10 +289,8 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	list_for_item_safe(clist, tmp, &icd->cd->bsink_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
 
-		buffer_c->source = NULL;
-		buffer_release(buffer_c);
+		buffer->source = NULL;
 		/* Also if it isn't shared - we are about to modify uncached data */
 		dcache_writeback_invalidate_region(uncache_to_cache(buffer),
 						   sizeof(*buffer));

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -80,7 +80,7 @@ int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd)
  */
 static void comp_update_params(uint32_t flag,
 			       struct sof_ipc_stream_params *params,
-			       struct comp_buffer __sparse_cache *buffer)
+			       struct comp_buffer *buffer)
 {
 	if (flag & BUFF_PARAMS_FRAME_FMT)
 		params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -103,7 +103,6 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
-	struct comp_buffer __sparse_cache *buffer_c;
 
 	if (!config) {
 		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",
@@ -145,11 +144,10 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		 * all formats, such as 8/16/24/32 bits.
 		 */
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		if (dd->dma_buffer) {
-			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
-			buffer_release(buffer_c);
-		}
+		if (dd->dma_buffer)
+			audio_stream_set_frm_fmt(&dd->dma_buffer->stream,
+						 dev->ipc_config.frame_fmt);
+
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
@@ -170,11 +168,9 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		break;
 	case SOF_DAI_AMD_DMIC:
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		if (dd->dma_buffer) {
-			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
-			buffer_release(buffer_c);
-		}
+		if (dd->dma_buffer)
+			audio_stream_set_frm_fmt(&dd->dma_buffer->stream,
+						 dev->ipc_config.frame_fmt);
 		break;
 	case SOF_DAI_AMD_HS:
 	case SOF_DAI_AMD_HS_VIRTUAL:

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -454,7 +454,7 @@ int ipc_buffer_new(struct ipc *ipc, const struct sof_ipc_buffer *desc)
 	}
 
 	/* register buffer with pipeline */
-	buffer = buffer_new(desc);
+	buffer = buffer_new(desc, false);
 	if (!buffer) {
 		tr_err(&ipc_tr, "ipc_buffer_new(): buffer_new() failed");
 		return -ENOMEM;
@@ -572,6 +572,10 @@ static int ipc_comp_to_buffer_connect(struct ipc_comp_dev *comp,
 	tr_dbg(&ipc_tr, "ipc: comp sink %d, source %d -> connect", buffer->id,
 	       comp->id);
 
+	if (comp->core != buffer->cb->core) {
+		tr_err(&ipc_tr, "ipc: shared buffers are not supported for IPC3");
+		return -ENOTSUP;
+	}
 	return comp_buffer_connect(comp->cd, comp->core, buffer->cb,
 				   PPL_CONN_DIR_COMP_TO_BUFFER);
 }
@@ -582,6 +586,10 @@ static int ipc_buffer_to_comp_connect(struct ipc_comp_dev *buffer,
 	tr_dbg(&ipc_tr, "ipc: comp sink %d, source %d -> connect", comp->id,
 	       buffer->id);
 
+	if (comp->core != buffer->cb->core) {
+		tr_err(&ipc_tr, "ipc: shared buffers are not supported for IPC3");
+		return -ENOTSUP;
+	}
 	return comp_buffer_connect(comp->cd, comp->core, buffer->cb,
 				   PPL_CONN_DIR_BUFFER_TO_COMP);
 }

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -487,7 +487,6 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 	unsigned int core;
 	bool sink_active = false;
 	bool source_active = false;
-	struct comp_buffer __sparse_cache *buffer_c;
 
 	/* check whether buffer exists */
 	ibd = ipc_get_buffer_by_id(ipc, buffer_id);
@@ -498,8 +497,6 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 	if (!cpu_is_me(ibd->core))
 		return ipc_process_on_core(ibd->core, false);
 
-	buffer_c = buffer_acquire(ibd->cb);
-
 	/* try to find sink/source components to check if they still exists */
 	list_for_item(clist, &ipc->comp_list) {
 		icd = container_of(clist, struct ipc_comp_dev, list);
@@ -507,20 +504,18 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 			continue;
 
 		/* check comp state if sink and source are valid */
-		if (buffer_c->sink == icd->cd) {
-			sink = buffer_c->sink;
-			if (buffer_c->sink->state != COMP_STATE_READY)
+		if (ibd->cb->sink == icd->cd) {
+			sink = ibd->cb->sink;
+			if (ibd->cb->sink->state != COMP_STATE_READY)
 				sink_active = true;
 		}
 
-		if (buffer_c->source == icd->cd) {
-			source = buffer_c->source;
-			if (buffer_c->source->state != COMP_STATE_READY)
+		if (ibd->cb->source == icd->cd) {
+			source = ibd->cb->source;
+			if (ibd->cb->source->state != COMP_STATE_READY)
 				source_active = true;
 		}
 	}
-
-	buffer_release(buffer_c);
 
 	/*
 	 * A buffer could be connected to 2 different pipelines. When one pipeline is freed, the

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -241,14 +241,11 @@ static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 		/* free sink buffer allocated by current component in bind function */
 		list_for_item_safe(list, _list, &icd->cd->bsink_list) {
-			struct comp_buffer __sparse_cache *buffer_c;
 			struct comp_dev *sink;
 
 			buffer = container_of(list, struct comp_buffer, source_list);
 			pipeline_disconnect(icd->cd, buffer, PPL_CONN_DIR_COMP_TO_BUFFER);
-			buffer_c = buffer_acquire(buffer);
-			sink = buffer_c->sink;
-			buffer_release(buffer_c);
+			sink = buffer->sink;
 
 			/* free the buffer only when the sink module has also been disconnected */
 			if (!sink)
@@ -257,14 +254,11 @@ static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 		/* free source buffer allocated by current component in bind function */
 		list_for_item_safe(list, _list, &icd->cd->bsource_list) {
-			struct comp_buffer __sparse_cache *buffer_c;
 			struct comp_dev *source;
 
 			buffer = container_of(list, struct comp_buffer, sink_list);
 			pipeline_disconnect(icd->cd, buffer, PPL_CONN_DIR_BUFFER_TO_COMP);
-			buffer_c = buffer_acquire(buffer);
-			source = buffer_c->source;
-			buffer_release(buffer_c);
+			source = buffer->source;
 
 			/* free the buffer only when the source module has also been disconnected */
 			if (!source)
@@ -337,7 +331,6 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 {
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
 	struct comp_dev *source;
 	struct comp_dev *sink;
 	struct ipc4_base_module_cfg source_src_cfg;
@@ -388,10 +381,8 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	 *	OBS of a buffer is IBS of destination component
 	 */
 
-	buffer_c = buffer_acquire(buffer);
-	source_set_ibs(audio_stream_get_source(&buffer_c->stream), source_src_cfg.obs);
-	sink_set_obs(audio_stream_get_sink(&buffer_c->stream), sink_src_cfg.ibs);
-	buffer_release(buffer_c);
+	source_set_ibs(audio_stream_get_source(&buffer->stream), source_src_cfg.obs);
+	sink_set_obs(audio_stream_get_sink(&buffer->stream), sink_src_cfg.ibs);
 
 	/*
 	 * Connect and bind the buffer to both source and sink components with the interrupts
@@ -490,10 +481,7 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	buffer_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 	list_for_item(sink_list, &src->bsink_list) {
 		struct comp_buffer *buf = container_of(sink_list, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(buf);
-		bool found = buf_c->id == buffer_id;
-
-		buffer_release(buf_c);
+		bool found = buf->id == buffer_id;
 
 		if (found) {
 			buffer = buf;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -829,7 +829,7 @@ void ipc4_base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *ba
 		params->chmap[i] = (base_cfg->audio_fmt.ch_map >> i * 4) & 0xf;
 }
 
-void ipc4_update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
+void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 			       const struct ipc4_audio_format *fmt)
 {
 	enum sof_ipc_frame valid_fmt, frame_fmt;

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -325,7 +325,7 @@ int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
 			 struct comp_buffer __sparse_cache *sink,
 			 dma_process_func process, uint32_t source_bytes)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
+	struct audio_stream *istream = &source->stream;
 	uint32_t samples = source_bytes /
 			   audio_stream_sample_bytes(istream);
 	uint32_t sink_bytes = audio_stream_sample_bytes(&sink->stream) *
@@ -354,7 +354,7 @@ int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
 		       struct comp_buffer __sparse_cache *sink,
 		       dma_process_func process, uint32_t sink_bytes)
 {
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint32_t samples = sink_bytes /
 			   audio_stream_sample_bytes(ostream);
 	uint32_t source_bytes = audio_stream_sample_bytes(&source->stream) *
@@ -383,7 +383,7 @@ int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
 				    struct comp_buffer __sparse_cache *sink,
 				    dma_process_func process, uint32_t source_bytes)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
+	struct audio_stream *istream = &source->stream;
 	uint32_t samples = source_bytes /
 			   audio_stream_sample_bytes(istream);
 	uint32_t sink_bytes = audio_stream_sample_bytes(&sink->stream) *

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -321,8 +321,8 @@ void dma_sg_free(struct dma_sg_elem_array *elem_array)
 	dma_sg_init(elem_array);
 }
 
-int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from(struct comp_buffer *source,
+			 struct comp_buffer *sink,
 			 dma_process_func process, uint32_t source_bytes)
 {
 	struct audio_stream *istream = &source->stream;
@@ -350,8 +350,8 @@ int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
 	return ret;
 }
 
-int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
-		       struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_to(struct comp_buffer *source,
+		       struct comp_buffer *sink,
 		       dma_process_func process, uint32_t sink_bytes)
 {
 	struct audio_stream *ostream = &sink->stream;
@@ -379,8 +379,8 @@ int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
 	return ret;
 }
 
-int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
-				    struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
+				    struct comp_buffer *sink,
 				    dma_process_func process, uint32_t source_bytes)
 {
 	struct audio_stream *istream = &source->stream;

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -879,7 +879,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 {
 	struct probe_pdata *_probe = probe_get();
 	struct buffer_cb_transact *cb_data = data;
-	struct comp_buffer __sparse_cache *buffer = cb_data->buffer;
+	struct comp_buffer *buffer = cb_data->buffer;
 	struct probe_dma_ext *dma;
 	uint32_t buffer_id;
 	uint32_t head, tail;

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1066,7 +1066,6 @@ static bool probe_purpose_needs_ext_dma(uint32_t purpose)
 static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point_id_t probe_point)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
 	struct list_item *sink_list, *source_list;
 	unsigned int queue_id;
 
@@ -1074,9 +1073,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 	case PROBE_TYPE_INPUT:
 		list_for_item(source_list, &dev->cd->bsource_list) {
 			buf = container_of(source_list, struct comp_buffer, sink_list);
-			buf_c = buffer_acquire(buf);
-			queue_id = IPC4_SRC_QUEUE_ID(buf_c->id);
-			buffer_release(buf_c);
+			queue_id = IPC4_SRC_QUEUE_ID(buf->id);
 
 			if (queue_id == probe_point.fields.index)
 				return buf;
@@ -1085,9 +1082,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 	case PROBE_TYPE_OUTPUT:
 		list_for_item(sink_list, &dev->cd->bsink_list) {
 			buf = container_of(sink_list, struct comp_buffer, source_list);
-			buf_c = buffer_acquire(buf);
-			queue_id = IPC4_SINK_QUEUE_ID(buf_c->id);
-			buffer_release(buf_c);
+			queue_id = IPC4_SINK_QUEUE_ID(buf->id);
 
 			if (queue_id == probe_point.fields.index)
 				return buf;

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -797,7 +797,6 @@ static int test_keyword_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb;
-	struct comp_buffer __sparse_cache *source_c;
 	unsigned int channels, rate;
 	enum sof_ipc_frame frame_fmt;
 	int err;
@@ -815,11 +814,9 @@ static int test_keyword_params(struct comp_dev *dev,
 	/* keyword components will only ever have 1 source */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	source_c = buffer_acquire(sourceb);
-	channels = audio_stream_get_channels(&source_c->stream);
-	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	rate = audio_stream_get_rate(&source_c->stream);
-	buffer_release(source_c);
+	channels = audio_stream_get_channels(&sourceb->stream);
+	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
+	rate = audio_stream_get_rate(&sourceb->stream);
 
 	if (channels != 1) {
 		comp_err(dev, "test_keyword_params(): only single-channel supported");
@@ -881,7 +878,6 @@ static int test_keyword_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
 	uint32_t frames;
 
 	comp_dbg(dev, "test_keyword_copy()");
@@ -889,23 +885,19 @@ static int test_keyword_copy(struct comp_dev *dev)
 	/* keyword components will only ever have 1 source */
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
-	source_c = buffer_acquire(source);
 
-	if (!audio_stream_get_avail(&source_c->stream)) {
-		buffer_release(source_c);
+	if (!audio_stream_get_avail(&source->stream)) {
 		return PPL_STATUS_PATH_STOP;
 	}
 
-	frames = audio_stream_get_avail_frames(&source_c->stream);
+	frames = audio_stream_get_avail_frames(&source->stream);
 
 	/* copy and perform detection */
-	buffer_stream_invalidate(source_c, audio_stream_get_avail_bytes(&source_c->stream));
-	cd->detect_func(dev, &source_c->stream, frames);
+	buffer_stream_invalidate(source, audio_stream_get_avail_bytes(&source->stream));
+	cd->detect_func(dev, &source->stream, frames);
 
 	/* calc new available */
-	comp_update_buffer_consume(source_c, audio_stream_get_avail_bytes(&source_c->stream));
-
-	buffer_release(source_c);
+	comp_update_buffer_consume(source, audio_stream_get_avail_bytes(&source->stream));
 
 	return 0;
 }

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -101,7 +101,7 @@ struct comp_data {
 	struct ipc_msg *msg;	/**< host notification */
 
 	void (*detect_func)(struct comp_dev *dev,
-			    const struct audio_stream __sparse_cache *source, uint32_t frames);
+			    const struct audio_stream *source, uint32_t frames);
 	struct sof_ipc_comp_event event;
 
 #if CONFIG_AMS
@@ -209,7 +209,7 @@ void detect_test_notify(const struct comp_dev *dev)
 }
 
 static void default_detect_test(struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
+				const struct audio_stream *source,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -35,7 +35,7 @@ static int kwd_nn_detect_postprocess(uint8_t confidences[KWD_NN_CONFIDENCES_SIZE
 }
 
 void kwd_nn_detect_test(struct comp_dev *dev,
-			const struct audio_stream __sparse_cache *source,
+			const struct audio_stream *source,
 			uint32_t frames)
 {
 	void *src;

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -28,8 +28,8 @@ DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(smart_amp_comp_uuid),
 	       LOG_LEVEL_INFO);
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink, uint32_t frames,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink, uint32_t frames,
 			     int8_t *chan_map);
 
 struct smart_amp_data {
@@ -330,8 +330,8 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 }
 
 static int smart_amp_process_s16(struct comp_dev *dev,
-				 const struct audio_stream __sparse_cache *source,
-				 const struct audio_stream __sparse_cache *sink,
+				 const struct audio_stream *source,
+				 const struct audio_stream *sink,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
@@ -362,8 +362,8 @@ static int smart_amp_process_s16(struct comp_dev *dev,
 }
 
 static int smart_amp_process_s32(struct comp_dev *dev,
-				 const struct audio_stream __sparse_cache *source,
-				 const struct audio_stream __sparse_cache *sink,
+				 const struct audio_stream *source,
+				 const struct audio_stream *sink,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -342,7 +342,7 @@ static int smart_amp_reset(struct processing_module *mod)
 }
 
 static int smart_amp_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
+			     struct sof_source **sources, int num_of_sources,
 			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -92,7 +92,6 @@ static void smart_amp_set_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
 
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 
@@ -102,11 +101,9 @@ static void smart_amp_set_params(struct processing_module *mod)
 		struct ipc4_audio_format out_fmt = sink_fmt->audio_fmt;
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 
-		ipc4_update_buffer_format(sink_c, &out_fmt);
-		params->frame_fmt = audio_stream_get_frm_fmt(&sink_c->stream);
-		buffer_release(sink_c);
+		ipc4_update_buffer_format(sink, &out_fmt);
+		params->frame_fmt = audio_stream_get_frm_fmt(&sink->stream);
 	}
 }
 
@@ -352,7 +349,6 @@ static int smart_amp_prepare(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source_buffer;
 	struct comp_buffer *sink_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
 	struct list_item *blist;
 	int ret;
 
@@ -365,22 +361,18 @@ static int smart_amp_prepare(struct processing_module *mod,
 	list_for_item(blist, &dev->bsource_list) {
 		source_buffer = container_of(blist, struct comp_buffer,
 					     sink_list);
-		buffer_c = buffer_acquire(source_buffer);
-		audio_stream_init_alignment_constants(1, 1, &buffer_c->stream);
-		if (IPC4_SINK_QUEUE_ID(buffer_c->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
-			audio_stream_set_channels(&buffer_c->stream, sad->config.feedback_channels);
-			audio_stream_set_rate(&buffer_c->stream,
+		audio_stream_init_alignment_constants(1, 1, &source_buffer->stream);
+		if (IPC4_SINK_QUEUE_ID(source_buffer->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
+			audio_stream_set_channels(&source_buffer->stream, sad->config.feedback_channels);
+			audio_stream_set_rate(&source_buffer->stream,
 					      mod->priv.cfg.base_cfg.audio_fmt.sampling_frequency);
 		}
-		buffer_release(buffer_c);
 	}
 
 	sink_buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	buffer_c = buffer_acquire(sink_buffer);
-	sad->out_channels = audio_stream_get_channels(&buffer_c->stream);
-	audio_stream_init_alignment_constants(1, 1, &buffer_c->stream);
-	sad->process = get_smart_amp_process(dev, buffer_c);
-	buffer_release(buffer_c);
+	sad->out_channels = audio_stream_get_channels(&sink_buffer->stream);
+	audio_stream_init_alignment_constants(1, 1, &sink_buffer->stream);
+	sad->process = get_smart_amp_process(dev, sink_buffer);
 
 	if (!sad->process) {
 		comp_err(dev, "smart_amp_prepare(): get_smart_amp_process failed");

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -255,7 +255,7 @@ static int smart_amp_process_s32(struct processing_module *mod,
 }
 
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev,
-					    struct comp_buffer __sparse_cache *buf)
+					    struct comp_buffer *buf)
 {
 	switch (audio_stream_get_frm_fmt(&buf->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
@@ -275,9 +275,9 @@ static int smart_amp_process(struct processing_module *mod,
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct comp_buffer __sparse_cache *fb_buf_c;
-	struct comp_buffer __sparse_cache *buf;
-	struct module_source_info __sparse_cache *mod_source_info;
+	struct comp_buffer *fb_buf_c;
+	struct comp_buffer *buf;
+	struct module_source_info *mod_source_info;
 	struct input_stream_buffer *fb_input = NULL;
 	/* if there is only one input stream, it should be the source input */
 	struct input_stream_buffer *src_input = &input_buffers[0];
@@ -290,9 +290,7 @@ static int smart_amp_process(struct processing_module *mod,
 
 	if (num_input_buffers == SMART_AMP_NUM_IN_PINS)
 		for (i = 0; i < num_input_buffers; i++) {
-			buf = attr_container_of(input_buffers[i].data,
-						struct comp_buffer __sparse_cache,
-						stream, __sparse_cache);
+			buf = container_of(input_buffers[i].data, struct comp_buffer, stream);
 
 			if (IPC4_SINK_QUEUE_ID(buf->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
 				fb_input = &input_buffers[i];

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -193,8 +193,8 @@ static int smart_amp_process_s16(struct processing_module *mod,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *src;
 	int16_t *dest;
 	uint32_t in_frag = 0;
@@ -226,8 +226,8 @@ static int smart_amp_process_s32(struct processing_module *mod,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *src;
 	int32_t *dest;
 	uint32_t in_frag = 0;

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -343,7 +343,7 @@ static int smart_amp_reset(struct processing_module *mod)
 
 static int smart_amp_prepare(struct processing_module *mod,
 			     struct sof_source **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/test/cmocka/src/audio/buffer/buffer_copy.c
+++ b/test/cmocka/src/audio/buffer/buffer_copy.c
@@ -29,8 +29,8 @@ static void test_audio_buffer_copy_underrun(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -56,8 +56,8 @@ static void test_audio_buffer_copy_overrun(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -85,8 +85,8 @@ static void test_audio_buffer_copy_success(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -111,8 +111,8 @@ static void test_audio_buffer_copy_fit_space_constraint(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -139,8 +139,8 @@ static void test_audio_buffer_copy_fit_no_space_constraint(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(src);
 	assert_non_null(snk);

--- a/test/cmocka/src/audio/buffer/buffer_new.c
+++ b/test/cmocka/src/audio/buffer/buffer_new.c
@@ -27,7 +27,7 @@ static void test_audio_buffer_new(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/audio/buffer/buffer_wrap.c
+++ b/test/cmocka/src/audio/buffer/buffer_wrap.c
@@ -27,7 +27,7 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 		.size = 10
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/audio/buffer/buffer_write.c
+++ b/test/cmocka/src/audio/buffer/buffer_write.c
@@ -28,7 +28,7 @@ static void test_audio_buffer_write_10_bytes_out_of_256_and_read_back
 		.size = 256
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
@@ -63,7 +63,7 @@ static void test_audio_buffer_fill_10_bytes(void **state)
 		.size = 10
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/math/fft/fft.c
+++ b/test/cmocka/src/math/fft/fft.c
@@ -265,8 +265,8 @@ static void test_math_fft_256(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 256 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 256;
@@ -307,8 +307,8 @@ static void test_math_fft_512(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 512;
@@ -349,8 +349,8 @@ static void test_math_fft_1024(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 1024;
@@ -391,9 +391,9 @@ static void test_math_fft_1024_ifft(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 4 * 2,
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *intm = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *intm = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	float db;
 	int64_t signal = 0;
@@ -432,9 +432,9 @@ static void test_math_fft_512_2ch(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 4 * 2,
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink1 = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink2 = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink1 = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink2 = buffer_new(&test_buf_desc, false);
 	struct icomplex32 *out1 = (struct icomplex32 *)sink1->stream.addr;
 	struct icomplex32 *out2 = (struct icomplex32 *)sink2->stream.addr;
 	uint32_t fft_size = 512;
@@ -625,8 +625,8 @@ static void test_math_fft_256_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 256 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 256;
@@ -667,8 +667,8 @@ static void test_math_fft_512_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 512;
@@ -709,8 +709,8 @@ static void test_math_fft_1024_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 1024;
@@ -751,9 +751,9 @@ static void test_math_fft_1024_ifft_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc);
-	struct comp_buffer *intm = buffer_new(&test_buf_desc);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *intm = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	float db;
 	int64_t signal = 0;

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -23,7 +23,7 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 		},
 		.size = buffer_size,
 	};
-	struct comp_buffer *buffer = buffer_new(&desc);
+	struct comp_buffer *buffer = buffer_new(&desc, false);
 
 	memset(buffer->stream.addr, 0, buffer_size);
 
@@ -58,7 +58,7 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 		},
 		.size = buffer_size,
 	};
-	struct comp_buffer *buffer = buffer_new(&desc);
+	struct comp_buffer *buffer = buffer_new(&desc, false);
 
 	memset(buffer->stream.addr, 0, buffer_size);
 

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -254,8 +254,8 @@ struct dma_info {
 };
 
 struct audio_stream;
-typedef int (*dma_process_func)(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+typedef int (*dma_process_func)(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t frames);
 
 /**
@@ -530,8 +530,8 @@ typedef void (*dma_process)(const struct audio_stream *,
 			    struct audio_stream *, uint32_t);
 
 /* copies data from DMA buffer using provided processing function */
-int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from(struct comp_buffer *source,
+			 struct comp_buffer *sink,
 			 dma_process_func process, uint32_t source_bytes);
 
 /*
@@ -539,13 +539,13 @@ int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
  * conversion function. DMA buffer consume should be performed after the data has been copied
  * to all sinks.
  */
-int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
-				    struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
+				    struct comp_buffer *sink,
 				    dma_process_func process, uint32_t source_bytes);
 
 /* copies data to DMA buffer using provided processing function */
-int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
-		       struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_to(struct comp_buffer *source,
+		       struct comp_buffer *sink,
 		       dma_process_func process, uint32_t sink_bytes);
 
 /* generic DMA DSP <-> Host copier */


### PR DESCRIPTION
This PR is a quick POC for discussuion https://github.com/thesofproject/sof/issues/8006

There are a lot of TODOs, yet it is ready to be tested in IPC4/MTL

TODOs:
1) Check if there is no need to extra spinlocks!!!! in case of shared buffers probably - yes because buffer_aquire was also performing as a mutex when in shared mode.
In not-shared there's no need for locks because LLs are processed one by one in a single thread
2) remove buffer_aquire from the code (in inteligent way, keep point 1 in mind)
3) remove lots of __sparse_cache
4) add __sparse_cache to pointers pointing audio samples buffers
