### PR TITLE
helper: add a condition before updating the component direction

### DIFF
--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -56,7 +56,7 @@ int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma, bool *delay);
 int ipc4_process_on_core(uint32_t core, bool blocking);
-int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id);
+int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id, uint32_t cmd);
 int ipc4_find_dma_config(struct ipc_config_dai *dai, uint8_t *data_buffer, uint32_t size);
 int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd);
 int ipc4_pipeline_trigger(struct ipc_comp_dev *ppl_icd, uint32_t cmd, bool *delayed);

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -274,7 +274,7 @@ int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd)
 		switch (status) {
 		case COMP_STATE_INIT:
 			tr_dbg(&ipc_tr, "pipeline %d: reset from init", ppl_icd->id);
-			ret = ipc4_pipeline_complete(ipc, ppl_icd->id);
+			ret = ipc4_pipeline_complete(ipc, ppl_icd->id, cmd);
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 
@@ -296,7 +296,7 @@ int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd)
 		switch (status) {
 		case COMP_STATE_INIT:
 			tr_dbg(&ipc_tr, "pipeline %d: pause from init", ppl_icd->id);
-			ret = ipc4_pipeline_complete(ipc, ppl_icd->id);
+			ret = ipc4_pipeline_complete(ipc, ppl_icd->id, cmd);
 			if (ret < 0)
 				ret = IPC4_INVALID_REQUEST;
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -630,7 +630,7 @@ static int ipc4_update_comps_direction(struct ipc *ipc, uint32_t ppl_id)
 	return 0;
 }
 
-int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
+int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id, uint32_t cmd)
 {
 	struct ipc_comp_dev *ipc_pipe;
 	int ret;
@@ -649,9 +649,11 @@ int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	 * pipeline w/o connection to gateway, so direction is not configured in binding phase.
 	 * Need to update direction for such modules when pipeline is completed.
 	 */
-	ret = ipc4_update_comps_direction(ipc, comp_id);
-	if (ret < 0)
-		return ret;
+	if (cmd != SOF_IPC4_PIPELINE_STATE_RESET) {
+		ret = ipc4_update_comps_direction(ipc, comp_id);
+		if (ret < 0)
+			return ret;
+	}
 
 	return ipc_pipeline_complete(ipc, comp_id);
 }


### PR DESCRIPTION
At the pipeline reset stage, the direction of the components is not always known (example for the pipeline below), resulting in a call to a field that is null (src_buf->source->direction_set/src_buf->source->direction) and consequently a crash/timeout.

![image](https://github.com/thesofproject/sof/assets/93710754/64224ce2-9d83-4acc-974e-2b651b3a42e0)
