### PR TITLE
smart-amp: remove unused header

### DIFF
--- a/src/include/sof/samples/audio/smart_amp_test.h
+++ b/src/include/sof/samples/audio/smart_amp_test.h
@@ -8,7 +8,6 @@
 #ifndef __SOF_AUDIO_SMART_AMP_H__
 #define __SOF_AUDIO_SMART_AMP_H__
 
-#include <sof/platform.h>
 #include <sof/audio/component.h>
 #include <sof/audio/data_blob.h>
 


### PR DESCRIPTION
platform.h isn't needed in smart_amp_test.h, remove it from there.