### PR TITLE
zephyr: ll-schedule: stop using zephyr/timeout_q.h

### DIFF
--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -23,7 +23,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/timeout_q.h>
 
 LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
@@ -112,7 +111,7 @@ static void zephyr_domain_timer_fn(struct k_timer *timer)
 	 * registered again next time.
 	 */
 	if (!zephyr_domain) {
-		z_abort_timeout(&timer->timeout);
+		k_timer_stop(timer);
 		return;
 	}
 


### PR DESCRIPTION
Replace the call to z_abort_timeout() to be able to drop dependency to timeout_q.h. This header is intended to be Zephyr kernel private and plan is to remove this.

Unblock https://github.com/zephyrproject-rtos/zephyr/pull/62051