### PR TITLE
Introducing initial silence in DMIC path to remove the popping noise

### DIFF
--- a/src/drivers/amd/common/acp_dmic_dai.c
+++ b/src/drivers/amd/common/acp_dmic_dai.c
@@ -17,6 +17,9 @@
 #include <platform/fw_scratch_mem.h>
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
+#include <platform/acp_dmic_dma.h>
+
+extern struct acp_dmic_silence acp_initsilence;
 
 /*0ae40946-dfd2-4140-91-52-0d-d5-a3-ea-ae-81*/
 DECLARE_SOF_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
@@ -37,6 +40,7 @@ static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai
 	clk_ctrl = (acp_wov_clk_ctrl_t)io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_DMA_ENABLE);
 	clk_ctrl.u32all = 0;
 	pdm_channels.u32all = io_reg_read(PU_REGISTER_BASE + ACP_WOV_PDM_NO_OF_CHANNELS);
+	acp_initsilence.samplerate_khz = acpdata->dmic_params.pdm_rate / 1000;
 	switch (acpdata->dmic_params.pdm_rate) {
 	case 48000:
 		/* DMIC Clock for 48K sample rate */
@@ -51,6 +55,7 @@ static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai
 		return -EINVAL;
 	}
 	io_reg_write(PU_REGISTER_BASE + ACP_WOV_CLK_CTRL, clk_ctrl.u32all);
+	acp_initsilence.num_chs = acpdata->dmic_params.pdm_ch;
 	switch (acpdata->dmic_params.pdm_ch) {
 	case 2:
 		pdm_channels.bits.pdm_no_of_channels = 0;
@@ -146,6 +151,7 @@ static int acp_dmic_dai_get_hw_params(struct dai *dai,
 	}
 	params->buffer_fmt = SOF_IPC_BUFFER_INTERLEAVED;
 	params->frame_fmt = SOF_IPC_FRAME_S32_LE;
+	acp_initsilence.bytes_per_sample = 4;
 	return 0;
 }
 

--- a/src/platform/amd/common/include/platform/acp_dmic_dma.h
+++ b/src/platform/amd/common/include/platform/acp_dmic_dma.h
@@ -14,6 +14,21 @@
 
 /* 109c7aba-a7ba-43c3-b9-42-59-e2-0a-66-11-be */
 
+#define DMIC_SETTLING_TIME_MS 360
+#define DMIC_SMOOTH_TIME_MS 40
+
+struct acp_dmic_silence {
+	uint32_t bytes_per_sample;
+	uint32_t num_chs;
+	uint32_t samplerate_khz;
+	uint32_t silence_cnt;
+	uint32_t silence_incr;
+	int coeff;
+	int numfilterbuffers;
+	char *dmic_rngbuff_addr1;
+	int *dmic_rngbuff_iaddr;
+};
+
 int acp_dmic_dma_start(struct dma_chan_data *channel);
 int acp_dmic_dma_stop(struct dma_chan_data *channel);
 int acp_dmic_dma_set_config(struct dma_chan_data *channel,


### PR DESCRIPTION
AMD: DMIC: Initial silence in DMIC path to remove the popping noise during the start of DMIC.