### PR TITLE
Tools: Topology: Add ASRC capture to cavs-nocodec.conf topologies

### DIFF
--- a/tools/topology/topology2/development/cavs-nocodec-asrc.conf
+++ b/tools/topology/topology2/development/cavs-nocodec-asrc.conf
@@ -1,0 +1,694 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+<vendor-token.conf>
+<manifest.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<host-gateway-capture.conf>
+<host-gateway-playback.conf>
+<io-gateway-capture.conf>
+<io-gateway.conf>
+<dai-copier-asrc-capture.conf>
+<asrc-dai-copier-playback.conf>
+<gain-playback.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<dmic.conf>
+<intel/hw_config_cardinal_clk.conf>
+<manifest.conf>
+<route.conf>
+<intel/common_definitions.conf>
+<dai-copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<input_pin_binding.conf>
+<output_pin_binding.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+<dmic-default.conf>
+
+Define {
+	MCLK 				24576000
+	NUM_DMICS			0
+	DMIC0_DAI_COPIER		'dai-copier.DMIC.NoCodec-6.capture'
+	DMIC0_NAME			'NoCodec-6'
+	PLATFORM 			"none"
+	SSP0_PCM_NAME			"Port0"
+	SSP1_PCM_NAME			"Port1"
+	SSP2_PCM_NAME			"Port2"
+	SSP0_PCM_ID			0
+	SSP1_PCM_ID			1
+	SSP2_PCM_ID			2
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"tgl"	"platform/intel/tgl.conf"
+	"adl"	"platform/intel/tgl.conf"
+	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/mtl.conf"
+}
+
+# Dmic-->ASRC-->host copier
+
+Object.Dai.SSP [
+	{
+		id 		0
+		dai_index	0
+		direction	"duplex"
+		name		NoCodec-0
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk		$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP0"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+
+	{
+		id 		1
+		dai_index	1
+		direction	"duplex"
+		name		NoCodec-1
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk		$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP1"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+
+	{
+		id 		2
+		dai_index	2
+		direction	"duplex"
+		name		NoCodec-2
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk		$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP2"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+]
+
+Object.Dai.DMIC [
+	{
+		dai_index 0
+		name			$DMIC0_NAME
+		id 			$DMIC0_ID
+		driver_version		$DMIC_DRIVER_VERSION
+		io_clk			$DMIC_IO_CLK
+		clk_min		500000
+		clk_max		4800000
+		unmute_ramp_time_ms	200
+		# num_pdm_active should always set to 2 but depending on the number of DMIC's
+		# the mic's are enabled or disabled in each PDM.
+		num_pdm_active 	2
+
+		Object.Base.hw_config.1 {
+			id	0
+			name	"DMIC0"
+		}
+
+		# PDM controller config
+		Object.Base.pdm_config.1 {
+			mic_a_enable	$PDM0_MIC_A_ENABLE
+			mic_b_enable	$PDM0_MIC_B_ENABLE
+			ctrl_id	0
+		}
+
+		Object.Base.pdm_config.2 {
+			ctrl_id	1
+			mic_a_enable	$PDM1_MIC_A_ENABLE
+			mic_b_enable	$PDM1_MIC_B_ENABLE
+		}
+	}
+]
+
+# Dmic-->ASRC-->host copier PCM ASRC Capture3
+# SSP0-->host copier PCM Port0
+# SSP1-->ASRC-->host copier PCM Port1
+# SSP2-->ASRC-->host copier PCM Port2
+Object.Pipeline.dai-copier-asrc-capture [
+	{
+		index		1
+		core_id		$DMIC_CORE_ID
+		Object.Widget.dai-copier.1 {
+			dai_index	0
+			dai_type	"DMIC"
+			copier_type	"DMIC"
+			type		dai_out
+			stream_name	$DMIC0_NAME
+			node_type $DMIC_LINK_INPUT_CLASS
+			num_input_audio_formats	2
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+				{
+					in_channels		4
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
+			num_output_audio_formats	2
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+				{
+					out_channels		4
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
+		}
+
+		Object.Widget.asrc."1" {
+			rate_out 48000
+			num_input_audio_formats	2
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+				{
+					in_channels		4
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
+			num_output_audio_formats	2
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+				{
+					out_channels		4
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
+		}
+
+		Object.Widget.pipeline."1" {
+			core $DMIC_CORE_ID
+		}
+	}
+
+	{
+		index		7
+		Object.Widget.dai-copier."1" {
+			dai_index	1
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-1"
+			node_type	$I2S_LINK_INPUT_CLASS
+		}
+
+		Object.Widget.asrc."1" {
+			rate_out 48000
+			num_input_audio_formats	1
+		}
+	}
+
+	{
+		index		11
+		Object.Widget.dai-copier."1" {
+			dai_index	2
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-2"
+			node_type	$I2S_LINK_INPUT_CLASS
+		}
+
+		Object.Widget.asrc."1" {
+			rate_out 48000
+			num_input_audio_formats	1
+			Object.Base.input_audio_format [
+				{
+					in_channels		2
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			num_output_audio_formats	1
+			Object.Base.output_audio_format [
+				{
+					in_channels		2
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.io-gateway-capture [
+	{
+		index		3
+		direction	capture
+		Object.Widget.dai-copier."1" {
+			dai_index	0
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-0"
+			node_type	$I2S_LINK_INPUT_CLASS
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-capture [
+	{
+		index 	2
+		Object.Widget.host-copier.1 {
+			stream_name "ASRC Capture 3"
+			pcm_id	3
+			num_input_audio_formats 2
+			num_output_audio_formats 2
+			Object.Base.audio_format.1 {
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_bit_depth		32
+				out_valid_bit_depth	32
+			}
+			Object.Base.audio_format.2 {
+				in_channels		4
+				in_bit_depth		32
+				in_valid_bit_depth	32
+				out_channels		4
+				out_bit_depth		32
+				out_valid_bit_depth	32
+				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+				in_ch_map	$CHANNEL_MAP_3_POINT_1
+				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+				out_ch_map	$CHANNEL_MAP_3_POINT_1
+			}
+		}
+	}
+
+	{
+		index 	4
+		Object.Widget.host-copier.1 {
+			stream_name "SSP0 Capture"
+			pcm_id		4
+		}
+	}
+
+	{
+		index 	8
+		Object.Widget.host-copier.1 {
+			stream_name "SSP1 Capture"
+			pcm_id		$SSP1_PCM_ID
+			<include/components/src_format_s32_to_sxx_convert.conf>
+		}
+	}
+
+	{
+		index 	12
+		Object.Widget.host-copier.1 {
+			stream_name "SSP2 Capture"
+			pcm_id		5
+			<include/components/src_format_s32_to_sxx_convert.conf>
+		}
+	}
+]
+Object.Base.route [
+	{
+		source $DMIC0_DAI_COPIER
+		sink "asrc.1.1"
+	}
+
+	{
+		source "asrc.1.1"
+		sink	"host-copier.3.capture"
+	}
+
+	{
+		source	"dai-copier.SSP.NoCodec-0.capture"
+		sink	"host-copier.4.capture"
+	}
+
+	{
+		source	"dai-copier.SSP.NoCodec-1.capture"
+		sink	"asrc.7.1"
+	}
+
+	{
+		source	"asrc.7.1"
+		sink	"host-copier.$SSP1_PCM_ID.capture"
+	}
+
+	{
+		source	"dai-copier.SSP.NoCodec-2.capture"
+		sink	"asrc.11.1"
+	}
+
+	{
+		source	"asrc.11.1"
+		sink	"host-copier.5.capture"
+	}
+
+
+]
+
+Object.PCM.pcm [
+	{
+		name	"ASRC Capture 3"
+		id 3
+		direction	"capture"
+		Object.Base.fe_dai."ASRC Capture 3" {}
+
+		Object.PCM.pcm_caps."capture" {
+			name "ASRC Capture 3"
+			# only 32-bit capture supported now
+			formats 'S16_LE,S24_LE,S32_LE'
+			channels_min $NUM_DMICS
+			channels_max $NUM_DMICS
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+
+	{
+		name	"Port 0 Capture"
+		id 4
+		direction	"capture"
+		Object.Base.fe_dai.1 {
+			name	"Port 0 Capture"
+		}
+		Object.PCM.pcm_caps."capture" {
+			name "SSP0 Capture"
+			# only 32-bit capture supported now
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+
+	{
+		name	"Port 2 Capture"
+		id 5
+		direction	"capture"
+		Object.Base.fe_dai.1 {
+			name	"Port 2 Capture"
+		}
+		Object.PCM.pcm_caps."capture" {
+			name "SSP2 Capture"
+			# only 32-bit capture supported now
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+]
+
+
+Object.PCM.pcm [
+	{
+		name	"$SSP0_PCM_NAME"
+		id $SSP0_PCM_ID
+		direction	"playback"
+		Object.Base.fe_dai.1 {
+			name	"$SSP0_PCM_NAME"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			name "SSP0 Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+
+	{
+		name	"$SSP1_PCM_NAME"
+		id $SSP1_PCM_ID
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	"$SSP1_PCM_NAME"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP1 Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name "SSP1 Capture"
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+
+	{
+		name	"$SSP2_PCM_NAME"
+		id $SSP2_PCM_ID
+		direction	"playback"
+		Object.Base.fe_dai.1 {
+			name	"$SSP2_PCM_NAME"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP2 Playback"
+			formats 'S16_LE,S24_LE,S32_LE'
+			rate_min 8000
+			rate_max 192000
+		}
+	}
+]
+
+
+
+# PCM0 --> ASRC--> SSP0
+
+# PCM1 --> ASRC--> SSP1
+
+# PCM2--> SSP2
+
+Object.Pipeline.asrc-dai-copier-playback [
+	{
+		index	5
+		Object.Widget.dai-copier.1 {
+			dai_index 0
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-0"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_pins 1
+			<include/components/src_format_s32_to_sxx_convert.conf>
+		}
+		Object.Widget.asrc."1" {
+		}
+	}
+
+	{
+		index	9
+		Object.Widget.dai-copier.1 {
+			dai_index 1
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-1"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			<include/components/src_format_s32_to_sxx_convert.conf>
+		}
+
+		Object.Widget.asrc."1" {
+			asynchronous_mode	"synchronous"
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-playback [
+	{
+		index		6
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP0 Playback'
+			pcm_id $SSP0_PCM_ID
+			<include/components/src_format_sxx_to_s32_convert.conf>
+		}
+	}
+
+	{
+		index		10
+		Object.Widget.host-copier.1 {
+
+			stream_name 'SSP1 Playback'
+			pcm_id $SSP1_PCM_ID
+			<include/components/src_format_sxx_to_s32_convert.conf>
+		}
+	}
+
+	{
+		index		13
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP2 Playback'
+			pcm_id $SSP2_PCM_ID
+
+			num_input_audio_formats 3
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+			]
+			num_output_audio_formats 3
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth           16
+					out_valid_bit_depth     16
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     24
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     32
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.io-gateway [
+	{
+		index	14
+		direction	playback
+		Object.Widget.dai-copier.1 {
+			dai_index 2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_pins 1
+			num_input_audio_formats 3
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth            16
+					in_valid_bit_depth      16
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      24
+				}
+				{
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+			]
+			num_output_audio_formats 3
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth           16
+					out_valid_bit_depth     16
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     24
+				}
+				{
+					out_bit_depth           32
+					out_valid_bit_depth     32
+				}
+			]
+		}
+	}
+]
+
+Object.Base.route [
+	{
+		source	"host-copier.$SSP0_PCM_ID.playback"
+		sink	"asrc.5.1"
+	}
+	{
+		source	"asrc.5.1"
+		sink	"dai-copier.SSP.NoCodec-0.playback"
+	}
+
+	{
+		source	"host-copier.$SSP1_PCM_ID.playback"
+		sink	"asrc.9.1"
+	}
+	{
+		source	"asrc.9.1"
+		sink	"dai-copier.SSP.NoCodec-1.playback"
+	}
+
+	{
+		source	"host-copier.$SSP2_PCM_ID.playback"
+		sink	"dai-copier.SSP.NoCodec-2.playback"
+	}
+]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -146,4 +146,9 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-crossover.bin,EFX_CROSSOVE
 # Topology to test RTC AEC
 "development/cavs-nocodec-rtcaec\;sof-tgl-nocodec-rtcaec\;PLATFORM=tgl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-rtcaec.bin"
+
+# Topology to test IPC4 ASRC
+"development/cavs-nocodec-asrc\;sof-tgl-nocodec-asrc\;NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-asrc.bin,DEEPBUFFER_FW_DMA_MS=100,\
+SSP0_MIXER_2LEVEL=1,PLATFORM=tgl"
 )

--- a/tools/topology/topology2/include/components/asrc.conf
+++ b/tools/topology/topology2/include/components/asrc.conf
@@ -94,6 +94,6 @@ Class.Widget."asrc" {
 	# Default attributes for asrc
 	#
 	type		"asrc"
-	uuid 		"f6:72:ec:c8:26:85:af:4f:9d:39:a2:3d:0b:54:1d:e2"
+	uuid 		"2d:40:b4:66:68:b4:f2:42:81:a7:b3:71:21:86:3d:d4"
 	no_pm		"true"
 }

--- a/tools/topology/topology2/include/components/asrc.conf
+++ b/tools/topology/topology2/include/components/asrc.conf
@@ -48,11 +48,34 @@ Class.Widget."asrc" {
 	DefineAttribute."asynchronous_mode" {
 		# Token set reference name and type
 		token_ref	"asrc.word"
+		type	"string"
+		constraints {
+			!valid_values [
+				"synchronous"
+				"asynchronous"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
 	}
 
+	# Operation_mode: push for playback/uplink; pull for capture/downlink
 	DefineAttribute."operation_mode" {
 		# Token set reference name and type
 		token_ref	"asrc.word"
+		type	"string"
+		constraints {
+			!valid_values [
+				"push"
+				"pull"
+			]
+			!tuple_values [
+				0
+				1
+			]
+		}
 	}
 
 	attributes {
@@ -66,10 +89,12 @@ Class.Widget."asrc" {
 		]
 
 		!mandatory [
-			"format"
-			"rate_out"
 			"asynchronous_mode"
 			"operation_mode"
+			"num_input_audio_formats"
+			"num_output_audio_formats"
+			"num_input_pins"
+			"num_output_pins"
 		]
 
 		#
@@ -96,4 +121,6 @@ Class.Widget."asrc" {
 	type		"asrc"
 	uuid 		"2d:40:b4:66:68:b4:f2:42:81:a7:b3:71:21:86:3d:d4"
 	no_pm		"true"
+	num_input_pins		1
+	num_output_pins		1
 }

--- a/tools/topology/topology2/include/components/asrc_format_s32_convert_from_24k.conf
+++ b/tools/topology/topology2/include/components/asrc_format_s32_convert_from_24k.conf
@@ -1,0 +1,27 @@
+#asrc format array
+			num_output_audio_formats 2
+
+			Object.Base.output_audio_format [
+				# 8khz output
+				{
+					out_rate                 8000
+					out_bit_depth            32
+					out_valid_bit_depth      32
+				}
+				# 16khz output
+				{
+					out_rate                 16000
+					out_bit_depth            32
+					out_valid_bit_depth      32
+				}
+			]
+
+			num_input_audio_formats 1
+
+			Object.Base.input_audio_format [
+				{
+					in_rate                 24000
+					in_bit_depth            32
+					in_valid_bit_depth      32
+				}
+			]

--- a/tools/topology/topology2/include/pipelines/cavs/asrc-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/asrc-dai-copier-playback.conf
@@ -1,0 +1,81 @@
+#
+# CAVS ASRC capture pipeline
+#
+# A simple asrc pipeline. All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.asrc-dai-copier-playback.N.attribute_name".
+#
+# Usage: asrc-dai-copier-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.asrc-dai-copier-playback."N" {
+# 	format		"s16le"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/dai-copier.conf>
+<include/components/asrc.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."asrc-dai-copier-playback" {
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		unique	"instance"
+	}
+
+	Object.Widget {
+		dai-copier."1" {
+			type dai_in
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_audio_formats 1
+			num_output_audio_formats 1
+			num_input_pins 1
+
+			Object.Base.audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+
+		asrc."1" {
+			asynchronous_mode	"asynchronous"
+			operation_mode		"push"
+			rate_out 48000
+			<include/components/src_format_s32_convert_to_48k.conf>
+		}
+
+		pipeline."1" {
+			priority	0
+			lp_mode		0
+		}
+	}
+
+	direction	"playback"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	1
+	channels_max	8
+	rate		48000
+	rate_min	8000
+	rate_max	192000
+}

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-asrc-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-asrc-capture.conf
@@ -1,0 +1,70 @@
+#
+# CAVS ASRC capture pipeline
+#
+# A simple asrc pipeline. All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.dai-copier-asrc-capture.N.attribute_name".
+#
+# Usage:dai-copier-asrc-capturepipeline object can be instantiated as:
+#
+# Object.Pipeline.dai-copier-asrc-capture."N" {
+# 	format		"s16le"
+# 	period		1000
+# 	time_domain	"timer"
+# 	channels	2
+# 	rate		48000
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/common/audio_format.conf>
+<include/components/dai-copier.conf>
+<include/components/asrc.conf>
+<include/components/pipeline.conf>
+
+Class.Pipeline."dai-copier-asrc-capture" {
+
+	<include/pipelines/pipeline-common.conf>
+
+	attributes {
+		!constructor [
+			"index"
+		]
+
+		!immutable [
+			"direction"
+		]
+
+		unique	"instance"
+	}
+
+	Object.Widget {
+		dai-copier."1" {
+			type dai_out
+			<include/components/src_format_sxx_to_s32_convert.conf>
+			num_output_pins 1
+		}
+
+		asrc."1" {
+			asynchronous_mode	"asynchronous"
+			operation_mode		"pull"
+			# reuse the format of src
+			<include/components/src_format_s32_convert_from_48k.conf>
+		}
+
+		pipeline."1" {
+			priority	0
+			lp_mode		0
+		}
+	}
+
+	direction	"capture"
+	dynamic_pipeline 1
+	time_domain	"timer"
+	channels	2
+	channels_min	1
+	channels_max	8
+	rate		48000
+	rate_min	8000
+	rate_max	192000
+}


### PR DESCRIPTION
This patch adds ASRC capture from Dmic such as sof-tgl-nocodec.tplg. Set ASRC_CAPTURE_ENABLE as true enables test of ASRC component with IPC4.