### PR TITLE
include: ipc4: module: fix component ID macros

### DIFF
--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -407,10 +407,10 @@ struct ipc4_module_load_library {
 	} data;
 } __packed __aligned(4);
 
-#define IPC4_COMP_ID(x, y)	((x) << 16 | (y))
-#define IPC4_MOD_ID(x) ((x) >> 16)
-#define IPC4_INST_ID(x)	((x) & 0xffff)
-#define IPC4_SRC_QUEUE_ID(x)	(((x) >> 16) & 0xffff)
-#define IPC4_SINK_QUEUE_ID(x)	((x) & 0xffff)
+#define IPC4_COMP_ID(x, y)	((y) << 16 | (x))
+#define IPC4_MOD_ID(x)	((x) & 0xffff)
+#define IPC4_INST_ID(x)	((x) >> 16)
+#define IPC4_SRC_QUEUE_ID(x)	((x) & 0xffff)
+#define IPC4_SINK_QUEUE_ID(x)	(((x) >> 16) & 0xffff)
 
 #endif

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -50,8 +50,6 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-#define IPC4_MOD_ID(x) ((x) >> 16)
-
 extern struct tr_ctx comp_tr;
 
 void ipc_build_stream_posn(struct sof_ipc_stream_posn *posn, uint32_t type,


### PR DESCRIPTION
The existing component ID is composed with
'module_id << 16 | instance_id', it doesn't
comply to the initial instance IPC structure:

struct {
    uint32_t module_id   : 16;
    uint32_t instance_id : 8;
    ...
};

When the ID is logged through mtrace, it is
hard to use the ID to find the related linux
kernel message.

This patch fixes component ID composition macros,
thus helps to eliminate component ID inconsistency
 between firmware and linux kernel.

Link: https://github.com/thesofproject/sof/issues/8051