### PR TITLE
west.yml: update Zephyr to b92e749c3e5f

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 431108d89e1750dbea05dce64dbb7fd329aa610e
+      revision: b92e749c3e5ff259345c7a4c28d6370fd008d8b5
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 2211 commits, including following directly affecting SOF targets:

ab0ed577111b mm: intel_adsp_tlb: Handle address space conversion warnings
823e6b70d240 arch: xtensa: Implement arch_float_enable&disable
be779f2a6195 intel_adsp: hda: fix usage of FIFORDY bit
498f294b2720 west: update sof ref in manifest
42ca64d60cd2 tests: dma_sg: intel_adsp_ace15 specific config
0e373019d65e dma: intel_adsp_gpdma: Unmask interrupt on ACE
6e66efa08871 soc: intel_adsp_ace15: Include stdint.h
250748bfe671 intel_adsp: Add option about switch off hpsram
b4293ec026c4 dts: xtensa: nxp: add nodes for IPC
1295283a8a72 soc: xtensa: nxp: add resource_table section in linker script
e6d89268572d xtensa: set no optimization for arch_cpu_idle() with xt-clang
a458d0443a91 xtensa: allow arch-specific arch_spin_relax() with more NOPs
f60306193844 soc: xtensa: intel_adsp: cavs: fix PM hooks guards
385ad46a39ca boards/xtensa: Skip cleaning intermediate binaries up
1c0c2a095b48 drivers: intel_adsp_gpdma: Fix release ownership
e55fb88bcbe7 soc: intel_adsp/ace: update clock rate
35e8e6fa03fa soc/xtensa/nxp_adsp/CMakeLists.txt: use new WEST_SIGN_OPTS variable
c35d97534fd1 include: util_internal: add Z_SPARSE_LIST_{ODD|EVEN}_NUMBERS
25c6553edde5 soc: intel_adsp/ace: use functions to do CPU power control
3764814831a7 intel_adsp: boot: d3: hp sram reinit