### PR TITLE
audio: module adapter: split out module adapter ipc3 and ipc4 code

### DIFF
--- a/src/audio/module_adapter/CMakeLists.txt
+++ b/src/audio/module_adapter/CMakeLists.txt
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-add_local_sources(sof module_adapter.c module/generic.c)
+if(CONFIG_IPC_MAJOR_3)
+	add_local_sources(sof module_adapter.c module_adapter_ipc3.c module/generic.c)
+elseif(CONFIG_IPC_MAJOR_4)
+	add_local_sources(sof module_adapter.c module_adapter_ipc4.c module/generic.c)
+endif()
 
 if(NOT CONFIG_COMP_MODULE_SHARED_LIBRARY_BUILD)
 	if(CONFIG_CADENCE_CODEC)

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -519,3 +519,14 @@ int module_unbind(struct processing_module *mod, void *data)
 		return md->ops->unbind(mod, data);
 	return 0;
 }
+
+void module_update_buffer_position(struct input_stream_buffer *input_buffers,
+				   struct output_stream_buffer *output_buffers,
+				   uint32_t frames)
+{
+	struct audio_stream *source = input_buffers->data;
+	struct audio_stream *sink = output_buffers->data;
+
+	input_buffers->consumed += audio_stream_frame_bytes(source) * frames;
+	output_buffers->size += audio_stream_frame_bytes(sink) * frames;
+}

--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2023 Intel Corporation. All rights reserved.
+//
+// Author: Baofeng Tian <baofeng.tian@intel.com>
+
+/**
+ * \file
+ * \brief Module Adapter ipc3: module adapter ipc3 specific code
+ * \author Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/component.h>
+#include <sof/audio/ipc-config.h>
+#include <sof/audio/module_adapter/module/generic.h>
+#include <sof/audio/pipeline.h>
+#include <sof/common.h>
+#include <sof/platform.h>
+#include <sof/ut.h>
+#include <rtos/interrupt.h>
+#include <limits.h>
+#include <stdint.h>
+
+LOG_MODULE_DECLARE(module_adapter, CONFIG_SOF_LOG_LEVEL);
+
+/*
+ * \module adapter data initialize.
+ * \param[in] dev - device.
+ * \param[in] config - component ipc descriptor pointer.
+ * \param[in] dst - module adapter config data.
+ * \param[in] spec - passdowned data from driver.
+ *
+ * \return: 0 - no error; < 0, error happened.
+ */
+int module_adapter_init_data(struct comp_dev *dev,
+			     struct module_config *dst,
+			     const struct comp_ipc_config *config,
+			     const void *spec)
+{
+	int ret;
+
+	const unsigned char *data;
+	uint32_t size;
+
+	switch (config->type) {
+	case SOF_COMP_VOLUME:
+	{
+		const struct ipc_config_volume *ipc_volume = spec;
+
+		size = sizeof(*ipc_volume);
+		data = spec;
+		break;
+	}
+	case SOF_COMP_SRC:
+	{
+		const struct ipc_config_src *ipc_src = spec;
+
+		size = sizeof(*ipc_src);
+		data = spec;
+		break;
+	}
+	default:
+	{
+		const struct ipc_config_process *ipc_module_adapter = spec;
+
+		size = ipc_module_adapter->size;
+		data = ipc_module_adapter->data;
+		break;
+	}
+	}
+
+	/* Copy initial config */
+	if (size) {
+		ret = module_load_config(dev, data, size);
+		if (ret < 0) {
+			comp_err(dev, "module_adapter_new() error %d: config loading has failed.",
+				 ret);
+			return ret;
+		}
+		dst->init_data = dst->data;
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+void module_adapter_reset_data(struct module_config *dst)
+{
+}
+
+void module_adapter_check_data(struct processing_module *mod, struct comp_dev *dev,
+			       struct comp_buffer *sink)
+{
+	/* Check if audio stream client has only one source and one sink buffer to use a
+	 * simplified copy function.
+	 */
+	if (IS_PROCESSING_MODE_AUDIO_STREAM(mod) && mod->num_of_sources == 1 &&
+	    mod->num_of_sinks == 1) {
+		mod->source_comp_buffer = list_first_item(&dev->bsource_list,
+							  struct comp_buffer, sink_list);
+		mod->sink_comp_buffer = sink;
+		mod->stream_copy_single_to_single = true;
+	}
+}
+
+void module_adapter_set_params(struct processing_module *mod, struct sof_ipc_stream_params *params)
+{
+}
+
+static int module_source_status_count(struct comp_dev *dev, uint32_t status)
+{
+	struct list_item *blist;
+	int count = 0;
+
+	/* count source with state == status */
+	list_for_item(blist, &dev->bsource_list) {
+		/*
+		 * FIXME: this is racy, state can be changed by another core.
+		 * This is implicitly protected by serialised IPCs. Even when
+		 * IPCs are processed in the pipeline thread, the next IPC will
+		 * not be sent until the thread has processed and replied to the
+		 * current one.
+		 */
+		struct comp_buffer *source = container_of(blist, struct comp_buffer,
+							  sink_list);
+
+		if (source->source && source->source->state == status)
+			count++;
+	}
+
+	return count;
+}
+
+int module_adapter_set_state(struct processing_module *mod, struct comp_dev *dev,
+			     int cmd)
+{
+	if (mod->num_of_sources > 1) {
+		bool sources_active;
+		int ret;
+
+		sources_active = module_source_status_count(dev, COMP_STATE_ACTIVE) ||
+				 module_source_status_count(dev, COMP_STATE_PAUSED);
+
+		/* don't stop/start module if one of the sources is active/paused */
+		if ((cmd == COMP_TRIGGER_STOP || cmd == COMP_TRIGGER_PRE_START) && sources_active) {
+			dev->state = COMP_STATE_ACTIVE;
+			return PPL_STATUS_PATH_STOP;
+		}
+
+		ret = comp_set_state(dev, cmd);
+		if (ret == COMP_STATUS_STATE_ALREADY_SET)
+			return PPL_STATUS_PATH_STOP;
+
+		return ret;
+	}
+
+	return comp_set_state(dev, cmd);
+}
+

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2023 Intel Corporation. All rights reserved.
+//
+// Author: Baofeng Tian <baofeng.tian@intel.com>
+
+/**
+ * \file
+ * \brief Module Adapter ipc4: module adapter ipc4 specific code
+ * \author Baofeng Tian <baofeng.tian@intel.com>
+ */
+
+#include <sof/audio/buffer.h>
+#include <sof/audio/component.h>
+#include <sof/audio/ipc-config.h>
+#include <sof/audio/module_adapter/module/generic.h>
+#include <sof/audio/pipeline.h>
+#include <sof/common.h>
+#include <sof/platform.h>
+#include <sof/ut.h>
+#include <rtos/interrupt.h>
+#include <limits.h>
+#include <stdint.h>
+
+LOG_MODULE_DECLARE(module_adapter, CONFIG_SOF_LOG_LEVEL);
+
+/*
+ * \module adapter data initialize.
+ * \param[in] dev - device.
+ * \param[in] config - component ipc descriptor pointer.
+ * \param[in] dst - module adapter config data.
+ * \param[in] spec - passdowned data from driver.
+ *
+ * \return: 0 - no error; < 0, error happened.
+ */
+int module_adapter_init_data(struct comp_dev *dev,
+			     struct module_config *dst,
+			     const struct comp_ipc_config *config,
+			     const void *spec)
+{
+	if (dev->drv->type == SOF_COMP_MODULE_ADAPTER) {
+		const struct ipc_config_process *ipc_module_adapter = spec;
+
+		dst->init_data = ipc_module_adapter->data;
+		dst->size = ipc_module_adapter->size;
+		dst->avail = true;
+
+		memcpy_s(&dst->base_cfg,  sizeof(dst->base_cfg), ipc_module_adapter->data,
+			 sizeof(dst->base_cfg));
+	} else {
+		dst->init_data = spec;
+	}
+
+	return 0;
+}
+
+void module_adapter_reset_data(struct module_config *dst)
+{
+	dst->init_data = NULL;
+}
+
+void module_adapter_check_data(struct processing_module *mod, struct comp_dev *dev,
+			       struct comp_buffer *sink)
+{
+}
+
+void module_adapter_set_params(struct processing_module *mod, struct sof_ipc_stream_params *params)
+{
+	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
+	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, mod->stream_params);
+}
+
+int module_adapter_set_state(struct processing_module *mod, struct comp_dev *dev,
+			     int cmd)
+{
+	return comp_set_state(dev, cmd);
+}
+
+int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
+			    bool last_block, uint32_t data_offset_size, const char *data)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct module_data *md = &mod->priv;
+	enum module_cfg_fragment_position pos;
+	size_t fragment_size;
+
+	/* set fragment position */
+	pos = first_last_block_to_frag_pos(first_block, last_block);
+
+	switch (pos) {
+	case MODULE_CFG_FRAGMENT_SINGLE:
+		fragment_size = data_offset_size;
+		break;
+	case MODULE_CFG_FRAGMENT_MIDDLE:
+		fragment_size = MAILBOX_DSPBOX_SIZE;
+		break;
+	case MODULE_CFG_FRAGMENT_FIRST:
+		md->new_cfg_size = data_offset_size;
+		fragment_size = MAILBOX_DSPBOX_SIZE;
+		break;
+	case MODULE_CFG_FRAGMENT_LAST:
+		fragment_size = md->new_cfg_size - data_offset_size;
+		break;
+	default:
+		comp_err(dev, "module_set_large_config(): invalid fragment position");
+		return -EINVAL;
+	}
+
+	if (md->ops->set_configuration)
+		return md->ops->set_configuration(mod, param_id, pos, data_offset_size,
+						  (const uint8_t *)data,
+						  fragment_size, NULL, 0);
+	return 0;
+}
+
+int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
+			    bool last_block, uint32_t *data_offset_size, char *data)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct module_data *md = &mod->priv;
+	size_t fragment_size;
+
+	/* set fragment size */
+	if (first_block) {
+		if (last_block)
+			fragment_size = md->cfg.size;
+		else
+			fragment_size = SOF_IPC_MSG_MAX_SIZE;
+	} else {
+		if (!last_block)
+			fragment_size = SOF_IPC_MSG_MAX_SIZE;
+		else
+			fragment_size = md->cfg.size - *data_offset_size;
+	}
+
+	if (md->ops->get_configuration)
+		return md->ops->get_configuration(mod, param_id, data_offset_size,
+						  (uint8_t *)data, fragment_size);
+	return 0;
+}
+
+int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		memcpy_s(value, sizeof(struct ipc4_base_module_cfg),
+			 &mod->priv.cfg.base_cfg, sizeof(mod->priv.cfg.base_cfg));
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static bool module_adapter_multi_sink_source_check(struct comp_dev *dev)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct list_item *blist;
+	int num_sources = 0;
+	int num_sinks = 0;
+
+	list_for_item(blist, &dev->bsource_list)
+		num_sources++;
+
+	list_for_item(blist, &dev->bsink_list)
+		num_sinks++;
+
+	comp_dbg(dev, "num_sources=%d num_sinks=%d", num_sources, num_sinks);
+
+	if (num_sources != 1 || num_sinks != 1)
+		return true;
+
+	/* re-assign the source/sink modules */
+	mod->sink_comp_buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	mod->source_comp_buffer = list_first_item(&dev->bsource_list,
+						  struct comp_buffer, sink_list);
+
+	return false;
+}
+
+int module_adapter_bind(struct comp_dev *dev, void *data)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	int ret;
+
+	ret = module_bind(mod, data);
+	if (ret < 0)
+		return ret;
+
+	mod->stream_copy_single_to_single = !module_adapter_multi_sink_source_check(dev);
+
+	return 0;
+}
+
+int module_adapter_unbind(struct comp_dev *dev, void *data)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	int ret;
+
+	ret = module_unbind(mod, data);
+	if (ret < 0)
+		return ret;
+
+	mod->stream_copy_single_to_single = !module_adapter_multi_sink_source_check(dev);
+
+	return 0;
+}
+
+uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
+						 uint32_t stream_no, bool input)
+{
+	struct processing_module *mod = comp_get_drvdata(dev);
+	struct module_data *md = &mod->priv;
+
+	if (md->ops->endpoint_ops && md->ops->endpoint_ops->get_total_data_processed)
+		return md->ops->endpoint_ops->get_total_data_processed(dev, stream_no, input);
+
+	if (input)
+		return mod->total_data_produced;
+	else
+		return mod->total_data_consumed;
+}
+

--- a/test/cmocka/src/audio/eq_fir/CMakeLists.txt
+++ b/test/cmocka/src/audio/eq_fir/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(audio_for_eq_fir STATIC
 	${PROJECT_SOURCE_DIR}/src/math/fir_hifi3.c
 	${PROJECT_SOURCE_DIR}/src/math/numbers.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter_ipc3.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/source_api_helper.c

--- a/test/cmocka/src/audio/eq_iir/CMakeLists.txt
+++ b/test/cmocka/src/audio/eq_iir/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(audio_for_eq_iir STATIC
 	${PROJECT_SOURCE_DIR}/src/math/iir_df2t_hifi3.c
 	${PROJECT_SOURCE_DIR}/src/math/numbers.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter_ipc3.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/source_api_helper.c

--- a/test/cmocka/src/audio/mixer/CMakeLists.txt
+++ b/test/cmocka/src/audio/mixer/CMakeLists.txt
@@ -11,6 +11,7 @@ cmocka_test(mixer
 	${PROJECT_SOURCE_DIR}/src/ipc/ipc-common.c
 	${PROJECT_SOURCE_DIR}/src/ipc/ipc-helper.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter_ipc3.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/source_api_helper.c

--- a/test/cmocka/src/audio/mux/CMakeLists.txt
+++ b/test/cmocka/src/audio/mux/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
 	${PROJECT_SOURCE_DIR}/src/ipc/ipc-helper.c
 	${PROJECT_SOURCE_DIR}/test/cmocka/src/notifier_mocks.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter_ipc3.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 )
 sof_append_relative_path_definitions(audio_mux)

--- a/test/cmocka/src/audio/volume/CMakeLists.txt
+++ b/test/cmocka/src/audio/volume/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(audio_for_volume STATIC
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_hifi3_with_peakvol.c
 	${PROJECT_SOURCE_DIR}/src/audio/volume/volume_hifi4_with_peakvol.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter.c
+	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module_adapter_ipc3.c
 	${PROJECT_SOURCE_DIR}/src/audio/module_adapter/module/generic.c
 	${PROJECT_SOURCE_DIR}/src/audio/buffer.c
 	${PROJECT_SOURCE_DIR}/src/audio/source_api_helper.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -525,10 +525,19 @@ elseif(CONFIG_IPC_MAJOR_4)
 )
 endif()
 
+if(CONFIG_IPC_MAJOR_3)
 zephyr_library_sources_ifdef(CONFIG_COMP_MODULE_ADAPTER
 	${SOF_AUDIO_PATH}/module_adapter/module_adapter.c
+	${SOF_AUDIO_PATH}/module_adapter/module_adapter_ipc3.c
 	${SOF_AUDIO_PATH}/module_adapter/module/generic.c
 )
+elseif(CONFIG_IPC_MAJOR_4)
+zephyr_library_sources_ifdef(CONFIG_COMP_MODULE_ADAPTER
+	${SOF_AUDIO_PATH}/module_adapter/module_adapter.c
+	${SOF_AUDIO_PATH}/module_adapter/module_adapter_ipc4.c
+	${SOF_AUDIO_PATH}/module_adapter/module/generic.c
+)
+endif()
 
 zephyr_library_sources_ifdef(CONFIG_LIBRARY_MANAGER
 	${SOF_SRC_PATH}/library_manager/lib_manager.c


### PR DESCRIPTION
Create ipc3 and ipc4 specific source file, these files will only be used to store specific code.
Then move code from module_adapter.c to module_adapter_ipc3.c and module_adapter_ipc4.c.