### PR TITLE
Audio: Crossover: Fix build error

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -170,14 +170,14 @@ static int crossover_assign_sinks(struct processing_module *mod,
 		if (i < 0) {
 			comp_err(dev,
 				 "crossover_assign_sinks(), could not find sink %d in config",
-				 pipeline_id);
+				 sink_id);
 			break;
 		}
 
 		if (sinks[i]) {
 			comp_err(dev,
 				 "crossover_assign_sinks(), multiple sinks from pipeline %d are assigned",
-				 pipeline_id);
+				 sink_id);
 			break;
 		}
 


### PR DESCRIPTION
The component build fails if it is enabled in Kconfig. The variable pipeline_id is not defined, it should be sink_id.

Fixes: 5bcbcf19f7e1 ("Audio: Crossover: Convert to module adapter")