### PR TITLE
module-adapter: make interface const

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -254,8 +254,8 @@ static int aria_process(struct processing_module *mod,
 	return 0;
 }
 
-static struct module_interface aria_interface = {
-	.init  = aria_init,
+static const struct module_interface aria_interface = {
+	.init = aria_init,
 	.prepare = aria_prepare,
 	.process_audio_stream = aria_process,
 	.reset = aria_reset,

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1000,8 +1000,8 @@ static struct module_endpoint_ops copier_endpoint_ops = {
 	.trigger = copier_comp_trigger
 };
 
-static struct module_interface copier_interface = {
-	.init  = copier_init,
+static const struct module_interface copier_interface = {
+	.init = copier_init,
 	.prepare = copier_prepare,
 	.process_audio_stream = copier_process,
 	.reset = copier_reset,

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -832,8 +832,8 @@ static int crossover_reset(struct processing_module *mod)
 }
 
 /** \brief Crossover Filter component definition. */
-static struct module_interface crossover_interface = {
-	.init  = crossover_init,
+static const struct module_interface crossover_interface = {
+	.init = crossover_init,
 	.prepare = crossover_prepare,
 	.process_audio_stream = crossover_process_audio_stream,
 	.set_configuration = crossover_set_config,

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -316,8 +316,8 @@ static int dcblock_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface dcblock_interface = {
-	.init  = dcblock_init,
+static const struct module_interface dcblock_interface = {
+	.init = dcblock_init,
 	.prepare = dcblock_prepare,
 	.process_audio_stream = dcblock_process,
 	.set_configuration = dcblock_set_config,

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -360,8 +360,8 @@ static int drc_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface drc_interface = {
-	.init  = drc_init,
+static const struct module_interface drc_interface = {
+	.init = drc_init,
 	.prepare = drc_prepare,
 	.process_audio_stream = drc_process,
 	.set_configuration = drc_set_config,

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -636,7 +636,7 @@ static int eq_fir_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface eq_fir_interface = {
+static const struct module_interface eq_fir_interface = {
 		.init = eq_fir_init,
 		.free = eq_fir_free,
 		.set_configuration = eq_fir_set_config,

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -960,8 +960,8 @@ static int eq_iir_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface eq_iir_interface = {
-	.init  = eq_iir_init,
+static const struct module_interface eq_iir_interface = {
+	.init = eq_iir_init,
 	.prepare = eq_iir_prepare,
 	.process_audio_stream = eq_iir_process,
 	.set_configuration = eq_iir_set_config,

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -268,14 +268,14 @@ static int mfcc_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface mfcc_interface = {
-		.init = mfcc_init,
-		.free = mfcc_free,
-		.set_configuration = mfcc_set_config,
-		.get_configuration = mfcc_get_config,
-		.process_audio_stream = mfcc_process,
-		.prepare = mfcc_prepare,
-		.reset = mfcc_reset,
+static const struct module_interface mfcc_interface = {
+	.init = mfcc_init,
+	.free = mfcc_free,
+	.set_configuration = mfcc_set_config,
+	.get_configuration = mfcc_get_config,
+	.process_audio_stream = mfcc_process,
+	.prepare = mfcc_prepare,
+	.reset = mfcc_reset,
 };
 
 DECLARE_MODULE_ADAPTER(mfcc_interface, mfcc_uuid, mfcc_tr);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -266,8 +266,8 @@ static int mixer_prepare(struct processing_module *mod,
 	return 0;
 }
 
-static struct module_interface mixer_interface = {
-	.init  = mixer_init,
+static const struct module_interface mixer_interface = {
+	.init = mixer_init,
 	.prepare = mixer_prepare,
 	.process_audio_stream = mixer_process,
 	.reset = mixer_reset,

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -852,8 +852,8 @@ static int mixin_set_config(struct processing_module *mod, uint32_t config_id,
 	return 0;
 }
 
-static struct module_interface mixin_interface = {
-	.init  = mixin_init,
+static const struct module_interface mixin_interface = {
+	.init = mixin_init,
 	.prepare = mixin_prepare,
 	.process_audio_stream = mixin_process,
 	.set_configuration = mixin_set_config,
@@ -864,8 +864,8 @@ static struct module_interface mixin_interface = {
 DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
 SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
 
-static struct module_interface mixout_interface = {
-	.init  = mixout_init,
+static const struct module_interface mixout_interface = {
+	.init = mixout_init,
 	.prepare = mixout_prepare,
 	.process_audio_stream = mixout_process,
 	.reset = mixout_reset,

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -879,8 +879,8 @@ cadence_codec_set_configuration(struct processing_module *mod, uint32_t config_i
 	return 0;
 }
 
-static struct module_interface cadence_interface = {
-	.init  = cadence_codec_init,
+static const struct module_interface cadence_interface = {
+	.init = cadence_codec_init,
 	.prepare = cadence_codec_prepare,
 	.process_raw_data = cadence_codec_process,
 	.set_configuration = cadence_codec_set_configuration,

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -451,8 +451,8 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	return 0;
 }
 
-static struct module_interface dts_interface = {
-	.init  = dts_codec_init,
+static const struct module_interface dts_interface = {
+	.init = dts_codec_init,
 	.prepare = dts_codec_prepare,
 	.process_raw_data = dts_codec_process,
 	.set_configuration = dts_codec_set_configuration,

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -222,8 +222,7 @@ int module_prepare(struct processing_module *mod,
 	 * as it has been applied during the procedure - it is safe to
 	 * free it.
 	 */
-	if (md->cfg.data)
-		rfree(md->cfg.data);
+	rfree(md->cfg.data);
 
 	md->cfg.avail = false;
 	md->cfg.data = NULL;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -75,7 +75,7 @@ err:
 	return ret;
 }
 
-int module_init(struct processing_module *mod, struct module_interface *interface)
+int module_init(struct processing_module *mod, const struct module_interface *interface)
 {
 	int ret;
 	struct module_data *md = &mod->priv;

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -375,8 +375,8 @@ static int modules_reset(struct processing_module *mod)
 }
 
 /* Processing Module Adapter API*/
-static struct module_interface interface = {
-	.init  = modules_init,
+static const struct module_interface interface = {
+	.init = modules_init,
 	.prepare = modules_prepare,
 	.process_raw_data = modules_process,
 	.set_processing_mode = modules_set_processing_mode,

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -116,8 +116,8 @@ static int passthrough_codec_free(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface passthrough_interface = {
-	.init  = passthrough_codec_init,
+static const struct module_interface passthrough_interface = {
+	.init = passthrough_codec_init,
 	.prepare = passthrough_codec_prepare,
 	.process_raw_data = passthrough_codec_process,
 	.reset = passthrough_codec_reset,

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -883,8 +883,8 @@ waves_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	return 0;
 }
 
-static struct module_interface waves_interface = {
-	.init  = waves_codec_init,
+static const struct module_interface waves_interface = {
+	.init = waves_codec_init,
 	.prepare = waves_codec_prepare,
 	.process_raw_data = waves_codec_process,
 	.set_configuration = waves_codec_set_configuration,

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -46,7 +46,7 @@ LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
  */
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config,
-				    struct module_interface *interface, const void *spec)
+				    const struct module_interface *interface, const void *spec)
 {
 	int ret;
 	struct comp_dev *dev;

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -551,8 +551,8 @@ static int multiband_drc_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface multiband_drc_interface = {
-	.init  = multiband_drc_init,
+static const struct module_interface multiband_drc_interface = {
+	.init = multiband_drc_init,
 	.prepare = multiband_drc_prepare,
 	.process_audio_stream = multiband_drc_process,
 	.set_configuration = multiband_drc_set_config,

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -675,8 +675,8 @@ static int mux_set_config(struct processing_module *mod, uint32_t config_id,
 				  fragment, fragment_size);
 }
 
-static struct module_interface mux_interface = {
-	.init  = mux_init,
+static const struct module_interface mux_interface = {
+	.init = mux_init,
 	.set_configuration = mux_set_config,
 	.get_configuration = mux_get_config,
 	.prepare = mux_prepare,
@@ -688,8 +688,8 @@ static struct module_interface mux_interface = {
 DECLARE_MODULE_ADAPTER(mux_interface, mux_uuid, mux_tr);
 SOF_MODULE_INIT(mux, sys_comp_module_mux_interface_init);
 
-static struct module_interface demux_interface = {
-	.init  = demux_init,
+static const struct module_interface demux_interface = {
+	.init = demux_init,
 	.set_configuration = mux_set_config,
 	.get_configuration = mux_get_config,
 	.prepare = mux_prepare,

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -965,7 +965,7 @@ static int selector_reset(struct processing_module *mod)
 }
 
 /** \brief Selector component definition. */
-static struct module_interface selector_interface = {
+static const struct module_interface selector_interface = {
 	.init			= selector_init,
 	.prepare		= selector_prepare,
 	.process_audio_stream	= selector_process,

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -1068,8 +1068,8 @@ static int src_free(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface src_interface = {
-	.init  = src_init,
+static const struct module_interface src_interface = {
+	.init = src_init,
 	.prepare = src_prepare,
 	.process = src_process,
 	.is_ready_to_process = src_is_ready_to_process,

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -819,7 +819,7 @@ static int tdfb_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface tdfb_interface = {
+static const struct module_interface tdfb_interface = {
 	.init = tdfb_init,
 	.free = tdfb_free,
 	.set_configuration = tdfb_set_config,

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -456,8 +456,8 @@ up_down_mixer_process(struct processing_module *mod,
 	return 0;
 }
 
-static struct module_interface up_down_mixer_interface = {
-	.init  = up_down_mixer_init,
+static const struct module_interface up_down_mixer_interface = {
+	.init = up_down_mixer_init,
 	.prepare = up_down_mixer_prepare,
 	.process_audio_stream = up_down_mixer_process,
 	.reset = up_down_mixer_reset,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -745,8 +745,8 @@ static int volume_reset(struct processing_module *mod)
 	return 0;
 }
 
-static struct module_interface volume_interface = {
-	.init  = volume_init,
+static const struct module_interface volume_interface = {
+	.init = volume_init,
 	.prepare = volume_prepare,
 	.process_audio_stream = volume_process,
 	.set_configuration = volume_set_config,
@@ -759,8 +759,8 @@ DECLARE_MODULE_ADAPTER(volume_interface, volume_uuid, volume_tr);
 SOF_MODULE_INIT(volume, sys_comp_module_volume_interface_init);
 
 #if CONFIG_COMP_GAIN
-static struct module_interface gain_interface = {
-	.init  = volume_init,
+static const struct module_interface gain_interface = {
+	.init = volume_init,
 	.prepare = volume_prepare,
 	.process_audio_stream = volume_process,
 	.set_configuration = volume_set_config,

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -155,7 +155,7 @@ struct module_data {
 	void *private; /**< self object, memory tables etc here */
 	void *runtime_params;
 	struct module_config cfg; /**< module configuration data */
-	struct module_interface *ops; /**< module specific operations */
+	const struct module_interface *ops; /**< module specific operations */
 	struct module_memory memory; /**< memory allocated by module */
 	struct module_processing_data mpd; /**< shared data comp <-> module */
 	void *module_adapter; /**<loadable module interface handle */
@@ -240,7 +240,7 @@ struct processing_module {
 /* Module generic interfaces						     */
 /*****************************************************************************/
 int module_load_config(struct comp_dev *dev, const void *cfg, size_t size);
-int module_init(struct processing_module *mod, struct module_interface *interface);
+int module_init(struct processing_module *mod, const struct module_interface *interface);
 void *module_allocate_memory(struct processing_module *mod, uint32_t size, uint32_t alignment);
 int module_free_memory(struct processing_module *mod, void *ptr);
 void module_free_all_memory(struct processing_module *mod);
@@ -290,7 +290,7 @@ int module_unbind(struct processing_module *mod, void *data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config,
-				    struct module_interface *interface, const void *spec);
+				    const struct module_interface *interface, const void *spec);
 int module_adapter_prepare(struct comp_dev *dev);
 int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *params);
 int module_adapter_copy(struct comp_dev *dev);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -387,8 +387,8 @@ static int smart_amp_prepare(struct processing_module *mod,
 	return ret;
 }
 
-static struct module_interface smart_amp_interface = {
-	.init  = smart_amp_init,
+static const struct module_interface smart_amp_interface = {
+	.init = smart_amp_init,
 	.prepare = smart_amp_prepare,
 	.process_audio_stream = smart_amp_process,
 	.set_configuration = smart_amp_set_config,


### PR DESCRIPTION
Module adapter interfaces are a collection of methods, implementing the API, they never change. Make them const.