### PR TITLE
Ipc4 multicore issue fixes

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -67,7 +67,7 @@ static struct ipc4_msg_data msg_data;
 /* fw sends a fw ipc message to send the status of the last host ipc message */
 static struct ipc_msg msg_reply = {0, 0, 0, 0, LIST_INIT(msg_reply.list)};
 
-static struct ipc_msg msg_notify;
+static struct ipc_msg msg_notify = {0, 0, 0, 0, LIST_INIT(msg_notify.list)};
 
 /*
  * Global IPC Operations.
@@ -1235,28 +1235,15 @@ void ipc_send_panic_notification(void)
 
 #ifdef CONFIG_LOG_BACKEND_ADSP_MTRACE
 
-static bool is_notification_queued(void)
+static bool is_notification_queued(struct ipc_msg *msg)
 {
 	struct ipc *ipc = ipc_get();
-	struct list_item *slist;
-	struct ipc_msg *msg;
 	k_spinlock_key_t key;
 	bool queued = false;
 
 	key = k_spin_lock(&ipc->lock);
-	if (list_is_empty(&ipc->msg_list))
-		goto out;
-
-	list_for_item(slist, &ipc->msg_list) {
-		msg = container_of(slist, struct ipc_msg, list);
-
-		if (msg == &msg_notify) {
-			queued = true;
-			break;
-		}
-	}
-
-out:
+	if (!list_is_empty(&msg->list))
+		queued = true;
 	k_spin_unlock(&ipc->lock, key);
 
 	return queued;
@@ -1265,13 +1252,12 @@ out:
 void ipc_send_buffer_status_notify(void)
 {
 	/* a single msg_notify object is used */
-	if (is_notification_queued())
+	if (is_notification_queued(&msg_notify))
 		return;
 
 	msg_notify.header = SOF_IPC4_NOTIF_HEADER(SOF_IPC4_NOTIFY_LOG_BUFFER_STATUS);
 	msg_notify.extension = 0;
 	msg_notify.tx_size = 0;
-	list_init(&msg_notify.list);
 
 	tr_dbg(&ipc_tr, "tx-notify\t: %#x|%#x", msg_notify.header, msg_notify.extension);
 


### PR DESCRIPTION
BUG: Various IPC timed out with multi-core run simultaneously https://github.com/thesofproject/sof/issues/7774.

This issue is very random and can be reproduced after many cycles test. The direct reason is that : there is a self loop
in the ipc message list like:   ipc msg -> M1 -> M2 ->..... > Mn ->Mn , this result to a infinite loop with ipc spin lock hold for the logging function. This is one major reason that the issue can't be reproduced with logging disabled.
````c
-static bool is_notification_queued(void)
 {
        struct ipc *ipc = ipc_get();
-       struct list_item *slist;
-       struct ipc_msg *msg;
        k_spinlock_key_t key;
        bool queued = false;
 
        key = k_spin_lock(&ipc->lock);
-       if (list_is_empty(&ipc->msg_list))
-               goto out;
-
-       list_for_item(slist, &ipc->msg_list) {
-               msg = container_of(slist, struct ipc_msg, list);
-
-               if (msg == &msg_notify) {
-                       queued = true;
-                       break;
-               }
-       }
-
-out:
        k_spin_unlock(&ipc->lock, key);
 
        return queued;

````
Why the single ipc message is double added ? The reason is that In multicore case, IPC message is dispatched from primary core to secondary core which send reply message to host. Primary core will do nothing if IPC_TASK_SECONDARY_CORE is set. But in rare case, the secondary code finish the reply message and clear this flag before the ipc thread in primary core check this flag because the primary core was busy with logging thread and check it after awhile, then primary core also send reply message again. This results to the reply message being inserted two times in ipc message list and result to infinite loop when visiting the list for the logging after awhile.

We can find some hint in kernel log before ipc timeout.
````
[58167.022730] snd_sof:sof_ipc4_route_setup: sof-audio-pci-intel-mtl 0000:00:1f.3: bind gain.4.1:0 -> dai-copier.SSP.NoCodec-1.playback:0
[58167.022743] snd_sof:: sof-audio-pci-intel-mtl 0000:00:1f.3: ipc tx      : 0x45050006|0x50004: MOD_BIND
[58167.023200] snd_sof:: sof-audio-pci-intel-mtl 0000:00:1f.3: ipc tx reply: 0x65000000|0x50004: MOD_BIND
[58167.023374] snd_sof:: sof-audio-pci-intel-mtl 0000:00:1f.3: ipc tx reply: 0x65000000|0x50004: MOD_BIND
[58167.023417] snd_sof:snd_sof_ipc_reply: 0000:00:1f.3: no reply expected, received 0x65000000, will be ignored
````
For the case in bug:https://github.com/thesofproject/sof/issues/7774
````
[ 2398.695476] : snd_sof:: sof-audio-pci-intel-mtl 0000:00:1f.3: ipc tx done : 0x40030006|0x2030010: MOD_INIT_INSTANCE [data size: 64]
[ 2398.695496] : sof-audio-pci-intel-mtl ipc tx 0x44030006|0x30000018: MOD_LARGE_CONFIG_SET [data size: 24]
[ 2398.695718] : sof-audio-pci-intel-mtl ipc tx reply: 0x64000000|0x30000018: MOD_LARGE_CONFIG_SET
[ 2398.695995] : sof-audio-pci-intel-mtl ipc tx reply: 0x64000000|0x30000018: MOD_LARGE_CONFIG_SET
[ 2398.696006] : sof-audio-pci-intel-mtl  ipc tx done : 0x44030006|0x30000018: MOD_LARGE_CONFIG_SET [data size: 24]
[ 2398.696018] : snd_sof:snd_sof_ipc_reply: 0000:00:1f.3: no reply expected, received 0x64000000, will be ignored
[ 2398.696043] : snd_sof:sof_widget_setup_unlocked: 0000:00:1f.3: widget gain.6.1 setup complete
[ 2398.696058] : snd_sof:sof_ipc4_widget_setup:  Create widget dai-copier.SSP.NoCodec-2.playback instance 3 - pipe 6 - core 2
[ 2398.696064] : snd_sof:sof_ipc4_log_header: : ipc tx      : 0x40030004|0x203002f: MOD_INIT_INSTANCE [data size: 188]
[ 2399.201595] : sof-audio-pci-intel-mtl 0000:00:1f.3: ipc timed out for 0x40030004|0x203002f
[ 2399.201612] : sof-audio-pci-intel-mtl 0000:00:1f.3: Attempting to prevent DSP from entering D3 state to preserve context
[ 2399.201618] : sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ IPC dump start ]------------
[ 2399.201643] : sof-audio-pci-intel-mtl 0000:00:1f.3: Host IPC initiator: 0xc0030004|0x203002f|0x0, target: 0x40030004|0x203002f|0x0, ctl: 0x3
[ 2399.201650] : sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ IPC dump end ]------------
[ 2399.201655] : sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ DSP dump start ]------------
[ 2399.201659] : sof-audio-pci-intel-mtl 0000:00:1f.3: IPC timeout
````
This PR checks whether the msg has been done by secondary core and do nothing for primary core. Also simply the check for logging.