### PR TITLE
imx: sai: Fix sof run fail issue on imx8ulp

### DIFF
--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -355,6 +355,7 @@ static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_
 		return -EINVAL;
 	}
 
+#ifndef CONFIG_IMX8ULP
 	switch (sai->params.tdm_slot_width) {
 	case 8:
 		val_cr4 |= REG_SAI_CR4_FPACK_8;
@@ -365,6 +366,7 @@ static inline int sai_set_config(struct dai *dai, struct ipc_config_dai *common_
 	default:
 		break;
 	}
+#endif
 
 	val_cr4 |= REG_SAI_CR4_FRSZ(sai->params.tdm_slots);
 	val_cr4 |= REG_SAI_CR4_CHMOD;


### PR DESCRIPTION
Fix sof run fail issue:
Don't need to enable packed mode for sai on 8ulp.
Also correct frame size for 8ulp.