### PR TITLE
Remove sparse cache annotations from buffer/audio_stream step2

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -72,8 +72,8 @@ static int aria_algo_init(struct aria_data *cd, void *buffer_desc,
 }
 
 static inline void aria_process_data(struct processing_module *mod,
-				     struct audio_stream __sparse_cache *source,
-				     struct audio_stream __sparse_cache *sink,
+				     struct audio_stream *source,
+				     struct audio_stream *sink,
 				     size_t frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
@@ -153,7 +153,7 @@ static int aria_free(struct processing_module *mod)
 static void aria_set_stream_params(struct comp_buffer *buffer,
 				   struct processing_module *mod)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	const struct ipc4_audio_format *audio_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
 
 	buffer_c = buffer_acquire(buffer);
@@ -169,8 +169,8 @@ static void aria_set_stream_params(struct comp_buffer *buffer,
 }
 
 static int aria_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_source **sources, int num_of_sources,
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct comp_buffer *source, *sink;

--- a/src/audio/aria/aria_generic.c
+++ b/src/audio/aria/aria_generic.c
@@ -20,7 +20,7 @@ const uint8_t INDEX_TAB[] = {
 };
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-				struct audio_stream __sparse_cache *source, int frames)
+				struct audio_stream *source, int frames)
 {
 	int32_t max_data = 0;
 	int32_t sample_abs;
@@ -50,7 +50,7 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 }
 
 void aria_algo_get_data(struct processing_module *mod,
-			struct audio_stream __sparse_cache *sink, int frames)
+			struct audio_stream *sink, int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
 	int32_t step, in_sample;

--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -21,7 +21,7 @@ const uint8_t INDEX_TAB[] = {
 };
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-				struct audio_stream __sparse_cache *source, int frames)
+				struct audio_stream *source, int frames)
 {
 	/* detecting maximum value in data chunk */
 	ae_int32x2 in_sample;
@@ -61,7 +61,7 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 }
 
 void aria_algo_get_data_odd_channel(struct processing_module *mod,
-				    struct audio_stream __sparse_cache *sink,
+				    struct audio_stream *sink,
 				    int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
@@ -118,7 +118,7 @@ void aria_algo_get_data_odd_channel(struct processing_module *mod,
 }
 
 void aria_algo_get_data_even_channel(struct processing_module *mod,
-				     struct audio_stream __sparse_cache *sink,
+				     struct audio_stream *sink,
 				     int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -48,8 +48,8 @@
 #define COEF_C2		Q_CONVERT_FLOAT(0.99, 30)
 
 typedef void (*asrc_proc_func)(struct comp_dev *dev,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int *consumed,
 			       int *produced);
 
@@ -122,8 +122,8 @@ static inline void src_inc_wrap_s16(int16_t **ptr, int16_t *end, size_t size)
 
 /* A fast copy function for same in and out rate */
 static void src_copy_s32(struct comp_dev *dev,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -194,8 +194,8 @@ static void src_copy_s32(struct comp_dev *dev,
 }
 
 static void src_copy_s16(struct comp_dev *dev,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 int *n_read, int *n_written)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -534,7 +534,7 @@ static int asrc_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	int err;
 
 	comp_info(dev, "asrc_params()");
@@ -604,7 +604,7 @@ static int asrc_params(struct comp_dev *dev,
 static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	int pid;
 
 	/* Get current pipeline ID and walk to find the DAI */
@@ -722,7 +722,7 @@ static int asrc_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	uint32_t source_period_bytes;
 	uint32_t sink_period_bytes;
 	int sample_bytes;
@@ -978,8 +978,8 @@ static int asrc_control_loop(struct comp_dev *dev, struct comp_data *cd)
 	return 0;
 }
 
-static void asrc_process(struct comp_dev *dev, struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink)
+static void asrc_process(struct comp_dev *dev, struct comp_buffer *source,
+			 struct comp_buffer *sink)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int consumed = 0;
@@ -1005,7 +1005,7 @@ static int asrc_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	int frames_src;
 	int frames_snk;
 	int ret;

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -8,9 +8,7 @@
 
 static size_t audio_stream_get_free_size(struct sof_sink *sink)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(sink, struct audio_stream,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	return audio_stream_get_free_bytes(audio_stream);
 }
@@ -18,9 +16,7 @@ static size_t audio_stream_get_free_size(struct sof_sink *sink)
 static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 				   void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(sink, struct audio_stream,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	if (req_size > audio_stream_get_free_size(sink))
 		return -ENODATA;
@@ -34,15 +30,11 @@ static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 
 static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(sink, struct audio_stream,
-					  sink_api, __sparse_cache);
-	struct comp_buffer *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer,
-					  stream, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (commit_size) {
-		buffer_stream_writeback(buffer_c, commit_size);
+		buffer_stream_writeback(buffer, commit_size);
 		audio_stream_produce(audio_stream, commit_size);
 	}
 
@@ -51,9 +43,7 @@ static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 
 static size_t audio_stream_get_data_available(struct sof_source *source)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(source, struct audio_stream,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	return audio_stream_get_avail_bytes(audio_stream);
 }
@@ -61,18 +51,13 @@ static size_t audio_stream_get_data_available(struct sof_source *source)
 static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 				 void  **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(source, struct audio_stream,
-					  source_api, __sparse_cache);
-
-	struct comp_buffer *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer,
-					  stream, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (req_size > audio_stream_get_data_available(source))
 		return -ENODATA;
 
-	buffer_stream_invalidate(buffer_c, req_size);
+	buffer_stream_invalidate(buffer, req_size);
 
 	/* get circular buffer parameters */
 	*data_ptr = audio_stream->r_ptr;
@@ -83,9 +68,7 @@ static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 
 static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(source, struct audio_stream,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	if (free_size)
 		audio_stream_consume(audio_stream, free_size);
@@ -97,12 +80,8 @@ static int audio_stream_set_ipc_params_source(struct sof_source *source,
 					      struct sof_ipc_stream_params *params,
 					      bool force_update)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(source, struct audio_stream,
-					  source_api, __sparse_cache);
-	struct comp_buffer *buffer =
-			attr_container_of(audio_stream, struct comp_buffer,
-					  stream, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
 }
@@ -111,12 +90,8 @@ static int audio_stream_set_ipc_params_sink(struct sof_sink *sink,
 					    struct sof_ipc_stream_params *params,
 					    bool force_update)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(sink, struct audio_stream,
-					  sink_api, __sparse_cache);
-	struct comp_buffer *buffer =
-			attr_container_of(audio_stream, struct comp_buffer,
-					  stream, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
 }
@@ -125,9 +100,7 @@ static int audio_stream_source_set_alignment_constants(struct sof_source *source
 						       const uint32_t byte_align,
 						       const uint32_t frame_align_req)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(source, struct audio_stream,
-					  source_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
 
@@ -138,9 +111,7 @@ static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 						     const uint32_t byte_align,
 						     const uint32_t frame_align_req)
 {
-	struct audio_stream *audio_stream =
-			attr_container_of(sink, struct audio_stream,
-					  sink_api, __sparse_cache);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
 
@@ -177,10 +148,8 @@ void audio_stream_init(struct audio_stream *audio_stream,
 	audio_stream_init_alignment_constants(1, 1, audio_stream);
 
 	source_init(audio_stream_get_source(audio_stream), &audio_stream_source_ops,
-		    (__sparse_force struct sof_audio_stream_params *)
 		    &audio_stream->runtime_stream_params);
 	sink_init(audio_stream_get_sink(audio_stream), &audio_stream_sink_ops,
-		  (__sparse_force struct sof_audio_stream_params *)
 		  &audio_stream->runtime_stream_params);
 	audio_stream_reset(audio_stream);
 }

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -6,20 +6,20 @@
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/buffer.h>
 
-static size_t audio_stream_get_free_size(struct sof_sink __sparse_cache *sink)
+static size_t audio_stream_get_free_size(struct sof_sink *sink)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(sink, struct audio_stream,
 					  sink_api, __sparse_cache);
 
 	return audio_stream_get_free_bytes(audio_stream);
 }
 
-static int audio_stream_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 				   void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(sink, struct audio_stream,
 					  sink_api, __sparse_cache);
 
 	if (req_size > audio_stream_get_free_size(sink))
@@ -32,13 +32,13 @@ static int audio_stream_get_buffer(struct sof_sink __sparse_cache *sink, size_t 
 	return 0;
 }
 
-static int audio_stream_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
+static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(sink, struct audio_stream,
 					  sink_api, __sparse_cache);
-	struct comp_buffer __sparse_cache *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+	struct comp_buffer *buffer_c =
+			attr_container_of(audio_stream, struct comp_buffer,
 					  stream, __sparse_cache);
 
 	if (commit_size) {
@@ -49,24 +49,24 @@ static int audio_stream_commit_buffer(struct sof_sink __sparse_cache *sink, size
 	return 0;
 }
 
-static size_t audio_stream_get_data_available(struct sof_source __sparse_cache *source)
+static size_t audio_stream_get_data_available(struct sof_source *source)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(source, struct audio_stream,
 					  source_api, __sparse_cache);
 
 	return audio_stream_get_avail_bytes(audio_stream);
 }
 
-static int audio_stream_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 				 void  **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(source, struct audio_stream,
 					  source_api, __sparse_cache);
 
-	struct comp_buffer __sparse_cache *buffer_c =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+	struct comp_buffer *buffer_c =
+			attr_container_of(audio_stream, struct comp_buffer,
 					  stream, __sparse_cache);
 
 	if (req_size > audio_stream_get_data_available(source))
@@ -81,10 +81,10 @@ static int audio_stream_get_data(struct sof_source __sparse_cache *source, size_
 	return 0;
 }
 
-static int audio_stream_release_data(struct sof_source __sparse_cache *source, size_t free_size)
+static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(source, struct audio_stream,
 					  source_api, __sparse_cache);
 
 	if (free_size)
@@ -93,40 +93,40 @@ static int audio_stream_release_data(struct sof_source __sparse_cache *source, s
 	return 0;
 }
 
-static int audio_stream_set_ipc_params_source(struct sof_source __sparse_cache *source,
+static int audio_stream_set_ipc_params_source(struct sof_source *source,
 					      struct sof_ipc_stream_params *params,
 					      bool force_update)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(source, struct audio_stream,
 					  source_api, __sparse_cache);
-	struct comp_buffer __sparse_cache *buffer =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+	struct comp_buffer *buffer =
+			attr_container_of(audio_stream, struct comp_buffer,
 					  stream, __sparse_cache);
 
 	return buffer_set_params(buffer, params, force_update);
 }
 
-static int audio_stream_set_ipc_params_sink(struct sof_sink __sparse_cache *sink,
+static int audio_stream_set_ipc_params_sink(struct sof_sink *sink,
 					    struct sof_ipc_stream_params *params,
 					    bool force_update)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(sink, struct audio_stream,
 					  sink_api, __sparse_cache);
-	struct comp_buffer __sparse_cache *buffer =
-			attr_container_of(audio_stream, struct comp_buffer __sparse_cache,
+	struct comp_buffer *buffer =
+			attr_container_of(audio_stream, struct comp_buffer,
 					  stream, __sparse_cache);
 
 	return buffer_set_params(buffer, params, force_update);
 }
 
-static int audio_stream_source_set_alignment_constants(struct sof_source __sparse_cache *source,
+static int audio_stream_source_set_alignment_constants(struct sof_source *source,
 						       const uint32_t byte_align,
 						       const uint32_t frame_align_req)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(source, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(source, struct audio_stream,
 					  source_api, __sparse_cache);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
@@ -134,12 +134,12 @@ static int audio_stream_source_set_alignment_constants(struct sof_source __spars
 	return 0;
 }
 
-static int audio_stream_sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 						     const uint32_t byte_align,
 						     const uint32_t frame_align_req)
 {
-	struct audio_stream __sparse_cache *audio_stream =
-			attr_container_of(sink, struct audio_stream __sparse_cache,
+	struct audio_stream *audio_stream =
+			attr_container_of(sink, struct audio_stream,
 					  sink_api, __sparse_cache);
 
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
@@ -163,7 +163,7 @@ static const struct sink_ops audio_stream_sink_ops = {
 	.set_alignment_constants = audio_stream_sink_set_alignment_constants
 };
 
-void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
+void audio_stream_init(struct audio_stream *audio_stream,
 		       void *buff_addr, uint32_t size)
 {
 	audio_stream->size = size;

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -134,8 +134,7 @@ static const struct sink_ops audio_stream_sink_ops = {
 	.set_alignment_constants = audio_stream_sink_set_alignment_constants
 };
 
-void audio_stream_init(struct audio_stream *audio_stream,
-		       void *buff_addr, uint32_t size)
+void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint32_t size)
 {
 	audio_stream->size = size;
 	audio_stream->addr = buff_addr;

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -228,7 +228,7 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 	audio_stream_produce(&buffer->stream, bytes);
 
-	notifier_event((__sparse_force void *)buffer, NOTIFIER_ID_BUFFER_PRODUCE,
+	notifier_event(buffer, NOTIFIER_ID_BUFFER_PRODUCE,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
 #if CONFIG_SOF_LOG_DBG_BUFFER
@@ -268,7 +268,7 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 
 	audio_stream_consume(&buffer->stream, bytes);
 
-	notifier_event((__sparse_force void *)buffer, NOTIFIER_ID_BUFFER_CONSUME,
+	notifier_event(buffer, NOTIFIER_ID_BUFFER_CONSUME,
 		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
 #if CONFIG_SOF_LOG_DBG_BUFFER

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -31,7 +31,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 				 bool is_shared)
 {
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	void *stream_addr;
 
 	tr_dbg(&buffer_tr, "buffer_alloc()");
@@ -80,7 +80,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	return buffer;
 }
 
-void buffer_zero(struct comp_buffer __sparse_cache *buffer)
+void buffer_zero(struct comp_buffer *buffer)
 {
 	buf_dbg(buffer, "stream_zero()");
 	CORE_CHECK_STRUCT(buffer);
@@ -92,7 +92,7 @@ void buffer_zero(struct comp_buffer __sparse_cache *buffer)
 					audio_stream_get_size(&buffer->stream));
 }
 
-int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment)
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment)
 {
 	void *new_ptr = NULL;
 
@@ -130,7 +130,7 @@ int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, ui
 	return 0;
 }
 
-int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
+int buffer_set_params(struct comp_buffer *buffer,
 		      struct sof_ipc_stream_params *params, bool force_update)
 {
 	int ret;
@@ -161,7 +161,7 @@ int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
 	return 0;
 }
 
-bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
+bool buffer_params_match(struct comp_buffer *buffer,
 			 struct sof_ipc_stream_params *params, uint32_t flag)
 {
 	assert(params);
@@ -206,7 +206,7 @@ void buffer_free(struct comp_buffer *buffer)
 	coherent_free_thread(buffer, c);
 }
 
-void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 {
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,
@@ -244,7 +244,7 @@ void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint3
 #endif
 }
 
-void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes)
+void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
 	struct buffer_cb_transact cb_data = {
 		.buffer = buffer,

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -238,7 +238,7 @@ static enum task_state chain_task_run(void *data)
 		 * mode task will update read position based on transferred data size to avoid
 		 * overwriting valid data and write position by half buffer size.
 		 */
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(cd->dma_buffer);
+		struct comp_buffer *buffer_c = buffer_acquire(cd->dma_buffer);
 		const size_t buff_size = audio_stream_get_size(&buffer_c->stream);
 		const size_t half_buff_size = buff_size / 2;
 
@@ -510,7 +510,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 		    uint32_t fifo_size)
 {
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t addr_align;
 	size_t buff_size;
 	void *buff_addr;

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -158,8 +158,8 @@ void sys_comp_init(struct sof *sof)
 	k_spinlock_init(&sof->comp_drivers->lock);
 }
 
-void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
-			  struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits(struct comp_buffer *source,
+			  struct comp_buffer *sink,
 			  struct comp_copy_limits *cl)
 {
 	cl->frames = audio_stream_avail_frames(&source->stream, &sink->stream);
@@ -169,8 +169,8 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
 	cl->sink_bytes = cl->frames * cl->sink_frame_bytes;
 }
 
-void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache *source,
-					const struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
+					const struct comp_buffer *sink,
 					struct comp_copy_limits *cl)
 {
 	cl->frames = audio_stream_avail_frames_aligned(&source->stream, &sink->stream);
@@ -182,8 +182,8 @@ void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache 
 
 #ifdef STREAMCOPY_HIFI3
 
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	ae_int16x4 *src = (ae_int16x4 *)((int8_t *)audio_stream_get_rptr(source) + ioffset * ssize);
@@ -227,8 +227,8 @@ int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t
 
 #else
 
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples)
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
 	uint8_t *src = audio_stream_wrap(source, (uint8_t *)audio_stream_get_rptr(source) +
@@ -279,7 +279,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
 }
 
 void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(sink); /* src fmt == sink fmt */
@@ -300,7 +300,7 @@ void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
 	}
 }
 
-void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *source, int ioffset,
+void audio_stream_copy_to_linear(const struct audio_stream *source, int ioffset,
 				 void *linear_sink, int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -178,8 +178,8 @@ static int copier_free(struct processing_module *mod)
 static int copier_params(struct processing_module *mod);
 
 static int copier_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_source **sources, int num_of_sources,
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct copier_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -266,7 +266,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	struct sof_ipc_stream_posn posn;
 	struct comp_dev *dai_copier;
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t latency;
 	int ret;
 
@@ -396,8 +396,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 static int do_conversion_copy(struct comp_dev *dev,
 			      struct copier_data *cd,
-			      struct comp_buffer __sparse_cache *src,
-			      struct comp_buffer __sparse_cache *sink,
+			      struct comp_buffer *src,
+			      struct comp_buffer *sink,
 			      struct comp_copy_limits *processed_data)
 {
 	int i;
@@ -423,10 +423,10 @@ static int do_conversion_copy(struct comp_dev *dev,
 }
 
 static int copier_copy_to_sinks(struct copier_data *cd, struct comp_dev *dev,
-				struct comp_buffer __sparse_cache *src_c,
+				struct comp_buffer *src_c,
 				struct comp_copy_limits *processed_data)
 {
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	struct comp_buffer *sink;
 	int ret = 0;
@@ -466,25 +466,25 @@ static int copier_module_copy(struct processing_module *mod,
 			      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *src_c;
+	struct comp_buffer *src_c;
 	struct comp_copy_limits processed_data;
 	int i;
 
 	if (!num_input_buffers || !num_output_buffers)
 		return 0;
 
-	src_c = attr_container_of(input_buffers[0].data, struct comp_buffer __sparse_cache,
+	src_c = attr_container_of(input_buffers[0].data, struct comp_buffer,
 				  stream, __sparse_cache);
 
 	processed_data.source_bytes = 0;
 
 	/* convert format and copy to each active sink */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *sink_c;
+		struct comp_buffer *sink_c;
 		struct comp_dev *sink_dev;
 
 		sink_c = attr_container_of(output_buffers[i].data,
-					   struct comp_buffer __sparse_cache,
+					   struct comp_buffer,
 					   stream, __sparse_cache);
 		sink_dev = sink_c->sink;
 		processed_data.sink_bytes = 0;
@@ -518,7 +518,7 @@ static int copier_module_copy(struct processing_module *mod,
 
 static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *src_c, *sink_c;
+	struct comp_buffer *src_c, *sink_c;
 	struct comp_copy_limits processed_data;
 	struct comp_buffer *src;
 	int ret;
@@ -649,7 +649,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	struct comp_buffer *sink;
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -473,8 +473,7 @@ static int copier_module_copy(struct processing_module *mod,
 	if (!num_input_buffers || !num_output_buffers)
 		return 0;
 
-	src_c = attr_container_of(input_buffers[0].data, struct comp_buffer,
-				  stream, __sparse_cache);
+	src_c = container_of(input_buffers[0].data, struct comp_buffer, stream);
 
 	processed_data.source_bytes = 0;
 
@@ -483,9 +482,7 @@ static int copier_module_copy(struct processing_module *mod,
 		struct comp_buffer *sink_c;
 		struct comp_dev *sink_dev;
 
-		sink_c = attr_container_of(output_buffers[i].data,
-					   struct comp_buffer,
-					   stream, __sparse_cache);
+		sink_c = container_of(output_buffers[i].data, struct comp_buffer, stream);
 		sink_dev = sink_c->sink;
 		processed_data.sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -310,9 +310,9 @@ int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd)
 	return 0;
 }
 
-static int copy_single_channel_c16(const struct audio_stream __sparse_cache *src,
+static int copy_single_channel_c16(const struct audio_stream *src,
 				   unsigned int src_channel,
-				   struct audio_stream __sparse_cache *dst,
+				   struct audio_stream *dst,
 				   unsigned int dst_channel, unsigned int frame_count)
 {
 	int16_t *r_ptr = (int16_t *)audio_stream_get_rptr(src) + src_channel;
@@ -351,9 +351,9 @@ static int copy_single_channel_c16(const struct audio_stream __sparse_cache *src
 	return 0;
 }
 
-static int copy_single_channel_c32(const struct audio_stream __sparse_cache *src,
+static int copy_single_channel_c32(const struct audio_stream *src,
 				   unsigned int src_channel,
-				   struct audio_stream __sparse_cache *dst,
+				   struct audio_stream *dst,
 				   unsigned int dst_channel, unsigned int frame_count)
 {
 	int32_t *r_ptr = (int32_t *)audio_stream_get_rptr(src) + src_channel;
@@ -395,7 +395,7 @@ static int copy_single_channel_c32(const struct audio_stream __sparse_cache *src
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index)
 {
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	struct sof_ipc_stream_params demuxed_params = *params;
 	const struct ipc4_audio_format *in_fmt = &cd->config.base.audio_fmt;
 	const struct ipc4_audio_format *out_fmt = &cd->config.out_fmt;

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -22,7 +22,7 @@ LOG_MODULE_DECLARE(copier, CONFIG_SOF_LOG_LEVEL);
 #include <stdint.h>
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
-		      struct comp_buffer __sparse_cache *sink, int frame)
+		      struct comp_buffer *sink, int frame)
 {
 	int i;
 	int n;
@@ -62,7 +62,7 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 			  struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sink, *source;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct list_item *sink_list;
 
 	memset(params, 0, sizeof(*params));
@@ -140,7 +140,7 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	enum sof_ipc_frame valid_fmt;
 	struct sof_ipc_buffer ipc_buf;
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t buf_size;
 	uint32_t chan_map;
 	int i;

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(copier_hifi, CONFIG_SOF_LOG_LEVEL);
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
-		      struct comp_buffer __sparse_cache *sink, int frame)
+		      struct comp_buffer *sink, int frame)
 {
 	int i;
 	int n;

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -246,7 +246,7 @@ void copier_host_dma_cb(struct comp_dev *dev, size_t bytes)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *sink, *source;
+	struct comp_buffer *sink, *source;
 	int ret, frames;
 
 	comp_dbg(dev, "copier_host_dma_cb() %p", dev);

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -37,7 +37,7 @@ static struct comp_dev *find_ipcgtw_by_node_id(union ipc4_connector_node_id node
 }
 
 static inline void audio_stream_copy_bytes_from_linear(const void *linear_source,
-						       struct audio_stream __sparse_cache *sink,
+						       struct audio_stream *sink,
 						       unsigned int bytes)
 {
 	const uint8_t *src = (const uint8_t *)linear_source;
@@ -55,7 +55,7 @@ static inline void audio_stream_copy_bytes_from_linear(const void *linear_source
 }
 
 static inline
-void audio_stream_copy_bytes_to_linear(const struct audio_stream __sparse_cache *source,
+void audio_stream_copy_bytes_to_linear(const struct audio_stream *source,
 				       void *linear_sink, unsigned int bytes)
 {
 	uint8_t *src = audio_stream_wrap(source, audio_stream_get_rptr(source));
@@ -93,7 +93,7 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 	const struct ipc4_ipc_gateway_cmd_data *in;
 	struct comp_dev *dev;
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	uint32_t data_size;
 	struct ipc4_ipc_gateway_cmd_data_reply *out;
 
@@ -184,7 +184,7 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 			 struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	int err;
 
 	comp_dbg(dev, "ipcgtw_params()");
@@ -214,7 +214,7 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	struct comp_buffer *buf = get_buffer(dev);
 
 	if (buf) {
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(buf);
+		struct comp_buffer *buf_c = buffer_acquire(buf);
 
 		audio_stream_reset(&buf_c->stream);
 		buffer_release(buf_c);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -133,7 +133,7 @@ static int crossover_assign_sinks(struct processing_module *mod,
 	struct sof_crossover_config *config = cd->config;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	int num_sinks = 0;
 	int i;
@@ -486,7 +486,7 @@ static int crossover_check_sink_assign(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	int num_assigned_sinks = 0;
 	uint8_t assigned_sinks[SOF_CROSSOVER_MAX_STREAMS] = {0};
@@ -623,7 +623,7 @@ static int crossover_process_audio_stream(struct processing_module *mod,
 	bool enabled_buffers[PLATFORM_MAX_STREAMS] = { false };
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
 	uint32_t num_sinks;
 	uint32_t num_assigned_sinks = 0;
 	/* The frames count to process from module adapter applies for source buffer and
@@ -691,7 +691,7 @@ static int crossover_process_audio_stream(struct processing_module *mod,
 static void crossover_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct list_item *sink_list;
 	struct comp_dev *dev = mod->dev;
@@ -721,13 +721,13 @@ static void crossover_params(struct processing_module *mod)
  * \return Error code.
  */
 static int crossover_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_source **sources, int num_of_sources,
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct list_item *sink_list;
 	int channels;
 	int ret = 0;

--- a/src/audio/crossover/crossover_generic.c
+++ b/src/audio/crossover/crossover_generic.c
@@ -93,8 +93,8 @@ static void crossover_s16_default_pass(struct comp_data *cd,
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *sink_stream;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
+	const struct audio_stream *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
 	int16_t *x;
 	int32_t *y;
 	int i, j;
@@ -121,8 +121,8 @@ static void crossover_s32_default_pass(struct comp_data *cd,
 				       int32_t num_sinks,
 				       uint32_t frames)
 {
-	const struct audio_stream __sparse_cache *sink_stream;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
+	const struct audio_stream *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
 	int32_t *x, *y;
 	int i, j;
 	int n = audio_stream_get_channels(source_stream) * frames;
@@ -149,8 +149,8 @@ static void crossover_s16_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int16_t *x, *y;
 	int ch, i, j;
 	int idx;
@@ -187,8 +187,8 @@ static void crossover_s24_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;
@@ -225,8 +225,8 @@ static void crossover_s32_default(struct comp_data *cd,
 				  uint32_t frames)
 {
 	struct crossover_state *state;
-	const struct audio_stream __sparse_cache *source_stream = bsource->data;
-	struct audio_stream __sparse_cache *sink_stream;
+	const struct audio_stream *source_stream = bsource->data;
+	struct audio_stream *sink_stream;
 	int32_t *x, *y;
 	int ch, i, j;
 	int idx;

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -97,7 +97,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	struct comp_dev *dev = arg;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t bytes = next->elem.size;
-	struct comp_buffer __sparse_cache *local_buf, *dma_buf;
+	struct comp_buffer *local_buf, *dma_buf;
 	int ret;
 
 	comp_dbg(dev, "dai_dma_cb()");
@@ -138,7 +138,7 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 
 	/* assert dma_buffer_copy succeed */
 	if (ret < 0) {
-		struct comp_buffer __sparse_cache *source_c, *sink_c;
+		struct comp_buffer *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
 					local_buf : dma_buf;
@@ -357,7 +357,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
+	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
 	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
@@ -419,7 +419,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
+	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
 	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
@@ -491,7 +491,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
 	uint32_t period_bytes;
@@ -685,7 +685,7 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 
 int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	int ret;
 
 	dd->total_data_processed = 0;
@@ -815,7 +815,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		 * this is only supported at capture mode.
 		 */
 		if (dev->direction == SOF_IPC_STREAM_CAPTURE) {
-			struct comp_buffer __sparse_cache *buffer_c =
+			struct comp_buffer *buffer_c =
 				buffer_acquire(dd->dma_buffer);
 
 			buffer_zero(buffer_c);
@@ -947,7 +947,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
+	struct comp_buffer *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
@@ -965,7 +965,7 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 {
 	uint32_t dma_fmt;
 	uint32_t sampling;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -226,7 +226,7 @@ static enum dma_cb_status
 dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 	   pcm_converter_func *converter)
 {
-	struct comp_buffer __sparse_cache *local_buf, *dma_buf;
+	struct comp_buffer *local_buf, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	int ret;
 
@@ -276,7 +276,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 			 * function
 			 */
 			list_for_item(sink_list, &dev->bsink_list) {
-				struct comp_buffer __sparse_cache *sink_c;
+				struct comp_buffer *sink_c;
 				struct comp_dev *sink_dev;
 				struct comp_buffer *sink;
 				int j;
@@ -318,7 +318,7 @@ err:
 
 	/* assert dma_buffer_copy succeed */
 	if (ret < 0) {
-		struct comp_buffer __sparse_cache *source_c, *sink_c;
+		struct comp_buffer *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
 					local_buf : dma_buf;
@@ -346,7 +346,7 @@ static enum dma_cb_status
 dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t frames,
 			  struct comp_buffer *multi_endpoint_buffer)
 {
-	struct comp_buffer __sparse_cache *multi_buf_c, *dma_buf;
+	struct comp_buffer *multi_buf_c, *dma_buf;
 	enum dma_cb_status dma_status = DMA_CB_STATUS_RELOAD;
 	uint32_t i, bytes;
 
@@ -592,7 +592,7 @@ static int dai_playback_params(struct dai_data *dd, struct comp_dev *dev, uint32
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
 	struct dma_block_config *prev = NULL;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
+	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
 	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
@@ -734,7 +734,7 @@ static int dai_capture_params(struct dai_data *dd, struct comp_dev *dev, uint32_
 	struct dma_config *dma_cfg;
 	struct dma_block_config *dma_block_cfg;
 	struct dma_block_config *prev = NULL;
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer),
+	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
 		*local_buf = buffer_acquire(dd->local_buffer);
 	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
 	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
@@ -885,7 +885,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
 	uint32_t period_bytes;
@@ -1064,7 +1064,7 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 
 int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	int ret;
 
 	dd->total_data_processed = 0;
@@ -1193,7 +1193,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		 * this is only supported at capture mode.
 		 */
 		if (dev->direction == SOF_IPC_STREAM_CAPTURE) {
-			struct comp_buffer __sparse_cache *buffer_c =
+			struct comp_buffer *buffer_c =
 				buffer_acquire(dd->dma_buffer);
 
 			buffer_zero(buffer_c);
@@ -1339,7 +1339,7 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 /* report xrun occurrence */
 static void dai_report_xrun(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(dd->local_buffer);
+	struct comp_buffer *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
@@ -1357,7 +1357,7 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 				   struct comp_buffer *multi_endpoint_buffer,
 				   int num_endpoints)
 {
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	uint32_t avail_bytes = UINT32_MAX;
 	uint32_t free_bytes = UINT32_MAX;
 	uint32_t frames;
@@ -1476,8 +1476,8 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 
 static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *dma_buf = buffer_acquire(dd->dma_buffer);
-	struct comp_buffer __sparse_cache *local_buf;
+	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer);
+	struct comp_buffer *local_buf;
 	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
 	uint32_t local_fmt;
 
@@ -1509,7 +1509,7 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_func *converter)
 {
 	uint32_t sampling = dd->sampling;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	struct dma_status stat;
 	uint32_t avail_bytes;
 	uint32_t free_bytes;
@@ -1792,7 +1792,7 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 #ifdef CONFIG_IPC_MAJOR_4
 int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 {
-	struct comp_buffer __sparse_cache *local_buf_c;
+	struct comp_buffer *local_buf_c;
 	struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -194,8 +194,8 @@ static int dcblock_process(struct processing_module *mod,
 			   int num_output_buffers)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	uint32_t frames = input_buffers[0].size;
 
 	comp_dbg(mod->dev, "dcblock_process()");
@@ -207,8 +207,8 @@ static int dcblock_process(struct processing_module *mod,
 }
 
 /* init and calculate the aligned setting for available frames and free frames retrieve*/
-static inline void dcblock_set_frame_alignment(struct audio_stream __sparse_cache *source,
-					       struct audio_stream __sparse_cache *sink)
+static inline void dcblock_set_frame_alignment(struct audio_stream *source,
+					       struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 1;
@@ -221,7 +221,7 @@ static inline void dcblock_set_frame_alignment(struct audio_stream __sparse_cach
 static void dcblock_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -248,12 +248,12 @@ static void dcblock_params(struct processing_module *mod)
  * \return Error code.
  */
 static int dcblock_prepare(struct processing_module *mod,
-			   struct sof_source __sparse_cache **sources, int num_of_sources,
-			   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			   struct sof_source **sources, int num_of_sources,
+			   struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 
 	comp_info(dev, "dcblock_prepare()");

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -36,8 +36,8 @@ static int32_t dcblock_generic(struct dcblock_state *state,
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct dcblock_state *state;
@@ -76,8 +76,8 @@ static void dcblock_s16_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct dcblock_state *state;
@@ -116,8 +116,8 @@ static void dcblock_s24_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	struct dcblock_state *state;

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -29,7 +29,7 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Setup circular for component source */
-static inline void dcblock_set_circular(const struct audio_stream __sparse_cache *source)
+static inline void dcblock_set_circular(const struct audio_stream *source)
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(audio_stream_get_addr(source));
@@ -38,8 +38,8 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int16 *src = audio_stream_get_rptr(source);
@@ -85,8 +85,8 @@ static void dcblock_s16_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int32 *src = audio_stream_get_rptr(source);
@@ -132,8 +132,8 @@ static void dcblock_s24_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int32 *src = audio_stream_get_rptr(source);

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -29,8 +29,8 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Setup circular for component sink and source */
-static inline void dcblock_set_circular(const struct audio_stream __sparse_cache *source,
-					const struct audio_stream __sparse_cache *sink)
+static inline void dcblock_set_circular(const struct audio_stream *source,
+					const struct audio_stream *sink)
 {
 	/* Set source as circular buffer 0 */
 	AE_SETCBEGIN0(audio_stream_get_addr(source));
@@ -43,8 +43,8 @@ static inline void dcblock_set_circular(const struct audio_stream __sparse_cache
 
 #if CONFIG_FORMAT_S16LE
 static void dcblock_s16_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int16 *in;
@@ -80,8 +80,8 @@ static void dcblock_s16_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S24LE
 static void dcblock_s24_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int32 *in;
@@ -118,8 +118,8 @@ static void dcblock_s24_default(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S32LE
 static void dcblock_s32_default(struct comp_data *cd,
-				const struct audio_stream __sparse_cache *source,
-				const struct audio_stream __sparse_cache *sink,
+				const struct audio_stream *source,
+				const struct audio_stream *sink,
 				uint32_t frames)
 {
 	ae_int32 *in;

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -227,8 +227,8 @@ static int drc_get_config(struct processing_module *mod,
 	return comp_data_blob_get_cmd(cd->model_handler, cdata, fragment_size);
 }
 
-static void drc_set_alignment(struct audio_stream __sparse_cache *source,
-			      struct audio_stream __sparse_cache *sink)
+static void drc_set_alignment(struct audio_stream *source,
+			      struct audio_stream *sink)
 {
 	/* Currently no optimizations those would use wider loads and stores */
 	audio_stream_init_alignment_constants(1, 1, source);
@@ -243,8 +243,8 @@ static int drc_process(struct processing_module *mod,
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	int frames = input_buffers[0].size;
 	int ret;
 
@@ -272,7 +272,7 @@ static int drc_process(struct processing_module *mod,
 static void drc_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -294,12 +294,12 @@ static void drc_params(struct processing_module *mod)
 #endif /* CONFIG_IPC_MAJOR_4 */
 
 static int drc_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	int channels;
 	int rate;

--- a/src/audio/drc/drc_generic.c
+++ b/src/audio/drc/drc_generic.c
@@ -466,8 +466,8 @@ static void drc_process_one_division(struct drc_state *state,
 }
 
 void drc_default_pass(struct processing_module *mod,
-		      const struct audio_stream __sparse_cache *source,
-		      struct audio_stream __sparse_cache *sink, uint32_t frames)
+		      const struct audio_stream *source,
+		      struct audio_stream *sink, uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -479,8 +479,8 @@ static inline void drc_pre_delay_index_inc(int *idx, int increment)
 
 #if CONFIG_FORMAT_S16LE
 static void drc_delay_input_sample_s16(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int16_t **x, int16_t **y, int samples)
 {
 	int16_t *x1;
@@ -528,8 +528,8 @@ static void drc_delay_input_sample_s16(struct drc_state *state,
 }
 
 static void drc_s16_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int16_t *x = audio_stream_get_rptr(source);
@@ -574,8 +574,8 @@ static void drc_s16_default(struct processing_module *mod,
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 static void drc_delay_input_sample_s32(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int32_t **x, int32_t **y, int samples)
 {
 	int32_t *x1;
@@ -625,8 +625,8 @@ static void drc_delay_input_sample_s32(struct drc_state *state,
 
 #if CONFIG_FORMAT_S24LE
 static void drc_delay_input_sample_s24(struct drc_state *state,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       int32_t **x, int32_t **y, int samples)
 {
 	int32_t *x1;
@@ -674,8 +674,8 @@ static void drc_delay_input_sample_s24(struct drc_state *state,
 }
 
 static void drc_s24_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);
@@ -722,8 +722,8 @@ static void drc_s24_default(struct processing_module *mod,
 
 #if CONFIG_FORMAT_S32LE
 static void drc_s32_default(struct processing_module *mod,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    uint32_t frames)
 {
 	int32_t *x = audio_stream_get_rptr(source);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -174,7 +174,7 @@ static int eq_fir_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -213,8 +213,8 @@ static void eq_fir_passthrough(struct fir_state_32x16 fir[],
 			       struct output_stream_buffer *bsink,
 			       int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -512,7 +512,7 @@ static int eq_fir_process(struct processing_module *mod,
 			  int num_output_buffers)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
 	uint32_t frame_count = input_buffers[0].size;
 	int ret;
 
@@ -554,8 +554,8 @@ static int eq_fir_process(struct processing_module *mod,
 	return 0;
 }
 
-static void eq_fir_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void eq_fir_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */
@@ -565,12 +565,12 @@ static void eq_fir_set_alignment(struct audio_stream __sparse_cache *source,
 }
 
 static int eq_fir_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_source **sources, int num_of_sources,
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	int channels;
 	enum sof_ipc_frame frame_fmt;

--- a/src/audio/eq_fir/eq_fir_generic.c
+++ b/src/audio/eq_fir/eq_fir_generic.c
@@ -23,8 +23,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int16_t *x0, *y0;
@@ -61,8 +61,8 @@ void eq_fir_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t z;
 	int32_t *x0, *y0;
@@ -99,8 +99,8 @@ void eq_fir_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsourc
 void eq_fir_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *filter;
 	int32_t *x0, *y0;
 	int32_t *x = audio_stream_get_rptr(source);

--- a/src/audio/eq_fir/eq_fir_hifi2ep.c
+++ b/src/audio/eq_fir/eq_fir_hifi2ep.c
@@ -28,8 +28,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = audio_stream_get_wptr(sink);
@@ -72,8 +72,8 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *snk = audio_stream_get_wptr(sink);
@@ -120,8 +120,8 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *snk = audio_stream_get_wptr(sink);

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -27,8 +27,8 @@ LOG_MODULE_DECLARE(eq_fir, CONFIG_SOF_LOG_LEVEL);
 void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
@@ -84,8 +84,8 @@ void eq_fir_2x_s32(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d0 = 0;
 	ae_int32x2 d1 = 0;
@@ -156,8 +156,8 @@ void eq_fir_2x_s24(struct fir_state_32x16 fir[], struct input_stream_buffer *bso
 void eq_fir_2x_s16(struct fir_state_32x16 fir[], struct input_stream_buffer *bsource,
 		   struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct fir_state_32x16 *f;
 	ae_int16x4 d0 = AE_ZERO16();
 	ae_int16x4 d1 = AE_ZERO16();

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -64,8 +64,8 @@ static void eq_iir_s16_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int16_t *x0;
 	int16_t *y0;
@@ -112,8 +112,8 @@ static void eq_iir_s24_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -160,8 +160,8 @@ static void eq_iir_s32_default(struct processing_module *mod, struct input_strea
 			       struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -209,8 +209,8 @@ static void eq_iir_s32_16_default(struct processing_module *mod,
 				  struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int16_t *y0;
@@ -257,8 +257,8 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 				  struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct iir_state_df1 *filter;
 	int32_t *x0;
 	int32_t *y0;
@@ -303,8 +303,8 @@ static void eq_iir_s32_24_default(struct processing_module *mod,
 static void eq_iir_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 			struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 
 	audio_stream_copy(source, 0, sink, 0, frames * audio_stream_get_channels(source));
 }
@@ -314,8 +314,8 @@ static void eq_iir_pass(struct processing_module *mod, struct input_stream_buffe
 static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 				struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int nmax;
@@ -344,8 +344,8 @@ static void eq_iir_s32_s16_pass(struct processing_module *mod, struct input_stre
 static void eq_iir_s32_s24_pass(struct processing_module *mod, struct input_stream_buffer *bsource,
 				struct output_stream_buffer *bsink, uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int nmax;
@@ -694,7 +694,7 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 				struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	uint32_t buffer_flag;
 	int ret;
 
@@ -794,8 +794,8 @@ static int eq_iir_process(struct processing_module *mod,
 			  struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	uint32_t frame_count = input_buffers[0].size;
 	int ret;
 
@@ -821,8 +821,8 @@ static int eq_iir_process(struct processing_module *mod,
  * \param[in,out] source Structure pointer of source.
  * \param[in,out] sink Structure pointer of sink.
  */
-static void eq_iir_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void eq_iir_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 	const uint32_t byte_align = 8;
 	const uint32_t frame_align_req = 2;
@@ -838,7 +838,7 @@ static int eq_iir_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -880,12 +880,12 @@ static void eq_iir_set_passthrough_func(struct comp_data *cd,
 }
 
 static int eq_iir_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_source **sources, int num_of_sources,
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame source_format;
 	enum sof_ipc_frame sink_format;

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -159,7 +159,7 @@ static int ghd_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sourceb;
-	struct comp_buffer __sparse_cache *source_c;
+	struct comp_buffer *source_c;
 	int ret;
 
 	/* Detector is used only in KPB topology. It always requires channels
@@ -383,8 +383,8 @@ static int ghd_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
-	struct audio_stream __sparse_cache *stream;
+	struct comp_buffer *source_c;
+	struct audio_stream *stream;
 	uint32_t bytes, tail_bytes, head_bytes = 0;
 	int ret;
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -89,7 +89,7 @@ static int google_rtc_audio_processing_params(
 	int ret;
 #if CONFIG_IPC_MAJOR_4
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct comp_buffer *sink;
 
 	/* update sink buffer format */
@@ -502,7 +502,7 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 {
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
 	struct list_item *source_buffer_list_item;
-	struct comp_buffer __sparse_cache *output_c;
+	struct comp_buffer *output_c;
 	unsigned int aec_channels = 0, frame_fmt, rate;
 	int ret;
 
@@ -512,7 +512,7 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 	list_for_item(source_buffer_list_item, &dev->bsource_list) {
 		struct comp_buffer *source = container_of(source_buffer_list_item,
 							  struct comp_buffer, sink_list);
-		struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
+		struct comp_buffer *source_c = buffer_acquire(source);
 
 #if CONFIG_IPC_MAJOR_4
 		if (IPC4_SINK_QUEUE_ID(source_c->id) == SOF_AEC_FEEDBACK_QUEUE_ID) {
@@ -592,7 +592,7 @@ static int google_rtc_audio_processing_reset(struct comp_dev *dev)
 static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 {
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *buffer_c, *mic_buf, *output_buf;
+	struct comp_buffer *buffer_c, *mic_buf, *output_buf;
 	struct comp_copy_limits cl;
 	int16_t *src, *dst, *ref;
 	uint32_t num_aec_reference_frames;

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -105,7 +105,7 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
  */
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(hd->local_buffer);
+	struct comp_buffer *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 
 	/* calculate minimum size to copy */
@@ -168,7 +168,7 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(hd->local_buffer);
+	struct comp_buffer *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 	uint32_t split_value;
 
@@ -232,8 +232,8 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *source;
-	struct comp_buffer __sparse_cache *sink;
+	struct comp_buffer *source;
+	struct comp_buffer *sink;
 	int ret;
 	bool update_mailbox = false;
 	bool send_ipc = false;
@@ -372,7 +372,7 @@ static void host_dma_cb(void *arg, enum notify_id type, void *data)
  */
 static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
@@ -446,7 +446,7 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
 			      uint32_t buffer_bytes)
 {
-	struct comp_buffer __sparse_cache *dma_buf_c;
+	struct comp_buffer *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
@@ -690,8 +690,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params, notifier_callback_t cb)
 {
 	struct dma_sg_config *config = &hd->config;
-	struct comp_buffer __sparse_cache *host_buf_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
+	struct comp_buffer *host_buf_c;
+	struct comp_buffer *dma_buf_c;
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;
@@ -886,7 +886,7 @@ static int host_params(struct comp_dev *dev,
 
 int host_common_prepare(struct host_data *hd)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(hd->dma_buffer);
+	struct comp_buffer *buf_c = buffer_acquire(hd->dma_buffer);
 
 	buffer_zero(buf_c);
 	buffer_release(buf_c);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -109,7 +109,7 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
 {
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t copy_bytes;
 
 	buffer_c = buffer_acquire(buffer);
@@ -175,7 +175,7 @@ static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t copy_bytes;
 	uint32_t split_value;
 
@@ -241,8 +241,8 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes)
 {
-	struct comp_buffer __sparse_cache *source;
-	struct comp_buffer __sparse_cache *sink;
+	struct comp_buffer *source;
+	struct comp_buffer *sink;
 	int ret;
 	bool update_mailbox = false;
 	bool send_ipc = false;
@@ -379,8 +379,8 @@ static void host_dma_cb(struct comp_dev *dev, size_t bytes)
 static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev *dev)
 {
 	struct comp_buffer *buffer = hd->local_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
+	struct comp_buffer *buffer_c;
+	struct comp_buffer *dma_buf_c;
 	struct dma_status dma_stat;
 	uint32_t avail_samples;
 	uint32_t free_samples;
@@ -464,7 +464,7 @@ static inline bool stream_sync(struct host_data *hd, struct comp_dev *dev)
  */
 static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t copy_bytes;
 	const unsigned int threshold =
 #if CONFIG_HOST_DMA_RELOAD_DELAY_ENABLE
@@ -512,7 +512,7 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
 			      uint32_t buffer_bytes, uint32_t direction)
 {
-	struct comp_buffer __sparse_cache *dma_buf_c;
+	struct comp_buffer *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
@@ -759,8 +759,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	struct dma_sg_elem *sg_elem;
 	struct dma_config *dma_cfg = &hd->z_config;
 	struct dma_block_config dma_block_cfg;
-	struct comp_buffer __sparse_cache *host_buf_c;
-	struct comp_buffer __sparse_cache *dma_buf_c;
+	struct comp_buffer *host_buf_c;
+	struct comp_buffer *dma_buf_c;
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;
@@ -1007,7 +1007,7 @@ static int host_params(struct comp_dev *dev,
 
 int host_common_prepare(struct host_data *hd)
 {
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(hd->dma_buffer);
+	struct comp_buffer *buf_c = buffer_acquire(hd->dma_buffer);
 
 	buffer_zero(buf_c);
 	buffer_release(buf_c);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -66,8 +66,8 @@ static void igo_nr_lib_process(struct comp_data *cd)
 
 #if CONFIG_FORMAT_S16LE
 static void igo_nr_capture_s16(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);
@@ -125,8 +125,8 @@ static void igo_nr_capture_s16(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S24LE
 static void igo_nr_capture_s24(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);
@@ -184,8 +184,8 @@ static void igo_nr_capture_s24(struct comp_data *cd,
 
 #if CONFIG_FORMAT_S32LE
 static void igo_nr_capture_s32(struct comp_data *cd,
-			       const struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink,
+			       const struct audio_stream *source,
+			       struct audio_stream *sink,
 			       int32_t frames)
 {
 	int32_t nch = audio_stream_get_channels(source);
@@ -379,7 +379,7 @@ static int32_t igo_nr_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	int32_t err;
 
 	comp_info(dev, "igo_nr_params()");
@@ -619,8 +619,8 @@ static int32_t igo_nr_cmd(struct comp_dev *dev,
 }
 
 static void igo_nr_process(struct comp_dev *dev,
-			   struct comp_buffer __sparse_cache *source,
-			   struct comp_buffer __sparse_cache *sink,
+			   struct comp_buffer *source,
+			   struct comp_buffer *sink,
 			   struct comp_copy_limits *cl,
 			   int32_t frames)
 
@@ -701,7 +701,7 @@ static int32_t igo_nr_copy(struct comp_dev *dev)
 {
 	struct comp_copy_limits cl;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t src_frames;
 	int32_t sink_frames;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -120,18 +120,18 @@ static int kpb_register_client(struct comp_data *kpb, struct kpb_client *cli);
 static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli);
 static enum task_state kpb_draining_task(void *arg);
 static int kpb_buffer_data(struct comp_dev *dev,
-			   const struct comp_buffer __sparse_cache *source, size_t size);
+			   const struct comp_buffer *source, size_t size);
 static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 					  size_t hb_size_req);
 static void kpb_clear_history_buffer(struct history_buffer *buff);
 static void kpb_free_history_buffer(struct history_buffer *buff);
 static inline bool kpb_is_sample_width_supported(uint32_t sampling_width);
-static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
-			     struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_copy_samples(struct comp_buffer *sink,
+			     struct comp_buffer *source, size_t size,
 			     size_t sample_width, uint32_t channels);
-static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *sink,
+static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width);
-static void kpb_buffer_samples(const struct audio_stream __sparse_cache *source,
+static void kpb_buffer_samples(const struct audio_stream *source,
 			       int offset, void *sink, size_t size,
 			       size_t sample_width);
 static void kpb_reset_history_buffer(struct history_buffer *buff);
@@ -330,7 +330,7 @@ static int kpb_bind(struct comp_dev *dev, void *data)
 
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink = container_of(blist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
+		struct comp_buffer *sink_c = buffer_acquire(sink);
 		int sink_buf_id;
 
 		if (!sink_c->sink) {
@@ -848,7 +848,7 @@ static int kpb_prepare(struct comp_dev *dev)
 
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink = container_of(blist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
+		struct comp_buffer *sink_c = buffer_acquire(sink);
 		enum sof_comp_type type;
 
 		if (!sink_c->sink) {
@@ -886,7 +886,7 @@ static int kpb_prepare(struct comp_dev *dev)
 		list_for_item(sink_list, &dev->bsink_list) {
 			struct comp_buffer *sink =
 				container_of(sink_list, struct comp_buffer, source_list);
-			struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
+			struct comp_buffer *sink_c = buffer_acquire(sink);
 
 			audio_stream_init_alignment_constants(byte_align, frame_align_req,
 							      &sink_c->stream);
@@ -991,12 +991,12 @@ static int kpb_reset(struct comp_dev *dev)
 
 #ifdef KPB_HIFI3
 #if CONFIG_FORMAT_S16LE
-static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy16(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint16_t ch;
 	size_t i;
 
@@ -1024,12 +1024,12 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 }
 #endif
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
-static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy32(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint16_t ch;
 	size_t i;
 
@@ -1058,12 +1058,12 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 }
 #endif
 #else
-static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy16(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels,  uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 
 	buffer_stream_invalidate(source, size);
 	size_t out_samples;
@@ -1090,12 +1090,12 @@ static void kpb_micselect_copy16(struct comp_buffer __sparse_cache *sink,
 	}
 }
 
-static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
-				 struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_micselect_copy32(struct comp_buffer *sink,
+				 struct comp_buffer *source, size_t size,
 				 uint32_t in_channels, uint32_t micsel_channels, uint32_t *offsets)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 
 	buffer_stream_invalidate(source, size);
 	size_t out_samples;
@@ -1121,8 +1121,8 @@ static void kpb_micselect_copy32(struct comp_buffer __sparse_cache *sink,
 	}
 }
 #endif
-static void kpb_micselect_copy(struct comp_dev *dev, struct comp_buffer __sparse_cache *sink_c,
-			       struct comp_buffer __sparse_cache *source_c, size_t copy_bytes,
+static void kpb_micselect_copy(struct comp_dev *dev, struct comp_buffer *sink_c,
+			       struct comp_buffer *source_c, size_t copy_bytes,
 			       uint32_t channels)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
@@ -1167,7 +1167,7 @@ static int kpb_copy(struct comp_dev *dev)
 	int ret = 0;
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *source_c, *sink_c = NULL;
+	struct comp_buffer *source_c, *sink_c = NULL;
 	size_t copy_bytes = 0, produced_bytes = 0;
 	size_t sample_width = kpb->config.sampling_width;
 	struct draining_data *dd = &kpb->draining_task_data;
@@ -1365,7 +1365,7 @@ out:
  *
  */
 static int kpb_buffer_data(struct comp_dev *dev,
-			   const struct comp_buffer __sparse_cache *source, size_t size)
+			   const struct comp_buffer *source, size_t size)
 {
 	int ret = 0;
 	size_t size_to_copy = size;
@@ -1729,7 +1729,7 @@ static void kpb_init_draining(struct comp_dev *dev, struct kpb_client *cli)
 static enum task_state kpb_draining_task(void *arg)
 {
 	struct draining_data *draining_data = (struct draining_data *)arg;
-	struct comp_buffer __sparse_cache *sink = buffer_acquire(draining_data->sink);
+	struct comp_buffer *sink = buffer_acquire(draining_data->sink);
 	struct history_buffer *buff = draining_data->hb;
 	size_t drain_req = draining_data->drain_req;
 	size_t sample_width = draining_data->sample_width;
@@ -1880,7 +1880,7 @@ out:
 
 #ifdef KPB_HIFI3
 static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int n_samples)
 {
 	int ssize = audio_stream_sample_bytes(sink);
@@ -1928,7 +1928,7 @@ static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
 }
 #else
 static void kpb_convert_24b_to_32b(const void *source, int ioffset,
-				   struct audio_stream __sparse_cache *sink,
+				   struct audio_stream *sink,
 				   int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(sink);
@@ -1960,7 +1960,7 @@ static void kpb_convert_24b_to_32b(const void *source, int ioffset,
  *
  * \return none.
  */
-static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *sink,
+static void kpb_drain_samples(void *source, struct audio_stream *sink,
 			      size_t size, size_t sample_width)
 {
 	unsigned int samples;
@@ -1989,7 +1989,7 @@ static void kpb_drain_samples(void *source, struct audio_stream __sparse_cache *
 }
 
 #ifdef KPB_HIFI3
-static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *source, int ioffset,
+static void kpb_convert_32b_to_24b(const struct audio_stream *source, int ioffset,
 				   void *linear_sink, int ooffset, unsigned int n_samples)
 {
 	int ssize = audio_stream_sample_bytes(source);
@@ -2027,7 +2027,7 @@ static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *sou
 	}
 }
 #else
-static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *source, int ioffset,
+static void kpb_convert_32b_to_24b(const struct audio_stream *source, int ioffset,
 				   void *sink, int ooffset, unsigned int samples)
 {
 	int ssize = audio_stream_sample_bytes(source);
@@ -2060,7 +2060,7 @@ static void kpb_convert_32b_to_24b(const struct audio_stream __sparse_cache *sou
  * \param[in] size Requested copy size in bytes.
  * \param[in] sample_width Sample size.
  */
-static void kpb_buffer_samples(const struct audio_stream __sparse_cache *source,
+static void kpb_buffer_samples(const struct audio_stream *source,
 			       int offset, void *sink, size_t size,
 			       size_t sample_width)
 {
@@ -2147,8 +2147,8 @@ static inline bool kpb_is_sample_width_supported(uint32_t sampling_width)
 }
 
 #ifdef KPB_HIFI3
-static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-				struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+static void kpb_copy_24b_in_32b(const struct audio_stream *source, uint32_t ioffset,
+				struct audio_stream *sink, uint32_t ooffset,
 				uint32_t n_samples)
 {
 	int ssize = audio_stream_sample_bytes(source); /* src fmt == sink fmt */
@@ -2181,8 +2181,8 @@ static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source
 	}
 }
 #else
-static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static void kpb_copy_24b_in_32b(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -2217,12 +2217,12 @@ static void kpb_copy_24b_in_32b(const struct audio_stream __sparse_cache *source
  *
  * \return none.
  */
-static void kpb_copy_samples(struct comp_buffer __sparse_cache *sink,
-			     struct comp_buffer __sparse_cache *source, size_t size,
+static void kpb_copy_samples(struct comp_buffer *sink,
+			     struct comp_buffer *source, size_t size,
 			     size_t sample_width, uint32_t channels)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *istream = &source->stream;
+	struct audio_stream *ostream = &sink->stream;
 	unsigned int samples;
 
 	buffer_stream_invalidate(source, size);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -161,8 +161,8 @@ static int mfcc_process(struct processing_module *mod,
 			struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers->data;
-	struct audio_stream __sparse_cache *sink = output_buffers->data;
+	struct audio_stream *source = input_buffers->data;
+	struct audio_stream *sink = output_buffers->data;
 	int frames = input_buffers->size;
 
 	comp_dbg(mod->dev, "mfcc_process(), start");
@@ -187,14 +187,14 @@ static void mfcc_set_alignment(struct audio_stream *source, struct audio_stream 
 }
 
 static int mfcc_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_source **sources, int num_of_sources,
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *source_c;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *source_c;
+	struct comp_buffer *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame source_format;
 	enum sof_ipc_frame sink_format;

--- a/src/audio/mfcc/mfcc_common.c
+++ b/src/audio/mfcc/mfcc_common.c
@@ -143,7 +143,7 @@ static int mfcc_stft_process(const struct comp_dev *dev, struct mfcc_state *stat
 void mfcc_s16_default(struct processing_module *mod, struct input_stream_buffer *bsource,
 		      struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *sink = bsink->data;
 	struct mfcc_comp_data *cd = module_get_private_data(mod);
 	struct mfcc_state *state = &cd->state;
 	struct mfcc_buffer *buf = &cd->state.buf;

--- a/src/audio/mfcc/mfcc_generic.c
+++ b/src/audio/mfcc/mfcc_generic.c
@@ -27,7 +27,7 @@
 void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfcc_buffer *buf,
 			  struct mfcc_pre_emph *emph, int frames, int source_channel)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream *source = bsource->data;
 	int32_t s;
 	int16_t *x0;
 	int16_t *x = audio_stream_get_rptr(source);

--- a/src/audio/mfcc/mfcc_hifi3.c
+++ b/src/audio/mfcc/mfcc_hifi3.c
@@ -36,7 +36,7 @@ static inline void set_circular_buf0(const void *start, const void *end)
 void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfcc_buffer *buf,
 			  struct mfcc_pre_emph *emph, int frames, int source_channel)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream *source = bsource->data;
 	int copied;
 	int nmax;
 	int n;

--- a/src/audio/mfcc/mfcc_hifi4.c
+++ b/src/audio/mfcc/mfcc_hifi4.c
@@ -42,7 +42,7 @@ static inline void set_circular_buf1(const void *start, const void *end)
 void mfcc_source_copy_s16(struct input_stream_buffer *bsource, struct mfcc_buffer *buf,
 			  struct mfcc_pre_emph *emph, int frames, int source_channel)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
+	struct audio_stream *source = bsource->data;
 	int num_channels = audio_stream_get_channels(source);
 	ae_int16 *in = (ae_int16 *)source->r_ptr + source_channel;
 	ae_int16 *out = (ae_int16 *)buf->w_ptr;

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -82,7 +82,7 @@ static int mixer_process(struct processing_module *mod,
 {
 	struct mixer_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	const struct audio_stream __sparse_cache *sources_stream[PLATFORM_MAX_STREAMS];
+	const struct audio_stream *sources_stream[PLATFORM_MAX_STREAMS];
 	int sources_indices[PLATFORM_MAX_STREAMS];
 	int32_t i = 0, j = 0;
 	uint32_t frames = INT32_MAX;
@@ -174,7 +174,7 @@ static int mixer_reset(struct processing_module *mod)
 			/* FIXME: this is racy and implicitly protected by serialised IPCs */
 			struct comp_buffer *source = container_of(blist, struct comp_buffer,
 								  sink_list);
-			struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
+			struct comp_buffer *source_c = buffer_acquire(source);
 			bool stop = false;
 
 			if (source_c->source && source_c->source->state > COMP_STATE_READY)
@@ -194,7 +194,7 @@ static int mixer_reset(struct processing_module *mod)
 }
 
 /* init and calculate the aligned setting for available frames and free frames retrieve*/
-static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache *source)
+static inline void mixer_set_frame_alignment(struct audio_stream *source)
 {
 #if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
 
@@ -220,11 +220,11 @@ static inline void mixer_set_frame_alignment(struct audio_stream __sparse_cache 
 }
 
 static int mixer_prepare(struct processing_module *mod,
-			 struct sof_source __sparse_cache **sources, int num_of_sources,
-			 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			 struct sof_source **sources, int num_of_sources,
+			 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mixer_data *md = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
 	struct list_item *blist;
@@ -239,7 +239,7 @@ static int mixer_prepare(struct processing_module *mod,
 	/* check each mixer source state */
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer *source;
-		struct comp_buffer __sparse_cache *source_c;
+		struct comp_buffer *source_c;
 		bool stop;
 
 		/*

--- a/src/audio/mixer/mixer_generic.c
+++ b/src/audio/mixer/mixer_generic.c
@@ -11,8 +11,8 @@
 
 #if CONFIG_FORMAT_S16LE
 /* Mix n 16 bit PCM source streams to one sink stream */
-static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int16_t *src[PLATFORM_MAX_CHANNELS];
@@ -57,8 +57,8 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE
 /* Mix n 24 bit PCM source streams to one sink stream */
-static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int32_t *src[PLATFORM_MAX_CHANNELS];
@@ -105,8 +105,8 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S32LE
 /* Mix n 32 bit PCM source streams to one sink stream */
-static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	int32_t *src[PLATFORM_MAX_CHANNELS];

--- a/src/audio/mixer/mixer_hifi3.c
+++ b/src/audio/mixer/mixer_hifi3.c
@@ -13,8 +13,8 @@
 
 #if CONFIG_FORMAT_S16LE
 /* Mix n 16 bit PCM source streams to one sink stream */
-static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s16(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_int16x4 * in[PLATFORM_MAX_CHANNELS];
@@ -69,8 +69,8 @@ static void mix_n_s16(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE
 /* Mix n 24 bit PCM source streams to one sink stream */
-static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s24(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_int32x2 *in[PLATFORM_MAX_CHANNELS];
@@ -114,8 +114,8 @@ static void mix_n_s24(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S32LE
 /* Mix n 32 bit PCM source streams to one sink stream */
-static void mix_n_s32(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+static void mix_n_s32(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t num_sources,
 		      uint32_t frames)
 {
 	ae_q32s * in[PLATFORM_MAX_CHANNELS];

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -285,9 +285,8 @@ static int mixin_process(struct processing_module *mod,
 		uint32_t free_frames, pending_frames;
 
 		/* unused buffer between mixin and mixout */
-		unused_in_between_buf_c = attr_container_of(output_buffers[i].data,
-							    struct comp_buffer,
-							    stream, __sparse_cache);
+		unused_in_between_buf_c = container_of(output_buffers[i].data, struct comp_buffer,
+						       stream);
 		mixout = unused_in_between_buf_c->sink;
 		sink_id = IPC4_SRC_QUEUE_ID(unused_in_between_buf_c->id);
 
@@ -341,9 +340,8 @@ static int mixin_process(struct processing_module *mod,
 			audio_stream_period_bytes(input_buffers[0].data, frames_to_copy);
 		if (bytes_to_consume_from_source_buf > 0) {
 			input_buffers[0].consumed = bytes_to_consume_from_source_buf;
-			source_c = attr_container_of(input_buffers[0].data,
-						     struct comp_buffer,
-						     stream, __sparse_cache);
+			source_c = container_of(input_buffers[0].data, struct comp_buffer,
+						stream);
 			buffer_stream_invalidate(source_c, bytes_to_consume_from_source_buf);
 		}
 	} else {
@@ -461,9 +459,8 @@ static int mixout_process(struct processing_module *mod,
 		int source_index;
 
 		source_stream = input_buffers[i].data;
-		unused_in_between_buf = attr_container_of(source_stream,
-							  struct comp_buffer,
-							  stream, __sparse_cache);
+		unused_in_between_buf = container_of(source_stream, struct comp_buffer,
+						     stream);
 
 		source = unused_in_between_buf->source;
 
@@ -487,9 +484,8 @@ static int mixout_process(struct processing_module *mod,
 			uint32_t pending_frames;
 
 			source_stream = input_buffers[i].data;
-			unused_in_between_buf = attr_container_of(source_stream,
-								  struct comp_buffer,
-								  stream, __sparse_cache);
+			unused_in_between_buf = container_of(source_stream,
+							     struct comp_buffer, stream);
 
 			source = unused_in_between_buf->source;
 

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -17,9 +17,9 @@
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s16(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -61,7 +61,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s16(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int32_t skip_mixed_frames, n, left_frames, i, channel_count, frames, samples;
@@ -101,9 +101,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s24(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -153,9 +153,9 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s32(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int32_t frames_to_mix, frames_to_copy, left_frames;
@@ -198,7 +198,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s32(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int32_t skip_mixed_frames, left_frames, n, channel_count, i, frames, samples;

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -16,9 +16,9 @@
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s16(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -104,7 +104,7 @@ static void normal_mix_channel_s16(struct audio_stream __sparse_cache *sink, int
 	}
 }
 
-static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s16(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int skip_mixed_frames, left_frames;
@@ -140,9 +140,9 @@ static void mute_channel_s16(struct audio_stream __sparse_cache *stream, int32_t
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s24(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -230,9 +230,9 @@ static void normal_mix_channel_s24(struct audio_stream __sparse_cache *sink, int
  * parameters: multichannel stream is treated as single channel and so the entire stream
  * contents is mixed.
  */
-static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+static void normal_mix_channel_s32(struct audio_stream *sink, int32_t start_frame,
 				   int32_t mixed_frames,
-				   const struct audio_stream __sparse_cache *source,
+				   const struct audio_stream *source,
 				   int32_t frame_count, uint16_t gain)
 {
 	int frames_to_mix, frames_to_copy, left_frames;
@@ -315,7 +315,7 @@ static void normal_mix_channel_s32(struct audio_stream __sparse_cache *sink, int
 #endif	/* CONFIG_FORMAT_S32LE */
 
 #if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
-static void mute_channel_s32(struct audio_stream __sparse_cache *stream, int32_t channel_index,
+static void mute_channel_s32(struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count)
 {
 	int skip_mixed_frames, left_frames;

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -633,8 +633,8 @@ static int cadence_codec_init_process(struct processing_module *mod)
 }
 
 static int cadence_codec_prepare(struct processing_module *mod,
-				 struct sof_source __sparse_cache **sources, int num_of_sources,
-				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				 struct sof_source **sources, int num_of_sources,
+				 struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret = 0, mem_tabs_size;
 	struct comp_dev *dev = mod->dev;
@@ -716,7 +716,7 @@ cadence_codec_process(struct processing_module *mod,
 		      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct comp_buffer *local_buff;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -78,8 +78,8 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 {
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	struct comp_buffer __sparse_cache *source_c;
-	const struct audio_stream __sparse_cache *stream;
+	struct comp_buffer *source_c;
+	const struct audio_stream *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;
 	unsigned int buffer_fmt, frame_fmt, rate, channels;
@@ -184,8 +184,8 @@ static int dts_codec_init(struct processing_module *mod)
 }
 
 static int dts_codec_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_source **sources, int num_of_sources,
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -196,8 +196,8 @@ static int validate_config(struct module_config *cfg)
 }
 
 int module_prepare(struct processing_module *mod,
-		   struct sof_source __sparse_cache **sources, int num_of_sources,
-		   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		   struct sof_source **sources, int num_of_sources,
+		   struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct module_data *md = &mod->priv;
@@ -283,8 +283,8 @@ int module_process_legacy(struct processing_module *mod,
 }
 
 int module_process_sink_src(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			    struct sof_source **sources, int num_of_sources,
+			    struct sof_sink **sinks, int num_of_sinks)
 
 {
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -155,8 +155,8 @@ static int modules_init(struct processing_module *mod)
  *          There is one assumption - all IADK modules utilize IPC4 protocol.
  */
 static int modules_prepare(struct processing_module *mod,
-			   struct sof_source __sparse_cache **sources, int num_of_sources,
-			   struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			   struct sof_source **sources, int num_of_sources,
+			   struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	int ret = 0;

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -21,8 +21,8 @@ static int passthrough_codec_init(struct processing_module *mod)
 }
 
 static int passthrough_codec_prepare(struct processing_module *mod,
-				     struct sof_source __sparse_cache **sources, int num_of_sources,
-				     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				     struct sof_source **sources, int num_of_sources,
+				     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -220,10 +220,10 @@ static int waves_effect_check(struct comp_dev *dev)
 						    source_list);
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
-	struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
-	const struct audio_stream __sparse_cache *src_fmt = &source_c->stream;
-	const struct audio_stream __sparse_cache *snk_fmt = &sink_c->stream;
+	struct comp_buffer *source_c = buffer_acquire(source);
+	struct comp_buffer *sink_c = buffer_acquire(sink);
+	const struct audio_stream *src_fmt = &source_c->stream;
+	const struct audio_stream *snk_fmt = &sink_c->stream;
 	int ret = 0;
 
 	/* Init sink & source buffers */
@@ -303,10 +303,10 @@ static int waves_effect_init(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
+	struct comp_buffer *source_c = buffer_acquire(source);
 	struct module_data *codec = &mod->priv;
 	struct waves_codec_data *waves_codec = codec->private;
-	const struct audio_stream __sparse_cache *src_fmt = &source_c->stream;
+	const struct audio_stream *src_fmt = &source_c->stream;
 	MaxxStatus_t status;
 	MaxxBuffer_Format_t sample_format;
 	MaxxBuffer_Layout_t buffer_format;
@@ -686,8 +686,8 @@ static int waves_codec_init(struct processing_module *mod)
 }
 
 static int waves_codec_prepare(struct processing_module *mod,
-			       struct sof_source __sparse_cache **sources, int num_of_sources,
-			       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			       struct sof_source **sources, int num_of_sources,
+			       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	int ret;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -175,10 +175,10 @@ err:
 
 static int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *source_buffers_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer __sparse_cache *sinks_buffers_c[PLATFORM_MAX_STREAMS];
-	struct sof_sink __sparse_cache *audio_sink[PLATFORM_MAX_STREAMS];
-	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *source_buffers_c[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *sinks_buffers_c[PLATFORM_MAX_STREAMS];
+	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
+	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_of_sources = 0;
@@ -236,8 +236,8 @@ int module_adapter_prepare(struct comp_dev *dev)
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
-	struct comp_buffer __sparse_cache *buffer_c;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *buffer_c;
+	struct comp_buffer *sink_c;
 	struct comp_buffer *sink;
 	struct list_item *blist, *_blist;
 	uint32_t buff_periods;
@@ -567,7 +567,7 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
  * @bytes: number of bytes available in the source buffer
  */
 static void
-ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
+ca_copy_from_source_to_module(const struct audio_stream *source,
 			      void __sparse_cache *buff, uint32_t buff_size, size_t bytes)
 {
 	/* head_size - available data until end of source buffer */
@@ -595,7 +595,7 @@ ca_copy_from_source_to_module(const struct audio_stream __sparse_cache *source,
  * @bytes: number of bytes available in the module output buffer
  */
 static void
-ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
+ca_copy_from_module_to_sink(const struct audio_stream *sink,
 			    void __sparse_cache *buff, size_t bytes)
 {
 	/* head_size - free space until end of sink buffer */
@@ -624,7 +624,7 @@ ca_copy_from_module_to_sink(const struct audio_stream __sparse_cache *sink,
  *
  * \return: none.
  */
-static void generate_zeroes(struct comp_buffer __sparse_cache *sink, uint32_t bytes)
+static void generate_zeroes(struct comp_buffer *sink, uint32_t bytes)
 {
 	uint32_t tmp, copy_bytes = bytes;
 	void *ptr;
@@ -639,8 +639,8 @@ static void generate_zeroes(struct comp_buffer __sparse_cache *sink, uint32_t by
 	comp_update_buffer_produce(sink, bytes);
 }
 
-static void module_copy_samples(struct comp_dev *dev, struct comp_buffer __sparse_cache *src_buffer,
-				struct comp_buffer __sparse_cache *sink_buffer, uint32_t produced)
+static void module_copy_samples(struct comp_dev *dev, struct comp_buffer *src_buffer,
+				struct comp_buffer *sink_buffer, uint32_t produced)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_copy_limits cl;
@@ -681,7 +681,7 @@ static void module_adapter_process_output(struct comp_dev *dev)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct list_item *blist;
 	int i = 0;
 
@@ -692,7 +692,7 @@ static void module_adapter_process_output(struct comp_dev *dev)
 	list_for_item(blist, &mod->sink_buffer_list) {
 		if (mod->output_buffers[i].size > 0) {
 			struct comp_buffer *buffer;
-			struct comp_buffer __sparse_cache *buffer_c;
+			struct comp_buffer *buffer_c;
 
 			buffer = container_of(blist, struct comp_buffer, sink_list);
 			buffer_c = buffer_acquire(buffer);
@@ -714,7 +714,7 @@ static void module_adapter_process_output(struct comp_dev *dev)
 		list_for_item(_blist, &mod->sink_buffer_list) {
 			if (i == j) {
 				struct comp_buffer *source;
-				struct comp_buffer __sparse_cache *source_c;
+				struct comp_buffer *source_c;
 
 				sink = container_of(blist, struct comp_buffer, source_list);
 				source = container_of(_blist, struct comp_buffer, sink_list);
@@ -739,8 +739,8 @@ static void module_adapter_process_output(struct comp_dev *dev)
 
 static uint32_t
 module_single_sink_setup(struct comp_dev *dev,
-			 struct comp_buffer __sparse_cache **source_c,
-			 struct comp_buffer __sparse_cache **sinks_c)
+			 struct comp_buffer **source_c,
+			 struct comp_buffer **sinks_c)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
@@ -780,8 +780,8 @@ module_single_sink_setup(struct comp_dev *dev,
 
 static uint32_t
 module_single_source_setup(struct comp_dev *dev,
-			   struct comp_buffer __sparse_cache **source_c,
-			   struct comp_buffer __sparse_cache **sinks_c)
+			   struct comp_buffer **source_c,
+			   struct comp_buffer **sinks_c)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
@@ -824,8 +824,8 @@ module_single_source_setup(struct comp_dev *dev,
 static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_c;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *source_c;
+	struct comp_buffer *sink_c;
 	uint32_t num_output_buffers = 0;
 	uint32_t frames;
 	int ret;
@@ -872,8 +872,8 @@ static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 
 static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *source_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer __sparse_cache *sinks_c[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *source_c[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *sinks_c[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_input_buffers, num_output_buffers;
@@ -949,10 +949,10 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* consume from all active input buffers */
 	for (i = 0; i < num_input_buffers; i++) {
-		struct comp_buffer __sparse_cache *src_c;
+		struct comp_buffer *src_c;
 
 		src_c = attr_container_of(mod->input_buffers[i].data,
-					  struct comp_buffer __sparse_cache,
+					  struct comp_buffer,
 					  stream, __sparse_cache);
 		if (mod->input_buffers[i].consumed)
 			audio_stream_consume(&src_c->stream, mod->input_buffers[i].consumed);
@@ -972,10 +972,10 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* produce data into all active output buffers */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer __sparse_cache *sink_c;
+		struct comp_buffer *sink_c;
 
 		sink_c = attr_container_of(mod->output_buffers[i].data,
-					   struct comp_buffer __sparse_cache,
+					   struct comp_buffer,
 					   stream, __sparse_cache);
 
 		if (!mod->skip_sink_buffer_writeback)
@@ -1010,10 +1010,10 @@ out:
 
 static int module_adapter_sink_source_copy(struct comp_dev *dev)
 {
-	struct comp_buffer __sparse_cache *source_buffers_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer __sparse_cache *sinks_buffers_c[PLATFORM_MAX_STREAMS];
-	struct sof_sink __sparse_cache *audio_sink[PLATFORM_MAX_STREAMS];
-	struct sof_source __sparse_cache *audio_src[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *source_buffers_c[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *sinks_buffers_c[PLATFORM_MAX_STREAMS];
+	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
+	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_of_sources = 0;
@@ -1075,7 +1075,7 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
 	struct comp_buffer *source, *sink;
-	struct comp_buffer __sparse_cache *sink_c = NULL;
+	struct comp_buffer *sink_c = NULL;
 	struct list_item *blist;
 	size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
 	uint32_t min_free_frames = UINT_MAX;
@@ -1094,7 +1094,7 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 
 	/* copy source samples into input buffer */
 	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer __sparse_cache *src_c;
+		struct comp_buffer *src_c;
 		uint32_t bytes_to_process;
 		int frames, source_frame_bytes;
 
@@ -1139,7 +1139,7 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	i = 0;
 	/* consume from all input buffers */
 	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer __sparse_cache *src_c;
+		struct comp_buffer *src_c;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
 		src_c = buffer_acquire(source);
@@ -1334,7 +1334,7 @@ static int module_source_status_count(struct comp_dev *dev, uint32_t status)
 		 */
 		struct comp_buffer *source = container_of(blist, struct comp_buffer,
 							  sink_list);
-		struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
+		struct comp_buffer *source_c = buffer_acquire(source);
 
 		if (source_c->source && source_c->source->state == status)
 			count++;
@@ -1424,7 +1424,7 @@ int module_adapter_reset(struct comp_dev *dev)
 	list_for_item(blist, &mod->sink_buffer_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  sink_list);
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
+		struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
 		buffer_zero(buffer_c);
 		buffer_release(buffer_c);

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -388,8 +388,8 @@ static int multiband_drc_get_config(struct processing_module *mod,
 	return comp_data_blob_get_cmd(cd->model_handler, cdata, fragment_size);
 }
 
-static void multiband_drc_set_alignment(struct audio_stream __sparse_cache *source,
-					struct audio_stream __sparse_cache *sink)
+static void multiband_drc_set_alignment(struct audio_stream *source,
+					struct audio_stream *sink)
 {
 	/* Currently no optimizations those would use wider loads and stores */
 	audio_stream_init_alignment_constants(1, 1, source);
@@ -403,8 +403,8 @@ static int multiband_drc_process(struct processing_module *mod,
 {
 	struct multiband_drc_comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	int frames = input_buffers[0].size;
 	int ret;
 
@@ -435,7 +435,7 @@ static int multiband_drc_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -466,13 +466,13 @@ static int multiband_drc_params(struct processing_module *mod)
 #endif /* CONFIG_IPC_MAJOR_4 */
 
 static int multiband_drc_prepare(struct processing_module *mod,
-				 struct sof_source __sparse_cache **sources, int num_of_sources,
-				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				 struct sof_source **sources, int num_of_sources,
+				 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	int channels;
 	int rate;
 	int ret = 0;

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -11,8 +11,8 @@
 #include <sof/math/iir_df2t.h>
 
 static void multiband_drc_default_pass(const struct processing_module *mod,
-				       const struct audio_stream __sparse_cache *source,
-				       struct audio_stream __sparse_cache *sink,
+				       const struct audio_stream *source,
+				       struct audio_stream *sink,
 				       uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, audio_stream_get_channels(source) * frames);
@@ -203,8 +203,8 @@ static void multiband_drc_process_deemp(struct multiband_drc_state *state,
   */
 #if CONFIG_FORMAT_S16LE
 static void multiband_drc_s16_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
@@ -270,8 +270,8 @@ static void multiband_drc_s16_default(const struct processing_module *mod,
 
 #if CONFIG_FORMAT_S24LE
 static void multiband_drc_s24_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
@@ -337,8 +337,8 @@ static void multiband_drc_s24_default(const struct processing_module *mod,
 
 #if CONFIG_FORMAT_S32LE
 static void multiband_drc_s32_default(const struct processing_module *mod,
-				      const struct audio_stream __sparse_cache *source,
-				      struct audio_stream __sparse_cache *sink,
+				      const struct audio_stream *source,
+				      struct audio_stream *sink,
 				      uint32_t frames)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -274,7 +274,7 @@ static void set_mux_params(struct processing_module *mod)
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink, *source;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct list_item *source_list;
 	int j;
 	const uint32_t byte_align = 1;
@@ -375,10 +375,10 @@ static struct mux_look_up *get_lookup_table(struct comp_dev *dev, struct comp_da
 }
 
 static void mux_prepare_active_look_up(struct comp_data *cd,
-				       struct audio_stream __sparse_cache *sink,
-				       const struct audio_stream __sparse_cache **sources)
+				       struct audio_stream *sink,
+				       const struct audio_stream **sources)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	int elem;
 	int active_elem = 0;
 
@@ -400,8 +400,8 @@ static void mux_prepare_active_look_up(struct comp_data *cd,
 }
 
 static void demux_prepare_active_look_up(struct comp_data *cd,
-					 struct audio_stream __sparse_cache *sink,
-					 const struct audio_stream __sparse_cache *source,
+					 struct audio_stream *sink,
+					 const struct audio_stream *source,
 					 struct mux_look_up *look_up)
 {
 	int elem;
@@ -429,8 +429,8 @@ static int demux_process(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct list_item *clist;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
-	struct audio_stream __sparse_cache *sinks_stream[MUX_MAX_STREAMS] = { NULL };
+	struct comp_buffer *sink_c;
+	struct audio_stream *sinks_stream[MUX_MAX_STREAMS] = { NULL };
 	struct mux_look_up *look_ups[MUX_MAX_STREAMS] = { NULL };
 	int frames;
 	int sink_bytes;
@@ -487,9 +487,9 @@ static int mux_process(struct processing_module *mod,
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
+	struct comp_buffer *source_c;
 	struct list_item *clist;
-	const struct audio_stream __sparse_cache *sources_stream[MUX_MAX_STREAMS] = { NULL };
+	const struct audio_stream *sources_stream[MUX_MAX_STREAMS] = { NULL };
 	int frames = 0;
 	int sink_bytes;
 	int source_bytes;
@@ -560,7 +560,7 @@ static int mux_reset(struct processing_module *mod)
 		list_for_item(blist, &dev->bsource_list) {
 			struct comp_buffer *source = container_of(blist, struct comp_buffer,
 								  sink_list);
-			struct comp_buffer __sparse_cache *source_c = buffer_acquire(source);
+			struct comp_buffer *source_c = buffer_acquire(source);
 			int state = source_c->source->state;
 
 			buffer_release(source_c);
@@ -578,16 +578,16 @@ static int mux_reset(struct processing_module *mod)
 }
 
 static int mux_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
 	struct list_item *blist;
 	struct comp_buffer *source;
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *source_c;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *source_c;
+	struct comp_buffer *sink_c;
 	struct sof_mux_config *config;
 	size_t blob_size;
 	int state;

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -19,11 +19,11 @@
 
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
-static void mux_check_for_wrap(struct audio_stream __sparse_cache *sink,
-			       const struct audio_stream __sparse_cache **sources,
+static void mux_check_for_wrap(struct audio_stream *sink,
+			       const struct audio_stream **sources,
 			       struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* check sources and destinations for wrap */
@@ -36,8 +36,8 @@ static void mux_check_for_wrap(struct audio_stream __sparse_cache *sink,
 	}
 }
 
-static void demux_check_for_wrap(struct audio_stream __sparse_cache *sink,
-				 const struct audio_stream __sparse_cache *source,
+static void demux_check_for_wrap(struct audio_stream *sink,
+				 const struct audio_stream *source,
 				 struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -53,7 +53,7 @@ static void demux_check_for_wrap(struct audio_stream __sparse_cache *sink,
 
 #if CONFIG_FORMAT_S16LE
 
-static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream __sparse_cache *sink,
+static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 						   const struct audio_stream
 						   __sparse_cache *source,
 						   struct mux_look_up *lookup)
@@ -79,12 +79,12 @@ static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream __sparse_
 	return min_frames;
 }
 
-static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream __sparse_cache *sink,
+static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 						 const struct audio_stream
 						 __sparse_cache **sources,
 						 struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t frames;
 	uint32_t min_frames;
 	uint32_t elem;
@@ -111,11 +111,11 @@ static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream __sparse_ca
 	return min_frames;
 }
 
-static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *sink,
-					  const struct audio_stream __sparse_cache **sources,
+static void mux_init_look_up_pointers_s16(struct audio_stream *sink,
+					  const struct audio_stream **sources,
 					  struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* init pointers */
@@ -132,8 +132,8 @@ static void mux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *si
 	}
 }
 
-static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *sink,
-					    const struct audio_stream __sparse_cache *source,
+static void demux_init_look_up_pointers_s16(struct audio_stream *sink,
+					    const struct audio_stream *source,
 					    struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -162,8 +162,8 @@ static void demux_init_look_up_pointers_s16(struct audio_stream __sparse_cache *
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void demux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache *source, uint32_t frames,
+static void demux_s16le(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream *source, uint32_t frames,
 			struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -215,8 +215,8 @@ static void demux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void mux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t frames,
+static void mux_s16le(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -259,12 +259,12 @@ static void mux_s16le(struct comp_dev *dev, struct audio_stream __sparse_cache *
 
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 
-static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream __sparse_cache *sink,
+static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 						 const struct audio_stream
 						 __sparse_cache **sources,
 						 struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t frames;
 	uint32_t min_frames;
 	uint32_t elem;
@@ -289,7 +289,7 @@ static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream __sparse_ca
 	return min_frames;
 }
 
-static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream __sparse_cache *sink,
+static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 						   const struct audio_stream
 						   __sparse_cache *source,
 						   struct mux_look_up *lookup)
@@ -313,11 +313,11 @@ static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream __sparse_
 	return min_frames;
 }
 
-static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *sink,
-					  const struct audio_stream __sparse_cache **sources,
+static void mux_init_look_up_pointers_s32(struct audio_stream *sink,
+					  const struct audio_stream **sources,
 					  struct mux_look_up *lookup)
 {
-	const struct audio_stream __sparse_cache *source;
+	const struct audio_stream *source;
 	uint32_t elem;
 
 	/* init pointers */
@@ -334,8 +334,8 @@ static void mux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *si
 	}
 }
 
-static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *sink,
-					    const struct audio_stream __sparse_cache *source,
+static void demux_init_look_up_pointers_s32(struct audio_stream *sink,
+					    const struct audio_stream *source,
 					    struct mux_look_up *lookup)
 {
 	uint32_t elem;
@@ -364,8 +364,8 @@ static void demux_init_look_up_pointers_s32(struct audio_stream __sparse_cache *
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void demux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache *source, uint32_t frames,
+static void demux_s32le(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream *source, uint32_t frames,
 			struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -417,8 +417,8 @@ static void demux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache
  * @param[in] frames Number of frames to process.
  * @param[in] lookup mux look up table.
  */
-static void mux_s32le(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-		      const struct audio_stream __sparse_cache **sources, uint32_t frames,
+static void mux_s32le(struct comp_dev *dev, struct audio_stream *sink,
+		      const struct audio_stream **sources, uint32_t frames,
 		      struct mux_look_up *lookup)
 {
 	uint32_t i;
@@ -534,7 +534,7 @@ mux_func mux_get_processing_function(struct processing_module *mod)
 				source_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sinkb);
+		struct comp_buffer *sink_c = buffer_acquire(sinkb);
 		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sink_c->stream);
 
 
@@ -558,7 +558,7 @@ demux_func demux_get_processing_function(struct processing_module *mod)
 				sink_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer __sparse_cache *source_c = buffer_acquire(sourceb);
+		struct comp_buffer *source_c = buffer_acquire(sourceb);
 		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_c->stream);
 
 		buffer_release(source_c);

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -54,8 +54,7 @@ static void demux_check_for_wrap(struct audio_stream *sink,
 #if CONFIG_FORMAT_S16LE
 
 static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
-						   const struct audio_stream
-						   __sparse_cache *source,
+						   const struct audio_stream *source,
 						   struct mux_look_up *lookup)
 {
 	uint32_t frames;
@@ -80,8 +79,7 @@ static uint32_t demux_calc_frames_without_wrap_s16(struct audio_stream *sink,
 }
 
 static uint32_t mux_calc_frames_without_wrap_s16(struct audio_stream *sink,
-						 const struct audio_stream
-						 __sparse_cache **sources,
+						 const struct audio_stream **sources,
 						 struct mux_look_up *lookup)
 {
 	const struct audio_stream *source;
@@ -260,8 +258,7 @@ static void mux_s16le(struct comp_dev *dev, struct audio_stream *sink,
 #if CONFIG_FORMAT_S24LE || CONFIG_FORMAT_S32LE
 
 static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
-						 const struct audio_stream
-						 __sparse_cache **sources,
+						 const struct audio_stream **sources,
 						 struct mux_look_up *lookup)
 {
 	const struct audio_stream *source;
@@ -290,8 +287,7 @@ static uint32_t mux_calc_frames_without_wrap_s32(struct audio_stream *sink,
 }
 
 static uint32_t demux_calc_frames_without_wrap_s32(struct audio_stream *sink,
-						   const struct audio_stream
-						   __sparse_cache *source,
+						   const struct audio_stream *source,
 						   struct mux_look_up *lookup)
 {
 	uint32_t frames;

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -15,8 +15,8 @@
 #include <sof/audio/pcm_converter.h>
 #include <rtos/panic.h>
 
-int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-			  struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
+			  struct audio_stream *sink, uint32_t ooffset,
 			  uint32_t samples, pcm_converter_lin_func converter)
 {
 	const int s_size_in = audio_stream_sample_bytes(source);

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -34,9 +34,9 @@
 #define BYTES_TO_S32_SAMPLES	2
 
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
-static int pcm_convert_u8_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
-				uint32_t ooffset, uint32_t samples)
+static int pcm_convert_u8_to_s32(const struct audio_stream *source,
+				 uint32_t ioffset, struct audio_stream *sink,
+				 uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -63,9 +63,9 @@ static int pcm_convert_u8_to_s32(const struct audio_stream __sparse_cache *sourc
 	return samples;
 }
 
-static int pcm_convert_s32_to_u8(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
-				uint32_t ooffset, uint32_t samples)
+static int pcm_convert_s32_to_u8(const struct audio_stream *source,
+				 uint32_t ioffset, struct audio_stream *sink,
+				 uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = audio_stream_get_wptr(sink);
@@ -95,8 +95,8 @@ static int pcm_convert_s32_to_u8(const struct audio_stream __sparse_cache *sourc
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 
-static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -124,8 +124,8 @@ static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -157,8 +157,8 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -186,8 +186,8 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -219,8 +219,8 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -248,8 +248,8 @@ static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -277,8 +277,8 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *source,
-				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
+				     uint32_t ioffset, struct audio_stream *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -442,16 +442,16 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int16(_pcm_convert_f_to_i(src[i], 15));
 }
 
-static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s16_to_f_lin);
 }
 
-static int pcm_convert_f_to_s16(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s16(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -486,16 +486,16 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int24(_pcm_convert_f_to_i(src[i], 23));
 }
 
-static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s24_to_f_lin);
 }
 
-static int pcm_convert_f_to_s24(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s24(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -530,16 +530,16 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
 		dst[i] = _pcm_convert_f_to_i(src[i], 31);
 }
 
-static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s32_to_f_lin);
 }
 
-static int pcm_convert_f_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -599,8 +599,8 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -628,8 +628,8 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -658,8 +658,8 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -687,8 +687,8 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -717,8 +717,8 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -746,8 +746,8 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -777,8 +777,8 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
@@ -807,8 +807,8 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cache *source,
-					  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
+					  uint32_t ioffset, struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -841,8 +841,8 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cac
 }
 
 /* 2x24bit samples are packed into 3x16bit samples for hda link dma */
-static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream __sparse_cache *source,
-						   uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *source,
+						   uint32_t ioffset, struct audio_stream *sink,
 						   uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -36,8 +36,8 @@
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static int pcm_convert_s16_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	ae_int16x4 sample = AE_ZERO16();
@@ -110,8 +110,8 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	ae_int16x4 sample = AE_ZERO16();
@@ -181,8 +181,8 @@ static int pcm_convert_s24_to_s16(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -237,8 +237,8 @@ static int pcm_convert_s16_to_s32(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s16(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -303,8 +303,8 @@ static int pcm_convert_s32_to_s16(const struct audio_stream __sparse_cache *sour
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s32(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_s32(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -368,8 +368,8 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -413,8 +413,8 @@ static int pcm_convert_s32_to_s24(const struct audio_stream __sparse_cache *sour
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream __sparse_cache *source,
-				     uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
+				     uint32_t ioffset, struct audio_stream *sink,
 				     uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -541,8 +541,8 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s16_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -556,8 +556,8 @@ static int pcm_convert_s16_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s16(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s16(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -642,8 +642,8 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s24_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -657,8 +657,8 @@ static int pcm_convert_s24_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s24(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s24(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -739,8 +739,8 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_s32_to_f(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -754,8 +754,8 @@ static int pcm_convert_s32_to_f(const struct audio_stream __sparse_cache *source
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s32(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+static int pcm_convert_f_to_s32(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t samples)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
@@ -810,9 +810,9 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int16_t *src = audio_stream_get_rptr(source);
@@ -860,9 +860,9 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -919,9 +919,9 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -962,9 +962,9 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1007,9 +1007,9 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1062,9 +1062,9 @@ static ae_int32x2 pcm_shift_s24_c32_to_s16(ae_int32x2 sample)
 	return sample;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);
@@ -1109,9 +1109,9 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream __sparse_cac
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
@@ -1156,9 +1156,9 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream __sparse_cac
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream __sparse_cache *source,
+static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 					  uint32_t ioffset,
-					  struct audio_stream __sparse_cache *sink,
+					  struct audio_stream *sink,
 					  uint32_t ooffset, uint32_t samples)
 {
 	int32_t *src = audio_stream_get_rptr(source);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -168,7 +168,7 @@ free:
 static void buffer_set_comp(struct comp_buffer *buffer, struct comp_dev *comp,
 			    int dir)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
+	struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
 		buffer_c->source = comp;
@@ -410,7 +410,7 @@ int pipeline_for_each_comp(struct comp_dev *current,
 	/* run this operation further */
 	list_for_item(clist, buffer_list) {
 		struct comp_buffer *buffer = buffer_from_list(clist, dir);
-		struct comp_buffer __sparse_cache *buffer_c;
+		struct comp_buffer *buffer_c;
 		struct comp_dev *buffer_comp;
 		int err = 0;
 

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -30,7 +30,7 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 				    int dir)
 {
 	struct pipeline_data *ppl_data = ctx->comp_data;
-	struct comp_buffer __sparse_cache *buf_c = buffer_acquire(calling_buf);
+	struct comp_buffer *buf_c = buffer_acquire(calling_buf);
 	int err = 0;
 
 	pipe_dbg(current->pipeline, "pipeline_comp_params_neg(), current->comp.id = %u, dir = %u",
@@ -131,7 +131,7 @@ static int pipeline_comp_params(struct comp_dev *current,
 }
 
 /* save params changes made by component */
-static void pipeline_update_buffer_pcm_params(struct comp_buffer __sparse_cache *buffer,
+static void pipeline_update_buffer_pcm_params(struct comp_buffer *buffer,
 					      void *data)
 {
 	struct sof_ipc_stream_params *params = data;
@@ -188,7 +188,7 @@ static int pipeline_comp_hw_params_buf(struct comp_dev *current,
 		return ret;
 	/* set buffer parameters */
 	if (calling_buf) {
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(calling_buf);
+		struct comp_buffer *buf_c = buffer_acquire(calling_buf);
 
 		ret = buffer_set_params(buf_c, &ppl_data->params->params,
 					BUFFER_UPDATE_IF_UNSET);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -325,7 +325,7 @@ static int rtnr_params(struct comp_dev *dev, struct sof_ipc_stream_params *param
 	int ret;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	bool channels_valid;
 
 	comp_info(dev, "rtnr_params()");
@@ -727,7 +727,7 @@ static int rtnr_trigger(struct comp_dev *dev, int cmd)
 }
 
 static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
-				      struct audio_stream __sparse_cache *src)
+				      struct audio_stream *src)
 {
 
 	dst->size = audio_stream_get_size(src);
@@ -739,7 +739,7 @@ static void rtnr_copy_from_sof_stream(struct audio_stream_rtnr *dst,
 	dst->end_addr = audio_stream_get_end_addr(src);
 }
 
-static void rtnr_copy_to_sof_stream(struct audio_stream __sparse_cache *dst,
+static void rtnr_copy_to_sof_stream(struct audio_stream *dst,
 				    struct audio_stream_rtnr *src)
 {
 	audio_stream_set_size(dst, src->size);
@@ -851,7 +851,7 @@ static int rtnr_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	int ret;
 
 	comp_dbg(dev, "rtnr_prepare()");

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -60,7 +60,7 @@ static int selector_verify_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *buffer, *sinkb;
-	struct comp_buffer __sparse_cache *buffer_c, *sink_c;
+	struct comp_buffer *buffer_c, *sink_c;
 	uint32_t in_channels;
 	uint32_t out_channels;
 
@@ -358,7 +358,7 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 static int selector_trigger(struct comp_dev *dev, int cmd)
 {
 	struct comp_buffer *sourceb;
-	struct comp_buffer __sparse_cache *source_c;
+	struct comp_buffer *source_c;
 	enum sof_comp_type type;
 	int ret;
 
@@ -391,7 +391,7 @@ static int selector_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sink, *source;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	uint32_t frames;
 	uint32_t source_bytes;
 	uint32_t sink_bytes;
@@ -444,7 +444,7 @@ static int selector_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	size_t sink_size;
 	int ret;
 
@@ -673,7 +673,7 @@ static void set_selector_params(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
-	struct comp_buffer __sparse_cache *source;
+	struct comp_buffer *source;
 	const struct sof_selector_ipc4_config *sel_cfg = &cd->sel_ipc4_cfg;
 	const struct ipc4_audio_format *out_fmt = NULL;
 	struct comp_buffer *src_buf;
@@ -700,7 +700,7 @@ static void set_selector_params(struct processing_module *mod,
 	list_for_item(sink_list, &dev->bsink_list) {
 		struct comp_buffer *sink_buf =
 			container_of(sink_list, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *sink = buffer_acquire(sink_buf);
+		struct comp_buffer *sink = buffer_acquire(sink_buf);
 
 		ipc4_update_buffer_format(sink, out_fmt);
 		audio_stream_set_channels(&sink->stream, params->channels);
@@ -729,7 +729,7 @@ static int selector_verify_params(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	uint32_t in_channels = cd->config.in_channels_count;
 	uint32_t out_channels = cd->config.out_channels_count;
 
@@ -862,14 +862,14 @@ static int selector_process(struct processing_module *mod,
  * \return Error code.
  */
 static int selector_prepare(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			    struct sof_source **sources, int num_of_sources,
+			    struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	size_t sink_size;
 	int ret;
 

--- a/src/audio/selector/selector_generic.c
+++ b/src/audio/selector/selector_generic.c
@@ -32,8 +32,8 @@ LOG_MODULE_DECLARE(selector, CONFIG_SOF_LOG_LEVEL);
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int16_t *src = audio_stream_get_rptr(source);
@@ -72,8 +72,8 @@ static void sel_s16le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = audio_stream_get_wptr(sink);
@@ -104,8 +104,8 @@ static void sel_s16le_nch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	int32_t *src = audio_stream_get_rptr(source);
@@ -144,8 +144,8 @@ static void sel_s32le_1ch(struct comp_dev *dev, struct audio_stream __sparse_cac
  * \param[in,out] source Source buffer.
  * \param[in] frames Number of frames to process.
  */
-static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames)
+static void sel_s32le_nch(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames)
 {
 	int8_t *src = audio_stream_get_rptr(source);
 	int8_t *dst = audio_stream_get_wptr(sink);
@@ -206,8 +206,8 @@ static void sel_s16le(struct processing_module *mod, struct input_stream_buffer 
 		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *src = audio_stream_get_rptr(source);
 	int16_t *dest = audio_stream_get_wptr(sink);
 	int nmax;
@@ -277,8 +277,8 @@ static void sel_s32le(struct processing_module *mod, struct input_stream_buffer 
 		      struct output_stream_buffer *bsink, uint32_t frames)
 {
 	struct comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dest = audio_stream_get_wptr(sink);
 	int nmax;

--- a/src/audio/sink_api_helper.c
+++ b/src/audio/sink_api_helper.c
@@ -7,19 +7,19 @@
 #include <sof/audio/sink_api_implementation.h>
 #include <sof/audio/audio_stream.h>
 
-void sink_init(struct sof_sink __sparse_cache *sink, const struct sink_ops *ops,
+void sink_init(struct sof_sink *sink, const struct sink_ops *ops,
 	       struct sof_audio_stream_params *audio_stream_params)
 {
 	sink->ops = ops;
 	sink->audio_stream_params = audio_stream_params;
 }
 
-size_t sink_get_free_size(struct sof_sink __sparse_cache *sink)
+size_t sink_get_free_size(struct sof_sink *sink)
 {
 	return sink->ops->get_free_size(sink);
 }
 
-int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+int sink_get_buffer(struct sof_sink *sink, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
 	int ret;
@@ -35,7 +35,7 @@ int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
 	return ret;
 }
 
-int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
+int sink_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
 	int ret;
 
@@ -56,47 +56,47 @@ int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
 	return ret;
 }
 
-size_t sink_get_num_of_processed_bytes(struct sof_sink __sparse_cache *sink)
+size_t sink_get_num_of_processed_bytes(struct sof_sink *sink)
 {
 	return sink->num_of_bytes_processed;
 }
 
-void sink_reset_num_of_processed_bytes(struct sof_sink __sparse_cache *sink)
+void sink_reset_num_of_processed_bytes(struct sof_sink *sink)
 {
 	sink->num_of_bytes_processed = 0;
 }
 
-enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink __sparse_cache *sink)
+enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->frame_fmt;
 }
 
-enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink __sparse_cache *sink)
+enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->valid_sample_fmt;
 }
 
-uint32_t sink_get_rate(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_rate(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->rate;
 }
 
-uint32_t sink_get_channels(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_channels(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->channels;
 }
 
-uint32_t sink_get_buffer_fmt(struct sof_sink __sparse_cache *sink)
+uint32_t sink_get_buffer_fmt(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->buffer_fmt;
 }
 
-bool sink_get_overrun(struct sof_sink __sparse_cache *sink)
+bool sink_get_overrun(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->overrun_permitted;
 }
 
-int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame frame_fmt)
+int sink_set_frm_fmt(struct sof_sink *sink, enum sof_ipc_frame frame_fmt)
 {
 	sink->audio_stream_params->frame_fmt = frame_fmt;
 
@@ -106,7 +106,7 @@ int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame fr
 	return 0;
 }
 
-int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink,
+int sink_set_valid_fmt(struct sof_sink *sink,
 		       enum sof_ipc_frame valid_sample_fmt)
 {
 	sink->audio_stream_params->valid_sample_fmt = valid_sample_fmt;
@@ -115,7 +115,7 @@ int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate)
+int sink_set_rate(struct sof_sink *sink, unsigned int rate)
 {
 	sink->audio_stream_params->rate = rate;
 	if (sink->ops->on_audio_format_set)
@@ -123,7 +123,7 @@ int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate)
 	return 0;
 }
 
-int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channels)
+int sink_set_channels(struct sof_sink *sink, unsigned int channels)
 {
 	sink->audio_stream_params->channels = channels;
 	if (sink->ops->on_audio_format_set)
@@ -131,7 +131,7 @@ int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channel
 	return 0;
 }
 
-int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fmt)
+int sink_set_buffer_fmt(struct sof_sink *sink, uint32_t buffer_fmt)
 {
 	sink->audio_stream_params->buffer_fmt = buffer_fmt;
 	if (sink->ops->on_audio_format_set)
@@ -139,7 +139,7 @@ int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fm
 	return 0;
 }
 
-int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitted)
+int sink_set_overrun(struct sof_sink *sink, bool overrun_permitted)
 {
 	sink->audio_stream_params->overrun_permitted = overrun_permitted;
 	if (sink->ops->on_audio_format_set)
@@ -147,19 +147,19 @@ int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitte
 	return 0;
 }
 
-size_t sink_get_frame_bytes(struct sof_sink __sparse_cache *sink)
+size_t sink_get_frame_bytes(struct sof_sink *sink)
 {
 	return get_frame_bytes(sink_get_frm_fmt(sink),
 				sink_get_channels(sink));
 }
 
-size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink)
+size_t sink_get_free_frames(struct sof_sink *sink)
 {
 	return sink_get_free_size(sink) /
 			sink_get_frame_bytes(sink);
 }
 
-int sink_set_params(struct sof_sink __sparse_cache *sink,
+int sink_set_params(struct sof_sink *sink,
 		    struct sof_ipc_stream_params *params, bool force_update)
 {
 	if (sink->ops->audio_set_ipc_params)
@@ -167,7 +167,7 @@ int sink_set_params(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+int sink_set_alignment_constants(struct sof_sink *sink,
 				 const uint32_t byte_align,
 				 const uint32_t frame_align_req)
 {
@@ -176,12 +176,12 @@ int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
 	return 0;
 }
 
-void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs)
+void sink_set_obs(struct sof_sink *sink, size_t obs)
 {
 	sink->obs = obs;
 }
 
-size_t sink_get_obs(struct sof_sink __sparse_cache *sink)
+size_t sink_get_obs(struct sof_sink *sink)
 {
 	return sink->obs;
 }

--- a/src/audio/sink_source_utils.c
+++ b/src/audio/sink_source_utils.c
@@ -12,8 +12,8 @@
 #include <sof/math/numbers.h>
 #include <limits.h>
 
-int source_to_sink_copy(struct sof_source __sparse_cache *source,
-			struct sof_sink __sparse_cache *sink, bool free, size_t size)
+int source_to_sink_copy(struct sof_source *source,
+			struct sof_sink *sink, bool free, size_t size)
 {
 	uint8_t *src_ptr;
 	uint8_t *src_begin;

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -26,8 +26,8 @@ DECLARE_TR_CTX(maxim_dsm_comp_tr, SOF_UUID(maxim_dsm_comp_uuid),
 #define SOF_SMART_AMP_MODEL 1
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink, uint32_t frames,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink, uint32_t frames,
 			     int8_t *chan_map, bool is_feedback);
 
 struct smart_amp_data {
@@ -518,7 +518,7 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
 		if (sad->feedback_buf) {
-			struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
+			struct comp_buffer *buf = buffer_acquire(sad->feedback_buf);
 			buffer_zero(buf);
 			buffer_release(buf);
 		}
@@ -534,8 +534,8 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 }
 
 static int smart_amp_process(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink,
 			     uint32_t frames, int8_t *chan_map,
 			     bool is_feedback)
 {
@@ -558,7 +558,7 @@ static int smart_amp_process(struct comp_dev *dev,
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
+	struct comp_buffer *source_buf = buffer_acquire(sad->source_buf);
 	enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_buf->stream);
 
 	buffer_release(source_buf);
@@ -577,8 +577,8 @@ static smart_amp_proc get_smart_amp_process(struct comp_dev *dev)
 static int smart_amp_copy(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
-	struct comp_buffer __sparse_cache *sink_buf = buffer_acquire(sad->sink_buf);
+	struct comp_buffer *source_buf = buffer_acquire(sad->source_buf);
+	struct comp_buffer *sink_buf = buffer_acquire(sad->sink_buf);
 	uint32_t avail_passthrough_frames;
 	uint32_t avail_feedback_frames;
 	uint32_t avail_frames;
@@ -595,7 +595,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	avail_frames = avail_passthrough_frames;
 
 	if (sad->feedback_buf) {
-		struct comp_buffer __sparse_cache *feedback_buf = buffer_acquire(sad->feedback_buf);
+		struct comp_buffer *feedback_buf = buffer_acquire(sad->feedback_buf);
 
 		if (comp_get_state(dev, feedback_buf->source) == dev->state) {
 			/* feedback */
@@ -661,7 +661,7 @@ static int smart_amp_reset(struct comp_dev *dev)
 static int smart_amp_prepare(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_c, *buf_c;
+	struct comp_buffer *source_c, *buf_c;
 	struct list_item *blist;
 	int ret;
 	int bitwidth;

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -24,9 +24,9 @@ static void smart_amp_fb_generic(int32_t x)
 
 #if CONFIG_FORMAT_S16LE
 static void smart_amp_s16_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int16_t *x;
@@ -52,9 +52,9 @@ static void smart_amp_s16_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void smart_amp_s24_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -80,9 +80,9 @@ static void smart_amp_s24_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void smart_amp_s32_ff_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -106,9 +106,9 @@ static void smart_amp_s32_ff_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S16LE
 static void smart_amp_s16_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int16_t *x;
@@ -130,9 +130,9 @@ static void smart_amp_s16_fb_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S24LE
 static void smart_amp_s24_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;
@@ -154,9 +154,9 @@ static void smart_amp_s24_fb_default(const struct comp_dev *dev,
 
 #if CONFIG_FORMAT_S32LE
 static void smart_amp_s32_fb_default(const struct comp_dev *dev,
-				     const struct audio_stream __sparse_cache *source,
-				     const struct audio_stream __sparse_cache *sink,
-				     const struct audio_stream __sparse_cache *feedback,
+				     const struct audio_stream *source,
+				     const struct audio_stream *sink,
+				     const struct audio_stream *feedback,
 				     uint32_t frames)
 {
 	int32_t *x;

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -579,7 +579,7 @@ int smart_amp_check_audio_fmt(int sample_rate, int ch_num)
 }
 
 static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
-				const struct audio_stream __sparse_cache *stream,
+				const struct audio_stream *stream,
 				int8_t *chan_map, uint32_t num_ch)
 {
 	int idx, ch;
@@ -629,7 +629,7 @@ static int smart_amp_get_buffer(int32_t *buf, uint32_t frames,
 }
 
 static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
-				const struct audio_stream __sparse_cache *stream,
+				const struct audio_stream *stream,
 				int8_t *chan_map, uint32_t num_ch_in,
 				uint32_t num_ch_out)
 {
@@ -681,8 +681,8 @@ static int smart_amp_put_buffer(int32_t *buf, uint32_t frames,
 }
 
 int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch_in, uint32_t num_ch_out)
 {
@@ -741,8 +741,8 @@ err:
 }
 
 int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch)
 {

--- a/src/audio/source_api_helper.c
+++ b/src/audio/source_api_helper.c
@@ -7,7 +7,7 @@
 #include <sof/audio/source_api_implementation.h>
 #include <sof/audio/audio_stream.h>
 
-void source_init(struct sof_source __sparse_cache *source, const struct source_ops *ops,
+void source_init(struct sof_source *source, const struct source_ops *ops,
 		 struct sof_audio_stream_params *audio_stream_params)
 {
 	source->ops = ops;
@@ -15,12 +15,12 @@ void source_init(struct sof_source __sparse_cache *source, const struct source_o
 	source->audio_stream_params = audio_stream_params;
 }
 
-size_t source_get_data_available(struct sof_source __sparse_cache *source)
+size_t source_get_data_available(struct sof_source *source)
 {
 	return source->ops->get_data_available(source);
 }
 
-int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+int source_get_data(struct sof_source *source, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
 	int ret;
@@ -35,7 +35,7 @@ int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
 	return ret;
 }
 
-int source_release_data(struct sof_source __sparse_cache *source, size_t free_size)
+int source_release_data(struct sof_source *source, size_t free_size)
 {
 	int ret;
 
@@ -56,47 +56,47 @@ int source_release_data(struct sof_source __sparse_cache *source, size_t free_si
 	return ret;
 }
 
-size_t source_get_num_of_processed_bytes(struct sof_source __sparse_cache *source)
+size_t source_get_num_of_processed_bytes(struct sof_source *source)
 {
 	return source->num_of_bytes_processed;
 }
 
-void source_reset_num_of_processed_bytes(struct sof_source __sparse_cache *source)
+void source_reset_num_of_processed_bytes(struct sof_source *source)
 {
 	source->num_of_bytes_processed = 0;
 }
 
-enum sof_ipc_frame source_get_frm_fmt(struct sof_source __sparse_cache *source)
+enum sof_ipc_frame source_get_frm_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->frame_fmt;
 }
 
-enum sof_ipc_frame source_get_valid_fmt(struct sof_source __sparse_cache *source)
+enum sof_ipc_frame source_get_valid_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->valid_sample_fmt;
 }
 
-unsigned int source_get_rate(struct sof_source __sparse_cache *source)
+unsigned int source_get_rate(struct sof_source *source)
 {
 	return source->audio_stream_params->rate;
 }
 
-unsigned int source_get_channels(struct sof_source __sparse_cache *source)
+unsigned int source_get_channels(struct sof_source *source)
 {
 	return source->audio_stream_params->channels;
 }
 
-uint32_t source_get_buffer_fmt(struct sof_source __sparse_cache *source)
+uint32_t source_get_buffer_fmt(struct sof_source *source)
 {
 	return source->audio_stream_params->buffer_fmt;
 }
 
-bool source_get_underrun(struct sof_source __sparse_cache *source)
+bool source_get_underrun(struct sof_source *source)
 {
 	return source->audio_stream_params->underrun_permitted;
 }
 
-int source_set_valid_fmt(struct sof_source __sparse_cache *source,
+int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt)
 {
 	source->audio_stream_params->valid_sample_fmt = valid_sample_fmt;
@@ -105,7 +105,7 @@ int source_set_valid_fmt(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate)
+int source_set_rate(struct sof_source *source, unsigned int rate)
 {
 	source->audio_stream_params->rate = rate;
 	if (source->ops->on_audio_format_set)
@@ -113,7 +113,7 @@ int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate)
 	return 0;
 }
 
-int source_set_channels(struct sof_source __sparse_cache *source, unsigned int channels)
+int source_set_channels(struct sof_source *source, unsigned int channels)
 {
 	source->audio_stream_params->channels = channels;
 	if (source->ops->on_audio_format_set)
@@ -121,7 +121,7 @@ int source_set_channels(struct sof_source __sparse_cache *source, unsigned int c
 	return 0;
 }
 
-int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buffer_fmt)
+int source_set_buffer_fmt(struct sof_source *source, uint32_t buffer_fmt)
 {
 	source->audio_stream_params->buffer_fmt = buffer_fmt;
 	if (source->ops->on_audio_format_set)
@@ -129,7 +129,7 @@ int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buf
 	return 0;
 }
 
-int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_permitted)
+int source_set_underrun(struct sof_source *source, bool underrun_permitted)
 {
 	source->audio_stream_params->underrun_permitted = underrun_permitted;
 	if (source->ops->on_audio_format_set)
@@ -137,19 +137,19 @@ int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_
 	return 0;
 }
 
-size_t source_get_frame_bytes(struct sof_source __sparse_cache *source)
+size_t source_get_frame_bytes(struct sof_source *source)
 {
 	return get_frame_bytes(source_get_frm_fmt(source),
 				source_get_channels(source));
 }
 
-size_t source_get_data_frames_available(struct sof_source __sparse_cache *source)
+size_t source_get_data_frames_available(struct sof_source *source)
 {
 	return source_get_data_available(source) /
 			source_get_frame_bytes(source);
 }
 
-int source_set_params(struct sof_source __sparse_cache *source,
+int source_set_params(struct sof_source *source,
 		      struct sof_ipc_stream_params *params, bool force_update)
 {
 	if (source->ops->audio_set_ipc_params)
@@ -157,7 +157,7 @@ int source_set_params(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-int source_set_alignment_constants(struct sof_source __sparse_cache *source,
+int source_set_alignment_constants(struct sof_source *source,
 				   const uint32_t byte_align,
 				   const uint32_t frame_align_req)
 {
@@ -166,12 +166,12 @@ int source_set_alignment_constants(struct sof_source __sparse_cache *source,
 	return 0;
 }
 
-void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs)
+void source_set_ibs(struct sof_source *source, size_t ibs)
 {
 	source->ibs = ibs;
 }
 
-size_t source_get_ibs(struct sof_source __sparse_cache *source)
+size_t source_get_ibs(struct sof_source *source)
 {
 	return source->ibs;
 }

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -101,8 +101,8 @@ struct comp_data {
 	int sink_frames;
 	int sample_container_bytes;
 	int channels_count;
-	int (*src_func)(struct comp_data *cd, struct sof_source __sparse_cache *source,
-			struct sof_sink __sparse_cache *sink);
+	int (*src_func)(struct comp_data *cd, struct sof_source *source,
+			struct sof_sink *sink);
 	void (*polyphase_func)(struct src_stage_prm *s);
 };
 
@@ -335,15 +335,15 @@ int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
 }
 
 /* Fallback function */
-static int src_fallback(struct comp_data *cd, struct sof_source __sparse_cache *source,
-			struct sof_sink __sparse_cache *sink)
+static int src_fallback(struct comp_data *cd, struct sof_source *source,
+			struct sof_sink *sink)
 {
 	return 0;
 }
 
 /* Normal 2 stage SRC */
 static int src_2s(struct comp_data *cd,
-		  struct sof_source __sparse_cache *source, struct sof_sink __sparse_cache *sink)
+		  struct sof_source *source, struct sof_sink *sink)
 {
 	struct src_stage_prm s1;
 	struct src_stage_prm s2;
@@ -443,8 +443,8 @@ static int src_2s(struct comp_data *cd,
 }
 
 /* 1 stage SRC for simple conversions */
-static int src_1s(struct comp_data *cd, struct sof_source __sparse_cache *source,
-		  struct sof_sink __sparse_cache *sink)
+static int src_1s(struct comp_data *cd, struct sof_source *source,
+		  struct sof_sink *sink)
 {
 	struct src_stage_prm s1;
 	int ret;
@@ -482,8 +482,8 @@ static int src_1s(struct comp_data *cd, struct sof_source __sparse_cache *source
 }
 
 /* A fast copy function for same in and out rate */
-static int src_copy_sxx(struct comp_data *cd, struct sof_source __sparse_cache *source,
-			struct sof_sink __sparse_cache *sink)
+static int src_copy_sxx(struct comp_data *cd, struct sof_source *source,
+			struct sof_sink *sink)
 {
 	int frames = cd->param.blk_in;
 
@@ -531,7 +531,7 @@ static int src_stream_pcm_sink_rate_check(struct ipc4_config_src cfg,
  * set up param then verify param. BTW for IPC3 path, the param is sent by
  * host driver.
  */
-static int src_set_params(struct processing_module *mod, struct sof_sink __sparse_cache *sink)
+static int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 {
 	struct sof_ipc_stream_params src_params;
 	struct sof_ipc_stream_params *params = mod->stream_params;
@@ -561,7 +561,7 @@ static int src_set_params(struct processing_module *mod, struct sof_sink __spars
 	return ret;
 }
 
-static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_cache  *sink)
+static void src_set_sink_params(struct comp_dev *dev, struct sof_sink  *sink)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_data *cd = module_get_private_data(mod);
@@ -610,12 +610,12 @@ static int src_stream_pcm_source_rate_check(struct ipc_config_src cfg,
 	return 0;
 }
 
-static int src_set_params(struct processing_module *mod, struct sof_sink __sparse_cache *sink)
+static int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 {
 	return 0;
 }
 
-static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_cache *sink)
+static void src_set_sink_params(struct comp_dev *dev, struct sof_sink *sink)
 {
 	/* empty */
 }
@@ -624,8 +624,8 @@ static void src_set_sink_params(struct comp_dev *dev, struct sof_sink __sparse_c
 #error "No or invalid IPC MAJOR version selected."
 #endif /* CONFIG_IPC_MAJOR_4 */
 
-static void src_set_alignment(struct sof_source __sparse_cache *source,
-			      struct sof_sink __sparse_cache *sink)
+static void src_set_alignment(struct sof_source *source,
+			      struct sof_sink *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 1;
@@ -672,8 +672,8 @@ static int src_verify_params(struct processing_module *mod)
 }
 
 static bool src_get_copy_limits(struct comp_data *cd,
-				struct sof_source __sparse_cache *source,
-				struct sof_sink __sparse_cache *sink)
+				struct sof_source *source,
+				struct sof_sink *sink)
 {
 	struct src_param *sp;
 	struct src_stage *s1;
@@ -716,8 +716,8 @@ static bool src_get_copy_limits(struct comp_data *cd,
 }
 
 static int src_params_general(struct processing_module *mod,
-			      struct sof_source __sparse_cache *source,
-			      struct sof_sink __sparse_cache *sink)
+			      struct sof_source *source,
+			      struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -826,8 +826,8 @@ static int src_params_general(struct processing_module *mod,
 }
 
 static int src_prepare_general(struct processing_module *mod,
-			       struct sof_source __sparse_cache *source,
-			       struct sof_sink __sparse_cache *sink)
+			       struct sof_source *source,
+			       struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -983,8 +983,8 @@ static int src_init(struct processing_module *mod)
 }
 
 static int src_prepare(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 
@@ -1002,8 +1002,8 @@ static int src_prepare(struct processing_module *mod,
 
 
 static bool src_is_ready_to_process(struct processing_module *mod,
-				    struct sof_source __sparse_cache **sources, int num_of_sources,
-				    struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				    struct sof_source **sources, int num_of_sources,
+				    struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 
@@ -1011,8 +1011,8 @@ static bool src_is_ready_to_process(struct processing_module *mod,
 }
 
 static int src_process(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -660,8 +660,8 @@ static int tdfb_process(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = input_buffers[0].data;
-	struct audio_stream __sparse_cache *sink = output_buffers[0].data;
+	struct audio_stream *source = input_buffers[0].data;
+	struct audio_stream *sink = output_buffers[0].data;
 	int frame_count = input_buffers[0].size;
 	int ret;
 
@@ -715,8 +715,8 @@ static int tdfb_process(struct processing_module *mod,
 	return 0;
 }
 
-static void tdfb_set_alignment(struct audio_stream __sparse_cache *source,
-			       struct audio_stream __sparse_cache *sink)
+static void tdfb_set_alignment(struct audio_stream *source,
+			       struct audio_stream *sink)
 {
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */
@@ -726,12 +726,12 @@ static void tdfb_set_alignment(struct audio_stream __sparse_cache *source,
 }
 
 static int tdfb_prepare(struct processing_module *mod,
-			struct sof_source __sparse_cache **sources, int num_of_sources,
-			struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			struct sof_source **sources, int num_of_sources,
+			struct sof_sink **sinks, int num_of_sinks)
 {
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt;
 	int source_channels;

--- a/src/audio/tdfb/tdfb_generic.c
+++ b/src/audio/tdfb/tdfb_generic.c
@@ -58,8 +58,8 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -104,8 +104,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -150,8 +150,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;

--- a/src/audio/tdfb/tdfb_hifi3.c
+++ b/src/audio/tdfb/tdfb_hifi3.c
@@ -19,8 +19,8 @@
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int16x4 d;
@@ -108,8 +108,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;
@@ -197,8 +197,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	struct sof_tdfb_config *cfg = cd->config;
 	struct fir_state_32x16 *f;
 	ae_int32x2 d;

--- a/src/audio/tdfb/tdfb_hifiep.c
+++ b/src/audio/tdfb/tdfb_hifiep.c
@@ -58,8 +58,8 @@ static inline void tdfb_core(struct tdfb_comp_data *cd, int in_nch, int out_nch)
 void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x = audio_stream_get_rptr(source);
 	int16_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -104,8 +104,8 @@ void tdfb_fir_s16(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;
@@ -150,8 +150,8 @@ void tdfb_fir_s24(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource
 void tdfb_fir_s32(struct tdfb_comp_data *cd, struct input_stream_buffer *bsource,
 		  struct output_stream_buffer *bsink, int frames)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x = audio_stream_get_rptr(source);
 	int32_t *y = audio_stream_get_wptr(sink);
 	int fmax;

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -95,7 +95,7 @@ struct comp_data {
 	uint32_t frame_bytes;
 	uint32_t rate;
 	struct tone_state sg[PLATFORM_MAX_CHANNELS];
-	void (*tone_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+	void (*tone_func)(struct comp_dev *dev, struct audio_stream *sink,
 			  uint32_t frames);
 };
 
@@ -113,7 +113,7 @@ static inline void tone_circ_inc_wrap(int32_t **ptr, int32_t *end, size_t size)
 		*ptr = (int32_t *)((size_t)*ptr - size);
 }
 
-static void tone_s32_default(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
+static void tone_s32_default(struct comp_dev *dev, struct audio_stream *sink,
 			     uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -429,7 +429,7 @@ static int tone_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
@@ -634,7 +634,7 @@ static int tone_trigger(struct comp_dev *dev, int cmd)
 static int tone_copy(struct comp_dev *dev)
 {
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t free;
 	int ret = 0;

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -400,8 +400,8 @@ err:
 
 /* just stubs for now. Remove these after making these ops optional in the module adapter */
 static int up_down_mixer_prepare(struct processing_module *mod,
-				 struct sof_source __sparse_cache **sources, int num_of_sources,
-				 struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+				 struct sof_source **sources, int num_of_sources,
+				 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct up_down_mixer_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -57,7 +57,7 @@ LOG_MODULE_REGISTER(volume, CONFIG_SOF_LOG_LEVEL);
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s16(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	uint32_t curr_frames = frames;
@@ -105,7 +105,7 @@ static uint32_t vol_zc_get_s16(const struct audio_stream __sparse_cache *source,
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s24(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	int64_t sum;
@@ -153,7 +153,7 @@ static uint32_t vol_zc_get_s24(const struct audio_stream __sparse_cache *source,
  * \param[in] frames Number of frames.
  * \param[in,out] prev_sum Previous sum of channel samples.
  */
-static uint32_t vol_zc_get_s32(const struct audio_stream __sparse_cache *source,
+static uint32_t vol_zc_get_s32(const struct audio_stream *source,
 			       uint32_t frames, int64_t *prev_sum)
 {
 	int64_t sum;
@@ -575,7 +575,7 @@ static int volume_process(struct processing_module *mod,
  * \param[in,out] dev Volume base component device.
  */
 static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
-				       struct comp_buffer __sparse_cache *sinkb)
+				       struct comp_buffer *sinkb)
 {
 	int i;
 
@@ -593,8 +593,8 @@ static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
  * \param[in,out] source Structure pointer of source.
  * \param[in,out] sink Structure pointer of sink.
  */
-static void volume_set_alignment(struct audio_stream __sparse_cache *source,
-				 struct audio_stream __sparse_cache *sink)
+static void volume_set_alignment(struct audio_stream *source,
+				 struct audio_stream *sink)
 {
 #if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
 
@@ -631,14 +631,14 @@ static void volume_set_alignment(struct audio_stream __sparse_cache *source,
  * to also do some type of conversion here.
  */
 static int volume_prepare(struct processing_module *mod,
-			  struct sof_source __sparse_cache **sources, int num_of_sources,
-			  struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			  struct sof_source **sources, int num_of_sources,
+			  struct sof_sink **sinks, int num_of_sinks)
 {
 	struct vol_data *cd = module_get_private_data(mod);
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 	uint32_t sink_period_bytes;
 	int ret;
 	int i;

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -134,7 +134,7 @@ typedef void (*vol_scale_func)(struct processing_module *mod, struct input_strea
 /**
  * \brief volume interface for function getting nearest zero crossing frame
  */
-typedef uint32_t (*vol_zc_func)(const struct audio_stream __sparse_cache *source,
+typedef uint32_t (*vol_zc_func)(const struct audio_stream *source,
 				uint32_t frames, int64_t *prev_sum);
 
 /**
@@ -205,7 +205,7 @@ struct comp_zc_func_map {
  * \param[in] cd Volume data structure.
  */
 static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
-							 struct comp_buffer __sparse_cache *sinkb,
+							 struct comp_buffer *sinkb,
 							 struct vol_data *cd)
 {
 	int i;

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -110,8 +110,8 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x;
 	int32_t *y;
 	int nmax, n;
@@ -153,8 +153,8 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -205,8 +205,8 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x;
 	int32_t *y;
 	int nmax, n;
@@ -247,8 +247,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int16_t *x, *x0;
 	int16_t *y, *y0;
@@ -296,8 +296,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *x;
 	int16_t *y;
 	int nmax, n;

--- a/src/audio/volume/volume_generic_with_peakvol.c
+++ b/src/audio/volume/volume_generic_with_peakvol.c
@@ -57,8 +57,8 @@ static void vol_s24_to_s24(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -112,8 +112,8 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
@@ -166,8 +166,8 @@ static void vol_s32_to_s32(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
@@ -224,8 +224,8 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;
@@ -280,8 +280,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t vol;
 	int16_t *x, *x0;
 	int16_t *y, *y0;
@@ -336,8 +336,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *x, *x0;
 	int32_t *y, *y0;
 	int nmax, n, i, j;

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -147,8 +147,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -198,8 +198,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -289,8 +289,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -339,8 +339,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -436,8 +436,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/volume/volume_hifi3_with_peakvol.c
@@ -41,8 +41,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -116,8 +116,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int channel, n, i, m;
 	ae_f32 *in0 = (ae_f32 *)audio_stream_wrap(source, (char *)audio_stream_get_rptr(source)
@@ -176,8 +176,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -252,8 +252,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, channel, m;
 	const int channels_count = audio_stream_get_channels(sink);
@@ -312,8 +312,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
 	ae_f16x4 in_sample = AE_ZERO16();
@@ -394,8 +394,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, channel, m;
 	ae_f16 *in;

--- a/src/audio/volume/volume_hifi4.c
+++ b/src/audio/volume/volume_hifi4.c
@@ -61,8 +61,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -147,8 +147,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -198,8 +198,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -289,8 +289,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   struct output_stream_buffer *bsink, uint32_t frames,
 					   uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -338,8 +338,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -435,8 +435,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       struct output_stream_buffer *bsink, uint32_t frames,
 				       uint32_t attenuation)
 {
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -54,8 +54,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -150,8 +150,8 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 
 	int i, n, m;
@@ -217,8 +217,8 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 			       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	ae_f32x2 out_sample = AE_ZERO32();
 	ae_f32x2 volume = AE_ZERO32();
@@ -321,8 +321,8 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 					   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 in_sample = AE_ZERO32();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();
@@ -385,8 +385,8 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 			   uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f32x2 volume0 = AE_ZERO32();
 	ae_f32x2 volume1 = AE_ZERO32();
 	ae_f32x2 out_sample0 = AE_ZERO32();
@@ -501,8 +501,8 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 				       uint32_t attenuation)
 {
 	struct vol_data *cd = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	ae_f16x4 in_sample = AE_ZERO16();
 	int i, n, m;
 	ae_valign inu = AE_ZALIGN64();

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -37,7 +37,7 @@ LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
 void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_or_sink)
 {
 	struct comp_buffer *bufferb;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 
 	if (source_or_sink)
 		bufferb = list_first_item(&dev->bsource_list,

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -366,7 +366,7 @@ int volume_get_config(struct processing_module *mod,
 static int volume_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer __sparse_cache *sink_c, *source_c;
+	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 

--- a/src/include/ipc4/base-config.h
+++ b/src/include/ipc4/base-config.h
@@ -242,7 +242,7 @@ struct sof_ipc_stream_params;
 void ipc4_base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *base_cfg,
 					   struct sof_ipc_stream_params *params);
 struct comp_buffer;
-void ipc4_update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
+void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 			       const struct ipc4_audio_format *fmt);
 
 #endif

--- a/src/include/ipc4/copier.h
+++ b/src/include/ipc4/copier.h
@@ -272,7 +272,7 @@ struct copier_data {
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
-		      struct comp_buffer __sparse_cache *sink, int frame);
+		      struct comp_buffer *sink, int frame);
 
 pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 				      const struct ipc4_audio_format *out_fmt,

--- a/src/include/ipc4/mixin_mixout.h
+++ b/src/include/ipc4/mixin_mixout.h
@@ -105,15 +105,15 @@ struct ipc4_mixer_mode_config {
 /**
  * \brief normal mode mixin_mixout processing function interface
  */
-typedef void (*normal_mix_func)(struct audio_stream __sparse_cache *sink, int32_t start_frame,
+typedef void (*normal_mix_func)(struct audio_stream *sink, int32_t start_frame,
 				int32_t mixed_frames,
-				const struct audio_stream __sparse_cache *source,
+				const struct audio_stream *source,
 				int32_t frame_count, uint16_t gain);
 
 /**
  * \brief mixin_mixout mute processing function interface
  */
-typedef void (*mute_func) (struct audio_stream __sparse_cache *stream, int32_t channel_index,
+typedef void (*mute_func) (struct audio_stream *stream, int32_t channel_index,
 			     int32_t start_frame, int32_t mixed_frames, int32_t frame_count);
 
 /**

--- a/src/include/sof/audio/aria/aria.h
+++ b/src/include/sof/audio/aria/aria.h
@@ -48,14 +48,14 @@
  * \brief aria get data function interface
  */
 typedef void (*aria_get_data_func)(struct processing_module *mod,
-				   struct audio_stream __sparse_cache *sink, int frames);
+				   struct audio_stream *sink, int frames);
 
 struct aria_data;
 /**
  * \brief Aria gain processing function
  */
 void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
-			 struct audio_stream __sparse_cache *source, int frames);
+			 struct audio_stream *source, int frames);
 
 aria_get_data_func aria_algo_get_data_func(struct processing_module *mod);
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -139,14 +139,12 @@ static inline uint32_t audio_stream_get_free(const struct audio_stream *buf)
 	return buf->free;
 }
 
-static inline enum sof_ipc_frame audio_stream_get_frm_fmt(
-	const struct audio_stream *buf)
+static inline enum sof_ipc_frame audio_stream_get_frm_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.frame_fmt;
 }
 
-static inline enum sof_ipc_frame audio_stream_get_valid_fmt(
-	const struct audio_stream *buf)
+static inline enum sof_ipc_frame audio_stream_get_valid_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.valid_sample_fmt;
 }
@@ -441,8 +439,7 @@ static inline void audio_stream_init_alignment_constants(const uint32_t byte_ali
  * @param frames Number of processing frames.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf,
-						 uint32_t frames)
+static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf, uint32_t frames)
 {
 	return frames * audio_stream_frame_bytes(buf);
 }
@@ -454,8 +451,7 @@ static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf,
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_wrap(const struct audio_stream *buffer,
-				      void *ptr)
+static inline void *audio_stream_wrap(const struct audio_stream *buffer, void *ptr)
 {
 	if (ptr >= buffer->end_addr)
 		ptr = (char *)buffer->addr +
@@ -492,8 +488,7 @@ static inline void *cir_buf_wrap(void *ptr, void *buf_addr, void *buf_end)
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer,
-					     void *ptr)
+static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer, void *ptr)
 {
 	if (ptr < buffer->addr)
 		ptr = (char *)buffer->end_addr - ((char *)buffer->addr - (char *)ptr);
@@ -683,8 +678,7 @@ audio_stream_avail_frames_aligned(const struct audio_stream *source,
  * @param buffer Buffer to update.
  * @param bytes Number of written bytes.
  */
-static inline void audio_stream_produce(struct audio_stream *buffer,
-					uint32_t bytes)
+static inline void audio_stream_produce(struct audio_stream *buffer, uint32_t bytes)
 {
 	buffer->w_ptr = audio_stream_wrap(buffer,
 					  (char *)buffer->w_ptr + bytes);
@@ -711,8 +705,7 @@ static inline void audio_stream_produce(struct audio_stream *buffer,
  * @param buffer Buffer to update.
  * @param bytes Number of read bytes.
  */
-static inline void audio_stream_consume(struct audio_stream *buffer,
-					uint32_t bytes)
+static inline void audio_stream_consume(struct audio_stream *buffer, uint32_t bytes)
 {
 	buffer->r_ptr = audio_stream_wrap(buffer,
 					  (char *)buffer->r_ptr + bytes);
@@ -753,8 +746,7 @@ static inline void audio_stream_reset(struct audio_stream *buffer)
  * @param buff_addr Address of the memory block to assign.
  * @param size Size of the memory block in bytes.
  */
-void audio_stream_init(struct audio_stream *audio_stream,
-		       void *buff_addr, uint32_t size);
+void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint32_t size);
 
 /**
  * Invalidates (in DSP d-cache) the buffer in range [r_ptr, r_ptr+bytes],
@@ -762,8 +754,7 @@ void audio_stream_init(struct audio_stream *audio_stream,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to invalidate.
  */
-static inline void audio_stream_invalidate(struct audio_stream *buffer,
-					   uint32_t bytes)
+static inline void audio_stream_invalidate(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -786,8 +777,7 @@ static inline void audio_stream_invalidate(struct audio_stream *buffer,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to write back.
  */
-static inline void audio_stream_writeback(struct audio_stream *buffer,
-					  uint32_t bytes)
+static inline void audio_stream_writeback(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -811,8 +801,7 @@ static inline void audio_stream_writeback(struct audio_stream *buffer,
  * @return Number of data samples to buffer wrap.
  */
 static inline int
-audio_stream_bytes_without_wrap(const struct audio_stream *source,
-				const void *ptr)
+audio_stream_bytes_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	assert((intptr_t)source->end_addr >= (intptr_t)ptr);
 	return (intptr_t)source->end_addr - (intptr_t)ptr;
@@ -827,8 +816,7 @@ audio_stream_bytes_without_wrap(const struct audio_stream *source,
  *	   need to add size of sample to returned bytes count.
  */
 static inline int
-audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source,
-				       const void *ptr)
+audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	assert((intptr_t)ptr >= (intptr_t)source->addr);
 	int to_begin = (intptr_t)ptr - (intptr_t)source->addr;
@@ -843,8 +831,7 @@ audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source,
  * @return Previous position of the write pointer.
  */
 static inline uint32_t
-*audio_stream_rewind_wptr_by_bytes(const struct audio_stream *source,
-				       const uint32_t bytes)
+*audio_stream_rewind_wptr_by_bytes(const struct audio_stream *source, const uint32_t bytes)
 {
 	void *wptr = audio_stream_get_wptr(source);
 	int to_begin = audio_stream_rewind_bytes_without_wrap(source, wptr);
@@ -866,8 +853,7 @@ static inline uint32_t
  * @return Number of data s16 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s16(const struct audio_stream *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s16(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int16_t *)source->end_addr - (int16_t *)ptr;
 
@@ -883,8 +869,7 @@ audio_stream_samples_without_wrap_s16(const struct audio_stream *source,
  * @return Number of data s24 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s24(const struct audio_stream *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s24(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -900,8 +885,7 @@ audio_stream_samples_without_wrap_s24(const struct audio_stream *source,
  * @return Number of data s32 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s32(const struct audio_stream *source,
-				      const void *ptr)
+audio_stream_samples_without_wrap_s32(const struct audio_stream *source, const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
 
@@ -947,8 +931,7 @@ static inline int cir_buf_samples_without_wrap_s32(void *ptr, void *buf_end)
  * @return Number of data frames to buffer wrap.
  */
 static inline uint32_t
-audio_stream_frames_without_wrap(const struct audio_stream *source,
-				 const void *ptr)
+audio_stream_frames_without_wrap(const struct audio_stream *source, const void *ptr)
 {
 	uint32_t bytes = audio_stream_bytes_without_wrap(source, ptr);
 	uint32_t frame_bytes = audio_stream_frame_bytes(source);
@@ -1011,8 +994,7 @@ void audio_stream_copy_to_linear(const struct audio_stream *source, int ioffset,
  * @return 0 if there is enough free space in buffer.
  * @return 1 if there is not enough free space in buffer.
  */
-static inline int audio_stream_set_zero(struct audio_stream *buffer,
-					uint32_t bytes)
+static inline int audio_stream_set_zero(struct audio_stream *buffer, uint32_t bytes)
 {
 	uint32_t head_size = bytes;
 	uint32_t tail_size = 0;
@@ -1071,7 +1053,6 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 }
 
 /** get a handler to source API
- * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
 static inline struct sof_source *
 audio_stream_get_source(struct audio_stream *audio_stream)

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -104,148 +104,148 @@ struct audio_stream {
 	struct sof_audio_stream_params runtime_stream_params;
 };
 
-static inline void *audio_stream_get_rptr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_rptr(const struct audio_stream *buf)
 {
 	return buf->r_ptr;
 }
 
-static inline void *audio_stream_get_wptr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_wptr(const struct audio_stream *buf)
 {
 	return buf->w_ptr;
 }
 
-static inline void *audio_stream_get_end_addr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_end_addr(const struct audio_stream *buf)
 {
 	return buf->end_addr;
 }
 
-static inline void *audio_stream_get_addr(const struct audio_stream __sparse_cache *buf)
+static inline void *audio_stream_get_addr(const struct audio_stream *buf)
 {
 	return buf->addr;
 }
 
-static inline uint32_t audio_stream_get_size(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_size(const struct audio_stream *buf)
 {
 	return buf->size;
 }
 
-static inline uint32_t audio_stream_get_avail(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_avail(const struct audio_stream *buf)
 {
 	return buf->avail;
 }
 
-static inline uint32_t audio_stream_get_free(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_free(const struct audio_stream *buf)
 {
 	return buf->free;
 }
 
 static inline enum sof_ipc_frame audio_stream_get_frm_fmt(
-	const struct audio_stream __sparse_cache *buf)
+	const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.frame_fmt;
 }
 
 static inline enum sof_ipc_frame audio_stream_get_valid_fmt(
-	const struct audio_stream __sparse_cache *buf)
+	const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.valid_sample_fmt;
 }
 
-static inline uint32_t audio_stream_get_rate(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_rate(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.rate;
 }
 
-static inline uint32_t audio_stream_get_channels(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_channels(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.channels;
 }
 
-static inline bool audio_stream_get_underrun(const struct audio_stream __sparse_cache *buf)
+static inline bool audio_stream_get_underrun(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.underrun_permitted;
 }
 
-static inline uint32_t audio_stream_get_buffer_fmt(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_get_buffer_fmt(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.buffer_fmt;
 }
 
-static inline bool audio_stream_get_overrun(const struct audio_stream __sparse_cache *buf)
+static inline bool audio_stream_get_overrun(const struct audio_stream *buf)
 {
 	return buf->runtime_stream_params.overrun_permitted;
 }
 
-static inline void audio_stream_set_rptr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_rptr(struct audio_stream *buf, void *val)
 {
 	buf->r_ptr = val;
 }
 
-static inline void audio_stream_set_wptr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_wptr(struct audio_stream *buf, void *val)
 {
 	buf->w_ptr = val;
 }
 
-static inline void audio_stream_set_end_addr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_end_addr(struct audio_stream *buf, void *val)
 {
 	buf->end_addr = val;
 }
 
-static inline void audio_stream_set_addr(struct audio_stream __sparse_cache *buf, void *val)
+static inline void audio_stream_set_addr(struct audio_stream *buf, void *val)
 {
 	buf->addr = val;
 }
 
-static inline void audio_stream_set_size(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_size(struct audio_stream *buf, uint32_t val)
 {
 	buf->size = val;
 }
 
-static inline void audio_stream_set_avail(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_avail(struct audio_stream *buf, uint32_t val)
 {
 	buf->avail = val;
 }
 
-static inline void audio_stream_set_free(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_free(struct audio_stream *buf, uint32_t val)
 {
 	buf->free = val;
 }
 
-static inline void audio_stream_set_frm_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_frm_fmt(struct audio_stream *buf,
 					    enum sof_ipc_frame val)
 {
 	buf->runtime_stream_params.frame_fmt = val;
 }
 
-static inline void audio_stream_set_valid_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_valid_fmt(struct audio_stream *buf,
 					      enum sof_ipc_frame val)
 {
 	buf->runtime_stream_params.valid_sample_fmt = val;
 }
 
-static inline void audio_stream_set_rate(struct audio_stream __sparse_cache *buf, uint32_t val)
+static inline void audio_stream_set_rate(struct audio_stream *buf, uint32_t val)
 {
 	buf->runtime_stream_params.rate = val;
 }
 
-static inline void audio_stream_set_channels(struct audio_stream __sparse_cache *buf, uint16_t val)
+static inline void audio_stream_set_channels(struct audio_stream *buf, uint16_t val)
 {
 	buf->runtime_stream_params.channels = val;
 }
 
-static inline void audio_stream_set_underrun(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_underrun(struct audio_stream *buf,
 					     bool underrun_permitted)
 {
 	buf->runtime_stream_params.underrun_permitted = underrun_permitted;
 }
 
-static inline void audio_stream_set_overrun(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_overrun(struct audio_stream *buf,
 					    bool overrun_permitted)
 {
 	buf->runtime_stream_params.overrun_permitted = overrun_permitted;
 }
 
-static inline void audio_stream_set_buffer_fmt(struct audio_stream __sparse_cache *buf,
+static inline void audio_stream_set_buffer_fmt(struct audio_stream *buf,
 					       uint32_t buffer_fmt)
 {
 	buf->runtime_stream_params.buffer_fmt = buffer_fmt;
@@ -356,7 +356,7 @@ static inline void audio_stream_set_buffer_fmt(struct audio_stream __sparse_cach
  * @param params Parameters (frame format, rate, number of channels).
  * @return 0 if succeeded, error code otherwise.
  */
-static inline int audio_stream_set_params(struct audio_stream __sparse_cache *buffer,
+static inline int audio_stream_set_params(struct audio_stream *buffer,
 					  struct sof_ipc_stream_params *params)
 {
 	if (!params)
@@ -374,7 +374,7 @@ static inline int audio_stream_set_params(struct audio_stream __sparse_cache *bu
  * @param buf Component buffer.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_frame_bytes(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_frame_bytes(const struct audio_stream *buf)
 {
 	return get_frame_bytes(buf->runtime_stream_params.frame_fmt,
 			       buf->runtime_stream_params.channels);
@@ -385,7 +385,7 @@ static inline uint32_t audio_stream_frame_bytes(const struct audio_stream __spar
  * @param buf Component buffer.
  * @return Size of sample in bytes.
  */
-static inline uint32_t audio_stream_sample_bytes(const struct audio_stream __sparse_cache *buf)
+static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
 {
 	return get_sample_bytes(buf->runtime_stream_params.frame_fmt);
 }
@@ -423,7 +423,7 @@ static inline uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
  */
 static inline void audio_stream_init_alignment_constants(const uint32_t byte_align,
 							 const uint32_t frame_align_req,
-							 struct audio_stream __sparse_cache *stream)
+							 struct audio_stream *stream)
 {
 	uint32_t process_size;
 	uint32_t frame_size = audio_stream_frame_bytes(stream);
@@ -441,7 +441,7 @@ static inline void audio_stream_init_alignment_constants(const uint32_t byte_ali
  * @param frames Number of processing frames.
  * @return Period size in bytes.
  */
-static inline uint32_t audio_stream_period_bytes(const struct audio_stream __sparse_cache *buf,
+static inline uint32_t audio_stream_period_bytes(const struct audio_stream *buf,
 						 uint32_t frames)
 {
 	return frames * audio_stream_frame_bytes(buf);
@@ -454,7 +454,7 @@ static inline uint32_t audio_stream_period_bytes(const struct audio_stream __spa
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_wrap(const struct audio_stream __sparse_cache *buffer,
+static inline void *audio_stream_wrap(const struct audio_stream *buffer,
 				      void *ptr)
 {
 	if (ptr >= buffer->end_addr)
@@ -492,7 +492,7 @@ static inline void *cir_buf_wrap(void *ptr, void *buf_addr, void *buf_end)
  * @param ptr Pointer
  * @return Pointer, adjusted if necessary.
  */
-static inline void *audio_stream_rewind_wrap(const struct audio_stream __sparse_cache *buffer,
+static inline void *audio_stream_rewind_wrap(const struct audio_stream *buffer,
 					     void *ptr)
 {
 	if (ptr < buffer->addr)
@@ -509,7 +509,7 @@ static inline void *audio_stream_rewind_wrap(const struct audio_stream __sparse_
  * @return amount of data available for processing in bytes
  */
 static inline uint32_t
-audio_stream_get_avail_bytes(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_bytes(const struct audio_stream *stream)
 {
 	/*
 	 * In case of underrun-permitted stream, report buffer full instead of
@@ -529,7 +529,7 @@ audio_stream_get_avail_bytes(const struct audio_stream __sparse_cache *stream)
  * @return amount of data available for processing in samples
  */
 static inline uint32_t
-audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_samples(const struct audio_stream *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -541,7 +541,7 @@ audio_stream_get_avail_samples(const struct audio_stream __sparse_cache *stream)
  * @return amount of data available for processing in frames
  */
 static inline uint32_t
-audio_stream_get_avail_frames(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_avail_frames(const struct audio_stream *stream)
 {
 	return audio_stream_get_avail_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -553,7 +553,7 @@ audio_stream_get_avail_frames(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in bytes
  */
 static inline uint32_t
-audio_stream_get_free_bytes(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_bytes(const struct audio_stream *stream)
 {
 	/*
 	 * In case of overrun-permitted stream, report buffer empty instead of
@@ -573,7 +573,7 @@ audio_stream_get_free_bytes(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in samples
  */
 static inline uint32_t
-audio_stream_get_free_samples(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_samples(const struct audio_stream *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_sample_bytes(stream);
@@ -585,7 +585,7 @@ audio_stream_get_free_samples(const struct audio_stream __sparse_cache *stream)
  * @return amount of space free in frames
  */
 static inline uint32_t
-audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
+audio_stream_get_free_frames(const struct audio_stream *stream)
 {
 	return audio_stream_get_free_bytes(stream) /
 		audio_stream_frame_bytes(stream);
@@ -601,8 +601,8 @@ audio_stream_get_free_frames(const struct audio_stream __sparse_cache *stream)
  *  @return 1 if there is not enough free space in sink.
  *  @return -1 if there is not enough data in source.
  */
-static inline int audio_stream_can_copy_bytes(const struct audio_stream __sparse_cache *source,
-					      const struct audio_stream __sparse_cache *sink,
+static inline int audio_stream_can_copy_bytes(const struct audio_stream *source,
+					      const struct audio_stream *sink,
 					      uint32_t bytes)
 {
 	/* check for underrun */
@@ -626,8 +626,8 @@ static inline int audio_stream_can_copy_bytes(const struct audio_stream __sparse
  * @return Number of bytes.
  */
 static inline uint32_t
-audio_stream_get_copy_bytes(const struct audio_stream __sparse_cache *source,
-			    const struct audio_stream __sparse_cache *sink)
+audio_stream_get_copy_bytes(const struct audio_stream *source,
+			    const struct audio_stream *sink)
 {
 	uint32_t avail = audio_stream_get_avail_bytes(source);
 	uint32_t free = audio_stream_get_free_bytes(sink);
@@ -647,8 +647,8 @@ audio_stream_get_copy_bytes(const struct audio_stream __sparse_cache *source,
  * @return Number of frames.
  */
 static inline uint32_t
-audio_stream_avail_frames(const struct audio_stream __sparse_cache *source,
-			  const struct audio_stream __sparse_cache *sink)
+audio_stream_avail_frames(const struct audio_stream *source,
+			  const struct audio_stream *sink)
 {
 	uint32_t src_frames = audio_stream_get_avail_frames(source);
 	uint32_t sink_frames = audio_stream_get_free_frames(sink);
@@ -665,8 +665,8 @@ audio_stream_avail_frames(const struct audio_stream __sparse_cache *source,
  * @return Number of frames.
  */
 static inline uint32_t
-audio_stream_avail_frames_aligned(const struct audio_stream __sparse_cache *source,
-				  const struct audio_stream __sparse_cache *sink)
+audio_stream_avail_frames_aligned(const struct audio_stream *source,
+				  const struct audio_stream *sink)
 {
 	uint32_t src_frames = (audio_stream_get_avail_bytes(source) >>
 			source->runtime_stream_params.align_shift_idx) *
@@ -683,7 +683,7 @@ audio_stream_avail_frames_aligned(const struct audio_stream __sparse_cache *sour
  * @param buffer Buffer to update.
  * @param bytes Number of written bytes.
  */
-static inline void audio_stream_produce(struct audio_stream __sparse_cache *buffer,
+static inline void audio_stream_produce(struct audio_stream *buffer,
 					uint32_t bytes)
 {
 	buffer->w_ptr = audio_stream_wrap(buffer,
@@ -711,7 +711,7 @@ static inline void audio_stream_produce(struct audio_stream __sparse_cache *buff
  * @param buffer Buffer to update.
  * @param bytes Number of read bytes.
  */
-static inline void audio_stream_consume(struct audio_stream __sparse_cache *buffer,
+static inline void audio_stream_consume(struct audio_stream *buffer,
 					uint32_t bytes)
 {
 	buffer->r_ptr = audio_stream_wrap(buffer,
@@ -734,7 +734,7 @@ static inline void audio_stream_consume(struct audio_stream __sparse_cache *buff
  * Resets the buffer.
  * @param buffer Buffer to reset.
  */
-static inline void audio_stream_reset(struct audio_stream __sparse_cache *buffer)
+static inline void audio_stream_reset(struct audio_stream *buffer)
 {
 	/* reset read and write pointer to buffer bas */
 	buffer->w_ptr = buffer->addr;
@@ -753,7 +753,7 @@ static inline void audio_stream_reset(struct audio_stream __sparse_cache *buffer
  * @param buff_addr Address of the memory block to assign.
  * @param size Size of the memory block in bytes.
  */
-void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
+void audio_stream_init(struct audio_stream *audio_stream,
 		       void *buff_addr, uint32_t size);
 
 /**
@@ -762,7 +762,7 @@ void audio_stream_init(struct audio_stream __sparse_cache *audio_stream,
  * @param buffer Buffer.
  * @param bytes Size of the fragment to invalidate.
  */
-static inline void audio_stream_invalidate(struct audio_stream __sparse_cache *buffer,
+static inline void audio_stream_invalidate(struct audio_stream *buffer,
 					   uint32_t bytes)
 {
 	uint32_t head_size = bytes;
@@ -786,7 +786,7 @@ static inline void audio_stream_invalidate(struct audio_stream __sparse_cache *b
  * @param buffer Buffer.
  * @param bytes Size of the fragment to write back.
  */
-static inline void audio_stream_writeback(struct audio_stream __sparse_cache *buffer,
+static inline void audio_stream_writeback(struct audio_stream *buffer,
 					  uint32_t bytes)
 {
 	uint32_t head_size = bytes;
@@ -811,7 +811,7 @@ static inline void audio_stream_writeback(struct audio_stream __sparse_cache *bu
  * @return Number of data samples to buffer wrap.
  */
 static inline int
-audio_stream_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
+audio_stream_bytes_without_wrap(const struct audio_stream *source,
 				const void *ptr)
 {
 	assert((intptr_t)source->end_addr >= (intptr_t)ptr);
@@ -827,7 +827,7 @@ audio_stream_bytes_without_wrap(const struct audio_stream __sparse_cache *source
  *	   need to add size of sample to returned bytes count.
  */
 static inline int
-audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache *source,
+audio_stream_rewind_bytes_without_wrap(const struct audio_stream *source,
 				       const void *ptr)
 {
 	assert((intptr_t)ptr >= (intptr_t)source->addr);
@@ -843,7 +843,7 @@ audio_stream_rewind_bytes_without_wrap(const struct audio_stream __sparse_cache 
  * @return Previous position of the write pointer.
  */
 static inline uint32_t
-*audio_stream_rewind_wptr_by_bytes(const struct audio_stream __sparse_cache *source,
+*audio_stream_rewind_wptr_by_bytes(const struct audio_stream *source,
 				       const uint32_t bytes)
 {
 	void *wptr = audio_stream_get_wptr(source);
@@ -866,7 +866,7 @@ static inline uint32_t
  * @return Number of data s16 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s16(const struct audio_stream __sparse_cache *source,
+audio_stream_samples_without_wrap_s16(const struct audio_stream *source,
 				      const void *ptr)
 {
 	int to_end = (int16_t *)source->end_addr - (int16_t *)ptr;
@@ -883,7 +883,7 @@ audio_stream_samples_without_wrap_s16(const struct audio_stream __sparse_cache *
  * @return Number of data s24 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s24(const struct audio_stream __sparse_cache *source,
+audio_stream_samples_without_wrap_s24(const struct audio_stream *source,
 				      const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
@@ -900,7 +900,7 @@ audio_stream_samples_without_wrap_s24(const struct audio_stream __sparse_cache *
  * @return Number of data s32 samples until circular wrap need at end
  */
 static inline int
-audio_stream_samples_without_wrap_s32(const struct audio_stream __sparse_cache *source,
+audio_stream_samples_without_wrap_s32(const struct audio_stream *source,
 				      const void *ptr)
 {
 	int to_end = (int32_t *)source->end_addr - (int32_t *)ptr;
@@ -947,7 +947,7 @@ static inline int cir_buf_samples_without_wrap_s32(void *ptr, void *buf_end)
  * @return Number of data frames to buffer wrap.
  */
 static inline uint32_t
-audio_stream_frames_without_wrap(const struct audio_stream __sparse_cache *source,
+audio_stream_frames_without_wrap(const struct audio_stream *source,
 				 const void *ptr)
 {
 	uint32_t bytes = audio_stream_bytes_without_wrap(source, ptr);
@@ -965,8 +965,8 @@ audio_stream_frames_without_wrap(const struct audio_stream __sparse_cache *sourc
  * @param samples Number of samples to copy.
  * @return number of processed samples.
  */
-int audio_stream_copy(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-		      struct audio_stream __sparse_cache *sink, uint32_t ooffset, uint32_t samples);
+int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
+		      struct audio_stream *sink, uint32_t ooffset, uint32_t samples);
 
 /**
  * Copies data from one circular buffer to another circular buffer.
@@ -990,7 +990,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
  * @param samples Number of samples to copy.
  */
 void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
-				   struct audio_stream __sparse_cache *sink, int ooffset,
+				   struct audio_stream *sink, int ooffset,
 				   unsigned int samples);
 
 /**
@@ -1001,7 +1001,7 @@ void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
  * @param ooffset Offset (in samples) in sink buffer to start writing to.
  * @param samples Number of samples to copy.
  */
-void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *source, int ioffset,
+void audio_stream_copy_to_linear(const struct audio_stream *source, int ioffset,
 				 void *linear_sink, int ooffset, unsigned int samples);
 
 /**
@@ -1011,7 +1011,7 @@ void audio_stream_copy_to_linear(const struct audio_stream __sparse_cache *sourc
  * @return 0 if there is enough free space in buffer.
  * @return 1 if there is not enough free space in buffer.
  */
-static inline int audio_stream_set_zero(struct audio_stream __sparse_cache *buffer,
+static inline int audio_stream_set_zero(struct audio_stream *buffer,
 					uint32_t bytes)
 {
 	uint32_t head_size = bytes;
@@ -1073,14 +1073,14 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 /** get a handler to source API
  * NOTE! to use the handlers the buffer must be acquired by buffer_acquire
  */
-static inline struct sof_source __sparse_cache *
-audio_stream_get_source(struct audio_stream __sparse_cache *audio_stream)
+static inline struct sof_source *
+audio_stream_get_source(struct audio_stream *audio_stream)
 {
 	return &audio_stream->source_api;
 }
 
-static inline struct sof_sink __sparse_cache *
-audio_stream_get_sink(struct audio_stream __sparse_cache *audio_stream)
+static inline struct sof_sink *
+audio_stream_get_sink(struct audio_stream *audio_stream)
 {
 	return &audio_stream->sink_api;
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -163,7 +163,7 @@ struct comp_buffer {
 
 /* Only to be used for synchronous same-core notifications! */
 struct buffer_cb_transact {
-	struct comp_buffer __sparse_cache *buffer;
+	struct comp_buffer *buffer;
 	uint32_t transaction_amount;
 	void *transaction_begin_address;
 };
@@ -192,30 +192,30 @@ struct buffer_cb_free {
 struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align,
 				 bool is_shared);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared);
-int buffer_set_size(struct comp_buffer __sparse_cache *buffer, uint32_t size, uint32_t alignment);
+int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment);
 void buffer_free(struct comp_buffer *buffer);
-void buffer_zero(struct comp_buffer __sparse_cache *buffer);
+void buffer_zero(struct comp_buffer *buffer);
 
 /* called by a component after producing data into this buffer */
-void comp_update_buffer_produce(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
+void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes);
 
 /* called by a component after consuming data from this buffer */
-void comp_update_buffer_consume(struct comp_buffer __sparse_cache *buffer, uint32_t bytes);
+void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes);
 
-int buffer_set_params(struct comp_buffer __sparse_cache *buffer,
+int buffer_set_params(struct comp_buffer *buffer,
 		      struct sof_ipc_stream_params *params, bool force_update);
 
-bool buffer_params_match(struct comp_buffer __sparse_cache *buffer,
+bool buffer_params_match(struct comp_buffer *buffer,
 			 struct sof_ipc_stream_params *params, uint32_t flag);
 
-static inline void buffer_stream_invalidate(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_stream_invalidate(struct comp_buffer *buffer,
 					    uint32_t bytes)
 {
 	if (buffer->is_shared)
 		audio_stream_invalidate(&buffer->stream, bytes);
 }
 
-static inline void buffer_stream_writeback(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_stream_writeback(struct comp_buffer *buffer,
 					   uint32_t bytes)
 {
 	if (buffer->is_shared)
@@ -223,13 +223,12 @@ static inline void buffer_stream_writeback(struct comp_buffer __sparse_cache *bu
 }
 
 /* stubs for acquire/release for compilation, to be removed at last step */
-__must_check static inline struct comp_buffer __sparse_cache *buffer_acquire(
-	struct comp_buffer *buffer)
+__must_check static inline struct comp_buffer *buffer_acquire(struct comp_buffer *buffer)
 {
-	return (struct comp_buffer __sparse_cache *)buffer;
+	return (struct comp_buffer *)buffer;
 }
 
-static inline void buffer_release(struct comp_buffer __sparse_cache *buffer)
+static inline void buffer_release(struct comp_buffer *buffer)
 {
 	(void)buffer;
 }
@@ -252,14 +251,14 @@ void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir);
 
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)
 {
-	struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
+	struct comp_buffer *buffer_c = buffer_acquire(buffer);
 	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer_c->sink :
 		buffer_c->source;
 	buffer_release(buffer_c);
 	return comp;
 }
 
-static inline void buffer_reset_pos(struct comp_buffer __sparse_cache *buffer, void *data)
+static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)
 {
 	/* reset rw pointers and avail/free bytes counters */
 	audio_stream_reset(&buffer->stream);
@@ -269,7 +268,7 @@ static inline void buffer_reset_pos(struct comp_buffer __sparse_cache *buffer, v
 }
 
 /* Run-time buffer re-configuration calls this too, so it must use cached access */
-static inline void buffer_init(struct comp_buffer __sparse_cache *buffer,
+static inline void buffer_init(struct comp_buffer *buffer,
 			       uint32_t size, uint32_t caps)
 {
 	buffer->caps = caps;
@@ -278,7 +277,7 @@ static inline void buffer_init(struct comp_buffer __sparse_cache *buffer,
 	audio_stream_init(&buffer->stream, buffer->stream.addr, size);
 }
 
-static inline void buffer_reset_params(struct comp_buffer __sparse_cache *buffer, void *data)
+static inline void buffer_reset_params(struct comp_buffer *buffer, void *data)
 {
 	buffer->hw_params_configured = false;
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -208,15 +208,13 @@ int buffer_set_params(struct comp_buffer *buffer,
 bool buffer_params_match(struct comp_buffer *buffer,
 			 struct sof_ipc_stream_params *params, uint32_t flag);
 
-static inline void buffer_stream_invalidate(struct comp_buffer *buffer,
-					    uint32_t bytes)
+static inline void buffer_stream_invalidate(struct comp_buffer *buffer, uint32_t bytes)
 {
 	if (buffer->is_shared)
 		audio_stream_invalidate(&buffer->stream, bytes);
 }
 
-static inline void buffer_stream_writeback(struct comp_buffer *buffer,
-					   uint32_t bytes)
+static inline void buffer_stream_writeback(struct comp_buffer *buffer, uint32_t bytes)
 {
 	if (buffer->is_shared)
 		audio_stream_writeback(&buffer->stream, bytes);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -817,7 +817,7 @@ static inline void component_set_nearest_period_frames(struct comp_dev *current,
  * @param copy_bytes Requested size of data to be available.
  */
 static inline void comp_underrun(struct comp_dev *dev,
-				 struct comp_buffer __sparse_cache *source,
+				 struct comp_buffer *source,
 				 uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -839,7 +839,7 @@ static inline void comp_underrun(struct comp_dev *dev,
  * @param sink Sink buffer.
  * @param copy_bytes Requested size of free space to be available.
  */
-static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer __sparse_cache *sink,
+static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer *sink,
 				uint32_t copy_bytes)
 {
 	LOG_MODULE_DECLARE(component, CONFIG_SOF_LOG_LEVEL);
@@ -864,8 +864,8 @@ static inline void comp_overrun(struct comp_dev *dev, struct comp_buffer __spars
  * @param[in] sink Sink buffer.
  * @param[out] cl Current copy limits.
  */
-void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
-			  struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits(struct comp_buffer *source,
+			  struct comp_buffer *sink,
 			  struct comp_copy_limits *cl);
 
 /**
@@ -877,8 +877,8 @@ void comp_get_copy_limits(struct comp_buffer __sparse_cache *source,
  * @param[in] sink Buffer of sink.
  * @param[out] cl Current copy limits.
  */
-void comp_get_copy_limits_frame_aligned(const struct comp_buffer __sparse_cache *source,
-					const struct comp_buffer __sparse_cache *sink,
+void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
+					const struct comp_buffer *sink,
 					struct comp_copy_limits *cl);
 
 /**
@@ -894,7 +894,7 @@ void comp_get_copy_limits_with_lock(struct comp_buffer *source,
 				    struct comp_buffer *sink,
 				    struct comp_copy_limits *cl)
 {
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 
 	source_c = buffer_acquire(source);
 	sink_c = buffer_acquire(sink);
@@ -919,7 +919,7 @@ void comp_get_copy_limits_with_lock_frame_aligned(struct comp_buffer *source,
 						  struct comp_buffer *sink,
 						  struct comp_copy_limits *cl)
 {
-	struct comp_buffer __sparse_cache *source_c, *sink_c;
+	struct comp_buffer *source_c, *sink_c;
 
 	source_c = buffer_acquire(source);
 	sink_c = buffer_acquire(sink);

--- a/src/include/sof/audio/dcblock/dcblock.h
+++ b/src/include/sof/audio/dcblock/dcblock.h
@@ -43,8 +43,8 @@ struct dcblock_state {
 struct comp_data;
 
 typedef void (*dcblock_func)(struct comp_data *cd,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink,
 			     uint32_t frames);
 
 /* DC Blocking Filter component private data */

--- a/src/include/sof/audio/drc/drc.h
+++ b/src/include/sof/audio/drc/drc.h
@@ -60,8 +60,8 @@ struct drc_state {
 };
 
 typedef void (*drc_func)(struct processing_module *mod,
-			 const struct audio_stream __sparse_cache *source,
-			 struct audio_stream __sparse_cache *sink,
+			 const struct audio_stream *source,
+			 struct audio_stream *sink,
 			 uint32_t frames);
 
 /* DRC component private data */
@@ -83,8 +83,8 @@ extern const struct drc_proc_fnmap drc_proc_fnmap[];
 extern const size_t drc_proc_fncount;
 
 void drc_default_pass(struct processing_module *mod,
-		      const struct audio_stream __sparse_cache *source,
-		      struct audio_stream __sparse_cache *sink, uint32_t frames);
+		      const struct audio_stream *source,
+		      struct audio_stream *sink, uint32_t frames);
 /**
  * \brief Returns DRC processing function.
  */

--- a/src/include/sof/audio/igo_nr/igo_nr_comp.h
+++ b/src/include/sof/audio/igo_nr/igo_nr_comp.h
@@ -41,8 +41,8 @@ struct comp_data {
 	int32_t sink_frames_max;	/* Max # of frames to process at sink */
 	int32_t frames;		/* IO buffer length */
 	void (*igo_nr_func)(struct comp_data *cd,
-			    const struct audio_stream __sparse_cache *source,
-			    struct audio_stream __sparse_cache *sink,
+			    const struct audio_stream *source,
+			    struct audio_stream *sink,
 			    int32_t frames);
 };
 

--- a/src/include/sof/audio/mixer.h
+++ b/src/include/sof/audio/mixer.h
@@ -34,16 +34,16 @@ void sys_comp_module_mixer_interface_init(void);
 
 /* mixer component private data */
 struct mixer_data {
-	void (*mix_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			 const struct audio_stream __sparse_cache **sources, uint32_t count,
+	void (*mix_func)(struct comp_dev *dev, struct audio_stream *sink,
+			 const struct audio_stream **sources, uint32_t count,
 			 uint32_t frames);
 };
 
 /**
  * \brief mixer processing function interface
  */
-typedef void (*mixer_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			   const struct audio_stream __sparse_cache **sources, uint32_t num_sources,
+typedef void (*mixer_func)(struct comp_dev *dev, struct audio_stream *sink,
+			   const struct audio_stream **sources, uint32_t num_sources,
 			   uint32_t frames);
 
 /** \brief Volume processing functions map. */
@@ -64,7 +64,7 @@ extern const size_t mixer_func_count;
  * \param[in] sinkb Sink buffer to match against
  */
 static inline mixer_func mixer_get_processing_function(struct comp_dev *dev,
-						       struct comp_buffer __sparse_cache *sinkb)
+						       struct comp_buffer *sinkb)
 {
 	int i;
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -245,14 +245,14 @@ void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint3
 int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
 int module_prepare(struct processing_module *mod,
-		   struct sof_source __sparse_cache **sources, int num_of_sources,
-		   struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		   struct sof_source **sources, int num_of_sources,
+		   struct sof_sink **sinks, int num_of_sinks);
 
 static inline
 bool module_is_ready_to_process(struct processing_module *mod,
-				struct sof_source __sparse_cache **sources,
+				struct sof_source **sources,
 				int num_of_sources,
-				struct sof_sink __sparse_cache **sinks,
+				struct sof_sink **sinks,
 				int num_of_sinks)
 {
 	struct module_data *md = &mod->priv;
@@ -272,8 +272,8 @@ bool module_is_ready_to_process(struct processing_module *mod,
 }
 
 int module_process_sink_src(struct processing_module *mod,
-			    struct sof_source __sparse_cache **sources, int num_of_sources,
-			    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+			    struct sof_source **sources, int num_of_sources,
+			    struct sof_sink **sinks, int num_of_sinks);
 int module_process_legacy(struct processing_module *mod,
 			  struct input_stream_buffer *input_buffers, int num_input_buffers,
 			  struct output_stream_buffer *output_buffers,
@@ -319,8 +319,8 @@ static inline void module_update_buffer_position(struct input_stream_buffer *inp
 						 struct output_stream_buffer *output_buffers,
 						 uint32_t frames)
 {
-	struct audio_stream __sparse_cache *source = input_buffers->data;
-	struct audio_stream __sparse_cache *sink = output_buffers->data;
+	struct audio_stream *source = input_buffers->data;
+	struct audio_stream *sink = output_buffers->data;
 
 	input_buffers->consumed += audio_stream_frame_bytes(source) * frames;
 	output_buffers->size += audio_stream_frame_bytes(sink) * frames;

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -158,8 +158,8 @@ struct module_interface {
 	 * component preparation in .prepare()
 	 */
 	int (*prepare)(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * (optional) return true if the module is ready to process
@@ -177,8 +177,8 @@ struct module_interface {
 	 * the module
 	 */
 	bool (*is_ready_to_process)(struct processing_module *mod,
-				    struct sof_source __sparse_cache **sources, int num_of_sources,
-				    struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+				    struct sof_source **sources, int num_of_sources,
+				    struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * Module specific processing procedure
@@ -200,8 +200,8 @@ struct module_interface {
 	 *	- sinks are handlers to sink API struct sink*[]
 	 */
 	int (*process)(struct processing_module *mod,
-		       struct sof_source __sparse_cache **sources, int num_of_sources,
-		       struct sof_sink __sparse_cache **sinks, int num_of_sinks);
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks);
 
 	/**
 	 * process_audio_stream (depreciated)

--- a/src/include/sof/audio/module_adapter/module/module_interface.h
+++ b/src/include/sof/audio/module_adapter/module/module_interface.h
@@ -50,7 +50,7 @@ enum module_processing_mode {
  * \brief Input stream buffer
  */
 struct input_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
+	void *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 	uint32_t consumed; /* number of bytes consumed by the module */
 
@@ -63,7 +63,7 @@ struct input_stream_buffer {
  * \brief Output stream buffer
  */
 struct output_stream_buffer {
-	void __sparse_cache *data; /* data stream buffer */
+	void *data; /* data stream buffer */
 	uint32_t size; /* size of data in the buffer */
 };
 

--- a/src/include/sof/audio/multiband_drc/multiband_drc.h
+++ b/src/include/sof/audio/multiband_drc/multiband_drc.h
@@ -28,8 +28,8 @@ struct multiband_drc_state {
 };
 
 typedef void (*multiband_drc_func)(const struct processing_module *mod,
-				   const struct audio_stream __sparse_cache *source,
-				   struct audio_stream __sparse_cache *sink,
+				   const struct audio_stream *source,
+				   struct audio_stream *sink,
 				   uint32_t frames);
 
 /* Multiband DRC component private data */

--- a/src/include/sof/audio/mux.h
+++ b/src/include/sof/audio/mux.h
@@ -65,11 +65,11 @@ struct mux_stream_data {
 	uint8_t reserved2[3]; // padding to ensure proper alignment of following instances
 } __attribute__((packed, aligned(4)));
 
-typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			  const struct audio_stream __sparse_cache *source, uint32_t frames,
+typedef void(*demux_func)(struct comp_dev *dev, struct audio_stream *sink,
+			  const struct audio_stream *source, uint32_t frames,
 			  struct mux_look_up *look_up);
-typedef void(*mux_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			const struct audio_stream __sparse_cache **sources, uint32_t frames,
+typedef void(*mux_func)(struct comp_dev *dev, struct audio_stream *sink,
+			const struct audio_stream **sources, uint32_t frames,
 			struct mux_look_up *look_up);
 
 /**

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -45,8 +45,8 @@ struct audio_stream;
  * \param samples number of samples to convert
  * \return error code or number of processed samples.
  */
-typedef int (*pcm_converter_func)(const struct audio_stream __sparse_cache *source,
-				  uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+typedef int (*pcm_converter_func)(const struct audio_stream *source,
+				  uint32_t ioffset, struct audio_stream *sink,
 				  uint32_t ooffset, uint32_t samples);
 
 /**
@@ -156,8 +156,8 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
  * \param converter core conversion function working on linear memory regions
  * \return error code or number of processed samples
  */
-int pcm_convert_as_linear(const struct audio_stream __sparse_cache *source, uint32_t ioffset,
-			  struct audio_stream __sparse_cache *sink, uint32_t ooffset,
+int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
+			  struct audio_stream *sink, uint32_t ooffset,
 			  uint32_t samples, pcm_converter_lin_func converter);
 
 #endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -100,7 +100,7 @@ struct pipeline_walk_context {
 	int (*comp_func)(struct comp_dev *cd, struct comp_buffer *buffer,
 			 struct pipeline_walk_context *ctx, int dir);
 	void *comp_data;
-	void (*buff_func)(struct comp_buffer __sparse_cache *buffer, void *data);
+	void (*buff_func)(struct comp_buffer *buffer, void *data);
 	void *buff_data;
 	struct comp_buffer *incoming;
 	/**< pipelines to be scheduled after trigger walk */

--- a/src/include/sof/audio/selector.h
+++ b/src/include/sof/audio/selector.h
@@ -100,8 +100,8 @@ struct sof_selector_avs_ipc4_config {
 };
 
 #else
-typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream __sparse_cache *sink,
-			 const struct audio_stream __sparse_cache *source, uint32_t frames);
+typedef void (*sel_func)(struct comp_dev *dev, struct audio_stream *sink,
+			 const struct audio_stream *source, uint32_t frames);
 #endif
 
 /** \brief Selector component private data. */

--- a/src/include/sof/audio/sink_api.h
+++ b/src/include/sof/audio/sink_api.h
@@ -54,13 +54,13 @@ struct sof_ipc_stream_params;
  * Retrieves size of free space available in sink (in bytes)
  * return number of free bytes in buffer available to immediate filling
  */
-size_t sink_get_free_size(struct sof_sink __sparse_cache *sink);
+size_t sink_get_free_size(struct sof_sink *sink);
 
 /**
  * Retrieves size of free space available in sink (in frames)
  * return number of free bytes in buffer available to immediate filling
  */
-size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink);
+size_t sink_get_free_frames(struct sof_sink *sink);
 
 /**
  * Get a circular buffer to operate on (to write).
@@ -81,7 +81,7 @@ size_t sink_get_free_frames(struct sof_sink __sparse_cache *sink);
  * @retval -ENODATA if req_size is bigger than free space
  *
  */
-int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
+int sink_get_buffer(struct sof_sink *sink, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 /**
@@ -96,7 +96,7 @@ int sink_get_buffer(struct sof_sink __sparse_cache *sink, size_t req_size,
  *	  commit_buffer with commit_size==MAXINT
  * @return proper error code (0  on success)
  */
-int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size);
+int sink_commit_buffer(struct sof_sink *sink, size_t commit_size);
 
 /**
  * Get total number of bytes processed by the sink (meaning - committed by sink_commit_buffer())
@@ -104,33 +104,33 @@ int sink_commit_buffer(struct sof_sink __sparse_cache *sink, size_t commit_size)
  * @param sink a handler to sink
  * @return total number of processed data
  */
-size_t sink_get_num_of_processed_bytes(struct sof_sink __sparse_cache *sink);
+size_t sink_get_num_of_processed_bytes(struct sof_sink *sink);
 
 /**
  * sets counter of total number of bytes processed  to zero
  */
-void sink_reset_num_of_processed_bytes(struct sof_sink __sparse_cache *sink);
+void sink_reset_num_of_processed_bytes(struct sof_sink *sink);
 
 /** get size of a single audio frame (in bytes) */
-size_t sink_get_frame_bytes(struct sof_sink __sparse_cache *sink);
+size_t sink_get_frame_bytes(struct sof_sink *sink);
 
 /** set of functions for retrieve audio parameters */
-enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink __sparse_cache *sink);
-enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_rate(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_channels(struct sof_sink __sparse_cache *sink);
-uint32_t sink_get_buffer_fmt(struct sof_sink __sparse_cache *sink);
-bool sink_get_overrun(struct sof_sink __sparse_cache *sink);
+enum sof_ipc_frame sink_get_frm_fmt(struct sof_sink *sink);
+enum sof_ipc_frame sink_get_valid_fmt(struct sof_sink *sink);
+uint32_t sink_get_rate(struct sof_sink *sink);
+uint32_t sink_get_channels(struct sof_sink *sink);
+uint32_t sink_get_buffer_fmt(struct sof_sink *sink);
+bool sink_get_overrun(struct sof_sink *sink);
 
 /** set of functions for setting audio parameters */
-int sink_set_frm_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame frame_fmt);
-int sink_set_valid_fmt(struct sof_sink __sparse_cache *sink, enum sof_ipc_frame valid_sample_fmt);
-int sink_set_rate(struct sof_sink __sparse_cache *sink, unsigned int rate);
-int sink_set_channels(struct sof_sink __sparse_cache *sink, unsigned int channels);
-int sink_set_overrun(struct sof_sink __sparse_cache *sink, bool overrun_permitted);
-int sink_set_buffer_fmt(struct sof_sink __sparse_cache *sink, uint32_t buffer_fmt);
-void sink_set_obs(struct sof_sink __sparse_cache *sink, size_t obs);
-size_t sink_get_obs(struct sof_sink __sparse_cache *sink);
+int sink_set_frm_fmt(struct sof_sink *sink, enum sof_ipc_frame frame_fmt);
+int sink_set_valid_fmt(struct sof_sink *sink, enum sof_ipc_frame valid_sample_fmt);
+int sink_set_rate(struct sof_sink *sink, unsigned int rate);
+int sink_set_channels(struct sof_sink *sink, unsigned int channels);
+int sink_set_overrun(struct sof_sink *sink, bool overrun_permitted);
+int sink_set_buffer_fmt(struct sof_sink *sink, uint32_t buffer_fmt);
+void sink_set_obs(struct sof_sink *sink, size_t obs);
+size_t sink_get_obs(struct sof_sink *sink);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params
@@ -140,7 +140,7 @@ size_t sink_get_obs(struct sof_sink __sparse_cache *sink);
  * @param force_update tells the implementation that the params should override actual settings
  * @return 0 if success
  */
-int sink_set_params(struct sof_sink __sparse_cache *sink,
+int sink_set_params(struct sof_sink *sink,
 		    struct sof_ipc_stream_params *params, bool force_update);
 
 /**
@@ -158,7 +158,7 @@ int sink_set_params(struct sof_sink __sparse_cache *sink,
  *
  * @return 0 if success
  */
-int sink_set_alignment_constants(struct sof_sink __sparse_cache *sink,
+int sink_set_alignment_constants(struct sof_sink *sink,
 				 const uint32_t byte_align,
 				 const uint32_t frame_align_req);
 

--- a/src/include/sof/audio/sink_api_implementation.h
+++ b/src/include/sof/audio/sink_api_implementation.h
@@ -27,18 +27,18 @@ struct sink_ops {
 	/**
 	 * see comment of sink_get_free_size()
 	 */
-	size_t (*get_free_size)(struct sof_sink __sparse_cache *sink);
+	size_t (*get_free_size)(struct sof_sink *sink);
 
 	/**
 	 * see comment of sink_get_buffer()
 	 */
-	int (*get_buffer)(struct sof_sink __sparse_cache *sink, size_t req_size,
+	int (*get_buffer)(struct sof_sink *sink, size_t req_size,
 			  void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 	/**
 	 * see comment of sink_commit_buffer()
 	 */
-	int (*commit_buffer)(struct sof_sink __sparse_cache *sink, size_t commit_size);
+	int (*commit_buffer)(struct sof_sink *sink, size_t commit_size);
 
 	/**
 	 * OPTIONAL: Notification to the sink implementation about changes in audio format
@@ -49,20 +49,20 @@ struct sink_ops {
 	 *
 	 * @retval 0 if success, negative if new parameters are not supported
 	 */
-	int (*on_audio_format_set)(struct sof_sink __sparse_cache *sink);
+	int (*on_audio_format_set)(struct sof_sink *sink);
 
 	/**
 	 * OPTIONAL
 	 * see sink_set_params comments
 	 */
-	int (*audio_set_ipc_params)(struct sof_sink __sparse_cache *sink,
+	int (*audio_set_ipc_params)(struct sof_sink *sink,
 				    struct sof_ipc_stream_params *params, bool force_update);
 
 	/**
 	 * OPTIONAL
 	 * see comment for sink_set_alignment_constants
 	 */
-	int (*set_alignment_constants)(struct sof_sink __sparse_cache *sink,
+	int (*set_alignment_constants)(struct sof_sink *sink,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
 };
@@ -86,7 +86,7 @@ struct sof_sink {
  *	  the implementation must ensure coherent access to the parameteres
  *	  in case of i.e. cross core shared queue, it must be located in non-cached memory
  */
-void sink_init(struct sof_sink __sparse_cache *sink, const struct sink_ops *ops,
+void sink_init(struct sof_sink *sink, const struct sink_ops *ops,
 	       struct sof_audio_stream_params *audio_stream_params);
 
 #endif /* __SOF_SINK_API_IMPLEMENTATION_H__ */

--- a/src/include/sof/audio/sink_source_utils.h
+++ b/src/include/sof/audio/sink_source_utils.h
@@ -19,7 +19,7 @@
  *	       if false, data will remain in the source
  * @param size number of bytes to be copied
  */
-int source_to_sink_copy(struct sof_source __sparse_cache *source,
-			struct sof_sink __sparse_cache *sink, bool free, size_t size);
+int source_to_sink_copy(struct sof_source *source,
+			struct sof_sink *sink, bool free, size_t size);
 
 #endif /* SINK_SOURCE_UTILS_H */

--- a/src/include/sof/audio/smart_amp/smart_amp.h
+++ b/src/include/sof/audio/smart_amp/smart_amp.h
@@ -136,9 +136,9 @@ struct smart_amp_mod_struct_t {
 };
 
 typedef void (*smart_amp_func)(const struct comp_dev *dev,
-			       const struct audio_stream __sparse_cache *source,
-			       const struct audio_stream __sparse_cache *sink,
-			       const struct audio_stream __sparse_cache *feedback,
+			       const struct audio_stream *source,
+			       const struct audio_stream *sink,
+			       const struct audio_stream *feedback,
 			       uint32_t frames);
 struct smart_amp_func_map {
 	uint16_t frame_fmt;
@@ -151,14 +151,14 @@ int smart_amp_init(struct smart_amp_mod_struct_t *hspk, struct comp_dev *dev);
 int smart_amp_flush(struct smart_amp_mod_struct_t *hspk, struct comp_dev *dev);
 /* Feed forward processing function */
 int smart_amp_ff_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch_in, uint32_t num_ch_out);
 /* Feedback processing function */
 int smart_amp_fb_copy(struct comp_dev *dev, uint32_t frames,
-		      const struct audio_stream __sparse_cache *source,
-		      const struct audio_stream __sparse_cache *sink, int8_t *chan_map,
+		      const struct audio_stream *source,
+		      const struct audio_stream *sink, int8_t *chan_map,
 		      struct smart_amp_mod_struct_t *hspk,
 		      uint32_t num_ch);
 /* memory usage calculation for the component */

--- a/src/include/sof/audio/source_api.h
+++ b/src/include/sof/audio/source_api.h
@@ -54,13 +54,13 @@ struct sof_ipc_stream_params;
  * Retrieves size of available data (in bytes)
  * return number of bytes that are available for immediate use
  */
-size_t source_get_data_available(struct sof_source __sparse_cache *source);
+size_t source_get_data_available(struct sof_source *source);
 
 /**
  * Retrieves size of available data (in frames)
  * return number of bytes that are available for immediate use
  */
-size_t source_get_data_frames_available(struct sof_source __sparse_cache *source);
+size_t source_get_data_frames_available(struct sof_source *source);
 
 /**
  * Retrieves a fragment of circular data to be used by the caller (to read)
@@ -93,7 +93,7 @@ size_t source_get_data_frames_available(struct sof_source __sparse_cache *source
  *
  * @retval -ENODATA if req_size is bigger than available data
  */
-int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
+int source_get_data(struct sof_source *source, size_t req_size,
 		    void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 /**
@@ -110,38 +110,38 @@ int source_get_data(struct sof_source __sparse_cache *source, size_t req_size,
  *
  * @return proper error code (0  on success)
  */
-int source_release_data(struct sof_source __sparse_cache *source, size_t free_size);
+int source_release_data(struct sof_source *source, size_t free_size);
 
 /**
  * Get total number of bytes processed by the source (meaning - freed by source_release_data())
  */
-size_t source_get_num_of_processed_bytes(struct sof_source __sparse_cache *source);
+size_t source_get_num_of_processed_bytes(struct sof_source *source);
 
 /**
  * sets counter of total number of bytes processed  to zero
  */
-void source_reset_num_of_processed_bytes(struct sof_source __sparse_cache *source);
+void source_reset_num_of_processed_bytes(struct sof_source *source);
 
 /** get size of a single audio frame (in bytes) */
-size_t source_get_frame_bytes(struct sof_source __sparse_cache *source);
+size_t source_get_frame_bytes(struct sof_source *source);
 
 /** set of functions for retrieve audio parameters */
-enum sof_ipc_frame source_get_frm_fmt(struct sof_source __sparse_cache *source);
-enum sof_ipc_frame source_get_valid_fmt(struct sof_source __sparse_cache *source);
-unsigned int source_get_rate(struct sof_source __sparse_cache *source);
-unsigned int source_get_channels(struct sof_source __sparse_cache *source);
-uint32_t source_get_buffer_fmt(struct sof_source __sparse_cache *source);
-bool source_get_underrun(struct sof_source __sparse_cache *source);
+enum sof_ipc_frame source_get_frm_fmt(struct sof_source *source);
+enum sof_ipc_frame source_get_valid_fmt(struct sof_source *source);
+unsigned int source_get_rate(struct sof_source *source);
+unsigned int source_get_channels(struct sof_source *source);
+uint32_t source_get_buffer_fmt(struct sof_source *source);
+bool source_get_underrun(struct sof_source *source);
 
 /** set of functions for setting audio parameters */
-int source_set_valid_fmt(struct sof_source __sparse_cache *source,
+int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt);
-int source_set_rate(struct sof_source __sparse_cache *source, unsigned int rate);
-int source_set_channels(struct sof_source __sparse_cache *source, unsigned int channels);
-int source_set_underrun(struct sof_source __sparse_cache *source, bool underrun_permitted);
-int source_set_buffer_fmt(struct sof_source __sparse_cache *source, uint32_t buffer_fmt);
-void source_set_ibs(struct sof_source __sparse_cache *source, size_t ibs);
-size_t source_get_ibs(struct sof_source __sparse_cache *source);
+int source_set_rate(struct sof_source *source, unsigned int rate);
+int source_set_channels(struct sof_source *source, unsigned int channels);
+int source_set_underrun(struct sof_source *source, bool underrun_permitted);
+int source_set_buffer_fmt(struct sof_source *source, uint32_t buffer_fmt);
+void source_set_ibs(struct sof_source *source, size_t ibs);
+size_t source_get_ibs(struct sof_source *source);
 
 /**
  * initial set of audio parameters, provided in sof_ipc_stream_params
@@ -151,7 +151,7 @@ size_t source_get_ibs(struct sof_source __sparse_cache *source);
  * @param force_update tells the implementation that the params should override actual settings
  * @return 0 if success
  */
-int source_set_params(struct sof_source __sparse_cache *source,
+int source_set_params(struct sof_source *source,
 		      struct sof_ipc_stream_params *params, bool force_update);
 
 /**
@@ -169,7 +169,7 @@ int source_set_params(struct sof_source __sparse_cache *source,
  *
  * @return 0 if success
  */
-int source_set_alignment_constants(struct sof_source __sparse_cache *source,
+int source_set_alignment_constants(struct sof_source *source,
 				   const uint32_t byte_align,
 				   const uint32_t frame_align_req);
 

--- a/src/include/sof/audio/source_api_implementation.h
+++ b/src/include/sof/audio/source_api_implementation.h
@@ -27,18 +27,18 @@ struct source_ops {
 	/**
 	 * see comment of source_get_data_available()
 	 */
-	size_t (*get_data_available)(struct sof_source __sparse_cache *source);
+	size_t (*get_data_available)(struct sof_source *source);
 
 	/**
 	 * see comment of source_get_data_available()
 	 */
-	int (*get_data)(struct sof_source __sparse_cache *source, size_t req_size,
+	int (*get_data)(struct sof_source *source, size_t req_size,
 			void **data_ptr, void **buffer_start, size_t *buffer_size);
 
 	/**
 	 * see comment of source_release_data()
 	 */
-	int (*release_data)(struct sof_source __sparse_cache *source, size_t free_size);
+	int (*release_data)(struct sof_source *source, size_t free_size);
 
 	/**
 	 * OPTIONAL: Notification to the source implementation about changes in audio format
@@ -49,20 +49,20 @@ struct source_ops {
 	 *
 	 * @retval 0 if success, negative if new parameteres are not supported
 	 */
-	int (*on_audio_format_set)(struct sof_source __sparse_cache *source);
+	int (*on_audio_format_set)(struct sof_source *source);
 
 	/**
 	 * OPTIONAL
 	 * see source_set_params comments
 	 */
-	int (*audio_set_ipc_params)(struct sof_source __sparse_cache *source,
+	int (*audio_set_ipc_params)(struct sof_source *source,
 				    struct sof_ipc_stream_params *params, bool force_update);
 
 	/**
 	 * OPTIONAL
 	 * see comment for source_set_alignment_constants
 	 */
-	int (*set_alignment_constants)(struct sof_source __sparse_cache *source,
+	int (*set_alignment_constants)(struct sof_source *source,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
 };
@@ -86,7 +86,7 @@ struct sof_source {
  *	  the implementation must ensure coherent access to the parameteres
  *	  in case of i.e. cross core shared queue, it must be located in non-cached memory
  */
-void source_init(struct sof_source __sparse_cache *source, const struct source_ops *ops,
+void source_init(struct sof_source *source, const struct source_ops *ops,
 		 struct sof_audio_stream_params *audio_stream_params);
 
 #endif /* __SOF_SOURCE_API_IMPLEMENTATION_H__ */

--- a/src/include/sof/math/fir_hifi3.h
+++ b/src/include/sof/math/fir_hifi3.h
@@ -48,7 +48,7 @@ static inline void fir_core_setup_circular(struct fir_state_32x16 *fir)
 }
 
 /* Setup circular for component buffer */
-static inline void fir_comp_setup_circular(const struct audio_stream __sparse_cache *buffer)
+static inline void fir_comp_setup_circular(const struct audio_stream *buffer)
 {
 	AE_SETCBEGIN0(audio_stream_get_addr(buffer));
 	AE_SETCEND0(audio_stream_get_end_addr(buffer));

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -80,7 +80,7 @@ int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd)
  */
 static void comp_update_params(uint32_t flag,
 			       struct sof_ipc_stream_params *params,
-			       struct comp_buffer __sparse_cache *buffer)
+			       struct comp_buffer *buffer)
 {
 	if (flag & BUFF_PARAMS_FRAME_FMT)
 		params->frame_fmt = audio_stream_get_frm_fmt(&buffer->stream);
@@ -104,7 +104,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	struct list_item *clist;
 	struct comp_buffer *sinkb;
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	int dir = dev->direction;
 
 	if (!params) {
@@ -291,7 +291,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	irq_local_disable(flags);
 	list_for_item_safe(clist, tmp, &icd->cd->bsource_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, sink_list);
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
+		struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
 		buffer_c->sink = NULL;
 		buffer_release(buffer_c);
@@ -304,7 +304,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	list_for_item_safe(clist, tmp, &icd->cd->bsink_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *buffer_c = buffer_acquire(buffer);
+		struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
 		buffer_c->source = NULL;
 		buffer_release(buffer_c);

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -103,7 +103,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 
 	if (!config) {
 		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -487,7 +487,7 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 	unsigned int core;
 	bool sink_active = false;
 	bool source_active = false;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 
 	/* check whether buffer exists */
 	ibd = ipc_get_buffer_by_id(ipc, buffer_id);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -241,7 +241,7 @@ static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 		/* free sink buffer allocated by current component in bind function */
 		list_for_item_safe(list, _list, &icd->cd->bsink_list) {
-			struct comp_buffer __sparse_cache *buffer_c;
+			struct comp_buffer *buffer_c;
 			struct comp_dev *sink;
 
 			buffer = container_of(list, struct comp_buffer, source_list);
@@ -257,7 +257,7 @@ static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 		/* free source buffer allocated by current component in bind function */
 		list_for_item_safe(list, _list, &icd->cd->bsource_list) {
-			struct comp_buffer __sparse_cache *buffer_c;
+			struct comp_buffer *buffer_c;
 			struct comp_dev *source;
 
 			buffer = container_of(list, struct comp_buffer, sink_list);
@@ -337,7 +337,7 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 {
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_buffer *buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	struct comp_dev *source;
 	struct comp_dev *sink;
 	struct ipc4_base_module_cfg source_src_cfg;
@@ -490,7 +490,7 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	buffer_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 	list_for_item(sink_list, &src->bsink_list) {
 		struct comp_buffer *buf = container_of(sink_list, struct comp_buffer, source_list);
-		struct comp_buffer __sparse_cache *buf_c = buffer_acquire(buf);
+		struct comp_buffer *buf_c = buffer_acquire(buf);
 		bool found = buf_c->id == buffer_id;
 
 		buffer_release(buf_c);
@@ -841,7 +841,7 @@ void ipc4_base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *ba
 		params->chmap[i] = (base_cfg->audio_fmt.ch_map >> i * 4) & 0xf;
 }
 
-void ipc4_update_buffer_format(struct comp_buffer __sparse_cache *buf_c,
+void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 			       const struct ipc4_audio_format *fmt)
 {
 	enum sof_ipc_frame valid_fmt, frame_fmt;

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -321,11 +321,11 @@ void dma_sg_free(struct dma_sg_elem_array *elem_array)
 	dma_sg_init(elem_array);
 }
 
-int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from(struct comp_buffer *source,
+			 struct comp_buffer *sink,
 			 dma_process_func process, uint32_t source_bytes)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
+	struct audio_stream *istream = &source->stream;
 	uint32_t samples = source_bytes /
 			   audio_stream_sample_bytes(istream);
 	uint32_t sink_bytes = audio_stream_sample_bytes(&sink->stream) *
@@ -350,11 +350,11 @@ int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
 	return ret;
 }
 
-int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
-		       struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_to(struct comp_buffer *source,
+		       struct comp_buffer *sink,
 		       dma_process_func process, uint32_t sink_bytes)
 {
-	struct audio_stream __sparse_cache *ostream = &sink->stream;
+	struct audio_stream *ostream = &sink->stream;
 	uint32_t samples = sink_bytes /
 			   audio_stream_sample_bytes(ostream);
 	uint32_t source_bytes = audio_stream_sample_bytes(&source->stream) *
@@ -379,11 +379,11 @@ int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
 	return ret;
 }
 
-int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
-				    struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
+				    struct comp_buffer *sink,
 				    dma_process_func process, uint32_t source_bytes)
 {
-	struct audio_stream __sparse_cache *istream = &source->stream;
+	struct audio_stream *istream = &source->stream;
 	uint32_t samples = source_bytes /
 			   audio_stream_sample_bytes(istream);
 	uint32_t sink_bytes = audio_stream_sample_bytes(&sink->stream) *

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -879,7 +879,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 {
 	struct probe_pdata *_probe = probe_get();
 	struct buffer_cb_transact *cb_data = data;
-	struct comp_buffer __sparse_cache *buffer = cb_data->buffer;
+	struct comp_buffer *buffer = cb_data->buffer;
 	struct probe_dma_ext *dma;
 	uint32_t buffer_id;
 	uint32_t head, tail;
@@ -1066,7 +1066,7 @@ static bool probe_purpose_needs_ext_dma(uint32_t purpose)
 static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point_id_t probe_point)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer __sparse_cache *buf_c;
+	struct comp_buffer *buf_c;
 	struct list_item *sink_list, *source_list;
 	unsigned int queue_id;
 

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -101,7 +101,7 @@ struct comp_data {
 	struct ipc_msg *msg;	/**< host notification */
 
 	void (*detect_func)(struct comp_dev *dev,
-			    const struct audio_stream __sparse_cache *source, uint32_t frames);
+			    const struct audio_stream *source, uint32_t frames);
 	struct sof_ipc_comp_event event;
 
 #if CONFIG_AMS
@@ -209,7 +209,7 @@ void detect_test_notify(const struct comp_dev *dev)
 }
 
 static void default_detect_test(struct comp_dev *dev,
-				const struct audio_stream __sparse_cache *source,
+				const struct audio_stream *source,
 				uint32_t frames)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
@@ -797,7 +797,7 @@ static int test_keyword_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb;
-	struct comp_buffer __sparse_cache *source_c;
+	struct comp_buffer *source_c;
 	unsigned int channels, rate;
 	enum sof_ipc_frame frame_fmt;
 	int err;
@@ -881,7 +881,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer __sparse_cache *source_c;
+	struct comp_buffer *source_c;
 	uint32_t frames;
 
 	comp_dbg(dev, "test_keyword_copy()");

--- a/src/samples/audio/kwd_nn_detect_test.c
+++ b/src/samples/audio/kwd_nn_detect_test.c
@@ -35,7 +35,7 @@ static int kwd_nn_detect_postprocess(uint8_t confidences[KWD_NN_CONFIDENCES_SIZE
 }
 
 void kwd_nn_detect_test(struct comp_dev *dev,
-			const struct audio_stream __sparse_cache *source,
+			const struct audio_stream *source,
 			uint32_t frames)
 {
 	void *src;

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -28,8 +28,8 @@ DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(smart_amp_comp_uuid),
 	       LOG_LEVEL_INFO);
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
-			     const struct audio_stream __sparse_cache *source,
-			     const struct audio_stream __sparse_cache *sink, uint32_t frames,
+			     const struct audio_stream *source,
+			     const struct audio_stream *sink, uint32_t frames,
 			     int8_t *chan_map);
 
 struct smart_amp_data {
@@ -316,7 +316,7 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 	case COMP_TRIGGER_RELEASE:
 		if (sad->feedback_buf) {
-			struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
+			struct comp_buffer *buf = buffer_acquire(sad->feedback_buf);
 			buffer_zero(buf);
 			buffer_release(buf);
 		}
@@ -332,8 +332,8 @@ static int smart_amp_trigger(struct comp_dev *dev, int cmd)
 }
 
 static int smart_amp_process_s16(struct comp_dev *dev,
-				 const struct audio_stream __sparse_cache *source,
-				 const struct audio_stream __sparse_cache *sink,
+				 const struct audio_stream *source,
+				 const struct audio_stream *sink,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
@@ -364,8 +364,8 @@ static int smart_amp_process_s16(struct comp_dev *dev,
 }
 
 static int smart_amp_process_s32(struct comp_dev *dev,
-				 const struct audio_stream __sparse_cache *source,
-				 const struct audio_stream __sparse_cache *sink,
+				 const struct audio_stream *source,
+				 const struct audio_stream *sink,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
@@ -397,7 +397,7 @@ static int smart_amp_process_s32(struct comp_dev *dev,
 }
 
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev,
-					    struct comp_buffer __sparse_cache *buf)
+					    struct comp_buffer *buf)
 {
 	switch (audio_stream_get_frm_fmt(&buf->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
@@ -414,8 +414,8 @@ static smart_amp_proc get_smart_amp_process(struct comp_dev *dev,
 static int smart_amp_copy(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct comp_buffer __sparse_cache *source_buf = buffer_acquire(sad->source_buf);
-	struct comp_buffer __sparse_cache *sink_buf = buffer_acquire(sad->sink_buf);
+	struct comp_buffer *source_buf = buffer_acquire(sad->source_buf);
+	struct comp_buffer *sink_buf = buffer_acquire(sad->sink_buf);
 	uint32_t avail_passthrough_frames;
 	uint32_t avail_feedback_frames;
 	uint32_t avail_frames = 0;
@@ -431,7 +431,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 					  &sink_buf->stream);
 
 	if (sad->feedback_buf) {
-		struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
+		struct comp_buffer *buf = buffer_acquire(sad->feedback_buf);
 
 		if (buf->source && comp_get_state(dev, buf->source) == dev->state) {
 			/* feedback */
@@ -496,7 +496,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
 	struct comp_buffer *source_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	struct list_item *blist;
 	int ret;
 
@@ -535,7 +535,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	sad->in_channels = audio_stream_get_channels(&buffer_c->stream);
 
 	if (sad->feedback_buf) {
-		struct comp_buffer __sparse_cache *buf = buffer_acquire(sad->feedback_buf);
+		struct comp_buffer *buf = buffer_acquire(sad->feedback_buf);
 
 		audio_stream_set_channels(&buf->stream, sad->config.feedback_channels);
 		audio_stream_set_rate(&buf->stream, audio_stream_get_rate(&buffer_c->stream));

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -293,9 +293,7 @@ static int smart_amp_process(struct processing_module *mod,
 
 	if (num_input_buffers == SMART_AMP_NUM_IN_PINS)
 		for (i = 0; i < num_input_buffers; i++) {
-			buf = attr_container_of(input_buffers[i].data,
-						struct comp_buffer,
-						stream, __sparse_cache);
+			buf = container_of(input_buffers[i].data, struct comp_buffer, stream);
 
 			if (IPC4_SINK_QUEUE_ID(buf->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
 				fb_input = &input_buffers[i];

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -92,7 +92,7 @@ static void smart_amp_set_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_buffer *sink;
-	struct comp_buffer __sparse_cache *sink_c;
+	struct comp_buffer *sink_c;
 
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 
@@ -196,8 +196,8 @@ static int smart_amp_process_s16(struct processing_module *mod,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int16_t *src;
 	int16_t *dest;
 	uint32_t in_frag = 0;
@@ -229,8 +229,8 @@ static int smart_amp_process_s32(struct processing_module *mod,
 				 uint32_t frames, int8_t *chan_map)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
-	struct audio_stream __sparse_cache *source = bsource->data;
-	struct audio_stream __sparse_cache *sink = bsink->data;
+	struct audio_stream *source = bsource->data;
+	struct audio_stream *sink = bsink->data;
 	int32_t *src;
 	int32_t *dest;
 	uint32_t in_frag = 0;
@@ -258,7 +258,7 @@ static int smart_amp_process_s32(struct processing_module *mod,
 }
 
 static smart_amp_proc get_smart_amp_process(struct comp_dev *dev,
-					    struct comp_buffer __sparse_cache *buf)
+					    struct comp_buffer *buf)
 {
 	switch (audio_stream_get_frm_fmt(&buf->stream)) {
 	case SOF_IPC_FRAME_S16_LE:
@@ -278,8 +278,8 @@ static int smart_amp_process(struct processing_module *mod,
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct comp_buffer __sparse_cache *fb_buf_c;
-	struct comp_buffer __sparse_cache *buf;
+	struct comp_buffer *fb_buf_c;
+	struct comp_buffer *buf;
 	struct module_source_info __sparse_cache *mod_source_info;
 	struct input_stream_buffer *fb_input = NULL;
 	/* if there is only one input stream, it should be the source input */
@@ -294,7 +294,7 @@ static int smart_amp_process(struct processing_module *mod,
 	if (num_input_buffers == SMART_AMP_NUM_IN_PINS)
 		for (i = 0; i < num_input_buffers; i++) {
 			buf = attr_container_of(input_buffers[i].data,
-						struct comp_buffer __sparse_cache,
+						struct comp_buffer,
 						stream, __sparse_cache);
 
 			if (IPC4_SINK_QUEUE_ID(buf->id) == SOF_SMART_AMP_FEEDBACK_QUEUE_ID) {
@@ -345,14 +345,14 @@ static int smart_amp_reset(struct processing_module *mod)
 }
 
 static int smart_amp_prepare(struct processing_module *mod,
-			     struct sof_source __sparse_cache **sources, int num_of_sources,
-			     struct sof_sink __sparse_cache **sinks, int num_of_sinks)
+			     struct sof_source **sources, int num_of_sources,
+			     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct smart_amp_data *sad = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source_buffer;
 	struct comp_buffer *sink_buffer;
-	struct comp_buffer __sparse_cache *buffer_c;
+	struct comp_buffer *buffer_c;
 	struct list_item *blist;
 	int ret;
 

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -254,8 +254,8 @@ struct dma_info {
 };
 
 struct audio_stream;
-typedef int (*dma_process_func)(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
+typedef int (*dma_process_func)(const struct audio_stream *source,
+				uint32_t ioffset, struct audio_stream *sink,
 				uint32_t ooffset, uint32_t frames);
 
 /**
@@ -530,8 +530,8 @@ typedef void (*dma_process)(const struct audio_stream *,
 			    struct audio_stream *, uint32_t);
 
 /* copies data from DMA buffer using provided processing function */
-int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
-			 struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from(struct comp_buffer *source,
+			 struct comp_buffer *sink,
 			 dma_process_func process, uint32_t source_bytes);
 
 /*
@@ -539,13 +539,13 @@ int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
  * conversion function. DMA buffer consume should be performed after the data has been copied
  * to all sinks.
  */
-int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
-				    struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
+				    struct comp_buffer *sink,
 				    dma_process_func process, uint32_t source_bytes);
 
 /* copies data to DMA buffer using provided processing function */
-int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
-		       struct comp_buffer __sparse_cache *sink,
+int dma_buffer_copy_to(struct comp_buffer *source,
+		       struct comp_buffer *sink,
 		       dma_process_func process, uint32_t sink_bytes);
 
 /* generic DMA DSP <-> Host copier */


### PR DESCRIPTION
- [x]  https://github.com/thesofproject/sof/pull/8166

This is removal of sparse annotations:

struct audio_stream __sparse_cache => struct audio_stream
struct comp_buffer __sparse_cache => struct comp_buffer
struct sof_source __sparse_cache => struct sof_source
struct sof_sink __sparse_cache => struct sof_sink

One of the commits touches many files/lines, but is rather safe and easy to review because all changes were made by editors string find&replace - as above

To keep sparse checker happy there's no other choice - need remove all annotations in one step

UPDATE: for context https://github.com/thesofproject/sof/issues/8006

