### PR TITLE
audio: volume: enable linear ramp for ipc4 volume

### DIFF
--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -172,7 +172,6 @@ config COMP_VOLUME_WINDOWS_FADE
 config COMP_VOLUME_LINEAR_RAMP
        bool "Linear ramp volume transitions support"
 	   default y
-	   depends on IPC_MAJOR_3
        help
          This option enables volume linear ramp shape.
 


### PR DESCRIPTION
previously, linear ramp only applicable for ipc3, however, linear is also applicable for chrome/linux with ipc4, so remove ipc3 restriction.