### PR TITLE
lib_manager: Fix sparse warnings

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -529,8 +529,8 @@ static void __sparse_cache *lib_manager_allocate_store_mem(uint32_t size,
 		return NULL;
 	}
 
-	sys_cache_data_invd_range(local_add, size);
-	sys_cache_instr_invd_range(local_add, size);
+	dcache_invalidate_region(local_add, size);
+	icache_invalidate_region(local_add, size);
 
 	return local_add;
 }

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -561,7 +561,7 @@ static int lib_manager_store_library(struct lib_manager_dma_ext *dma_ext,
 	ret = lib_manager_store_data(dma_ext, (uint8_t __sparse_cache *)library_base_address +
 				     MAN_MAX_SIZE_V1_8, preload_size - MAN_MAX_SIZE_V1_8);
 	if (ret < 0) {
-		rfree(library_base_address);
+		rfree((__sparse_force void *)library_base_address);
 		return ret;
 	}
 


### PR DESCRIPTION
PR #7986 introduced 3 sparse warnings which got overlooked, fix them with a followup patch

There are sparse warnings on zephyr side as well, I will send a PR to fix that.