### PR TITLE
clean up IPC4 overlay for TGL/TGL-H

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -111,7 +111,7 @@ jobs:
           # - IPC4 default
           mtl, lnl,
           # Temporary testbed for Zephyr development.
-          -i IPC4 tgl tgl-h,
+          tgl tgl-h,
         ]
         build_opts: [""]
         # Sparse matrices are complicated, you must read this page slowly:
@@ -217,7 +217,7 @@ jobs:
           # - IPC4 default
           mtl,
           # Very few IPC3 platforms support IPC4 too.
-          -i IPC4 tgl tgl-h,
+          tgl tgl-h,
         ]
         build_opts: [""]
         # Sparse matrices are complicated, see comments on Linux matrix above.
@@ -397,7 +397,7 @@ jobs:
           # http://mywiki.wooledge.org/ParsingLs
           for regdir in 'linux-build *mtl' \
                         'windows-build *mtl' \
-                        'windows-build *-i IPC4 tgl tgl-h'; do
+                        'windows-build *tgl tgl-h'; do
             find . -maxdepth 1 | grep -q "\./${regdir}\$" ||
               { >&2 printf 'Missing %s\n' "${regdir}"; exit 1; }
           done

--- a/app/overlays/tgl-h/ipc4_overlay.conf
+++ b/app/overlays/tgl-h/ipc4_overlay.conf
@@ -1,5 +1,0 @@
-# This file is empty as IPC4 now the default.
-#
-# The file is kept around for the time being to
-# smoothen the transition for users who use
-# this overlay file in their build scripts.

--- a/app/overlays/tgl/ipc4_overlay.conf
+++ b/app/overlays/tgl/ipc4_overlay.conf
@@ -1,5 +1,0 @@
-# This file is empty as IPC4 now the default.
-#
-# The file is kept around for the time being to
-# smoothen the transition for users who use
-# this overlay file in their build scripts.

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -176,9 +176,6 @@ def parse_args():
 						help="List of platforms to build")
 	parser.add_argument("-d", "--debug", required=False, action="store_true",
 						help="Shortcut for: -o sof/app/debug_overlay.conf")
-	parser.add_argument("-i", "--ipc", required=False, choices=["IPC4"],
-			    help="""Applies --overlay <platform>/ipc4_overlay.conf
-and a different rimage config. Valid only for IPC3 platforms supporting IPC4 too.""")
     # NO SOF release will ever user the option --fw-naming.
     # This option is only for disguising SOF IPC4 as CAVS IPC4 and only in cases where
     # the kernel 'ipc_type' expects CAVS IPC4. In this way, developers and CI can test
@@ -265,10 +262,6 @@ This should be used with programmatic script invocations (eg. Continuous Integra
 		if not args.use_platform_subdir:
 			args.use_platform_subdir=True
 			warnings.warn("The option '--fw-naming AVS' has to be used with '--use-platform-subdir'. Enable '--use-platform-subdir' automatically.")
-		if args.ipc != "IPC4":
-			args.ipc="IPC4"
-			warnings.warn("The option '--fw-naming AVS' has to be used with '-i IPC4'. Enable '-i IPC4' automatically.")
-
 
 def execute_command(*run_args, **run_kwargs):
 	"""[summary] Provides wrapper for subprocess.run that prints
@@ -626,7 +619,7 @@ def rimage_options(platform_dict):
 	#                         test_00_01_load_fw_and_check_version
 	opts.append(("-b", "1"))
 
-	if args.ipc == "IPC4":
+	if platform_dict.get("IPC4_RIMAGE_DESC", None) is not None:
 		rimage_desc = platform_dict["IPC4_RIMAGE_DESC"]
 	else:
 		rimage_desc = platform_dict["name"] + ".toml"
@@ -724,13 +717,6 @@ def build_platforms():
 		# if both are provided, because it's no harm to merge the same overlay twice.
 		if args.debug:
 			overlays.append(str(pathlib.Path(SOF_TOP, "app", "debug_overlay.conf")))
-
-		# The '-i IPC4' is a shortcut for '-o path_to_ipc4_overlay' (and more), we
-		# are good if both are provided, because it's no harm to merge the same
-		# overlay twice.
-		if args.ipc == "IPC4":
-			overlays.append(str(pathlib.Path(SOF_TOP, "app", "overlays", platform,
-                            platform_dict["IPC4_CONFIG_OVERLAY"])))
 
 		if overlays:
 			overlays = ";".join(overlays)


### PR DESCRIPTION
For legacy CAVS platforms (TGL/ADL/EHL), the default build config is IPC4 now,
and the overlay file is already emptied. Remove the option in this build script.