### PR TITLE
topology1: sof-jsl-rt5650

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -148,6 +148,7 @@ set(TPLGS
 	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-cs42l42-mx98360a\;-DHEADPHONE=cs42l42\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-rt5682\;-DHEADPHONE=rt5682\;-DPLATFORM=icl\;-DNO_AMP"
+	"sof-jsl-rt5682\;sof-jsl-rt5650\;-DHEADPHONE=rt5650\;-DPLATFORM=jsl-rt1015"
 )
 
 add_custom_target(topologies ALL)

--- a/tools/topology/platform/intel/jsl-rt1015.m4
+++ b/tools/topology/platform/intel/jsl-rt1015.m4
@@ -10,9 +10,18 @@ define(`SPK_NAME', `SSP1-Codec')
 undefine(`SPK_DATA_FORMAT')
 define(`SPK_DATA_FORMAT', `s24le')
 
+ifelse(HEADPHONE, `rt5650', `
+define(`SET_SSP_CONFIG',
+				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+						SSP_CLOCK(bclk, 3072000, codec_slave),
+						SSP_CLOCK(fsync, 48000, codec_slave),
+						SSP_TDM(2, 32, 3, 3),
+						SSP_CONFIG_DATA(SSP, 1, 24, 0, 0, 0, SSP_CC_MCLK_AON))')
+', `
 define(`SET_SSP_CONFIG',
 				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 						SSP_CLOCK(bclk, 3072000, codec_slave),
 						SSP_CLOCK(fsync, 48000, codec_slave),
 						SSP_TDM(2, 32, 3, 3),
 						SSP_CONFIG_DATA(SSP, 1, 24))')
+')

--- a/tools/topology/sof-jsl-rt5682.m4
+++ b/tools/topology/sof-jsl-rt5682.m4
@@ -195,6 +195,14 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+', HEADPHONE, `rt5650', `
+# SSP 0 (ID: 0) ALC5650-I2S1
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3072000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_MCLK_AON)))
 ', )
 
 ifdef(`NO_AMP',`',`


### PR DESCRIPTION
Add a new topology sof-jsl-rt5650 for ALC5650 which supports SSP0 for headset and SSP1 for speakers since this codec implements two I2S interfaces.

DAI format changed to mclk: 24.576MHz, bclk: 3.072MHz, sample bits: 24-bit to avoid using ASRC function on codec side.