### PR TITLE
core: set timeout to 400ms for secondary core disabling

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -468,7 +468,7 @@ config SOF_STACK_SIZE
 
 config SECONDARY_CORE_DISABLING_TIMEOUT
 	int
-	default 5000
+	default 400
 	depends on MULTICORE
 	help
 	  Timeout value (in ms) for secondary core to enter D3 state.


### PR DESCRIPTION
Linux driver set ipc timeout duration to 500ms, but FW wait 5000ms in cpu_disable_core for SET_DX ipc message. This makes driver stop but fw is still waiting. Actually the disabling can be successful in far less than 5000ms and it was first designed for FPGA case. Now change it to 400ms to make debugging easier.

This patch changes cavs and ace15 platforms and doesn't change ace20 for its current state.

fix https://github.com/thesofproject/sof/issues/8115