### PR TITLE
Tools: Topology2: Change in capture gain curve_duration to 50 ms

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -335,6 +335,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -396,6 +397,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -454,6 +456,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -275,6 +275,7 @@ IncludeByKey.PASSTHROUGH {
 					pcm_id $SSP0_PCM_ID
 				}
 				Object.Widget.gain.1 {
+					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_PCM_NAME Capture Volume'
 					}
@@ -289,6 +290,7 @@ IncludeByKey.PASSTHROUGH {
 					pcm_id $SSP0_CAPTURE_PCM_ID
 				}
 				Object.Widget.gain.1 {
+					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_CAPTURE_PCM Volume'
 					}
@@ -329,6 +331,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -394,6 +397,7 @@ IncludeByKey.PASSTHROUGH {
 					}
 				}
 				Object.Widget.gain.1 {
+					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Pre Demux $SSP0_PCM_NAME Capture Volume'
 					}
@@ -699,6 +703,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -755,6 +760,7 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
+							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -102,6 +102,7 @@ IncludeByKey.PASSTHROUGH {
 					}
 				}
 				Object.Widget.gain.1 {
+					curve_duration 500000
 					num_input_audio_formats 2
 					num_output_audio_formats 2
 					Object.Base.audio_format.1 {


### PR DESCRIPTION
This change increases the ramp duration from 20 ms to 50 ms. It lowers the peak load of peak volume component due to longer same gain value blocks. The internal update rate for gain becomes 250 us instead of 125 us. The longer fade-in ramp also conceals better possible analog capture start transients.

This changes for 4ch capture for gain.11.1 in sof-hda-generic-4ch.tplg from

CPU_PEAK(MAX) = 21.95
PEAK(MAX)/AVG(AVG) = 7.51

to

CPU_PEAK(MAX) = 9.07
PEAK(MAX)/AVG(AVG) = 3.12