### PR TITLE
audio: host: continue optimization for  host path

### DIFF
--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -374,7 +374,6 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 {
 	struct comp_buffer *buffer = hd->local_buffer;
 	struct comp_buffer *buffer_c;
-	struct comp_buffer *dma_buf_c;
 	struct dma_status dma_stat;
 	uint32_t avail_samples;
 	uint32_t free_samples;
@@ -391,9 +390,7 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 		return 0;
 	}
 
-	dma_buf_c = buffer_acquire(hd->dma_buffer);
-	dma_sample_bytes = get_sample_bytes(audio_stream_get_frm_fmt(&dma_buf_c->stream));
-	buffer_release(dma_buf_c);
+	dma_sample_bytes = hd->config.src_width;
 
 	buffer_c = buffer_acquire(buffer);
 

--- a/src/include/sof/audio/host_copier.h
+++ b/src/include/sof/audio/host_copier.h
@@ -96,6 +96,7 @@ struct host_data {
 	/* stream info */
 	struct sof_ipc_stream_posn posn; /* TODO: update this */
 	struct ipc_msg *msg;	/**< host notification */
+	uint32_t dma_buffer_size;	/* dma buffer size */
 #if CONFIG_HOST_DMA_STREAM_SYNCHRONIZATION
 	bool is_grouped;
 	uint8_t group_id;


### PR DESCRIPTION
before copier move to module interface, with same condition, its one time cycle is 420, now, it is 455.

After this PR, copier host playback path is lower 3% compared with before module interface.