### PR TITLE
west.yml: update Zephyr to 5689916a70ad

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: b92e749c3e5ff259345c7a4c28d6370fd008d8b5
+      revision: 5689916a70ad5c363bd7d5511b772ada90067d51
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 367 commits, including following directly affecting SOF targets:

ffd2121c65d3 soc: xtensa: intel_adsp: cavs: fix power_down_cavs() signature
a1d7ffdc374d soc: xtensa: intel_adsp: cavs: fix incorrect cached/uncached cast
ce7c30c12978 soc: intel_adsp/ace: use WAIT_FOR for core power transitions
3f0ee7f6db7a power_domain: intel_adsp: initialize after DMA
ca23a5f0cf75 xtensa: mmu: allow SoC to do additional MMU init steps
088a31e2bffa xtensa: mmu: preload ITLB for VECBASE before restoring...
40f2486b685c xtensa: mmu: rename MMU_KERNEL_RING to Z_XTENSA_KERNEL_RING...
18eb17f4cd69 xtensa: mmu: add arch_reserved_pages_update
4778c13bbeab xtensa: mmu: handle all data TLB misses in double exception
c723d8b8d3ac xtensa: Add missing synchronization
24148718fc6e xtensa: mmu: cache common data and heap if !XTENSA_RPO_CACHE
b6ccbae58dc4 xtensa: mmu: use _image_ram_start/end for data region
257404a14327 xtensa: mmu: init: only clear enough entries in way 6
614e64325d48 xtensa: mmu: no longer identity map the first 512MB
b5016714b082 xtensa: mmu: handle TLB misses during user exception
98ffd1addd6a xtensa: crt1: call z_xtensa_mmu_init
38d4b7872401 xtensa: mmu: remove printing vaddr registers during exception
3d63e2060edf dts: cpu: add cdns,tensilica-xtensa-lx3