### PR TITLE
[SKIP SOF-TEST] native loadable up-down-mixer take 2

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -39,6 +39,7 @@ import json
 import gzip
 import dataclasses
 import concurrent.futures as concurrent
+import re
 
 from west import configuration as west_config
 
@@ -847,6 +848,13 @@ def install_platform(platform, sof_platform_output_dir, platf_build_environ):
 		for p_alias in platform_configs[platform].aliases:
 			symlink_or_copy(install_key_dir, output_fwname, f"sof-{p_alias}.ri")
 
+
+	# Copy loadable modules
+	for file in os.listdir(abs_build_dir):
+		if (os.path.isfile(abs_build_dir / file) and re.fullmatch(".+\.ri", file) and
+		not re.fullmatch(".*zephyr\.ri", file)):
+			shutil.copy2(abs_build_dir / file,
+				install_key_dir / "".join(["sof-", platform, "-lib-", file]))
 
 	# sof-info/ directory
 

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -137,6 +137,7 @@ static int modules_init(struct processing_module *mod)
 					(struct module_interface *)md->module_adapter;
 
 		ret = mod_in->init(mod);
+		mod->priv.ops = mod_in;
 	} else {
 		ret = iadk_wrapper_init(md->module_adapter);
 	}

--- a/src/audio/up_down_mixer/down_mixer.toml
+++ b/src/audio/up_down_mixer/down_mixer.toml
@@ -1,0 +1,79 @@
+version = [3, 0]
+
+[adsp]
+name = "mtl"
+image_size = "0x2C0000" # (22) bank * 128KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x1FF80000"
+size = "0x400"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xA104A000"
+size = "0x2000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xa00f0000"
+size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x40000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xA0000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "ADSP.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "ADSP"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+partition_usage = "0x23"
+[[signed_pkg.module]]
+name = "ADSP.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x40000"
+
+[module]
+count = 1
+
+	[[module.entry]]
+	name = "DWMIX"
+	uuid = "1234F1F1-1234-1A34-8C08-884BE5D14FAA"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0xC, 0xffff,
+			0, 0, 0xffff, 0xc, 0xC, 0xffff,
+			1, 0, 0xffff, 0xc, 0xC, 0xffff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 512, 256, 0, 0, 0]

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -4,8 +4,10 @@
 //
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@intel.com>
 // Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
+// Author: Adrian Warecki <adrian.warecki@intel.com>
 
 #include <sof/audio/coefficients/up_down_mixer/up_down_mixer.h>
+#include <sof/audio/up_down_mixer/up_down_mixer_manifest.h>
 #include <sof/audio/up_down_mixer/up_down_mixer.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/format.h>
@@ -36,7 +38,7 @@ DECLARE_SOF_RT_UUID("up_down_mixer", up_down_mixer_comp_uuid, 0x42f8060c, 0x832f
 		    0x4dbf, 0xb2, 0x47, 0x51, 0xe9, 0x61, 0x99, 0x7b, 0x34);
 
 DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_comp_uuid),
-	       LOG_LEVEL_INFO);
+		LOG_LEVEL_INFO);
 
 int32_t custom_coeffs[UP_DOWN_MIX_COEFFS_LENGTH];
 
@@ -455,13 +457,10 @@ static int up_down_mixer_process(struct processing_module *mod,
 	return 0;
 }
 
-static struct module_interface up_down_mixer_interface = {
+struct module_interface up_down_mixer_interface = {
 	.init  = up_down_mixer_init,
 	.prepare = up_down_mixer_prepare,
 	.process_audio_stream = up_down_mixer_process,
 	.reset = up_down_mixer_reset,
 	.free = up_down_mixer_free
 };
-
-DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_comp_uuid, up_down_mixer_comp_tr);
-SOF_MODULE_INIT(up_down_mixer, sys_comp_module_up_down_mixer_interface_init);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -419,8 +419,7 @@ static int up_down_mixer_reset(struct processing_module *mod)
 	return 0;
 }
 
-static int
-up_down_mixer_process(struct processing_module *mod,
+static int up_down_mixer_process(struct processing_module *mod,
 		      struct input_stream_buffer *input_buffers, int num_input_buffers,
 		      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {

--- a/src/audio/up_down_mixer/up_down_mixer.toml
+++ b/src/audio/up_down_mixer/up_down_mixer.toml
@@ -1,0 +1,86 @@
+version = [3, 0]
+
+[adsp]
+name = "mtl"
+image_size = "0x2C0000" # (22) bank * 128KB
+alias_mask = "0xE0000000"
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x1FF80000"
+size = "0x400"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xA104A000"
+size = "0x2000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xa00f0000"
+size = "0x100000"
+
+[[adsp.mem_alias]]
+type = "uncached"
+base = "0x40000000"
+[[adsp.mem_alias]]
+type = "cached"
+base = "0xA0000000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "ADSP.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "ADSP"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+partition_usage = "0x23"
+[[signed_pkg.module]]
+name = "ADSP.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x40000"
+
+[module]
+count = 1
+
+	[[module.entry]]
+	name = "UPDWMIX"
+	uuid = "42F8060C-832F-4DBF-B247-51E961997B34"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "5"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xffff, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 216, 706000, 12, 16, 0, 0, 0,
+				1, 0, 0, 0, 216, 1271000, 8, 8, 0, 0, 0,
+				2, 0, 0, 0, 216, 1839000, 89, 118, 0, 0, 0,
+				3, 0, 0, 0, 216, 2435000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 216, 3343000, 192, 192, 0, 0, 0,
+				5, 0, 0, 0, 216, 3961000, 177, 177, 0, 0, 0,
+				6, 0, 0, 0, 216, 4238000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 216, 6691000, 192, 256, 0, 0, 0]
+

--- a/src/include/sof/audio/up_down_mixer/up_down_mixer_manifest.h
+++ b/src/include/sof/audio/up_down_mixer/up_down_mixer_manifest.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * Author: Pawel Dobrowolski <pawelx.dobrowolski@intel.com>
+ */
+
+#ifndef __UP_DOWN_MIXER_MANIFEST_H__
+#define __UP_DOWN_MIXER_MANIFEST_H__
+
+#include <rimage/sof/user/manifest.h>
+#include <sof/audio/module_adapter/library/module_api_ver.h>
+
+#define ADSP_BUILD_INFO_FORMAT 0
+
+struct module_interface up_down_mixer_interface;
+
+void *loadable_udm_entry_point(void *mod_cfg, void *parent_ppl, void **mod_ptr) {
+	return &up_down_mixer_interface;
+}
+
+struct sof_module_api_build_info udm_build_info __attribute__((section(".buildinfo"))) = {
+	ADSP_BUILD_INFO_FORMAT,
+	{
+		((0x3FF & SOF_MODULE_API_MAJOR_VERSION)  << 20) |
+		((0x3FF & SOF_MODULE_API_MIDDLE_VERSION) << 10) |
+		((0x3FF & SOF_MODULE_API_MINOR_VERSION)  << 0)
+	}
+};
+
+extern struct module_interface up_down_mixer_interface;
+
+__attribute__((section(".module")))
+const struct sof_man_module_manifest udm_manifest = {
+	.module = {
+		.name = "UPDWMIX",
+		.uuid = {0x0C, 0x06, 0xF8, 0x42, 0x2F, 0x83, 0xBF, 0x4D,
+			 0xB2, 0x47, 0x51, 0xE9, 0x61, 0x99, 0x7B, 0x34},
+		.entry_point = (uint32_t)loadable_udm_entry_point,
+		.type = { .load_type = SOF_MAN_MOD_TYPE_MODULE,
+		.domain_ll = 1 },
+		.affinity_mask = 1,
+}
+};
+
+#endif /* __UP_DOWN_MIXER_MANIFEST_H__ */

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: rimage
       repo-path: rimage
       path: sof/rimage
-      revision: 4fb9fe00575bc2e9f14570803d811987fb27f010
+      revision: 48a39b6027af31b8242777eed5b5b577fcfd7102
 
     - name: tomlc99
       repo-path: tomlc99

--- a/west.yml
+++ b/west.yml
@@ -45,8 +45,8 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2f90ef488a4e97c94c2cc5b95dacd1b15de32216
-      remote: zephyrproject
+      revision: a9dad02189d3e0898eeab3d51c12dbcda4bcef25
+      remote: thesofproject
 
       # Import some projects listed in zephyr/west.yml@revision
       #

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -694,11 +694,6 @@ zephyr_library_sources_ifdef(CONFIG_MATH_EXP
 	${SOF_MATH_PATH}/exp_fcn_hifi.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_COMP_UP_DOWN_MIXER
-	${SOF_AUDIO_PATH}/up_down_mixer/up_down_mixer.c
-	${SOF_AUDIO_PATH}/up_down_mixer/up_down_mixer_hifi3.c
-)
-
 zephyr_library_sources_ifdef(CONFIG_COMP_MUX
 	${SOF_AUDIO_PATH}/mux/mux.c
 	${SOF_AUDIO_PATH}/mux/mux_generic.c
@@ -782,6 +777,15 @@ include(../scripts/cmake/version.cmake)
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)
+
+
+# Compile up_down_mixer as loadable module
+sof_loadable_library(updwmix ${SOF_AUDIO_PATH}/up_down_mixer/up_down_mixer.toml)
+
+zephyr_library_sources_ifdef(CONFIG_COMP_UP_DOWN_MIXER
+	${SOF_AUDIO_PATH}/up_down_mixer/up_down_mixer.c
+	${SOF_AUDIO_PATH}/up_down_mixer/up_down_mixer_hifi3.c
+)
 
 sof_loadable_library_finalize()
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -35,6 +35,22 @@ function(sof_append_relative_path_definitions target)
 	endforeach()
 endfunction()
 
+macro(sof_loadable_library name toml)
+	zephyr_library_named(loadable_library_${name})
+	set_property(TARGET loadable_library_${name} PROPERTY CXX_STANDARD 17)
+	set_property(TARGET loadable_library_${name} PROPERTY TOML_FILE ${toml})
+	zephyr_library_link_libraries(SOF)
+	list(APPEND loadable_modules_list ${name})
+endmacro()
+
+macro(sof_loadable_library_finalize)
+	foreach(name ${loadable_modules_list})
+		sof_append_relative_path_definitions(loadable_library_${name})
+	endforeach()
+
+	zephyr_add_loadable("${loadable_modules_list}")
+endmacro()
+
 # Initial SOF module will contain
 #
 # 1. Application logic - pipeline, audio components, IPC processing, topology
@@ -766,5 +782,7 @@ include(../scripts/cmake/version.cmake)
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)
+
+sof_loadable_library_finalize()
 
 endif() # CONFIG_SOF


### PR DESCRIPTION
This is second approach to native sof loadable modules. This time are used zephyr's linker scripts to create separate archive for modules and put them into specific for module sections. After that cmake files, using objcopy put code for up-down-mixer to udm.mod file which is being sign by rimage.

Full process of building module is automated and run by python building scripts:
`xtensa-build-zephyr.py -u mtl -k ../keys/<used_key_for_project>`