### PR TITLE
zephyr: cpu: use correct condition to init cpu

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -148,7 +148,7 @@ int cpu_enable_core(int id)
 	 * initialization. By reinitializing the idle thread, we would overwrite the kernel structs
 	 * and the idle thread stack.
 	 */
-	if (IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE) &&
+	if (!IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE) ||
 	    pm_state_next_get(id)->state == PM_STATE_ACTIVE)
 		z_init_cpu(id);
 #endif


### PR DESCRIPTION
When converting #ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE to if(IS_ENABLE( CONFIG_ADSP_IMR_CONTEXT_SAVE), we should use if (!IS_ENABLE() ||

At first I use
````c
#ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
     if (pm_state_next_get(id)->state == PM_STATE_ACTIVE)
#endif
        z_init_cpu(id);
````
Then refined it to
````c
	if (IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE)  && pm_state_next_get(id)->state == PM_STATE_ACTIVE)
		z_init_cpu(id);
````
After discussed with @lyakh found this is not equal. Now change it to
````c
	if (!IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE) ||pm_state_next_get(id)->state == PM_STATE_ACTIVE)
		z_init_cpu(id);
````