### PR TITLE
topology2: cavs-rt5682: use macros for all PCM IDs

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -99,7 +99,9 @@ Define {
 	GOOGLE_RTC_AEC_REF_SOURCE	'module-copier.8.2'
 	GOOGLE_AEC_CORE_ID		0
 	HEADSET_PCM_NAME		"Headset"
+	HEADSET_PCM_ID			0
 	SPEAKER_PCM_NAME		"Speakers"
+	SPEAKER_PCM_ID			1
 	INCLUDE_BT_OFFLOAD		true
 }
 
@@ -209,7 +211,7 @@ Object.Pipeline {
 
 			Object.Widget.host-copier.1 {
 				stream_name	'$HEADSET_PLAYBACK_PCM_STREAM_NAME'
-				pcm_id 0
+				pcm_id $HEADSET_PCM_ID
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
@@ -222,7 +224,7 @@ Object.Pipeline {
 
 			Object.Widget.host-copier.1 {
 				stream_name	'$SPEAKER_PLAYBACK_PCM_STREAM_NAME'
-				pcm_id 1
+				pcm_id $SPEAKER_PCM_ID
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
@@ -275,7 +277,7 @@ Object.Pipeline {
 
 			Object.Widget.host-copier.1 {
 				stream_name	'$HEADSET_CAPTURE_PCM_STREAM_NAME'
-				pcm_id 0
+				pcm_id $HEADSET_PCM_ID
 			}
 		}
 	]
@@ -312,7 +314,7 @@ Object.Pipeline {
 Object.PCM.pcm [
 	{
 		name	"$HEADSET_PCM_NAME"
-		id	0
+		id	$HEADSET_PCM_ID
 		direction	"duplex"
 		Object.Base.fe_dai.1 {
 			name	"$HEADSET_PCM_NAME"
@@ -332,7 +334,7 @@ Object.PCM.pcm [
 	}
 	{
 		name	"$SPEAKER_PCM_NAME"
-		id	1
+		id	$SPEAKER_PCM_ID
 		direction	"playback"
 		Object.Base.fe_dai.1 {
 			name	"$SPEAKER_PCM_NAME"
@@ -364,14 +366,14 @@ Object.Base.route [
 	}
 	{
 		source	"dai-copier.SSP.$HEADSET_CODEC_NAME.capture"
-		sink	"host-copier.0.capture"
+		sink	"host-copier.$HEADSET_PCM_ID.capture"
 	}
 	{
-		source	"host-copier.0.playback"
+		source	"host-copier.$HEADSET_PCM_ID.playback"
 		sink	"gain.1.1"
 	}
 		{
-		source	"host-copier.1.playback"
+		source	"host-copier.$SPEAKER_PCM_ID.playback"
 		sink	"gain.3.1"
 	}
 ]


### PR DESCRIPTION
Make it less error-prone for maintenance.