### PR TITLE
Add "is_ready_to_process" call to module API

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -670,9 +670,9 @@ static int src_verify_params(struct processing_module *mod)
 	return ret;
 }
 
-static int src_get_copy_limits(struct comp_data *cd,
-			       struct sof_source __sparse_cache *source,
-			       struct sof_sink __sparse_cache *sink)
+static bool src_get_copy_limits(struct comp_data *cd,
+				struct sof_source __sparse_cache *source,
+				struct sof_sink __sparse_cache *sink)
 {
 	struct src_param *sp;
 	struct src_stage *s1;
@@ -709,9 +709,9 @@ static int src_get_copy_limits(struct comp_data *cd,
 	}
 
 	if (sp->blk_in == 0 && sp->blk_out == 0)
-		return -EIO;
+		return false;
 
-	return 0;
+	return true;
 }
 
 static int src_params_general(struct processing_module *mod,
@@ -1004,21 +1004,16 @@ static int src_process(struct processing_module *mod,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct comp_dev *dev = mod->dev;
-	int ret;
 
-	comp_dbg(dev, "src_process()");
+	comp_dbg(mod->dev, "src_process()");
 
 	/* src component needs 1 source and 1 sink */
-	ret = src_get_copy_limits(cd, sources[0], sinks[0]);
-	if (ret) {
-		comp_dbg(dev, "No data to process.");
+	if (!src_get_copy_limits(cd, sources[0], sinks[0])) {
+		comp_dbg(mod->dev, "No data to process.");
 		return 0;
 	}
 
-	ret = cd->src_func(cd, sources[0], sinks[0]);
-
-	return ret;
+	return cd->src_func(cd, sources[0], sinks[0]);
 }
 
 static int src_set_config(struct processing_module *mod, uint32_t config_id,

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -999,6 +999,16 @@ static int src_prepare(struct processing_module *mod,
 	return src_prepare_general(mod, sources[0], sinks[0]);
 }
 
+
+static bool src_is_ready_to_process(struct processing_module *mod,
+				    struct sof_source __sparse_cache **sources, int num_of_sources,
+				    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+
+	return src_get_copy_limits(cd, sources[0], sinks[0]);
+}
+
 static int src_process(struct processing_module *mod,
 		       struct sof_source __sparse_cache **sources, int num_of_sources,
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
@@ -1059,6 +1069,7 @@ static struct module_interface src_interface = {
 	.init  = src_init,
 	.prepare = src_prepare,
 	.process = src_process,
+	.is_ready_to_process = src_is_ready_to_process,
 	.set_configuration = src_set_config,
 	.get_configuration = src_get_config,
 	.reset = src_reset,

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -162,6 +162,25 @@ struct module_interface {
 		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
 
 	/**
+	 * (optional) return true if the module is ready to process
+	 * This procedure should check if the module is ready for immediate
+	 * processing.
+	 *
+	 * NOTE! the call MUST NOT perform any time consuming operations
+	 *
+	 * this procedure will always return true for LL module
+	 *
+	 * For DP there's a default implementation that will do a simple check if there's
+	 * at least IBS bytes of data on first source and at least OBS free space on first sink
+	 *
+	 * In case more sophisticated check is needed the method should be implemented in
+	 * the module
+	 */
+	bool (*is_ready_to_process)(struct processing_module *mod,
+				    struct sof_source __sparse_cache **sources, int num_of_sources,
+				    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+
+	/**
 	 * Module specific processing procedure
 	 * This procedure is responsible to consume
 	 * samples provided by the module_adapter and produce/output the processed


### PR DESCRIPTION
dependencies:
- [x] github.com/thesofproject/sof/pull/8002

This is a modification of module API - add is_ready_to_process call

In case of LL modules all modules have "copy" or "process" method
called periodically, regardless if they're ready to process or not

In case of DP processing the module must have enough data on all
its inputs, enough space for result storage on all outputs, etc.
Unfortunately simply check of number of bytes at all sources/sinks
may not be sufficient (i.e. in case of variable rate audio formats)

The is_ready_to_process call will be called when DP scheduler makes
decision if the module is to be scheduled at this LL tick or not.
If the module wants its thread to start (and process called) it should
return TRUE