### PR TITLE
CAVS2.5: Make the MEM_WND really optional and make it depends on non zephyr drivers

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -15,7 +15,7 @@ config TIGERLAKE
 	select DMA_GW
 	select DW
 	select DW_DMA if !ZEPHYR_NATIVE_DRIVERS
-	select MEM_WND
+	select MEM_WND if !ZEPHYR_NATIVE_DRIVERS
 	select DMA_HW_LLI
 	select DW_DMA_AGGREGATED_IRQ
 	select DMA_FIFO_PARTITION

--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -306,14 +306,18 @@ int platform_boot_complete(uint32_t boot_message)
 
 	mailbox_dspbox_write(0, &ready, sizeof(ready));
 
+#if CONFIG_IPC_MAJOR_3
 	/* get any IPC specific boot message and optional data */
 	ipc_boot_complete_msg(&header, SRAM_WINDOW_HOST_OFFSET(0) >> 12);
 
 	/* tell host we are ready */
-#if CONFIG_IPC_MAJOR_3
 	ipc_write(IPC_DIPCIDD, header.dat[1]);
 	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | header.dat[0]);
 #elif CONFIG_IPC_MAJOR_4
+	/* get any IPC specific boot message and optional data */
+	ipc_boot_complete_msg(&header, 0);
+
+	/* tell host we are ready */
 	ipc_write(IPC_DIPCIDD, header.ext);
 	ipc_write(IPC_DIPCIDR, IPC_DIPCIDR_BUSY | header.pri);
 #endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -170,11 +170,14 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 	)
 	endif()
 
+	zephyr_library_sources_ifdef(CONFIG_MEM_WND
+		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
+	)
+
 	# Platform sources
 	if (NOT CONFIG_ZEPHYR_NATIVE_DRIVERS)
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
-		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
 		${SOF_PLATFORM_PATH}/tigerlake/lib/clk.c
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/power_down.S
 		${SOF_PLATFORM_PATH}/intel/cavs/lib/pm_runtime.c
@@ -186,7 +189,6 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 	else()
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
-		${SOF_PLATFORM_PATH}/intel/cavs/lib/mem_window.c
 		${SOF_PLATFORM_PATH}/tigerlake/lib/clk.c
 		lib/pm_runtime.c
 		lib/clk.c


### PR DESCRIPTION
Hi,

The SOF application should not try to manage the memory windows, it is the task of the OS.

Removing the `src/platform/intel/cavs/lib/mem_window.c` and `src/platform/intel/cavs/include/cavs/mem_window.h` is a bit more intrusive and involved, I have decided to go with the gentle way...