### PR TITLE
audio: volume: optimize windows volume ramp

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -243,6 +243,24 @@ static inline int32_t volume_windows_fade_ramp(struct vol_data *cd, int32_t ramp
 }
 #endif
 
+void volume_set_ramp_channel_counter(struct vol_data *cd, uint32_t channels_count)
+{
+	int i;
+	bool is_same_volume = true;
+
+	for (i = 1; i < channels_count; i++) {
+		if (cd->tvolume[0] != cd->tvolume[i]) {
+			is_same_volume = false;
+			break;
+		}
+	}
+
+	if (is_same_volume)
+		cd->ramp_channel_counter = 1;
+	else
+		cd->ramp_channel_counter = channels_count;
+}
+
 /**
  * \brief Ramps volume changes over time.
  * \param[in,out] vol_data Volume component data
@@ -272,7 +290,7 @@ static inline void volume_ramp(struct processing_module *mod)
 #endif
 
 	/* Update each volume if it's not at target for active channels */
-	for (i = 0; i < cd->channels; i++) {
+	for (i = 0; i < cd->ramp_channel_counter; i++) {
 		/* skip if target reached */
 		volume = cd->volume[i];
 		tvolume = cd->tvolume[i];
@@ -314,6 +332,9 @@ static inline void volume_ramp(struct processing_module *mod)
 		}
 		cd->volume[i] = new_vol;
 	}
+
+	for (i = cd->ramp_channel_counter; i < cd->channels; i++)
+		cd->volume[i] = cd->volume[0];
 
 	cd->is_passthrough = cd->ramp_finished;
 	for (i = 0; i < cd->channels; i++) {

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -332,7 +332,7 @@ static inline void volume_ramp(struct processing_module *mod)
 		}
 		cd->volume[i] = new_vol;
 	}
-
+	/* assign other channel volume as the first calculated volume with same volume case */
 	for (i = cd->ramp_channel_counter; i < cd->channels; i++)
 		cd->volume[i] = cd->volume[0];
 
@@ -557,8 +557,9 @@ static int volume_process(struct processing_module *mod,
 	comp_dbg(mod->dev, "volume_process()");
 
 	while (avail_frames) {
+#if CONFIG_COMP_PEAK_VOL
 		volume_update_current_vol_ipc4(cd);
-
+#endif
 		if (cd->ramp_finished || cd->vol_ramp_frames > avail_frames) {
 			/* without ramping process all at once */
 			frames = avail_frames;

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -176,6 +176,7 @@ struct vol_data {
 	bool copy_gain;				/**< control copy gain or not */
 	uint32_t attenuation;			/**< peakmeter adjustment in range [0 - 31] */
 	bool is_passthrough;			/**< is passthrough or do gain multiplication */
+	uint32_t ramp_channel_counter;		/**< channels need new ramp volume */
 };
 
 /** \brief Volume processing functions map. */
@@ -307,5 +308,7 @@ int volume_set_chan(struct processing_module *mod, int chan,
 void volume_set_chan_mute(struct processing_module *mod, int chan);
 
 void volume_set_chan_unmute(struct processing_module *mod, int chan);
+
+void volume_set_ramp_channel_counter(struct vol_data *cd, uint32_t channels_count);
 
 #endif /* __SOF_AUDIO_VOLUME_H__ */

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -145,6 +145,9 @@ int volume_init(struct processing_module *mod)
 		cd->muted[i] = false;
 	}
 
+	/* all target volume are same */
+	cd->ramp_channel_counter = 1;
+
 	switch (cd->ramp_type) {
 #if CONFIG_COMP_VOLUME_LINEAR_RAMP
 	case SOF_VOLUME_LINEAR:
@@ -217,6 +220,7 @@ int volume_set_config(struct processing_module *mod, uint32_t config_id,
 					return ret;
 			}
 		}
+		volume_set_ramp_channel_counter(cd, cd->channels);
 
 		volume_ramp_check(mod);
 		break;

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -159,7 +159,7 @@ int volume_init(struct processing_module *mod)
 
 	md->private = cd;
 
-	for (channel = 0; channel < channels_count ; channel++) {
+	for (channel = 0; channel < channels_count; channel++) {
 		if (vol->config[0].channel_id == IPC4_ALL_CHANNELS_MASK)
 			channel_cfg = 0;
 		else

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -176,6 +176,8 @@ int volume_init(struct processing_module *mod)
 
 	init_ramp(cd, vol->config[0].curve_duration, target_volume[0]);
 
+	volume_set_ramp_channel_counter(cd, channels_count);
+
 	cd->mailbox_offset = offsetof(struct ipc4_fw_registers, peak_vol_regs);
 	cd->mailbox_offset += instance_id * sizeof(struct ipc4_peak_volume_regs);
 
@@ -257,6 +259,8 @@ static int volume_set_volume(struct processing_module *mod, const uint8_t *data,
 			break;
 		}
 	}
+
+	volume_set_ramp_channel_counter(cd, channels_count);
 
 	cd->scale_vol = vol_get_processing_function(dev, cd);
 


### PR DESCRIPTION
windows volume ramp peak optimization, currently, with these patches, nearly 20% are reduced, measured on TGL with 48k 2 channel stream. if there is 4 channel or more, the reduction will be higher due to no matter channels you have, as long as target volume are same, ramp calculation only take once.