### PR TITLE
zephyr: edf-schedule: fix CONTAINER_OF type

### DIFF
--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -24,7 +24,8 @@ static K_THREAD_STACK_DEFINE(edf_workq_stack, 8192);
 
 static void edf_work_handler(struct k_work *work)
 {
-	struct task *task = CONTAINER_OF(work, struct task, z_delayed_work);
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct task *task = CONTAINER_OF(dwork, struct task, z_delayed_work);
 
 	task->state = SOF_TASK_STATE_RUNNING;
 


### PR DESCRIPTION
The z_delayed_work field in struct task is a delayed work, so to go from k_work to it safely there's an extra step. Add a
k_work_delayable_from_work to fix that.

This is harmless right now because k_work is the first field in k_work_delayable but the extra step is the safe way of doing it.