### PR TITLE
Audio: Volume: Handle all volume ramp types

### DIFF
--- a/src/audio/volume/peak_volume.h
+++ b/src/audio/volume/peak_volume.h
@@ -24,6 +24,7 @@
 #ifndef __SOF_IPC4_PEAK_VOL_H__
 #define __SOF_IPC4_PEAK_VOL_H__
 
+#include <ipc/topology.h>
 #include <ipc4/base-config.h>
 
 enum ipc4_vol_mode {
@@ -43,7 +44,11 @@ enum ipc4_peak_volume_param {
 
 enum ipc4_curve_type {
 	IPC4_AUDIO_CURVE_TYPE_NONE = 0,
-	IPC4_AUDIO_CURVE_TYPE_WINDOWS_FADE
+	IPC4_AUDIO_CURVE_TYPE_WINDOWS_FADE,
+	IPC4_AUDIO_CURVE_TYPE_LINEAR,
+	IPC4_AUDIO_CURVE_TYPE_LOG,
+	IPC4_AUDIO_CURVE_TYPE_LINEAR_ZC,
+	IPC4_AUDIO_CURVE_TYPE_LOG_ZC,
 };
 
 static const uint32_t IPC4_ALL_CHANNELS_MASK = 0xffffffff;
@@ -74,4 +79,28 @@ struct ipc4_peak_volume_module_cfg {
 	struct ipc4_base_module_cfg base_cfg;
 	struct ipc4_peak_volume_config config[];
 } __packed __aligned(8);
+
+static inline enum sof_volume_ramp ipc4_curve_type_convert(enum ipc4_curve_type ipc4_type)
+{
+	switch (ipc4_type) {
+	case IPC4_AUDIO_CURVE_TYPE_WINDOWS_FADE:
+		return SOF_VOLUME_WINDOWS_FADE;
+
+	case IPC4_AUDIO_CURVE_TYPE_LINEAR:
+		return SOF_VOLUME_LINEAR;
+
+	case IPC4_AUDIO_CURVE_TYPE_LOG:
+		return SOF_VOLUME_LOG;
+
+	case IPC4_AUDIO_CURVE_TYPE_LINEAR_ZC:
+		return SOF_VOLUME_LINEAR_ZC;
+
+	case IPC4_AUDIO_CURVE_TYPE_LOG_ZC:
+		return SOF_VOLUME_LOG_ZC;
+
+	case IPC4_AUDIO_CURVE_TYPE_NONE:
+	default:
+		return SOF_VOLUME_WINDOWS_NO_FADE;
+	}
+}
 #endif

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -283,18 +283,22 @@ static inline void volume_ramp(struct processing_module *mod)
 		 * calculated from previous gain and ramp time. The slope
 		 * coefficient is calculated in volume_set_chan().
 		 */
-#if defined CONFIG_COMP_VOLUME_WINDOWS_FADE && defined CONFIG_COMP_VOLUME_LINEAR_RAMP
-		if (cd->ramp_type == SOF_VOLUME_WINDOWS_FADE)
+		switch (cd->ramp_type) {
+#if CONFIG_COMP_VOLUME_WINDOWS_FADE
+		case SOF_VOLUME_WINDOWS_FADE:
 			new_vol = volume_windows_fade_ramp(cd, ramp_time, i);
-		else
-			new_vol = volume_linear_ramp(cd, ramp_time, i);
-#elif defined CONFIG_COMP_VOLUME_WINDOWS_FADE
-		new_vol = volume_windows_fade_ramp(cd, ramp_time, i);
-#elif defined CONFIG_COMP_VOLUME_LINEAR_RAMP
-		new_vol = volume_linear_ramp(cd, ramp_time, i);
-#else
-		new_vol = tvolume;
+			break;
 #endif
+#if CONFIG_COMP_VOLUME_LINEAR_RAMP
+		case SOF_VOLUME_LINEAR:
+		case SOF_VOLUME_LINEAR_ZC:
+			new_vol = volume_linear_ramp(cd, ramp_time, i);
+			break;
+#endif
+		default:
+			new_vol = tvolume;
+		}
+
 		if (volume < tvolume) {
 			/* ramp up, check if ramp completed */
 			if (new_vol < tvolume)

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -58,13 +58,10 @@ static int set_volume_ipc4(struct vol_data *cd, uint32_t const channel,
 	cd->mvolume[channel] = 0;
 	/* set muted as false*/
 	cd->muted[channel] = false;
-#if CONFIG_COMP_VOLUME_WINDOWS_FADE
+
 	/* ATM there is support for the same ramp for all channels */
-	if (curve_type == IPC4_AUDIO_CURVE_TYPE_WINDOWS_FADE)
-		cd->ramp_type = SOF_VOLUME_WINDOWS_FADE;
-	else
-		cd->ramp_type = SOF_VOLUME_WINDOWS_NO_FADE;
-#endif
+	cd->ramp_type = ipc4_curve_type_convert((enum ipc4_curve_type)curve_type);
+
 	return 0;
 }
 

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -86,8 +86,13 @@ static void init_ramp(struct vol_data *cd, uint32_t curve_duration, uint32_t tar
 	/* In IPC4 driver sends curve_duration in hundred of ns - it should be
 	 * converted into ms value required by firmware
 	 */
-	cd->initial_ramp = Q_MULTSR_32X32((int64_t)curve_duration,
-					  Q_CONVERT_FLOAT(1.0 / 10000, 31), 0, 31, 0);
+	if (cd->ramp_type == SOF_VOLUME_WINDOWS_NO_FADE) {
+		cd->initial_ramp = 0;
+		cd->ramp_finished = true;
+	} else {
+		cd->initial_ramp = Q_MULTSR_32X32((int64_t)curve_duration,
+						  Q_CONVERT_FLOAT(1.0 / 10000, 31), 0, 31, 0);
+	}
 
 	if (!cd->initial_ramp) {
 		/* In case when initial ramp time is equal to zero, vol_min and

--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -45,12 +45,20 @@ Class.Widget."gain" {
 		token_ref	"gain.word"
 		constraints {
 			!valid_values [
-				"no_fade"
-				"fade"
+				"windows_no_fade"
+				"windows_fade"
+				"linear"
+				"log"
+				"linear_zc"
+				"log_zc"
 			]
 			!tuple_values [
 				0
 				1
+				2
+				3
+				4
+				5
 			]
 		}
 	}
@@ -151,7 +159,7 @@ Class.Widget."gain" {
 	uuid 			"A8:A9:BC:61:D0:18:18:4A:8E:7B:26:39:21:98:04:B7"
 	no_pm			"true"
 	cpc 			10183
-	curve_type		"fade"
+	curve_type		"windows_fade"
 	curve_duration		200000		# 20 ms
 	init_value		0x7fffffff
 	num_input_pins		1


### PR DESCRIPTION
The first patch adds a conversion from IPC4 to SOF volume ramp types.

The second patch changes further volume to be able to handle the supported ramp types.

The third patch adds to gain.conf the other supported ramp types. The default is kept as windows fade.

