### PR TITLE
lib_manager: Fix compilation if MM_DRV is not enabled

### DIFF
--- a/src/library_manager/Kconfig
+++ b/src/library_manager/Kconfig
@@ -8,7 +8,6 @@ config LIBRARY_MANAGER
 	bool "Library Manager Support"
 	default n
 	depends on IPC_MAJOR_4
-	depends on MM_DRV
 	help
 	  This is support for dynamic modules loading.
 	  Externally developed modules both for SOF and Zephyr


### PR DESCRIPTION
The module allocate/free uses APIs from MM_DRV but it does not declare dependency on it.
Make the code compile in the case when MM_DRV is not selected by only providing a reduced allocate/free functions with a print only.

Use a local define (PAGE_SZ) to store the page size to be used in the library manager code and in case of !MM_DRV set it to a default 4096 which is also used by the rimage when creating the manifest for the libraries.