### PR TITLE
topology2: intel: bt-ssp-config: use cardinal clock as source

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config-lbm.conf
@@ -23,7 +23,7 @@ Object.Dai.SSP [
 			tx_slots	1
 			rx_slots	1
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 		Object.Base.hw_config.2 {
@@ -41,7 +41,7 @@ Object.Dai.SSP [
 			tx_slots	1
 			rx_slots	1
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 		Object.Base.hw_config.3 {
@@ -58,7 +58,7 @@ Object.Dai.SSP [
 			tx_slots	3
 			rx_slots	3
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 	}

--- a/tools/topology/topology2/platform/intel/bt-ssp-config.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config.conf
@@ -22,7 +22,7 @@ Object.Dai.SSP [
 			tx_slots	1
 			rx_slots	1
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 		Object.Base.hw_config.2 {
@@ -40,7 +40,7 @@ Object.Dai.SSP [
 			tx_slots	1
 			rx_slots	1
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 		Object.Base.hw_config.3 {
@@ -57,7 +57,7 @@ Object.Dai.SSP [
 			tx_slots	3
 			rx_slots	0
 			Object.Base.link_config.1 {
-				clock_source	0
+				clock_source	1
 			}
 		}
 	}


### PR DESCRIPTION
All existing SSP-based topologies use the audio cardinal clock, *EXCEPT* Bluetooth related ones. This doesn't make much sense, let's use the same clock source for all SSPs.