### PR TITLE
[TEST] HDA: chain-dma: show capture is broken

### DIFF
--- a/tools/topology/topology2/cavs-passthrough-hda.conf
+++ b/tools/topology/topology2/cavs-passthrough-hda.conf
@@ -1,0 +1,231 @@
+Define {
+	ANALOG_PLAYBACK_PCM		'Analog Playback'
+	ANALOG_CAPTURE_PCM		'Analog Capture'
+	HDA_ANALOG_DAI_NAME      	'Analog'
+}
+
+Object.Dai.HDA [
+	{
+		name $HDA_ANALOG_DAI_NAME
+		dai_index 0
+		id 4
+		default_hw_conf_id 4
+		Object.Base.hw_config.1 {
+			name	"HDA0"
+		}
+		direction duplex
+	}
+]
+
+Object.Pipeline {
+
+	host-gateway-playback [
+		{
+			index	0
+			use_chain_dma 0
+
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_PLAYBACK_PCM
+				pcm_id 0
+				num_output_pins 1
+				num_input_audio_formats 3
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth            16
+						in_valid_bit_depth      16
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      24
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      32
+					}
+				]
+				num_output_audio_formats 3
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           16
+						out_valid_bit_depth     16
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     24
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     32
+					}
+				]
+			}
+		}
+	]
+	io-gateway [
+		{
+			direction	"playback"
+			index 1
+			use_chain_dma 0
+
+			Object.Widget.dai-copier.1 {
+				dai_type 	"HDA"
+				type		"dai_in"
+				copier_type	"HDA"
+				stream_name	$HDA_ANALOG_DAI_NAME
+				node_type	$HDA_LINK_OUTPUT_CLASS
+				direction 	playback
+				num_input_pins 1
+				num_input_audio_formats 3
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth            16
+						in_valid_bit_depth      16
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      24
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      32
+					}
+				]
+				num_output_audio_formats 3
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           16
+						out_valid_bit_depth     16
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     24
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     32
+					}
+				]
+			}
+		}
+		{
+			direction	"capture"
+			index 2
+			use_chain_dma 0
+
+			Object.Widget.dai-copier.1 {
+				dai_type 	"HDA"
+				type		"dai_out"
+				copier_type	"HDA"
+				stream_name	$HDA_ANALOG_DAI_NAME
+				node_type	$HDA_LINK_INPUT_CLASS
+				direction 	capture
+				num_output_pins 1
+				num_input_audio_formats 3
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth            16
+						in_valid_bit_depth      16
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      24
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      32
+					}
+				]
+				num_output_audio_formats 3
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           16
+						out_valid_bit_depth     16
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     24
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     32
+					}
+				]
+			}
+		}
+	]
+	host-gateway-capture [
+		{
+			index 	3
+			use_chain_dma 0
+
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_CAPTURE_PCM
+				pcm_id 0
+				num_input_pins 1
+				num_input_audio_formats 3
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth            16
+						in_valid_bit_depth      16
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      24
+					}
+					{
+						in_bit_depth            32
+						in_valid_bit_depth      32
+					}
+				]
+				num_output_audio_formats 3
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           16
+						out_valid_bit_depth     16
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     24
+					}
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     32
+					}
+				]
+			}
+		}
+	]
+}
+
+Object.PCM.pcm [
+	{
+		id 0
+		name 'HDA Analog'
+		Object.Base.fe_dai.1 {
+			name "HDA Analog"
+		}
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name $ANALOG_PLAYBACK_PCM
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name $ANALOG_CAPTURE_PCM
+			formats 'S32_LE,S24_LE,S16_LE'
+		}
+		direction duplex
+	}
+]
+
+# top-level pipeline connections
+Object.Base.route [
+	{
+		sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+		source 'host-copier.0.playback'
+	}
+	{
+		source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+		sink 'host-copier.0.capture'
+	}
+]

--- a/tools/topology/topology2/cavs-passthrough-hda.conf
+++ b/tools/topology/topology2/cavs-passthrough-hda.conf
@@ -22,7 +22,7 @@ Object.Pipeline {
 	host-gateway-playback [
 		{
 			index	0
-			use_chain_dma 0
+			use_chain_dma 1
 
 			Object.Widget.host-copier.1 {
 				stream_name $ANALOG_PLAYBACK_PCM
@@ -65,7 +65,7 @@ Object.Pipeline {
 		{
 			direction	"playback"
 			index 1
-			use_chain_dma 0
+			use_chain_dma 1
 
 			Object.Widget.dai-copier.1 {
 				dai_type 	"HDA"
@@ -110,7 +110,7 @@ Object.Pipeline {
 		{
 			direction	"capture"
 			index 2
-			use_chain_dma 0
+			use_chain_dma 1
 
 			Object.Widget.dai-copier.1 {
 				dai_type 	"HDA"
@@ -156,7 +156,7 @@ Object.Pipeline {
 	host-gateway-capture [
 		{
 			index 	3
-			use_chain_dma 0
+			use_chain_dma 1
 
 			Object.Widget.host-copier.1 {
 				stream_name $ANALOG_CAPTURE_PCM

--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -4,15 +4,15 @@
 set(TPLGS
 # HDMI only topology with  chain-dma passthrough pipelines
 "sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true"
-# HDA topology with mixer-based pipelines for HDA and chain-dma passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=mix,USE_CHAIN_DMA=true"
+# HDA topology with passthrough pipelines for HDA and chain-dma passthrough pipelines for HDMI
+"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=passthrough,USE_CHAIN_DMA=true"
 # If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
 # topologies below.
 "sof-hda-generic\;sof-hda-generic-4ch\;PLATFORM=mtl,\
-HDA_CONFIG=mix,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-hda-generic-4ch.bin"
+HDA_CONFIG=passthrough,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,PREPROCESS_PLUGINS=nhlt,\
+NHLT_BIN=nhlt-sof-hda-generic-4ch.bin,USE_CHAIN_DMA=true"
 "sof-hda-generic\;sof-hda-generic-2ch\;PLATFORM=mtl,\
-HDA_CONFIG=mix,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-2ch.bin"
+HDA_CONFIG=passthrough,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-2ch.bin,USE_CHAIN_DMA=true"
 
 # SDW + DMIC topology with passthrough pipelines
 # We will change NUM_HDMIS to 3 once HDMI is enabled on MTL RVP

--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -2,10 +2,10 @@
 
 # Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 set(TPLGS
-# HDMI only topology with passthrough pipelines
-"sof-hda-generic\;sof-hda-generic-idisp\;"
-# HDA topology with mixer-based pipelines for HDA and passthrough pipelines for HDMI
-"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=mix"
+# HDMI only topology with  chain-dma passthrough pipelines
+"sof-hda-generic\;sof-hda-generic-idisp\;USE_CHAIN_DMA=true"
+# HDA topology with mixer-based pipelines for HDA and chain-dma passthrough pipelines for HDMI
+"sof-hda-generic\;sof-hda-generic\;HDA_CONFIG=mix,USE_CHAIN_DMA=true"
 # If the alsatplg plugins for NHLT are not available, the NHLT blobs will not be added to the
 # topologies below.
 "sof-hda-generic\;sof-hda-generic-4ch\;PLATFORM=mtl,\

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -64,6 +64,7 @@ IncludeByKey.HDA_CONFIG {
 	"efx"		"cavs-mixin-mixout-efx-hda.conf"
 	"src"		"cavs-src-mixin-mixout-hda.conf"
 	"benchmark"	"cavs-benchmark-hda.conf"
+	"passthrough"	"cavs-passthrough-hda.conf"
 }
 
 # include DMIC config if needed.


### PR DESCRIPTION
with a basic passthrough topology, the chain_dma works fine on playback and fails with an xrun on capture.

I detected this with tests on LunarLake and now this PR should prove the chain-dma is broken on capture on MTL as well.

````
root@jf-mtlp-rvp-hda-2:~# time arecord -Dhw:0,0 -c2 -r48000 -fS32_LE /dev/zero -d5
Recording WAVE '/dev/zero' : Signed 32 bit Little Endian, Rate 48000 Hz, Stereo
arecord: pcm_read:2221: read error: Input/output error

real	0m1.011s
user	0m0.001s
sys	0m0.009s
````

[dmesg.log](https://github.com/thesofproject/sof/files/12413130/dmesg.log)

