### PR TITLE
audio: xtensa: add Kconfig for inline functions

### DIFF
--- a/Kconfig.sof
+++ b/Kconfig.sof
@@ -114,6 +114,13 @@ config COMPILER_WORKAROUND_CACHE_ATTR
 	  There is a weird optimization bug with gcc10x and gcc8.1
 	  (with -O2 flags) on IMX platforms. See PR #4605.
 
+config COMPILER_INLINE_FUNCTION_OPTION
+        bool
+	default y if CAVS_VERSION_2_5 || ACE
+        default n
+        help
+          When enabled, -fno-inline-function option is not passed to compiler
+
 rsource "src/Kconfig"
 
 # See zephyr/modules/Kconfig

--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -98,7 +98,11 @@ else()
 endif()
 
 # C & ASM flags
-target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions ${XTENSA_C_ASM_FLAGS})
+if(CONFIG_COMPILER_INLINE_FUNCTION_OPTION)
+	target_compile_options(sof_options INTERFACE ${stdlib_flag} ${XTENSA_C_ASM_FLAGS})
+else()
+	target_compile_options(sof_options INTERFACE ${stdlib_flag} -fno-inline-functions ${XTENSA_C_ASM_FLAGS})
+endif()
 
 # C flags
 # TODO: Generator expressions are supported only with Make and Ninja,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -555,6 +555,8 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 	struct sof_ipc_stream_params hw_params;
 	int ret;
 
+	memset(&hw_params, 0, sizeof(hw_params));
+
 	ret = dai_common_get_hw_params(dd, dev, &hw_params, params->direction);
 	if (ret < 0) {
 		comp_err(dev, "dai_verify_params(): dai_verify_params failed ret %d", ret);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -799,8 +799,9 @@ set(VERSION_H_PATH ${GENERATED_DIRECTORY}/sof_versions.h)
 find_package(Python3 COMPONENTS Interpreter)
 set(PYTHON3 "${Python3_EXECUTABLE}")
 
-# We don't know why we have this https://github.com/thesofproject/sof/issues/5212
+if (NOT CONFIG_COMPILER_INLINE_FUNCTION_OPTION)
 target_compile_options(SOF INTERFACE -fno-inline-functions)
+endif()
 
 # SOF needs `typeof`, `__VA_ARGS__` and maybe other GNU C99
 # extensions. TODO other flags required ?


### PR DESCRIPTION
Enable inline function for cavs 2.5 and above platform, this is a follow up with issue:#5212