### PR TITLE
[Depends on 62522] zephyr: cavs: add secondary core context save support

### DIFF
--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -102,6 +102,10 @@ int platform_boot_complete(uint32_t boot_message)
 	return 0;
 }
 
+static struct pm_notifier pm_state_notifier = {
+	.state_exit = cpu_notify_state_exit,
+};
+
 /* Runs on the primary core only */
 int platform_init(struct sof *sof)
 {
@@ -149,6 +153,9 @@ int platform_init(struct sof *sof)
 	ret = dmac_init(sof);
 	if (ret < 0)
 		return ret;
+
+	/* register power states exit notifiers */
+	pm_notifier_register(&pm_state_notifier);
 
 	/* initialize the host IPC mechanisms */
 	trace_point(TRACE_BOOT_PLATFORM_IPC);

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -148,8 +148,7 @@ int cpu_enable_core(int id)
 	 * initialization. By reinitializing the idle thread, we would overwrite the kernel structs
 	 * and the idle thread stack.
 	 */
-	if (!IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE) ||
-	    pm_state_next_get(id)->state == PM_STATE_ACTIVE)
+	if (pm_state_next_get(id)->state == PM_STATE_ACTIVE)
 		z_init_cpu(id);
 #endif
 


### PR DESCRIPTION
Register pm_state_notifier to set ready_flag for secondary core when it is powered up for second time after first fw boot. We can remove CONFIG_ADSP_IMR_CONTEXT_SAVE check for cavs platform for this feature.

zephyr side pr: https://github.com/zephyrproject-rtos/zephyr/pull/62522

It has been discussed in https://github.com/thesofproject/sof/pull/8156 and https://github.com/thesofproject/sof/pull/8170

The IMR_CONTEXT_SAVE check was first introduced by https://github.com/thesofproject/sof/pull/8027