### PR TITLE
Audio: Crossover: Adjust error message for pin index usage in config

### DIFF
--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -176,7 +176,7 @@ static int crossover_assign_sinks(struct processing_module *mod,
 
 		if (sinks[i]) {
 			comp_err(dev,
-				 "crossover_assign_sinks(), multiple sinks from pipeline %d are assigned",
+				 "crossover_assign_sinks(), multiple sinks with id %d are assigned",
 				 sink_id);
 			break;
 		}


### PR DESCRIPTION
In IPC4 system the output sinks of crossover are not defined by pipeline identifiers but by pin indices. The error message is updated to be IPC version agnostic to avoid confusion.