### PR TITLE
TigerLake: disable memory windows setting on sof side

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -15,7 +15,6 @@ config TIGERLAKE
 	select DMA_GW
 	select DW
 	select DW_DMA if !ZEPHYR_NATIVE_DRIVERS
-	select MEM_WND
 	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -81,78 +81,7 @@ static const struct sof_ipc_fw_ready ready
 #endif
 };
 
-#if CONFIG_MEM_WND
 #define SRAM_WINDOW_HOST_OFFSET(x) (0x80000 + x * 0x20000)
-
-#define NUM_WINDOWS 7
-
-const struct ext_man_windows xsram_window
-		__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") __unused = {
-	.hdr = {
-		.type = EXT_MAN_ELEM_WINDOW,
-		.elem_size = ALIGN_UP_COMPILE(sizeof(struct ext_man_windows), EXT_MAN_ALIGN),
-	},
-	.window = {
-		.ext_hdr	= {
-			.hdr.cmd = SOF_IPC_FW_READY,
-			.hdr.size = sizeof(struct sof_ipc_window),
-			.type	= SOF_IPC_EXT_WINDOW,
-		},
-		.num_windows	= NUM_WINDOWS,
-		.window	= {
-			{
-				.type	= SOF_IPC_REGION_REGS,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_SW_REG_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_UPBOX,
-				.id	= 0,	/* map to host window 0 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DSPBOX_SIZE,
-				.offset	= MAILBOX_SW_REG_SIZE,
-			},
-			{
-				.type	= SOF_IPC_REGION_DOWNBOX,
-				.id	= 1,	/* map to host window 1 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_HOSTBOX_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_DEBUG,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_DEBUG_SIZE,
-				.offset	= 0,
-			},
-			{
-				.type	= SOF_IPC_REGION_EXCEPTION,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_EXCEPTION_SIZE,
-				.offset	= MAILBOX_EXCEPTION_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_STREAM,
-				.id	= 2,	/* map to host window 2 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_STREAM_SIZE,
-				.offset	= MAILBOX_STREAM_OFFSET,
-			},
-			{
-				.type	= SOF_IPC_REGION_TRACE,
-				.id	= 3,	/* map to host window 3 */
-				.flags	= 0, // TODO: set later
-				.size	= MAILBOX_TRACE_SIZE,
-				.offset	= 0,
-			},
-		},
-	},
-};
-#endif
 
 #if CONFIG_TIGERLAKE
 #define CAVS_DEFAULT_RO		SHIM_CLKCTL_RHROSCC
@@ -354,11 +283,6 @@ int platform_init(struct sof *sof)
 
 	trace_point(TRACE_BOOT_PLATFORM_IRQ);
 	platform_interrupt_init();
-
-#if CONFIG_MEM_WND
-	trace_point(TRACE_BOOT_PLATFORM_MBOX);
-	platform_memory_windows_init(MEM_WND_INIT_CLEAR);
-#endif
 
 #ifndef __ZEPHYR__
 	/* init timers, clocks and schedulers */


### PR DESCRIPTION
Memory windows is set on zephyr side, so remove it and also remove xsram_window for memory windows to save memory since it is not used by ipc4.

Currently we find bug that when we disable CONFIG_TRACE, memory windows can't work well since the CONFIG_TRACE affects memory windows size. It is designed for IPC3 but it is not fit for IPC4.