### PR TITLE
CODEOWNERS: add kv2019i to the list of default owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta
+*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta @kv2019i
 
 # Order is important. The last matching pattern has the most precedence.
 # File patterns work mostly like .gitignore. Try to keep this file


### PR DESCRIPTION
Add myself to the list of default owners that get added to all pull requests if no other entries match.