### PR TITLE
Revert "app/prj.conf: restore CONFIG_CLEANUP_INTERMEDIATE_FILES=n default"

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -9,14 +9,6 @@ CONFIG_BUILD_OUTPUT_BIN=n
 # and usage in xtensa-build-zephyr.py
 CONFIG_BUILD_OUTPUT_STRIPPED=y
 
-# Zephyr has hardcoded this to 'y' because it saves CI some disk space
-# when compiling hundreds of different zephyr/tests/, each in a separate
-# build directory. But when compiling just one "sof/app" it saves
-# practically no space, breaks the incremental build and can make it
-# more difficult to troubleshoot some build issues. So, reset it to the
-# default value.
-CONFIG_CLEANUP_INTERMEDIATE_FILES=n
-
 # Generate zephyr.lst file
 CONFIG_OUTPUT_DISASSEMBLY=y
 


### PR DESCRIPTION
This reverts commit 80c6738b89bc3e677cc125dd189aac97f111dfd5.

The Zephyr default changed in commit [385ad46a39ca](https://github.com/zephyrproject-rtos/zephyr/commit/385ad46a39ca) so this is not needed anymore.