### PR TITLE
Remove Tiger Lake XTOS platform Kconfig option (arch + platform)

### DIFF
--- a/src/arch/xtensa/CMakeLists.txt
+++ b/src/arch/xtensa/CMakeLists.txt
@@ -2,9 +2,7 @@
 
 # platform-specific values
 
-if(CONFIG_TIGERLAKE)
-	set(platform_folder tigerlake)
-elseif(CONFIG_IMX8)
+if(CONFIG_IMX8)
 	set(platform_folder imx8)
 elseif(CONFIG_IMX8X)
 	set(platform_folder imx8)

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -11,18 +11,8 @@ choice
 
 config TIGERLAKE
 	bool "Build for Tigerlake"
-	select XT_IRQ_MAP
-	select DMA_GW
-	select DW
-	select DW_DMA if !ZEPHYR_NATIVE_DRIVERS
-	select DMA_HW_LLI
-	select DW_DMA_AGGREGATED_IRQ
-	select DMA_FIFO_PARTITION
 	select CAVS
 	select CAVS_VERSION_2_5
-	select XT_WAITI_DELAY
-	select NO_SECONDARY_CORE_ROM
-	select CAVS_USE_LPRO_IN_WAITI
 	help
 	  Select if your target platform is Tigerlake-compatible
 


### PR DESCRIPTION
commit ae72e4bd342b37ea54c6a4874313f0135443a867 (HEAD -> 202308-tgl-kconfig-prune, kv/202308-tgl-kconfig-prune)
Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
Date:   Mon Aug 21 20:05:41 2023 +0300

    platform: tigerlake: remove XTOS options
    
    When CONFIG_TIGERLAKE is selected, omit all XTOS specific
    build options.
    
    Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>

 src/platform/Kconfig | 10 ----------
 1 file changed, 10 deletions(-)

commit 36db7c9c7b08100bca7c886faac194799a068183
Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
Date:   Mon Aug 21 19:51:36 2023 +0300

    arch: xtensa: remove tigerlake platform option
    
    Remove Intel Tiger Lake from available XTOS platforms in arch/xtensa.
    Now done in sof/zephyr/CMakeLists.txt instead.
    
    Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>

 src/arch/xtensa/CMakeLists.txt | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)
