### PR TITLE
lib-manager: Support for two stage library loading

### DIFF
--- a/src/include/ipc4/header.h
+++ b/src/include/ipc4/header.h
@@ -81,6 +81,8 @@ enum ipc4_message_type {
 	SOF_IPC4_GLB_RESTORE_PIPELINE = 23,
 	/**< Loads library */
 	SOF_IPC4_GLB_LOAD_LIBRARY = 24,
+	/**< Loads library prepare */
+	SOF_IPC4_GLB_LOAD_LIBRARY_PREPARE = 25,
 	/**< Internal FW message */
 	SOF_IPC4_GLB_INTERNAL_MESSAGE = 26,
 	/**< Notification (FW to SW driver) */

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -84,6 +84,8 @@ struct ext_library {
 	uint32_t mods_exec_load_cnt;
 	struct ipc_lib_msg *lib_notif_pool;
 	uint32_t lib_notif_count;
+
+	void *runtime_data;
 };
 
 /* lib manager context, used by lib_notification */
@@ -150,12 +152,14 @@ int lib_manager_free_module(const struct comp_driver *drv,
  *
  * param[in] dma_id - channel used to transfer binary from host
  * param[in] lib_id
+ * param[in] type - ipc command type
+ *           (SOF_IPC4_GLB_LOAD_LIBRARY or SOF_IPC4_GLB_LOAD_LIBRARY_PREPARE)
  *
  * Function will load library manifest into temporary buffer.
  * Then it will read library parameters, allocate memory for library and load it into
  * destination memory region.
  */
-int lib_manager_load_library(uint32_t dma_id, uint32_t lib_id);
+int lib_manager_load_library(uint32_t dma_id, uint32_t lib_id, uint32_t type);
 
 /*
  * \brief Initialize message

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -499,10 +499,16 @@ static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 static int ipc4_load_library(struct ipc4_message_request *ipc4)
 {
 	struct ipc4_module_load_library library;
+	int ret;
 
 	library.header.dat = ipc4->primary.dat;
 
-	return lib_manager_load_library(library.header.r.dma_id, library.header.r.lib_id);
+	ret = lib_manager_load_library(library.header.r.dma_id, library.header.r.lib_id,
+				       ipc4->primary.r.type);
+	if (ret != 0)
+		return (ret == -EINVAL) ? IPC4_ERROR_INVALID_PARAM : IPC4_FAILURE;
+
+	return IPC4_SUCCESS;
 }
 #endif
 
@@ -647,6 +653,9 @@ static int ipc4_process_glb_message(struct ipc4_message_request *ipc4)
 	/* Loads library (using Code Load or HD/A Host Output DMA) */
 #ifdef CONFIG_LIBRARY_MANAGER
 	case SOF_IPC4_GLB_LOAD_LIBRARY:
+		ret = ipc4_load_library(ipc4);
+		break;
+	case SOF_IPC4_GLB_LOAD_LIBRARY_PREPARE:
 		ret = ipc4_load_library(ipc4);
 		break;
 #endif


### PR DESCRIPTION
The hardware programming flow dictates that the DSP side should set the GEN bit first followed by the host setting the EN bit. We cannot assume that the GEN bit is already enabled (and it would in fact will leave the DMA on the DSP side wrongly configured at best).

To support the currently used flow (single step) and add support for the correct programming flow, the proposed solution is to use the lib_id as indication of the method the host software is going to use.

Two stage flow:
The first LOAD_LIBRARY_PREPARE with valid dma_id
 - just allocate and set the GEN bit Second LOAD_LIBRARY with valid lib_id and dma_id
 - proceed to the loading of the library via host DMA to local buffer

Single stage flow (currently supported)
LOAD_LIBRARY with valid lib_id and dma_id
 - allocate, set GEN bit and proceed to loading the library

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>
Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>