### PR TITLE
topology2: fix SoundWire files

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -25,35 +25,44 @@ Object.Pipeline {
 				num_input_audio_formats 3
 				num_output_audio_formats 3
 				num_input_pins 1
-
-				Object.Base.audio_format.0 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		2
-					out_channels		2
-				}
-				Object.Base.audio_format.2 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		8000
-					out_rate		8000
-				}
-				Object.Base.audio_format.3 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		16000
-					out_rate		16000
-				}
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		2
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			8000
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			16000
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		2
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		8000
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		16000
+					}
+				]
 			}
 		}
 	]
@@ -69,34 +78,45 @@ Object.Pipeline {
 				pcm_id $BT_PCM_ID
 				num_input_audio_formats 3
 				num_output_audio_formats 3
-				Object.Base.audio_format.0 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		2
-					out_channels		2
-				}
-				Object.Base.audio_format.2 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		8000
-					out_rate		8000
-				}
-				Object.Base.audio_format.3 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		16000
-					out_rate		16000
-				}
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		2
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			8000
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			16000
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		2
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		8000
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		16000
+					}
+				]
+
 			}
 		}
 	]
@@ -113,34 +133,44 @@ Object.Pipeline {
 				pcm_id	$BT_PCM_ID
 				num_input_audio_formats 3
 				num_output_audio_formats 3
-				Object.Base.audio_format.0 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		2
-					out_channels		2
-				}
-				Object.Base.audio_format.2 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		8000
-					out_rate		8000
-				}
-				Object.Base.audio_format.3 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		16000
-					out_rate		16000
-				}
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		2
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			8000
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			16000
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		2
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		8000
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		16000
+					}
+				]
 			}
 		}
 	]
@@ -160,36 +190,47 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	$BT_NAME
 				node_type	$I2S_LINK_INPUT_CLASS
-				num_input_audio_formats 4
-				num_output_audio_formats 4
-				Object.Base.audio_format.0 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		2
-					out_channels		2
-				}
-				Object.Base.audio_format.1 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		8000
-					out_rate		8000
-				}
-				Object.Base.audio_format.2 {
-					in_bit_depth		16
-					in_valid_bit_depth	16
-					out_bit_depth		16
-					out_valid_bit_depth	16
-					in_channels		1
-					out_channels		1
-					in_rate		16000
-					out_rate		16000
-				}
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		2
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			8000
+					}
+					{
+						in_bit_depth		16
+						in_valid_bit_depth	16
+						in_channels		1
+						in_rate			16000
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		2
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		8000
+					}
+					{
+						out_bit_depth		16
+						out_valid_bit_depth	16
+						out_channels		1
+						out_rate		16000
+					}
+				]
 			}
 		}
 	]

--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -3,7 +3,7 @@ IncludeByKey.BT_LOOPBACK_MODE {
 }
 
 IncludeByKey.BT_LOOPBACK_MODE {
-	"false"	"platform/intel/bt-ssp-config.conf"
+	"false"		"platform/intel/bt-ssp-config.conf"
 }
 
 Object.Pipeline {

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -67,7 +67,7 @@ Object.Dai.DMIC [
 ]
 
 IncludeByKey.PASSTHROUGH {
-"false" {
+	"false" {
 		IncludeByKey.INCLUDE_WOV {
 			"true"	"platform/intel/dmic-wov.conf"
 		}
@@ -198,7 +198,7 @@ IncludeByKey.PASSTHROUGH {
 			}
 		]
 	}
-"true"	{
+	"true"	{
 		Object.Pipeline.host-gateway-capture [
 			{
 				index 		$DMIC0_HOST_PIPELINE_ID

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -82,46 +82,62 @@ IncludeByKey.PASSTHROUGH {
 					pcm_id	$DMIC0_PCM_ID
 					num_input_audio_formats 2
 					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+						{
+							in_channels		4
+							in_bit_depth		32
+							in_valid_bit_depth	32
+							in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+						{
+							out_channels		4
+							out_bit_depth		32
+							out_valid_bit_depth	32
+							out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							out_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
 				}
 				Object.Widget.gain.1 {
 					num_input_audio_formats 2
 					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+						{
+							in_channels		4
+							in_bit_depth		32
+							in_valid_bit_depth	32
+							in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+						{
+							out_channels		4
+							out_bit_depth		32
+							out_valid_bit_depth	32
+							out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							out_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
 					Object.Control.mixer.1 {
 						name '$DMIC0_PCM_NAME Capture Volume'
 					}
@@ -130,24 +146,32 @@ IncludeByKey.PASSTHROUGH {
 				Object.Widget.module-copier."2" {
 					num_input_audio_formats 2
 					num_output_audio_formats 2
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
-					Object.Base.audio_format.2 {
-						in_channels		4
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_channels		4
-						out_bit_depth		32
-						out_valid_bit_depth	32
-						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						in_ch_map	$CHANNEL_MAP_3_POINT_1
-						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-						out_ch_map	$CHANNEL_MAP_3_POINT_1
-					}
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+						{
+							in_channels		4
+							in_bit_depth		32
+							in_valid_bit_depth	32
+							in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+						{
+							out_channels		4
+							out_bit_depth		32
+							out_valid_bit_depth	32
+							out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+							out_ch_map	$CHANNEL_MAP_3_POINT_1
+						}
+					]
 				}
 				Object.Widget.pipeline."1" {
 					core $DMIC_CORE_ID

--- a/tools/topology/topology2/platform/intel/dmic-wov.conf
+++ b/tools/topology/topology2/platform/intel/dmic-wov.conf
@@ -10,28 +10,36 @@ Object.Pipeline {
 			Object.Widget.host-copier.1 {
 				stream_name $DMIC1_PCM_CAPS
 				pcm_id 11
-				Object.Base.audio_format.1 {
-					in_rate			16000
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_rate		16000
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-				Object.Base.audio_format.2 {
-					in_rate			16000
-					in_channels		4
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_rate		16000
-					out_channels		4
-					out_bit_depth		32
-					out_valid_bit_depth	32
-					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-					in_ch_map	$CHANNEL_MAP_3_POINT_1
-					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-					out_ch_map	$CHANNEL_MAP_3_POINT_1
-				}
+				Object.Base.input_audio_format [
+					{
+						in_rate			16000
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+					{
+						in_rate			16000
+						in_channels		4
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+						in_ch_map	$CHANNEL_MAP_3_POINT_1
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_rate		16000
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+					{
+						out_rate		16000
+						out_channels		4
+						out_bit_depth		32
+						out_valid_bit_depth	32
+						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+						out_ch_map	$CHANNEL_MAP_3_POINT_1
+					}
+				]
 			}
 		}
 	]
@@ -55,28 +63,36 @@ Object.Pipeline {
 				node_type $DMIC_LINK_INPUT_CLASS
 				num_input_audio_formats 2
 				num_output_audio_formats 2
-				Object.Base.audio_format.1 {
-					in_rate			16000
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_rate		16000
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-				Object.Base.audio_format.2 {
-					in_rate			16000
-					in_channels		4
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_rate		16000
-					out_channels		4
-					out_bit_depth		32
-					out_valid_bit_depth	32
-					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-					in_ch_map	$CHANNEL_MAP_3_POINT_1
-					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-					out_ch_map	$CHANNEL_MAP_3_POINT_1
-				}
+				Object.Base.input_audio_format [
+					{
+						in_rate			16000
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+					{
+						in_rate			16000
+						in_channels		4
+						in_bit_depth		32
+						in_valid_bit_depth	32
+						in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+						in_ch_map	$CHANNEL_MAP_3_POINT_1
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_rate		16000
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+					{
+						out_rate		16000
+						out_channels		4
+						out_bit_depth		32
+						out_valid_bit_depth	32
+						out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+						out_ch_map	$CHANNEL_MAP_3_POINT_1
+					}
+				]
 			}
 
 			Object.Widget.kpb.1 {

--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -211,7 +211,7 @@ Object.Base.route [
 
 # Include HDMI4 DAI, pipelines, PCM and route conditionally
 IncludeByKey.NUM_HDMIS {
-"4"	{
+	"4"	{
 		Object.Dai.HDA [
 			{
 				dai_index 7

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -29,138 +29,137 @@ Object.Dai.ALH [
 ]
 
 IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Pipeline {
-		host-copier-gain-mixin-playback [
-			{
-				index 20
+	"false" {
+		Object.Pipeline {
+			host-copier-gain-mixin-playback [
+				{
+					index 20
 
+					Object.Widget.host-copier.1 {
+						stream_name "sdw amplifiers"
+						pcm_id 2
+					}
+					Object.Widget.gain.1 {
+						Object.Control.mixer.1 {
+							name 'Amplifier Volume'
+						}
+					}
+				}
+			]
+
+			mixout-gain-alh-dai-copier-playback [
+				{
+					index 21
+
+					Object.Widget.alh-copier.1 {
+						stream_name $SDW_SPK_STREAM
+						node_type $ALH_LINK_OUTPUT_CLASS
+					}
+					Object.Widget.gain.1 {
+						Object.Control.mixer.1 {
+							name 'Main Amplifier Volume'
+						}
+					}
+				}
+			]
+		}
+	}
+	"true" {
+		Object.Pipeline.host-gateway-playback [
+			{
+				index	20
 				Object.Widget.host-copier.1 {
 					stream_name "sdw amplifiers"
 					pcm_id 2
-				}
-				Object.Widget.gain.1 {
-					Object.Control.mixer.1 {
-						name 'Amplifier Volume'
-					}
+					num_input_audio_formats 3
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            16
+							in_valid_bit_depth      16
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      24
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					num_output_audio_formats 3
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           16
+							out_valid_bit_depth     16
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     24
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
 			}
 		]
 
-		mixout-gain-alh-dai-copier-playback [
-			{
-				index 21
-
-				Object.Widget.alh-copier.1 {
+		Object.Widget {
+			alh-copier [
+				{
 					stream_name $SDW_SPK_STREAM
 					node_type $ALH_LINK_OUTPUT_CLASS
+					num_input_pins 1
+					num_input_audio_formats 3
+					direction	playback
+					type	dai_in
+					index 21
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            16
+							in_valid_bit_depth      16
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      24
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					num_output_audio_formats 3
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           16
+							out_valid_bit_depth     16
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     24
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
-				Object.Widget.gain.1 {
-					Object.Control.mixer.1 {
-						name 'Main Amplifier Volume'
-					}
+			]
+			pipeline [
+				{
+					index			21
+					priority		0
+					lp_mode		0
+					dynamic_pipeline	1
 				}
-			}
-		]
-
-	}
-	}
-"true" {
-	Object.Pipeline.host-gateway-playback [
-		{
-			index	20
-			Object.Widget.host-copier.1 {
-				stream_name "sdw amplifiers"
-				pcm_id 2
-				num_input_audio_formats 3
-				Object.Base.input_audio_format [
-					{
-						in_bit_depth            16
-						in_valid_bit_depth      16
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      24
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      32
-					}
-				]
-				num_output_audio_formats 3
-				Object.Base.output_audio_format [
-					{
-						out_bit_depth           16
-						out_valid_bit_depth     16
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     24
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     32
-					}
-				]
-			}
+			]
 		}
-	]
-
-	Object.Widget {
-		alh-copier [
-			{
-				stream_name $SDW_SPK_STREAM
-				node_type $ALH_LINK_OUTPUT_CLASS
-				num_input_pins 1
-				num_input_audio_formats 3
-				direction	playback
-				type	dai_in
-				index 21
-				Object.Base.input_audio_format [
-					{
-						in_bit_depth            16
-						in_valid_bit_depth      16
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      24
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      32
-					}
-				]
-				num_output_audio_formats 3
-				Object.Base.output_audio_format [
-					{
-						out_bit_depth           16
-						out_valid_bit_depth     16
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     24
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     32
-					}
-				]
-			}
-		]
-		pipeline [
-			{
-				index			21
-				priority		0
-				lp_mode		0
-				dynamic_pipeline	1
-			}
-		]
-	}
 	}
 }
 
 IncludeByKey.NUM_SDW_AMP_LINKS {
-"2"	{
+	"2"	{
 		Define {
 			AMP_FEEDBACK_CH 4
 		}
@@ -255,21 +254,21 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 		# the gain and copier do not get established in the firmware. These are purely
 		# to show the existence of aggregation in the topology graph.
 		IncludeByKey.PASSTHROUGH {
-		"false" {
-			Object.Base.route [
-				{
-					source  "gain.21.1"
-					sink    "virtual.sdw-amp"
-				}
-			]
+			"false" {
+				Object.Base.route [
+					{
+						source  "gain.21.1"
+						sink    "virtual.sdw-amp"
+					}
+				]
 			}
-		"true" {
-			Object.Base.route [
-				{
-					source  "host-copier.2.playback"
-					sink    "virtual.sdw-amp"
-				}
-			]
+			"true" {
+			       Object.Base.route [
+					{
+						source  "host-copier.2.playback"
+						sink    "virtual.sdw-amp"
+					}
+				]
 			}
 		}
 		Object.Base.route [
@@ -298,30 +297,30 @@ Object.PCM.pcm [
 ]
 
 IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Base.route [
-		{
-			source	"gain.21.1"
-			sink	"alh-copier.$SDW_SPK_STREAM.0"
-		}
-		{
-			source 'mixin.20.1'
-			sink 'mixout.21.1'
-		}
-		{
-			source 'host-copier.2.playback'
-			sink 'gain.20.1'
-		}
-	]
-}
-"true" {
-	Object.Base.route [
-		{
-			source	"host-copier.2.playback"
-			sink	"alh-copier.$SDW_SPK_STREAM.0"
-		}
-	]
-}
+	"false" {
+		Object.Base.route [
+			{
+				source	"gain.21.1"
+				sink	"alh-copier.$SDW_SPK_STREAM.0"
+			}
+			{
+				source 'mixin.20.1'
+				sink 'mixout.21.1'
+			}
+			{
+				source 'host-copier.2.playback'
+				sink 'gain.20.1'
+			}
+		]
+	}
+	"true" {
+		Object.Base.route [
+			{
+				source	"host-copier.2.playback"
+				sink	"alh-copier.$SDW_SPK_STREAM.0"
+			}
+		]
+	}
 }
 
 IncludeByKey.SDW_AMP_FEEDBACK {
@@ -373,7 +372,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					num_output_pins 1
 
 					IncludeByKey.NUM_SDW_AMP_LINKS {
-					"2"	{
+						"2"	{
 							Object.Base.input_audio_format [
 								{
 									in_channels		4
@@ -393,21 +392,21 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 								}
 							]
 						}
-					"1"	{
-						# 32-bit 48KHz 2ch
-						Object.Base.input_audio_format [
-							{
-								in_bit_depth            32
-								in_valid_bit_depth      32
-							}
-						]
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth            32
-								out_valid_bit_depth      32
-							}
-						]
-					}
+						"1"	{
+							# 32-bit 48KHz 2ch
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth            32
+									in_valid_bit_depth      32
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth            32
+									out_valid_bit_depth      32
+								}
+							]
+						}
 					}
 				}
 			]

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -349,11 +349,21 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					Object.Widget.host-copier.1 {
 						stream_name	"amp feedback"
 						pcm_id 3
-						Object.Base.audio_format.1 {
-							# 32 -> 16 bits conversion is done here,
-							# so in_bit_depth is 32 (and out_bit_depth is 16).
-							in_bit_depth	32
-						}
+						num_input_audio_formats 1
+						num_output_audio_formats 1
+						num_input_pins 1
+						# 32 -> 16 bits conversion is done here,
+						# so in_bit_depth is 32 (and out_bit_depth is 16).
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth		32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth		16
+							}
+						]
 					}
 				}
 			]

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -30,11 +30,21 @@ Object.Pipeline {
 			Object.Widget.host-copier.1 {
 				stream_name	"sdw dmic"
 				pcm_id 4
-				Object.Base.audio_format.1 {
-					# 32 -> 16 bits conversion is done here,
-					# so in_bit_depth is 32 (and out_bit_depth is 16).
-					in_bit_depth	32
-				}
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				num_input_pins 1
+				# 32 -> 16 bits conversion is done here,
+				# so in_bit_depth is 32 (and out_bit_depth is 16).
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		16
+					}
+				]
 			}
 		}
 	]

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -1,10 +1,10 @@
 # include deep buffer config if buffer size is in 1 - 1000 ms.
 IncludeByKey.PASSTHROUGH {
-"false" {
-	IncludeByKey.DEEPBUFFER_FW_DMA_MS {
-		"([1-9]|[1-9][0-9]|[1-9][0-9][0-9]|1000)" "platform/intel/deep-buffer.conf"
+	"false" {
+		IncludeByKey.DEEPBUFFER_FW_DMA_MS {
+			"([1-9]|[1-9][0-9]|[1-9][0-9][0-9]|1000)" "platform/intel/deep-buffer.conf"
+		}
 	}
-}
 }
 
 Define {
@@ -50,132 +50,132 @@ Object.Dai.ALH [
 # Pipeline definitions
 #
 IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Pipeline {
-		host-copier-gain-mixin-playback [
-			{
-				index 0
+	"false" {
+		Object.Pipeline {
+			host-copier-gain-mixin-playback [
+				{
+					index 0
 
+					Object.Widget.host-copier.1 {
+						stream_name "volume playback 0"
+						pcm_id 0
+					}
+					Object.Widget.gain.1 {
+						Object.Control.mixer.1 {
+							name 'Pre Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
+						}
+					}
+				}
+			]
+
+			mixout-gain-alh-dai-copier-playback [
+				{
+					index 1
+
+					Object.Widget.alh-copier.1 {
+						stream_name $SDW_JACK_OUT_STREAM
+						node_type $ALH_LINK_OUTPUT_CLASS
+					}
+					Object.Widget.gain.1 {
+						Object.Control.mixer.1 {
+							name 'Post Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
+						}
+					}
+				}
+			]
+		}
+	}
+	"true" {
+		Object.Pipeline.host-gateway-playback [
+			{
+				index	0
 				Object.Widget.host-copier.1 {
 					stream_name "volume playback 0"
 					pcm_id 0
-				}
-				Object.Widget.gain.1 {
-					Object.Control.mixer.1 {
-							name 'Pre Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
+					num_input_audio_formats 3
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            16
+							in_valid_bit_depth      16
 						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      24
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					num_output_audio_formats 3
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           16
+							out_valid_bit_depth     16
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     24
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
 			}
 		]
 
-		mixout-gain-alh-dai-copier-playback [
-			{
-				index 1
-
-				Object.Widget.alh-copier.1 {
+		Object.Widget {
+			alh-copier [
+				{
 					stream_name $SDW_JACK_OUT_STREAM
 					node_type $ALH_LINK_OUTPUT_CLASS
+					num_input_audio_formats 3
+					index 1
+					type dai_in
+					direction	playback
+					num_input_pins 1
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth            16
+							in_valid_bit_depth      16
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      24
+						}
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+					num_output_audio_formats 3
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           16
+							out_valid_bit_depth     16
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     24
+						}
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
-				Object.Widget.gain.1 {
-					Object.Control.mixer.1 {
-						name 'Post Mixer $JACK_PLAYBACK_PCM_NAME Playback Volume'
-					}
+			]
+			pipeline [
+				{
+					index			1
+					priority		0
+					lp_mode		0
+					dynamic_pipeline	1
 				}
-			}
-		]
-	}
-}
-"true" {
-	Object.Pipeline.host-gateway-playback [
-		{
-			index	0
-			Object.Widget.host-copier.1 {
-				stream_name "volume playback 0"
-				pcm_id 0
-				num_input_audio_formats 3
-				Object.Base.input_audio_format [
-					{
-						in_bit_depth            16
-						in_valid_bit_depth      16
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      24
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      32
-					}
-				]
-				num_output_audio_formats 3
-				Object.Base.output_audio_format [
-					{
-						out_bit_depth           16
-						out_valid_bit_depth     16
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     24
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     32
-					}
-				]
-			}
+			]
 		}
-	]
-
-	Object.Widget {
-		alh-copier [
-			{
-				stream_name $SDW_JACK_OUT_STREAM
-				node_type $ALH_LINK_OUTPUT_CLASS
-				num_input_audio_formats 3
-				index 1
-				type dai_in
-				direction	playback
-				num_input_pins 1
-				Object.Base.input_audio_format [
-					{
-						in_bit_depth            16
-						in_valid_bit_depth      16
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      24
-					}
-					{
-						in_bit_depth            32
-						in_valid_bit_depth      32
-					}
-				]
-				num_output_audio_formats 3
-				Object.Base.output_audio_format [
-					{
-						out_bit_depth           16
-						out_valid_bit_depth     16
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     24
-					}
-					{
-						out_bit_depth           32
-						out_valid_bit_depth     32
-					}
-				]
-			}
-		]
-		pipeline [
-			{
-				index			1
-				priority		0
-				lp_mode		0
-				dynamic_pipeline	1
-			}
-		]
-	}
 	}
 }
 
@@ -273,25 +273,25 @@ Object.Widget {
 }
 
 IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Widget.eqiir [
-		{
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-			index		11
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+	"false" {
+		Object.Widget.eqiir [
+			{
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				index		11
+				Object.Base.audio_format.1 {
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
 
-			Object.Control.bytes."1" {
-				<include/components/eqiir/highpass_40hz_0db_48khz.conf>
-				name '$JACK_CAPTURE_PCM_NAME Capture IIR Eq'
+				Object.Control.bytes."1" {
+					<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+					name '$JACK_CAPTURE_PCM_NAME Capture IIR Eq'
+				}
 			}
-		}
-	]
+		]
 	}
 }
 
@@ -327,40 +327,40 @@ Object.PCM.pcm [
 ]
 
 IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Base.route [
-		{
-			source	"gain.1.1"
-			sink	"alh-copier.$SDW_JACK_OUT_STREAM.0"
-		}
-		{
-			source "mixin.0.1"
-			sink "mixout.1.1"
-		}
-		{
-			source	"alh-copier.$SDW_JACK_IN_STREAM.0"
-			sink	"eqiir.11.0"
-		}
-		{
-			source	"eqiir.11.0"
-			sink	"host-copier.1.capture"
-		}
-		{
-			source	"host-copier.0.playback"
-			sink	"gain.0.1"
-		}
-	]
+	"false" {
+		Object.Base.route [
+			{
+				source	"gain.1.1"
+				sink	"alh-copier.$SDW_JACK_OUT_STREAM.0"
+			}
+			{
+				source "mixin.0.1"
+				sink "mixout.1.1"
+			}
+			{
+				source	"alh-copier.$SDW_JACK_IN_STREAM.0"
+				sink	"eqiir.11.0"
+			}
+			{
+				source	"eqiir.11.0"
+				sink	"host-copier.1.capture"
+			}
+			{
+				source	"host-copier.0.playback"
+				sink	"gain.0.1"
+			}
+		]
 	}
-"true"	{
-	Object.Base.route [
-		{
-			source	"alh-copier.$SDW_JACK_IN_STREAM.0"
-			sink	"host-copier.1.capture"
-		}
-		{
-			source	"host-copier.0.playback"
-			sink	"alh-copier.$SDW_JACK_OUT_STREAM.0"
-		}
-	]
+	"true"	{
+		Object.Base.route [
+			{
+				source	"alh-copier.$SDW_JACK_IN_STREAM.0"
+				sink	"host-copier.1.capture"
+			}
+			{
+				source	"host-copier.0.playback"
+				sink	"alh-copier.$SDW_JACK_OUT_STREAM.0"
+			}
+		]
 	}
 }

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -186,56 +186,58 @@ Object.Pipeline.host-gateway-capture [
 		Object.Widget.host-copier.1 {
 			stream_name	"Passthrough Capture 0"
 			pcm_id 1
-			num_input_audio_formats 9
-			num_output_audio_formats 9
-			Object.Base.audio_format.1 {
-				# 32/32 -> 16/16 bits conversion is done here
-				in_bit_depth	32
-				in_valid_bit_depth	32
-			}
-			# 32-bit 48KHz 1ch
-			Object.Base.input_audio_format.7 {
-				in_channels		1
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				in_ch_cfg	$CHANNEL_CONFIG_MONO
-				in_ch_map	$CHANNEL_MAP_MONO
-			}
-			Object.Base.output_audio_format.7 {
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				out_channels		1
-				out_ch_cfg	$CHANNEL_CONFIG_MONO
-				out_ch_map	$CHANNEL_MAP_MONO
-			}
-			# 24-bit 48KHz 1ch
-			Object.Base.input_audio_format.8 {
-				in_channels		1
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				in_ch_cfg	$CHANNEL_CONFIG_MONO
-				in_ch_map	$CHANNEL_MAP_MONO
-			}
-			Object.Base.output_audio_format.8 {
-				out_bit_depth		32
-				out_valid_bit_depth	24
-				out_channels		1
-				out_ch_cfg	$CHANNEL_CONFIG_MONO
-				out_ch_map	$CHANNEL_MAP_MONO
-			}
-			# 16-bit 48KHz 1ch
-			Object.Base.input_audio_format.9 {
-				in_channels		1
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				in_ch_cfg	$CHANNEL_CONFIG_MONO
-				in_ch_map	$CHANNEL_MAP_MONO
-			}
-			Object.Base.output_audio_format.9 {
-				out_channels		1
-				out_ch_cfg	$CHANNEL_CONFIG_MONO
-				out_ch_map	$CHANNEL_MAP_MONO
-			}
+			num_input_audio_formats 3
+			num_output_audio_formats 3
+			num_input_pins 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth            16
+					in_valid_bit_depth      16
+					in_ch_cfg	$CHANNEL_CONFIG_MONO
+					in_ch_map	$CHANNEL_MAP_MONO
+					in_channels		1
+
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      24
+					in_ch_cfg	$CHANNEL_CONFIG_MONO
+					in_ch_map	$CHANNEL_MAP_MONO
+					in_channels		1
+
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      32
+					in_ch_cfg	$CHANNEL_CONFIG_MONO
+					in_ch_map	$CHANNEL_MAP_MONO
+					in_channels		1
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth           16
+					out_valid_bit_depth     16
+					out_ch_cfg	$CHANNEL_CONFIG_MONO
+					out_ch_map	$CHANNEL_MAP_MONO
+					out_channels		1
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     24
+					out_ch_cfg	$CHANNEL_CONFIG_MONO
+					out_ch_map	$CHANNEL_MAP_MONO
+					out_channels		1
+
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     32
+					out_ch_cfg	$CHANNEL_CONFIG_MONO
+					out_ch_map	$CHANNEL_MAP_MONO
+					out_channels		1
+				}
+			]
 		}
 	}
 ]
@@ -253,12 +255,18 @@ Object.Widget {
 			num_output_audio_formats 1
 			num_output_pins 1
 
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 	]
 
@@ -279,12 +287,21 @@ IncludeByKey.PASSTHROUGH {
 				num_input_audio_formats 1
 				num_output_audio_formats 1
 				index		11
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
+				num_input_pins 1
+				num_output_pins 1
+
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 
 				Object.Control.bytes."1" {
 					<include/components/eqiir/highpass_40hz_0db_48khz.conf>

--- a/tools/topology/topology2/platform/intel/speaker-echo-ref.conf
+++ b/tools/topology/topology2/platform/intel/speaker-echo-ref.conf
@@ -33,12 +33,22 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	$SPEAKER_CODEC_NAME
 				node_type	$I2S_LINK_INPUT_CLASS
-				Object.Base.audio_format.1 {
-					in_bit_depth		32
-					in_valid_bit_depth	32
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
+				num_input_audio_formats 1
+				num_output_audio_formats 1
+				num_output_pins 1
+
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 			}
 			Object.Widget.pipeline."1" {
 				core	$ECHO_REF_CORE_ID


### PR DESCRIPTION
The topology2 seems to be in a constant state of poorly maintained stuff piled of top of mistakes with no agreed indentation style.

It's really scary. This PR is a simple attempt to at least cleanup the SoundWire parts. I could be wrong on some of the changes, but the existing code has a number of issues as well, e.g. a number of formats and configurations that make absolutely no sense.

@ranj063 @bardliao @jsarha please review. This is both urgent and important at this point.