### PR TITLE
smart amp : Do not use DYNAMIC topology with DTS

### DIFF
--- a/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
@@ -19,6 +19,10 @@ DEBUG_START
 # define the default macros.
 # define them in your specific platform .m4 if needed.
 
+#undefine the DYNAMIC flag (if enabled, save it) for smart amplifier as it uses volatile kcontrols
+ifdef(`DYNAMIC', `define(`SAVED_DYNAMIC', DYNAMIC)',`')
+undefine(`DYNAMIC')
+
 
 ifelse(SDW, `1',
 `
@@ -227,5 +231,8 @@ DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
 		      SSP_TDM(8, 32, 15, 255),
 		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 32, 0, SMART_SSP_QUIRK)))
 ')
+
+#Re-enable DYNAMIC flag if it was enabled for other pipelines
+ifdef(`SAVED_DYNAMIC', `define(`DYNAMIC', 1)',`')
 
 DEBUG_END


### PR DESCRIPTION
Follows after:
    214f98378 ("smart amp : Do not use DYNAMIC topology")

which makes DYNAMIC undefined during smart amp tplg pipeline pcm/dai config due to the use of volatile Kcontrols.

This commit applies the same on sof-eq-iir-dts-codec-smart-amplifier.m4 which is used for (DTS + smart amp) projects.