### PR TITLE
west.yml: Update rimage revision to 4fb9fe00575b

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: aa0ac9eae67506b86e30d66ec75b6f514d729150
+      revision: 4fb9fe00575bc2e9f14570803d811987fb27f010
 
     - name: tomlc99
       repo-path: tomlc99


### PR DESCRIPTION
Includes following rimage commits:

4fb9fe00575b config: lnl+mtl: fix length of ADSP.man CSE manifest 
c809af816859 Config: Add crossover component for TGL and TGL-H cAVS platforms 
8c8440070a08 style: trailing whitespace is the root of all evil 
d20f1d8a85e7 actions: remove travis
af9a2fe58f21 Config: Fix comment typo for EQ FIR module 
b8ee1aa8f695 Config: Add DRC component to TGL, TGL-H, MTL, LNL