### PR TITLE
Math: Cleanup FIR and IIR build type select

### DIFF
--- a/src/include/sof/math/fir_config.h
+++ b/src/include/sof/math/fir_config.h
@@ -21,41 +21,42 @@
 #endif
 #endif
 
-/* If next defines are set to 1 the EQ is configured automatically. Setting
- * to zero temporarily is useful is for testing needs.
- * Setting EQ_FIR_AUTOARCH to 0 allows to manually set the code variant.
+/* Define SOFM_FIR_FORCEARCH 0/2/3 in build command line or temporarily in
+ * this file to override the default auto detection.
  */
-#define FIR_AUTOARCH    1
-
-/* Force manually some code variant when EQ_FIR_AUTODSP is set to zero. These
- * are useful in code debugging.
- */
-#if FIR_AUTOARCH == 0
-#define FIR_GENERIC	0
-#define FIR_HIFIEP	0
-#define FIR_HIFI3	1
-#endif
-
-/* Select optimized code variant when xt-xcc compiler is used */
-#if FIR_AUTOARCH == 1
-#if defined __XCC__
-#include <xtensa/config/core-isa.h>
-#define FIR_GENERIC	0
-#if XCHAL_HAVE_HIFI2EP == 1
-#define FIR_HIFIEP	1
-#define FIR_HIFI3	0
-#elif XCHAL_HAVE_HIFI3 == 1 || XCHAL_HAVE_HIFI4 == 1
-#define FIR_HIFI3	1
-#define FIR_HIFIEP	0
+#ifdef SOFM_FIR_FORCEARCH
+#  if SOFM_FIR_FORCEARCH == 3
+#    define FIR_GENERIC	0
+#    define FIR_HIFIEP	0
+#    define FIR_HIFI3	1
+#  elif SOFM_FIR_FORCEARCH == 2
+#    define FIR_GENERIC	0
+#    define FIR_HIFIEP	1
+#    define FIR_HIFI3	0
+#  elif SOFM_FIR_FORCEARCH == 0
+#    define FIR_GENERIC	1
+#    define FIR_HIFIEP	0
+#    define FIR_HIFI3	0
+#  else
+#    error "Unsupported SOFM_FIR_FORCEARCH value."
+#  endif
 #else
-#error "No HIFIEP or HIFI3 found. Cannot build FIR module."
-#endif
-#else
-/* GCC */
-#define FIR_GENERIC	1
-#define FIR_HIFIEP	0
-#define FIR_HIFI3	0
-#endif
-#endif
+#  if defined __XCC__
+#    include <xtensa/config/core-isa.h>
+#    define FIR_GENERIC	0
+#    if XCHAL_HAVE_HIFI2EP == 1
+#      define FIR_HIFIEP	1
+#      define FIR_HIFI3	0
+#    elif XCHAL_HAVE_HIFI3 == 1 || XCHAL_HAVE_HIFI4 == 1
+#      define FIR_HIFI3	1
+#      define FIR_HIFIEP	0
+#    else
+#      error "No HIFIEP or HIFI3 found. Cannot build FIR module."
+#    endif
+#  else
+#    define FIR_GENERIC	1
+#    define FIR_HIFI3	0
+#  endif /* __XCC__ */
+#endif /* SOFM_FIR_FORCEARCH */
 
 #endif /* __SOF_AUDIO_EQ_FIR_FIR_CONFIG_H__ */

--- a/src/include/sof/math/iir_df2t.h
+++ b/src/include/sof/math/iir_df2t.h
@@ -13,39 +13,34 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Get platforms configuration */
-
-/* If next defines are set to 1 the EQ is configured automatically. Setting
- * to zero temporarily is useful is for testing needs.
- * Setting EQ_FIR_AUTOARCH to 0 allows to manually set the code variant.
+/* Define SOFM_IIR_DF2T_FORCEARCH 0/3 in build command line or temporarily in
+ * this file to override the default auto detection.
  */
-#define IIR_AUTOARCH    1
-
-/* Force manually some code variant when IIR_AUTOARCH is set to zero. These
- * are useful in code debugging.
- */
-#if IIR_AUTOARCH == 0
-#define IIR_GENERIC	1
-#define IIR_HIFI3	0
-#endif
-
-/* Select optimized code variant when xt-xcc compiler is used */
-#if IIR_AUTOARCH == 1
-#if defined __XCC__
-#include <xtensa/config/core-isa.h>
-#if XCHAL_HAVE_HIFI3 == 1
-#define IIR_GENERIC	0
-#define IIR_HIFI3	1
+#ifdef SOFM_IIR_DF2T_FORCEARCH
+#  if SOFM_IIR_DF2T_FORCEARCH == 3
+#    define IIR_GENERIC	0
+#    define IIR_HIFI3	1
+#  elif SOFM_IIR_DF2T_FORCEARCH == 0
+#    define IIR_GENERIC	1
+#    define IIR_HIFI3	0
+#  else
+#    error "Unsupported SOFM_IIR_DF2T_FORCEARCH value."
+#  endif
 #else
-#define IIR_GENERIC	1
-#define IIR_HIFI3	0
-#endif /* XCHAL_HAVE_HIFI3 */
-#else
-/* GCC */
-#define IIR_GENERIC	1
-#define IIR_HIFI3	0
-#endif /* __XCC__ */
-#endif /* IIR_AUTOARCH */
+#  if defined __XCC__
+#    include <xtensa/config/core-isa.h>
+#    if XCHAL_HAVE_HIFI3 == 1
+#      define IIR_GENERIC	0
+#      define IIR_HIFI3		1
+#    else
+#      define IIR_GENERIC	1
+#      define IIR_HIFI3		0
+#    endif /* XCHAL_HAVE_HIFIn */
+#  else
+#    define IIR_GENERIC		1
+#    define IIR_HIFI3		0
+#  endif /* __XCC__ */
+#endif /* SOFM_IIR_DF2T_FORCEARCH */
 
 #define IIR_DF2T_NUM_DELAYS 2
 

--- a/src/include/sof/math/iir_df2t.h
+++ b/src/include/sof/math/iir_df2t.h
@@ -29,7 +29,7 @@
 #else
 #  if defined __XCC__
 #    include <xtensa/config/core-isa.h>
-#    if XCHAL_HAVE_HIFI3 == 1
+#    if XCHAL_HAVE_HIFI3 == 1 || XCHAL_HAVE_HIFI4 == 1
 #      define IIR_GENERIC	0
 #      define IIR_HIFI3		1
 #    else


### PR DESCRIPTION
The normally undefined SOF_FIR_FORCEARCH or SOF_IIR_DF2T_FORCEARCH can be defined at command line to force the build of other code optimized version for any compiler. The usage is only for debugging, e.g. build generic FIR version with xcc.