### PR TITLE
Audio: MFCC: Fix compile time error

### DIFF
--- a/src/audio/mfcc/mfcc_hifi4.c
+++ b/src/audio/mfcc/mfcc_hifi4.c
@@ -83,7 +83,7 @@ void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfcc_buffe
 
 	buf->s_avail += frames;
 	buf->s_free -= frames;
-	buf->w_ptr = out;
+	buf->w_ptr = (int16_t *)out;
 }
 
 void mfcc_fill_prev_samples(struct mfcc_buffer *buf, int16_t *prev_data,
@@ -116,7 +116,7 @@ void mfcc_fill_prev_samples(struct mfcc_buffer *buf, int16_t *prev_data,
 
 	buf->s_avail -= prev_data_length;
 	buf->s_free += prev_data_length;
-	buf->r_ptr = in;
+	buf->r_ptr = (int16_t *)in;
 }
 
 void mfcc_fill_fft_buffer(struct mfcc_state *state)


### PR DESCRIPTION
    Audio: MFCC: Fix compilation error
    
    /home/bamboo/sof_dir/sof/src/audio/mfcc/mfcc_hifi4.c: In function
    ‘mfcc_source_copy_s16’:
    /home/bamboo/sof_dir/sof/src/audio/mfcc/mfcc_hifi4.c:86: warning:
    assignment from incompatible pointer type
    /home/bamboo/sof_dir/sof/src/audio/mfcc/mfcc_hifi4.c: In function
    ‘mfcc_fill_prev_samples’:
    /home/bamboo/sof_dir/sof/src/audio/mfcc/mfcc_hifi4.c:119: warning:
    assignment from incompatible pointer type
    
    Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>
