### PR TITLE
imx: sdma: Add support for loading RAM script

### DIFF
--- a/src/drivers/imx/CMakeLists.txt
+++ b/src/drivers/imx/CMakeLists.txt
@@ -16,6 +16,10 @@ endif()
 
 if(CONFIG_IMX_SDMA)
 	add_local_sources(sof sdma.c)
+
+	if (CONFIG_HAVE_SDMA_FIRMWARE)
+		target_include_directories(sof PRIVATE ${CONFIG_SDMA_SCRIPT_CODE})
+	endif()
 endif()
 
 if(CONFIG_IMX_INTERRUPT_IRQSTEER)

--- a/src/drivers/imx/Kconfig
+++ b/src/drivers/imx/Kconfig
@@ -34,3 +34,18 @@ config IMX_INTERRUPT_GENERIC
 	help
 	  This has to be selected for i.MX NXP platform that do not have irqsteer.
 	  It enables NXP platforms-specific features.
+
+config HAVE_SDMA_FIRMWARE
+	bool
+	default n
+	help
+	  Select this to load SDMA firmware to enable additional functionality
+          for SDMA controller.
+
+if HAVE_SDMA_FIRMWARE
+	config SDMA_SCRIPT_CODE
+		string "SDMA script code path"
+		help
+		  This option is a string and provides the path where to find the sdma script
+		  code header.
+endif

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -265,6 +265,14 @@ static int sdma_upload_context(struct dma_chan_data *chan)
 			   sizeof(*pdata->ctx) / 4);
 }
 
+#if CONFIG_HAVE_SDMA_FIRMWARE
+static int sdma_load_firmware(struct dma *dma, void *buf, int addr, int size)
+{
+	return sdma_run_c0(dma->chan->dma, SDMA_CMD_C0_SET_PM,
+			   (uint32_t)buf, addr, size / 2);
+}
+#endif
+
 /* Below SOF related functions will be placed */
 
 static int sdma_probe(struct dma *dma)
@@ -335,6 +343,16 @@ static int sdma_probe(struct dma *dma)
 		tr_err(&sdma_tr, "SDMA: Unable to boot");
 		goto err;
 	}
+
+#if CONFIG_HAVE_SDMA_FIRMWARE
+	ret = sdma_load_firmware(dma, (void *)sdma_code,
+				 RAM_CODE_START_ADDR,
+				 RAM_CODE_SIZE * sizeof(short));
+	if (ret < 0) {
+		tr_err(&sdma_tr, "SDMA: Failed to load firmware");
+		goto err;
+	}
+#endif
 
 	goto out;
 err:

--- a/src/include/sof/drivers/sdma.h
+++ b/src/include/sof/drivers/sdma.h
@@ -151,4 +151,8 @@
 #define SDMA_SCRIPT_SHP2MCU_OFF		893
 #define SDMA_SCRIPT_MCU2SHP_OFF		962
 
+#ifdef CONFIG_SDMA_SCRIPT_CODE
+#include "sdma_script_code_imx7d_4_5.h"
+#endif
+
 #endif /* __SOF_DRIVERS_SDMA_H__ */


### PR DESCRIPTION
SDMA support loading firmware RAM scripts in order to enhance functionality. We will need this for supporting multi-fifo with upcoming MICFIL PDM driver.

Allow SDMA to load such scripts selected via CONFIG_HAVE_SDMA_FIRMWARE config.

A RAM script interface guarantees that there will be the following information provided:
- sdma_code, an array of bytes containting the actual script binary
- RAM_CODE_START_ADDR, location in RAM where to load the script
- RAM_CODE_SIZE, size of the sdma_code array.

Because RAM scripts are NXP proprietary binaries we won't make them public but offer the interface to integrate them with SOF in private builds.

We use for now sdma_script_code_imx7d_4_5.h header file which must be present in location indicated by CONFIG_SDMA_SCRIPT_CODE.