### PR TITLE
cache: remove buffer_acquire/release form infrastructure

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -31,7 +31,6 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 				 bool is_shared)
 {
 	struct comp_buffer *buffer;
-	struct comp_buffer *buffer_c;
 	void *stream_addr;
 
 	tr_dbg(&buffer_tr, "buffer_alloc()");
@@ -65,14 +64,11 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	}
 
 	/* From here no more uncached access to the buffer object, except its list headers */
-	buffer_c = buffer_acquire(buffer);
-	audio_stream_set_addr(&buffer_c->stream, stream_addr);
-	buffer_init(buffer_c, size, caps);
+	audio_stream_set_addr(&buffer->stream, stream_addr);
+	buffer_init(buffer, size, caps);
 
-	audio_stream_set_underrun(&buffer_c->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
-	audio_stream_set_overrun(&buffer_c->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
-
-	buffer_release(buffer_c);
+	audio_stream_set_underrun(&buffer->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
+	audio_stream_set_overrun(&buffer->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
 
 	list_init(&buffer->source_list);
 	list_init(&buffer->sink_list);
@@ -203,7 +199,7 @@ void buffer_free(struct comp_buffer *buffer)
 	notifier_unregister_all(NULL, buffer);
 
 	rfree(buffer->stream.addr);
-	coherent_free_thread(buffer, c);
+	rfree(buffer);
 }
 
 void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -175,8 +175,6 @@ err:
 
 static int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
-	struct comp_buffer *source_buffers_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer *sinks_buffers_c[PLATFORM_MAX_STREAMS];
 	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
 	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
@@ -184,41 +182,30 @@ static int module_adapter_sink_src_prepare(struct comp_dev *dev)
 	uint32_t num_of_sources = 0;
 	uint32_t num_of_sinks = 0;
 	int ret;
-	int i = 0;
 
 	/* acquire all sink and source buffers, get handlers to sink/source API */
 	list_for_item(blist, &dev->bsink_list) {
-		struct comp_buffer *sink_buffer_uc;
+		struct comp_buffer *sink_buffer;
 
-		sink_buffer_uc = container_of(blist, struct comp_buffer, source_list);
-		sinks_buffers_c[num_of_sinks] = buffer_acquire(sink_buffer_uc);
+		sink_buffer = container_of(blist, struct comp_buffer, source_list);
 		audio_sink[num_of_sinks] =
-				audio_stream_get_sink(&sinks_buffers_c[num_of_sinks]->stream);
+				audio_stream_get_sink(&sink_buffer->stream);
 		sink_reset_num_of_processed_bytes(audio_sink[num_of_sinks]);
 		num_of_sinks++;
 	}
 
 	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer *source_buffer_uc;
+		struct comp_buffer *source_buffer;
 
-		source_buffer_uc = container_of(blist, struct comp_buffer, sink_list);
-		source_buffers_c[num_of_sources] = buffer_acquire(source_buffer_uc);
+		source_buffer = container_of(blist, struct comp_buffer, sink_list);
 		audio_src[num_of_sources] =
-				audio_stream_get_source(&source_buffers_c[num_of_sources]->stream);
+				audio_stream_get_source(&source_buffer->stream);
 		source_reset_num_of_processed_bytes(audio_src[num_of_sources]);
 		num_of_sources++;
 	}
 
 	/* Prepare module */
 	ret = module_prepare(mod, audio_src, num_of_sources, audio_sink, num_of_sinks);
-
-	/* release all source buffers in reverse order */
-	for (i = num_of_sources - 1; i >= 0; i--)
-		buffer_release(source_buffers_c[i]);
-
-	/* release all sink buffers in reverse order */
-	for  (i = num_of_sinks - 1; i >= 0 ; i--)
-		buffer_release(sinks_buffers_c[i]);
 
 	return ret;
 }
@@ -236,8 +223,6 @@ int module_adapter_prepare(struct comp_dev *dev)
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
-	struct comp_buffer *buffer_c;
-	struct comp_buffer *sink_c;
 	struct comp_buffer *sink;
 	struct list_item *blist, *_blist;
 	uint32_t buff_periods;
@@ -286,12 +271,9 @@ int module_adapter_prepare(struct comp_dev *dev)
 	 * parameter from sink buffer is settled, and still prior to all references to period_bytes.
 	 */
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
 
-	mod->period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
+	mod->period_bytes = audio_stream_period_bytes(&sink->stream, dev->frames);
 	comp_dbg(dev, "module_adapter_prepare(): got period_bytes = %u", mod->period_bytes);
-
-	buffer_release(sink_c);
 
 	/*
 	 * compute number of input buffers and make the source_info shared if the module is on a
@@ -460,28 +442,23 @@ int module_adapter_prepare(struct comp_dev *dev)
 			buffer_attach(buffer, &mod->sink_buffer_list, PPL_DIR_UPSTREAM);
 			irq_local_enable(flags);
 
-			buffer_c = buffer_acquire(buffer);
-			buffer_set_params(buffer_c, mod->stream_params, BUFFER_UPDATE_FORCE);
-			buffer_reset_pos(buffer_c, NULL);
-			buffer_release(buffer_c);
+			buffer_set_params(buffer, mod->stream_params, BUFFER_UPDATE_FORCE);
+			buffer_reset_pos(buffer, NULL);
 		}
 	} else {
 		list_for_item(blist, &mod->sink_buffer_list) {
 			struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 								  sink_list);
 
-			buffer_c = buffer_acquire(buffer);
-			ret = buffer_set_size(buffer_c, buff_size, 0);
+			ret = buffer_set_size(buffer, buff_size, 0);
 			if (ret < 0) {
-				buffer_release(buffer_c);
 				comp_err(dev, "module_adapter_prepare(): buffer_set_size() failed, buff_size = %u",
 					 buff_size);
 				goto free;
 			}
 
-			buffer_set_params(buffer_c, mod->stream_params, BUFFER_UPDATE_FORCE);
-			buffer_reset_pos(buffer_c, NULL);
-			buffer_release(buffer_c);
+			buffer_set_params(buffer, mod->stream_params, BUFFER_UPDATE_FORCE);
+			buffer_reset_pos(buffer, NULL);
 		}
 	}
 
@@ -503,11 +480,11 @@ free:
 
 out_data_free:
 	for (i = 0; i < mod->num_output_buffers; i++)
-		rfree((__sparse_force void *)mod->output_buffers[i].data);
+		rfree(mod->output_buffers[i].data);
 
 in_data_free:
 	for (i = 0; i < mod->num_input_buffers; i++)
-		rfree((__sparse_force void *)mod->input_buffers[i].data);
+		rfree(mod->input_buffers[i].data);
 
 in_out_free:
 	rfree(mod->output_buffers);
@@ -678,7 +655,6 @@ static void module_adapter_process_output(struct comp_dev *dev)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	struct list_item *blist;
 	int i = 0;
 
@@ -689,15 +665,12 @@ static void module_adapter_process_output(struct comp_dev *dev)
 	list_for_item(blist, &mod->sink_buffer_list) {
 		if (mod->output_buffers[i].size > 0) {
 			struct comp_buffer *buffer;
-			struct comp_buffer *buffer_c;
 
 			buffer = container_of(blist, struct comp_buffer, sink_list);
-			buffer_c = buffer_acquire(buffer);
 
-			ca_copy_from_module_to_sink(&buffer_c->stream, mod->output_buffers[i].data,
+			ca_copy_from_module_to_sink(&buffer->stream, mod->output_buffers[i].data,
 						    mod->output_buffers[i].size);
-			audio_stream_produce(&buffer_c->stream, mod->output_buffers[i].size);
-			buffer_release(buffer_c);
+			audio_stream_produce(&buffer->stream, mod->output_buffers[i].size);
 		}
 		i++;
 	}
@@ -711,17 +684,12 @@ static void module_adapter_process_output(struct comp_dev *dev)
 		list_for_item(_blist, &mod->sink_buffer_list) {
 			if (i == j) {
 				struct comp_buffer *source;
-				struct comp_buffer *source_c;
 
 				sink = container_of(blist, struct comp_buffer, source_list);
 				source = container_of(_blist, struct comp_buffer, sink_list);
 
-				sink_c = buffer_acquire(sink);
-				source_c = buffer_acquire(source);
-				module_copy_samples(dev, source_c, sink_c,
+				module_copy_samples(dev, source, sink,
 						    mod->output_buffers[i].size);
-				buffer_release(source_c);
-				buffer_release(sink_c);
 
 				mod->output_buffers[i].size = 0;
 				break;
@@ -736,8 +704,8 @@ static void module_adapter_process_output(struct comp_dev *dev)
 
 static uint32_t
 module_single_sink_setup(struct comp_dev *dev,
-			 struct comp_buffer **source_c,
-			 struct comp_buffer **sinks_c)
+			 struct comp_buffer **source,
+			 struct comp_buffer **sinks)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
@@ -746,14 +714,14 @@ module_single_sink_setup(struct comp_dev *dev,
 	int i = 0;
 
 	list_for_item(blist, &dev->bsource_list) {
-		frames = audio_stream_avail_frames_aligned(&source_c[i]->stream,
-							   &sinks_c[0]->stream);
+		frames = audio_stream_avail_frames_aligned(&source[i]->stream,
+							   &sinks[0]->stream);
 
 		if (!mod->skip_src_buffer_invalidate) {
 			uint32_t source_frame_bytes;
 
-			source_frame_bytes = audio_stream_frame_bytes(&source_c[i]->stream);
-			buffer_stream_invalidate(source_c[i], frames * source_frame_bytes);
+			source_frame_bytes = audio_stream_frame_bytes(&source[i]->stream);
+			buffer_stream_invalidate(source[i], frames * source_frame_bytes);
 		}
 
 		/*
@@ -763,22 +731,22 @@ module_single_sink_setup(struct comp_dev *dev,
 		mod->input_buffers[i].size = frames;
 		mod->input_buffers[i].consumed = 0;
 
-		mod->input_buffers[i].data = &source_c[i]->stream;
+		mod->input_buffers[i].data = &source[i]->stream;
 		i++;
 	}
 
 	num_input_buffers = i;
 
 	mod->output_buffers[0].size = 0;
-	mod->output_buffers[0].data = &sinks_c[0]->stream;
+	mod->output_buffers[0].data = &sinks[0]->stream;
 
 	return num_input_buffers;
 }
 
 static uint32_t
 module_single_source_setup(struct comp_dev *dev,
-			   struct comp_buffer **source_c,
-			   struct comp_buffer **sinks_c)
+			   struct comp_buffer **source,
+			   struct comp_buffer **sinks)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
@@ -787,20 +755,20 @@ module_single_source_setup(struct comp_dev *dev,
 	uint32_t source_frame_bytes;
 	int i = 0;
 
-	source_frame_bytes = audio_stream_frame_bytes(&source_c[0]->stream);
+	source_frame_bytes = audio_stream_frame_bytes(&source[0]->stream);
 	if (list_is_empty(&dev->bsink_list)) {
-		min_frames = audio_stream_get_avail_frames(&source_c[0]->stream);
+		min_frames = audio_stream_get_avail_frames(&source[0]->stream);
 	} else {
 		uint32_t frames;
 
 		list_for_item(blist, &dev->bsink_list) {
-			frames = audio_stream_avail_frames_aligned(&source_c[0]->stream,
-								   &sinks_c[i]->stream);
+			frames = audio_stream_avail_frames_aligned(&source[0]->stream,
+								   &sinks[i]->stream);
 
 			min_frames = MIN(min_frames, frames);
 
 			mod->output_buffers[i].size = 0;
-			mod->output_buffers[i].data = &sinks_c[i]->stream;
+			mod->output_buffers[i].data = &sinks[i]->stream;
 			i++;
 		}
 	}
@@ -808,12 +776,12 @@ module_single_source_setup(struct comp_dev *dev,
 	num_output_buffers = i;
 
 	if (!mod->skip_src_buffer_invalidate)
-		buffer_stream_invalidate(source_c[0], min_frames * source_frame_bytes);
+		buffer_stream_invalidate(source[0], min_frames * source_frame_bytes);
 
 	/* note that the size is in number of frames not the number of bytes */
 	mod->input_buffers[0].size = min_frames;
 	mod->input_buffers[0].consumed = 0;
-	mod->input_buffers[0].data = &source_c[0]->stream;
+	mod->input_buffers[0].data = &source[0]->stream;
 
 	return num_output_buffers;
 }
@@ -821,28 +789,30 @@ module_single_source_setup(struct comp_dev *dev,
 static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct comp_buffer *source_c;
-	struct comp_buffer *sink_c;
 	uint32_t num_output_buffers = 0;
 	uint32_t frames;
 	int ret;
 
-	source_c = buffer_acquire(mod->source_comp_buffer);
-	sink_c = buffer_acquire(mod->sink_comp_buffer);
-	frames = audio_stream_avail_frames_aligned(&source_c->stream, &sink_c->stream);
+	frames = audio_stream_avail_frames_aligned(&mod->source_comp_buffer->stream,
+						   &mod->sink_comp_buffer->stream);
 	mod->input_buffers[0].size = frames;
 	mod->input_buffers[0].consumed = 0;
-	mod->input_buffers[0].data = &source_c->stream;
+	mod->input_buffers[0].data = &mod->source_comp_buffer->stream;
 	mod->output_buffers[0].size = 0;
-	mod->output_buffers[0].data = &sink_c->stream;
-	if (!mod->skip_src_buffer_invalidate) /* TODO: add mod->is_multi_core && optimization */
-		buffer_stream_invalidate(source_c,
-					 frames * audio_stream_frame_bytes(&source_c->stream));
+	mod->output_buffers[0].data = &mod->sink_comp_buffer->stream;
+
+	if (!mod->skip_src_buffer_invalidate) { /* TODO: add mod->is_multi_core && optimization */
+		/* moved bytes to its own variable to fix checkpatch */
+		uint32_t bytes =
+			frames * audio_stream_frame_bytes(&mod->source_comp_buffer->stream);
+		buffer_stream_invalidate(mod->source_comp_buffer,
+					 bytes);
+	}
 
 	/* Note: Source buffer state is not checked to enable mixout to generate zero
 	 * PCM codes when source is not active.
 	 */
-	if (sink_c->sink->state == dev->state)
+	if (mod->sink_comp_buffer->sink->state == dev->state)
 		num_output_buffers = 1;
 
 	ret = module_process_legacy(mod, mod->input_buffers, 1,
@@ -851,26 +821,24 @@ static int module_adapter_audio_stream_copy_1to1(struct comp_dev *dev)
 	/* consume from the input buffer */
 	mod->total_data_consumed += mod->input_buffers[0].consumed;
 	if (mod->input_buffers[0].consumed)
-		audio_stream_consume(&source_c->stream, mod->input_buffers[0].consumed);
+		audio_stream_consume(&mod->source_comp_buffer->stream,
+				     mod->input_buffers[0].consumed);
 
 	/* produce data into the output buffer */
 	mod->total_data_produced += mod->output_buffers[0].size;
 	if (!mod->skip_sink_buffer_writeback) /* TODO: add mod->is_multi_core && optimization */
-		buffer_stream_writeback(sink_c, mod->output_buffers[0].size);
+		buffer_stream_writeback(mod->sink_comp_buffer, mod->output_buffers[0].size);
 
 	if (mod->output_buffers[0].size)
-		comp_update_buffer_produce(sink_c, mod->output_buffers[0].size);
+		comp_update_buffer_produce(mod->sink_comp_buffer, mod->output_buffers[0].size);
 
-	/* release all buffers */
-	buffer_release(sink_c);
-	buffer_release(source_c);
 	return ret;
 }
 
 static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 {
-	struct comp_buffer *source_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer *sinks_c[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *sources[PLATFORM_MAX_STREAMS];
+	struct comp_buffer *sinks[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct list_item *blist;
 	uint32_t num_input_buffers, num_output_buffers;
@@ -892,7 +860,7 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 		struct comp_buffer *sink;
 
 		sink = container_of(blist, struct comp_buffer, source_list);
-		sinks_c[i++] = buffer_acquire(sink);
+		sinks[i++] = sink;
 	}
 	num_output_buffers = i;
 	if (num_output_buffers > mod->max_sinks) {
@@ -905,7 +873,7 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 		struct comp_buffer *source;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
-		source_c[i++] = buffer_acquire(source);
+		sources[i++] = source;
 	}
 	num_input_buffers = i;
 	if (num_input_buffers > mod->max_sources) {
@@ -915,16 +883,13 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* setup active input/output buffers for processing */
 	if (num_output_buffers == 1) {
-		module_single_sink_setup(dev, source_c, sinks_c);
-		if (sinks_c[0]->sink->state != dev->state) {
+		module_single_sink_setup(dev, sources, sinks);
+		if (sinks[0]->sink->state != dev->state)
 			num_output_buffers = 0;
-			buffer_release(sinks_c[0]);
-		}
 	} else if (num_input_buffers == 1) {
-		module_single_source_setup(dev, source_c, sinks_c);
-		if (source_c[0]->source->state != dev->state) {
+		module_single_source_setup(dev, sources, sinks);
+		if (sources[0]->source->state != dev->state) {
 			num_input_buffers = 0;
-			buffer_release(source_c[0]);
 		}
 	} else {
 		ret = -EINVAL;
@@ -946,11 +911,11 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* consume from all active input buffers */
 	for (i = 0; i < num_input_buffers; i++) {
-		struct comp_buffer *src_c;
+		struct comp_buffer *src =
+			container_of(mod->input_buffers[i].data, struct comp_buffer, stream);
 
-		src_c = container_of(mod->input_buffers[i].data, struct comp_buffer, stream);
 		if (mod->input_buffers[i].consumed)
-			audio_stream_consume(&src_c->stream, mod->input_buffers[i].consumed);
+			audio_stream_consume(&src->stream, mod->input_buffers[i].consumed);
 	}
 
 	/* compute data consumed based on pin 0 since it is processed with base config
@@ -960,39 +925,35 @@ static int module_adapter_audio_stream_type_copy(struct comp_dev *dev)
 
 	/* release all source buffers */
 	for (i = 0; i < num_input_buffers; i++) {
-		buffer_release(source_c[i]);
 		mod->input_buffers[i].size = 0;
 		mod->input_buffers[i].consumed = 0;
 	}
 
 	/* produce data into all active output buffers */
 	for (i = 0; i < num_output_buffers; i++) {
-		struct comp_buffer *sink_c =
+		struct comp_buffer *sink =
 			container_of(mod->output_buffers[i].data, struct comp_buffer, stream);
 
 		if (!mod->skip_sink_buffer_writeback)
-			buffer_stream_writeback(sink_c, mod->output_buffers[i].size);
+			buffer_stream_writeback(sink, mod->output_buffers[i].size);
 		if (mod->output_buffers[i].size)
-			comp_update_buffer_produce(sink_c, mod->output_buffers[i].size);
+			comp_update_buffer_produce(sink, mod->output_buffers[i].size);
 	}
 
 	mod->total_data_produced += mod->output_buffers[0].size;
 
 	/* release all sink buffers */
 	for (i = 0; i < num_output_buffers; i++) {
-		buffer_release(sinks_c[i]);
 		mod->output_buffers[i].size = 0;
 	}
 
 	return 0;
 out:
 	for (i = 0; i < num_output_buffers; i++) {
-		buffer_release(sinks_c[i]);
 		mod->output_buffers[i].size = 0;
 	}
 
 	for (i = 0; i < num_input_buffers; i++) {
-		buffer_release(source_c[i]);
 		mod->input_buffers[i].size = 0;
 		mod->input_buffers[i].consumed = 0;
 	}
@@ -1002,8 +963,6 @@ out:
 
 static int module_adapter_sink_source_copy(struct comp_dev *dev)
 {
-	struct comp_buffer *source_buffers_c[PLATFORM_MAX_STREAMS];
-	struct comp_buffer *sinks_buffers_c[PLATFORM_MAX_STREAMS];
 	struct sof_sink *audio_sink[PLATFORM_MAX_STREAMS];
 	struct sof_source *audio_src[PLATFORM_MAX_STREAMS];
 	struct processing_module *mod = comp_get_drvdata(dev);
@@ -1020,9 +979,8 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 		struct comp_buffer *sink_buffer;
 
 		sink_buffer = container_of(blist, struct comp_buffer, source_list);
-		sinks_buffers_c[num_of_sinks] = buffer_acquire(sink_buffer);
 		audio_sink[num_of_sinks] =
-				audio_stream_get_sink(&sinks_buffers_c[num_of_sinks]->stream);
+				audio_stream_get_sink(&sink_buffer->stream);
 		sink_reset_num_of_processed_bytes(audio_sink[num_of_sinks]);
 		num_of_sinks++;
 	}
@@ -1031,9 +989,8 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 		struct comp_buffer *source_buffer;
 
 		source_buffer = container_of(blist, struct comp_buffer, sink_list);
-		source_buffers_c[num_of_sources] = buffer_acquire(source_buffer);
 		audio_src[num_of_sources] =
-				audio_stream_get_source(&source_buffers_c[num_of_sources]->stream);
+				audio_stream_get_source(&source_buffer->stream);
 		source_reset_num_of_processed_bytes(audio_src[num_of_sources]);
 		num_of_sources++;
 	}
@@ -1048,13 +1005,11 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 	/* release all source buffers in reverse order */
 	for (i = num_of_sources - 1; i >= 0; i--) {
 		mod->total_data_consumed += source_get_num_of_processed_bytes(audio_src[i]);
-		buffer_release(source_buffers_c[i]);
 	}
 
 	/* release all sink buffers in reverse order */
 	for  (i = num_of_sinks - 1; i >= 0 ; i--) {
 		mod->total_data_produced += sink_get_num_of_processed_bytes(audio_sink[i]);
-		buffer_release(sinks_buffers_c[i]);
 	}
 
 	comp_dbg(dev, "module_adapter_sink_source_copy(): done");
@@ -1067,7 +1022,6 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct module_data *md = &mod->priv;
 	struct comp_buffer *source, *sink;
-	struct comp_buffer *sink_c = NULL;
 	struct list_item *blist;
 	size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
 	uint32_t min_free_frames = UINT_MAX;
@@ -1078,40 +1032,33 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	list_for_item(blist, &mod->sink_buffer_list) {
 		sink = container_of(blist, struct comp_buffer, sink_list);
 
-		sink_c = buffer_acquire(sink);
 		min_free_frames = MIN(min_free_frames,
-				      audio_stream_get_free_frames(&sink_c->stream));
-		buffer_release(sink_c);
+				      audio_stream_get_free_frames(&sink->stream));
 	}
 
 	/* copy source samples into input buffer */
 	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer *src_c;
 		uint32_t bytes_to_process;
 		int frames, source_frame_bytes;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
-		src_c = buffer_acquire(source);
 
 		/* check if the source dev is in the same state as the dev */
-		if (!src_c->source || src_c->source->state != dev->state) {
-			buffer_release(src_c);
+		if (!source->source || source->source->state != dev->state)
 			continue;
-		}
 
 		frames = MIN(min_free_frames,
-			     audio_stream_get_avail_frames(&src_c->stream));
-		source_frame_bytes = audio_stream_frame_bytes(&src_c->stream);
+			     audio_stream_get_avail_frames(&source->stream));
+		source_frame_bytes = audio_stream_frame_bytes(&source->stream);
 
 		bytes_to_process = MIN(frames * source_frame_bytes, md->mpd.in_buff_size);
 
-		buffer_stream_invalidate(src_c, bytes_to_process);
+		buffer_stream_invalidate(source, bytes_to_process);
 		mod->input_buffers[i].size = bytes_to_process;
 		mod->input_buffers[i].consumed = 0;
 
-		ca_copy_from_source_to_module(&src_c->stream, mod->input_buffers[i].data,
+		ca_copy_from_source_to_module(&source->stream, mod->input_buffers[i].data,
 					      md->mpd.in_buff_size, bytes_to_process);
-		buffer_release(src_c);
 		i++;
 	}
 
@@ -1131,13 +1078,10 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	i = 0;
 	/* consume from all input buffers */
 	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer *src_c;
 
 		source = container_of(blist, struct comp_buffer, sink_list);
-		src_c = buffer_acquire(source);
 
-		comp_update_buffer_consume(src_c, mod->input_buffers[i].consumed);
-		buffer_release(src_c);
+		comp_update_buffer_consume(source, mod->input_buffers[i].consumed);
 
 		bzero((__sparse_force void *)mod->input_buffers[i].data, size);
 		mod->input_buffers[i].size = 0;
@@ -1326,11 +1270,9 @@ static int module_source_status_count(struct comp_dev *dev, uint32_t status)
 		 */
 		struct comp_buffer *source = container_of(blist, struct comp_buffer,
 							  sink_list);
-		struct comp_buffer *source_c = buffer_acquire(source);
 
-		if (source_c->source && source_c->source->state == status)
+		if (source->source && source->source->state == status)
 			count++;
-		buffer_release(source_c);
 	}
 
 	return count;
@@ -1416,10 +1358,7 @@ int module_adapter_reset(struct comp_dev *dev)
 	list_for_item(blist, &mod->sink_buffer_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  sink_list);
-		struct comp_buffer *buffer_c = buffer_acquire(buffer);
-
-		buffer_zero(buffer_c);
-		buffer_release(buffer_c);
+		buffer_zero(buffer);
 	}
 
 	rfree(mod->stream_params);

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -30,7 +30,6 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 				    int dir)
 {
 	struct pipeline_data *ppl_data = ctx->comp_data;
-	struct comp_buffer *buf_c = buffer_acquire(calling_buf);
 	int err = 0;
 
 	pipe_dbg(current->pipeline, "pipeline_comp_params_neg(), current->comp.id = %u, dir = %u",
@@ -48,12 +47,12 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 		 * a component who has different channels input/output buffers
 		 * should explicitly configure the channels of the branched buffers.
 		 */
-		err = buffer_set_params(buf_c, &ppl_data->params->params,
+		err = buffer_set_params(calling_buf, &ppl_data->params->params,
 					BUFFER_UPDATE_FORCE);
 		break;
 	default:
 		/* return 0 if params matches */
-		if (!buffer_params_match(buf_c,
+		if (!buffer_params_match(calling_buf,
 					 &ppl_data->params->params,
 					 BUFF_PARAMS_FRAME_FMT |
 					 BUFF_PARAMS_RATE)) {
@@ -66,8 +65,6 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 			err = -EINVAL;
 		}
 	}
-
-	buffer_release(buf_c);
 	return err;
 }
 
@@ -188,11 +185,8 @@ static int pipeline_comp_hw_params_buf(struct comp_dev *current,
 		return ret;
 	/* set buffer parameters */
 	if (calling_buf) {
-		struct comp_buffer *buf_c = buffer_acquire(calling_buf);
-
-		ret = buffer_set_params(buf_c, &ppl_data->params->params,
+		ret = buffer_set_params(calling_buf, &ppl_data->params->params,
 					BUFFER_UPDATE_IF_UNSET);
-		buffer_release(buf_c);
 		if (ret < 0)
 			pipe_err(current->pipeline,
 				 "pipeline_comp_hw_params(): buffer_set_params(): %d", ret);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -832,7 +832,7 @@ static int rtnr_copy(struct comp_dev *dev)
 		comp_dbg(dev, "rtnr_copy() passthrough");
 
 		/* Get source, sink, number of frames etc. to process. */
-		comp_get_copy_limits_with_lock(source, sink, &cl);
+		comp_get_copy_limits(source, sink, &cl);
 
 		buffer_stream_invalidate(source, cl.source_bytes);
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -249,10 +249,8 @@ void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir);
 
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)
 {
-	struct comp_buffer *buffer_c = buffer_acquire(buffer);
-	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer_c->sink :
-		buffer_c->source;
-	buffer_release(buffer_c);
+	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer->sink :
+		buffer->source;
 	return comp;
 }
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -664,9 +664,7 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 
 	/*
 	 * Use uncached address everywhere to access components to rule out
-	 * multi-core failures. In the future we might decide to switch over to
-	 * the latest coherence API for performance. In that case components
-	 * will be acquired for cached access and released afterwards.
+	 * multi-core failures. TODO: verify if cached alias may be used in some cases
 	 */
 	dev = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, bytes);
 	if (!dev)
@@ -880,55 +878,6 @@ void comp_get_copy_limits(struct comp_buffer *source,
 void comp_get_copy_limits_frame_aligned(const struct comp_buffer *source,
 					const struct comp_buffer *sink,
 					struct comp_copy_limits *cl);
-
-/**
- * Version of comp_get_copy_limits that locks both buffers to guarantee
- * consistent state readings.
- *
- * @param[in] source Source buffer.
- * @param[in] sink Sink buffer
- * @param[out] cl Current copy limits.
- */
-static inline
-void comp_get_copy_limits_with_lock(struct comp_buffer *source,
-				    struct comp_buffer *sink,
-				    struct comp_copy_limits *cl)
-{
-	struct comp_buffer *source_c, *sink_c;
-
-	source_c = buffer_acquire(source);
-	sink_c = buffer_acquire(sink);
-
-	comp_get_copy_limits(source_c, sink_c, cl);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
-}
-
-/**
- * Version of comp_get_copy_limits_with_lock_frame_aligned that locks both
- * buffers to guarantee consistent state readings and the frames aligned with
- * the requirement.
- *
- * @param[in] source Buffer of source.
- * @param[in] sink Buffer of sink
- * @param[out] cl Current copy limits.
- */
-static inline
-void comp_get_copy_limits_with_lock_frame_aligned(struct comp_buffer *source,
-						  struct comp_buffer *sink,
-						  struct comp_copy_limits *cl)
-{
-	struct comp_buffer *source_c, *sink_c;
-
-	source_c = buffer_acquire(source);
-	sink_c = buffer_acquire(sink);
-
-	comp_get_copy_limits_frame_aligned(source_c, sink_c, cl);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
-}
 
 /**
  * Get component state.

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -104,7 +104,6 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	struct list_item *clist;
 	struct comp_buffer *sinkb;
 	struct comp_buffer *buf;
-	struct comp_buffer *buf_c;
 	int dir = dev->direction;
 
 	if (!params) {
@@ -128,22 +127,18 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 					      struct comp_buffer,
 					      source_list);
 
-		buf_c = buffer_acquire(buf);
-
 		/* update specific pcm parameter with buffer parameter if
 		 * specific flag is set.
 		 */
-		comp_update_params(flag, params, buf_c);
+		comp_update_params(flag, params, buf);
 
 		/* overwrite buffer parameters with modified pcm
 		 * parameters
 		 */
-		buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);
+		buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
 
 		/* set component period frames */
-		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
-
-		buffer_release(buf_c);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf->stream));
 	} else {
 		/* for other components we iterate over all downstream buffers
 		 * (for playback) or upstream buffers (for capture).
@@ -152,19 +147,15 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 
 		list_for_item(clist, buffer_list) {
 			buf = buffer_from_list(clist, dir);
-			buf_c = buffer_acquire(buf);
-			comp_update_params(flag, params, buf_c);
-			buffer_set_params(buf_c, params, BUFFER_UPDATE_FORCE);
-			buffer_release(buf_c);
+			comp_update_params(flag, params, buf);
+			buffer_set_params(buf, params, BUFFER_UPDATE_FORCE);
 		}
 
 		/* fetch sink buffer in order to calculate period frames */
 		sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 					source_list);
 
-		buf_c = buffer_acquire(sinkb);
-		component_set_nearest_period_frames(dev, audio_stream_get_rate(&buf_c->stream));
-		buffer_release(buf_c);
+		component_set_nearest_period_frames(dev, audio_stream_get_rate(&sinkb->stream));
 	}
 
 	return 0;
@@ -291,10 +282,8 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	irq_local_disable(flags);
 	list_for_item_safe(clist, tmp, &icd->cd->bsource_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, sink_list);
-		struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
-		buffer_c->sink = NULL;
-		buffer_release(buffer_c);
+		buffer->sink = NULL;
 		/* Also if it isn't shared - we are about to modify uncached data */
 		dcache_writeback_invalidate_region(uncache_to_cache(buffer),
 						   sizeof(*buffer));
@@ -304,10 +293,8 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	list_for_item_safe(clist, tmp, &icd->cd->bsink_list) {
 		struct comp_buffer *buffer = container_of(clist, struct comp_buffer, source_list);
-		struct comp_buffer *buffer_c = buffer_acquire(buffer);
 
-		buffer_c->source = NULL;
-		buffer_release(buffer_c);
+		buffer->source = NULL;
 		/* Also if it isn't shared - we are about to modify uncached data */
 		dcache_writeback_invalidate_region(uncache_to_cache(buffer),
 						   sizeof(*buffer));


### PR DESCRIPTION
this is step 3 of implementation of https://github.com/thesofproject/sof/issues/8006

Remove usage buffer_acquire and buffer_release from pipeline infrastructure files:
 - buffer.c
 - module_adapter,c
 - all ipc helpers
 - pipeline-graph
 - pipeline-params
 - component.h

 functions comp_get_copy_limits_with_lock and comp_get_copy_limits_with_lock_frame_aligned removed as those are identical to comp_get_copy_limits / comp_get_copy_limits_frame_aligned now
