### PR TITLE
Revert "IPC4: simplify pcm conversion function and add LSB & MSB support"

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -573,12 +573,6 @@ config FORMAT_S24LE
 	help
 	  Support 24 bit processing data format with sign and in little endian format
 
-config FORMAT_S24_3LE
-	bool "Support S24_3LE"
-	default n
-	help
-	  Support packed 24 bit processing data format with sign and in little endian format
-
 config FORMAT_S32LE
 	bool "Support S32LE"
 	default y

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -579,12 +579,6 @@ config FORMAT_S24_3LE
 	help
 	  Support packed 24 bit processing data format with sign and in little endian format
 
-config FORMAT_S24_4LE_MSB
-	bool "Support S24_4LE_MSB"
-	default y
-	help
-	  Support 24 bit processing data format with sign and in msb 24 bits format
-
 config FORMAT_S32LE
 	bool "Support S32LE"
 	default y
@@ -620,12 +614,6 @@ config PCM_CONVERTER_FORMAT_S24LE
 	default y
 	help
 	  Support 24 bit processing data format with sign and in little endian format
-
-config PCM_CONVERTER_FORMAT_S24_4LE_MSB
-	bool "Support S24_4LE_MSB"
-	default y
-	help
-	  Support 24 bit processing data format with sign and in msb 24 bits format
 
 config PCM_CONVERTER_FORMAT_S24_3LE
 	bool "Support S24_3LE"

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -284,11 +284,6 @@ pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 	audio_stream_fmt_conversion(out_fmt->depth, out_fmt->valid_bit_depth, &out, &out_valid,
 				    out_fmt->s_type);
 
-	if (in_fmt->s_type == IPC4_TYPE_MSB_INTEGER && in_valid == SOF_IPC_FRAME_S24_4LE)
-		in_valid = SOF_IPC_FRAME_S24_4LE_MSB;
-	if (out_fmt->s_type == IPC4_TYPE_MSB_INTEGER && out_valid == SOF_IPC_FRAME_S24_4LE)
-		out_valid = SOF_IPC_FRAME_S24_4LE_MSB;
-
 	/* check container & sample size */
 	if (use_no_container_convert_function(in, in_valid, out, out_valid))
 		return pcm_get_conversion_function(in, out);

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -1206,73 +1206,99 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
  */
 #endif
 
+/* Different gateway has different sample layout requirement
+ * (1) hda link gateway: 24le sample should be converted to 24be one
+ * (2) alh gateway: all data format layout should be in big-endian style in 32bit container,
+ *     .e.g. 24le stream should be convert to 24be one
+ * (3) ssp gateway: all sample should be in container size of 32bit
+ */
 const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s16_c16_to_s16_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c16_to_s16_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s16_c32_to_s16_c16 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s16_c16 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
-		pcm_convert_s16_c32_to_s32_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s16_c32_to_s32_c32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s32_c32_to_s16_c32 },
+		ipc4_gtw_all, ipc4_bidirection, pcm_convert_s32_c32_to_s16_c32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		pcm_convert_s16_c32_to_s24_c32 },
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s16_c32_to_s24_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s24_c32_to_s16_c32 },
+		ipc4_gtw_all & ~ipc4_gtw_alh, ipc4_bidirection, pcm_convert_s24_c32_to_s16_c32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
+		ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		audio_stream_copy},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
-		pcm_convert_s24_to_s32},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host | ipc4_gtw_dmic),
+		ipc4_bidirection, audio_stream_copy},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_dmic, ipc4_capture,
 		pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_playback, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_capture, pcm_convert_s24_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		ipc4_gtw_all & ~ipc4_gtw_host, ipc4_bidirection, pcm_convert_s24_to_s32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		ipc4_gtw_host, ipc4_playback, audio_stream_copy},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
+		ipc4_gtw_host, ipc4_capture, pcm_convert_s24_to_s32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host), ipc4_bidirection,
+		pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback, pcm_convert_s32_to_s24_be },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_link | ipc4_gtw_alh, ipc4_capture, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_playback, pcm_convert_s32_to_s24 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_host, ipc4_capture, pcm_convert_s32_to_s24_be },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		pcm_convert_s16_to_s24 },
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE,
-		pcm_convert_s24_to_s16 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE,
+		ipc4_gtw_all & ~(ipc4_gtw_link | ipc4_gtw_alh | ipc4_gtw_host),
+		ipc4_bidirection, pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_link | ipc4_gtw_alh, ipc4_playback,
+		pcm_convert_s16_to_s32},
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_host,
+		ipc4_playback, pcm_convert_s16_to_s24 },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_host,
+		ipc4_capture, pcm_convert_s16_to_s32 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all & ~ipc4_gtw_host,
+		ipc4_bidirection, pcm_convert_s24_to_s16 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_host, ipc4_playback, pcm_convert_s32_to_s16 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_host, ipc4_capture, pcm_convert_s24_to_s16 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S24_4LE, ipc4_gtw_all, ipc4_bidirection,
 		pcm_convert_s24_c24_to_s24_c32},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_4LE,
-		pcm_convert_s24_c32_to_s24_c24 },
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE,
-		pcm_convert_s24_c32_to_s24_c24_link_gtw },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_3LE,
+		SOF_IPC_FRAME_S24_3LE, ipc4_gtw_all & ~ipc4_gtw_link,
+		ipc4_bidirection, pcm_convert_s24_c32_to_s24_c24 },
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		audio_stream_copy },
-#endif
-
-#if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s24_to_s32},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, audio_stream_copy},
-#endif
-
-#if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be},
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S32_LE, audio_stream_copy},
-#endif
-
-#if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s16_to_s32 },
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S16_LE,
-		SOF_IPC_FRAME_S16_LE, pcm_convert_s32_to_s16 },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE,
+		SOF_IPC_FRAME_S16_LE, ipc4_gtw_all, ipc4_bidirection, audio_stream_copy },
 #endif
 };
 

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -56,7 +56,6 @@ enum sof_ipc_frame {
 	SOF_IPC_FRAME_FLOAT,
 	/* other formats here */
 	SOF_IPC_FRAME_S24_3LE,
-	SOF_IPC_FRAME_S24_4LE_MSB,
 	SOF_IPC_FRAME_U8,
 };
 

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,7 +29,7 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 28
+#define SOF_ABI_MINOR 27
 #define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -1055,13 +1055,10 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 		*valid_fmt = SOF_IPC_FRAME_U8;
 #endif /* CONFIG_FORMAT_U8 */
 
-	if (valid == 24) {
-#ifdef CONFIG_FORMAT_S24_3LE
-		if (depth == 24) {
-			*frame_fmt = SOF_IPC_FRAME_S24_3LE;
-			*valid_fmt = SOF_IPC_FRAME_S24_3LE;
-		}
-#endif
+	/* really 24_3LE */
+	if (valid == 24 && depth == 24) {
+		*frame_fmt = SOF_IPC_FRAME_S24_3LE;
+		*valid_fmt = SOF_IPC_FRAME_S24_3LE;
 	}
 
 	if (type == IPC4_TYPE_FLOAT && depth == 32) {

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -100,7 +100,8 @@ struct pcm_func_vc_map {
 	enum sof_ipc_frame valid_src_bits;	/**< source frame format */
 	enum sof_ipc_frame sink;	/**< sink frame container format */
 	enum sof_ipc_frame valid_sink_bits;	/**< sink frame format */
-
+	uint32_t type;	/**< gateway type */
+	enum ipc4_direction_type direction;	/**< support playback, capture or both */
 	pcm_converter_func func; /**< PCM conversion function */
 };
 
@@ -137,6 +138,12 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 		if (out_bits != pcm_func_vc_map[i].sink)
 			continue;
 		if (valid_out_bits != pcm_func_vc_map[i].valid_sink_bits)
+			continue;
+
+		if (!(type & pcm_func_vc_map[i].type))
+			continue;
+
+		if (!(dir & pcm_func_vc_map[i].direction))
 			continue;
 
 		return pcm_func_vc_map[i].func;

--- a/test/cmocka/src/audio/selector/selector_test.c
+++ b/test/cmocka/src/audio/selector/selector_test.c
@@ -440,7 +440,6 @@ static void test_audio_sel(void **state)
 #endif /* CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE */
 
 	/* TODO: add S24_3LE support */
-	/* TODO: add S24_4LE_MSB support */
 	/* TODO: add U8 support */
 	default:
 		break;

--- a/test/cmocka/src/audio/volume/volume_process.c
+++ b/test/cmocka/src/audio/volume/volume_process.c
@@ -280,7 +280,6 @@ static void test_audio_vol(void **state)
 		break;
 
 	/* TODO: add 3LE support */
-	/* TODO: add 4LE_MSB support */
 	/* TODO: add U8 support */
 	default:
 		break;

--- a/tools/topology/topology2/include/common/audio_format.conf
+++ b/tools/topology/topology2/include/common/audio_format.conf
@@ -211,13 +211,13 @@ Class.Base."audio_format" {
 	in_valid_bit_depth	16
 	in_channels		2
 	in_interleaving_style	"interleaved"
-	in_sample_type		$SAMPLE_TYPE_LSB_INTEGER
+	in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 	out_rate		48000
 	out_bit_depth		16
 	out_valid_bit_depth	16
 	out_channels		2
 	out_interleaving_style	"interleaved"
-	out_sample_type	$SAMPLE_TYPE_LSB_INTEGER
+	out_sample_type	$SAMPLE_TYPE_MSB_INTEGER
 	in_ch_cfg	$CHANNEL_CONFIG_STEREO
 	in_ch_map	$CHANNEL_MAP_STEREO
 	out_ch_cfg	$CHANNEL_CONFIG_STEREO

--- a/tools/topology/topology2/include/common/input_audio_format.conf
+++ b/tools/topology/topology2/include/common/input_audio_format.conf
@@ -124,7 +124,7 @@ Class.Base."input_audio_format" {
 	in_valid_bit_depth	16
 	in_channels		2
 	in_interleaving_style	"interleaved"
-	in_sample_type		$SAMPLE_TYPE_LSB_INTEGER
+	in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 	in_ch_cfg	$CHANNEL_CONFIG_STEREO
 	in_ch_map	$CHANNEL_MAP_STEREO
 

--- a/tools/topology/topology2/include/common/output_audio_format.conf
+++ b/tools/topology/topology2/include/common/output_audio_format.conf
@@ -124,7 +124,7 @@ Class.Base."output_audio_format" {
 	out_valid_bit_depth	16
 	out_channels		2
 	out_interleaving_style	"interleaved"
-	out_sample_type	$SAMPLE_TYPE_LSB_INTEGER
+	out_sample_type	$SAMPLE_TYPE_MSB_INTEGER
 	out_ch_cfg	$CHANNEL_CONFIG_STEREO
 	out_ch_map	$CHANNEL_MAP_STEREO
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -67,8 +67,6 @@ Class.Pipeline."dai-copier-be" {
 				in_valid_bit_depth	24
 				out_bit_depth		32
 				out_valid_bit_depth	24
-				out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-				out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 			}
 		}
 

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -54,8 +54,6 @@ Class.Pipeline."dai-kpb-be" {
 				in_valid_bit_depth      24
 				out_bit_depth           32
 				out_valid_bit_depth     24
-				out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-				out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 			}
 
 			Object.Base.audio_format.1 {

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -67,8 +67,6 @@ Class.Pipeline."io-gateway" {
 				{
 					out_bit_depth           32
 					out_valid_bit_depth     24
-					out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-					out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 				}
 				{
 					out_bit_depth		32


### PR DESCRIPTION
Reverts thesofproject/sof#7959

defect https://github.com/thesofproject/sof/issues/8086