### PR TITLE
[SKIP SOF-TEST] .github/zephyr.yml: remove spurious `zephyr_revsion` matrix variable

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -209,7 +209,6 @@ jobs:
         # Sparse matrices are complicated, see comments on Linux matrix above.
         include:
           - build_opts: -d
-            zephyr_revsion: mnfst
             platforms: mtl
 
 


### PR DESCRIPTION
Fixes commit 6f9f2ee28ecf (".github/zephyr: build with the debug overlay and CONFIG_ASSERT")

Remove misspelled `zephyr_revsion` matrix variable. It was a hasty copy/paste in that commit.

It's a harmless no-op because build-windows does not play any git tricks and always builds from the manifest. However it makes the list of configurations confusing in the Github interface.