### PR TITLE
Scripts: run-mocks.sh: Change default config to avoid error

### DIFF
--- a/scripts/run-mocks.sh
+++ b/scripts/run-mocks.sh
@@ -24,7 +24,7 @@ EOF
 parse_opts()
 {
 	# default config if none supplied
-	CONFIG="tgph_defconfig"
+	CONFIG="imx8_defconfig"
 	VALGRIND_CMD=""
 
 	while getopts "vc:" flag; do


### PR DESCRIPTION
The script runs the unit tests natively as gcc compiled.  The tgph_defconfig is no more available, so use another configuration that is available in src/arch/xtensa/configs.