### PR TITLE
[RFC] remove post-mixout gain for playback

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -16,7 +16,7 @@
 <io-gateway.conf>
 <io-gateway-capture.conf>
 <host-copier-gain-mixin-playback.conf>
-<mixout-gain-dai-copier-playback.conf>
+<mixout-dai-copier-playback.conf>
 <deepbuffer-playback.conf>
 <dai-copier-be.conf>
 <dai-copier-eqiir-module-copier-capture.conf>
@@ -232,7 +232,7 @@ Object.Pipeline {
 		}
 	]
 
-	mixout-gain-dai-copier-playback [
+	mixout-dai-copier-playback [
 		{
 			index	2
 
@@ -242,12 +242,6 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	"$HEADSET_CODEC_NAME"
 				node_type $I2S_LINK_OUTPUT_CLASS
-			}
-
-			Object.Widget.gain.1 {
-				Object.Control.mixer.1 {
-					name	'Post Mixer $HEADSET_PCM_NAME Playback Volume'
-				}
 			}
 		}
 		{
@@ -259,12 +253,6 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	"$SPEAKER_CODEC_NAME"
 				node_type	$I2S_LINK_OUTPUT_CLASS
-			}
-
-			Object.Widget.gain.1 {
-				Object.Control.mixer.1 {
-					name	'Post Mixer $SPEAKER_PCM_NAME Playback Volume'
-				}
 			}
 		}
 	]
@@ -347,7 +335,7 @@ Object.PCM.pcm [
 
 Object.Base.route [
 	{
-		source	"gain.2.1"
+		source	"mixout.2.1"
 		sink	"dai-copier.SSP.$HEADSET_CODEC_NAME.playback"
 	}
 	{
@@ -355,7 +343,7 @@ Object.Base.route [
 		sink	"mixout.2.1"
 	}
 	{
-		source	"gain.4.1"
+		source	"mixout.4.1"
 		sink	"dai-copier.SSP.$SPEAKER_CODEC_NAME.playback"
 	}
 	{


### PR DESCRIPTION
By removing the gain, we can save 10183 CPC, thus allows LF clock (38.4M) to be used for deep-buf and regular spk/hs playback use cases.