### PR TITLE
cache: remove buffer_acquire/release part 2

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -266,7 +266,6 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 	struct sof_ipc_stream_posn posn;
 	struct comp_dev *dai_copier;
 	struct comp_buffer *buffer;
-	struct comp_buffer *buffer_c;
 	uint32_t latency;
 	int ret;
 
@@ -358,10 +357,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		}
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
-		buffer_c = buffer_acquire(buffer);
 		pipe_reg.stream_start_offset = posn.dai_posn +
-			latency * audio_stream_get_size(&buffer_c->stream);
-		buffer_release(buffer_c);
+			latency * audio_stream_get_size(&buffer->stream);
 		pipe_reg.stream_end_offset = 0;
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg, sizeof(pipe_reg));
 	} else if (cmd == COMP_TRIGGER_PAUSE) {
@@ -384,9 +381,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		}
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
-		buffer_c = buffer_acquire(buffer);
-		pipe_reg.stream_start_offset += latency * audio_stream_get_size(&buffer_c->stream);
-		buffer_release(buffer_c);
+		pipe_reg.stream_start_offset += latency * audio_stream_get_size(&buffer->stream);
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg.stream_start_offset,
 				      sizeof(pipe_reg.stream_start_offset));
 	}
@@ -426,7 +421,6 @@ static int copier_copy_to_sinks(struct copier_data *cd, struct comp_dev *dev,
 				struct comp_buffer *src_c,
 				struct comp_copy_limits *processed_data)
 {
-	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	struct comp_buffer *sink;
 	int ret = 0;
@@ -436,14 +430,12 @@ static int copier_copy_to_sinks(struct copier_data *cd, struct comp_dev *dev,
 		struct comp_dev *sink_dev;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		sink_dev = sink_c->sink;
+		sink_dev = sink->sink;
 		processed_data->sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {
-			ret = do_conversion_copy(dev, cd, src_c, sink_c, processed_data);
+			ret = do_conversion_copy(dev, cd, src_c, sink, processed_data);
 			cd->output_total_data_processed += processed_data->sink_bytes;
 		}
-		buffer_release(sink_c);
 		if (ret < 0) {
 			comp_err(dev, "failed to copy buffer for comp %x",
 				 dev->ipc_config.id);
@@ -515,7 +507,6 @@ static int copier_module_copy(struct processing_module *mod,
 
 static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_dev *dev)
 {
-	struct comp_buffer *src_c, *sink_c;
 	struct comp_copy_limits processed_data;
 	struct comp_buffer *src;
 	int ret;
@@ -529,9 +520,7 @@ static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_de
 		if (ret < 0)
 			return ret;
 
-		src_c = buffer_acquire(cd->multi_endpoint_buffer);
-		ret = copier_copy_to_sinks(cd, dev, src_c, &processed_data);
-		buffer_release(src_c);
+		ret = copier_copy_to_sinks(cd, dev, cd->multi_endpoint_buffer, &processed_data);
 
 		return ret;
 	}
@@ -543,24 +532,18 @@ static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_de
 	}
 
 	src = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	src_c = buffer_acquire(src);
 
 	/* gateway(s) on output */
-	sink_c = buffer_acquire(cd->multi_endpoint_buffer);
-	ret = do_conversion_copy(dev, cd, src_c, sink_c, &processed_data);
-	buffer_release(sink_c);
-
+	ret = do_conversion_copy(dev, cd, src, cd->multi_endpoint_buffer, &processed_data);
 	if (ret < 0)
-		goto err;
+		return ret;
 
 	ret = dai_zephyr_multi_endpoint_copy(cd->dd, dev, cd->multi_endpoint_buffer,
 					     cd->endpoint_num);
 	if (!ret) {
-		comp_update_buffer_consume(src_c, processed_data.source_bytes);
+		comp_update_buffer_consume(src, processed_data.source_bytes);
 		cd->input_total_data_processed += processed_data.source_bytes;
 	}
-err:
-	buffer_release(src_c);
 
 	return ret;
 }
@@ -646,7 +629,6 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	struct comp_buffer *sink;
 
@@ -683,16 +665,12 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 		int sink_id;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 
-		sink_id = IPC4_SINK_QUEUE_ID(sink_c->id);
+		sink_id = IPC4_SINK_QUEUE_ID(sink->id);
 		if (sink_id == sink_fmt->sink_id) {
-			ipc4_update_buffer_format(sink_c, &sink_fmt->sink_fmt);
-			buffer_release(sink_c);
+			ipc4_update_buffer_format(sink, &sink_fmt->sink_fmt);
 			break;
 		}
-
-		buffer_release(sink_c);
 	}
 
 	return 0;

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -395,7 +395,6 @@ static int copy_single_channel_c32(const struct audio_stream *src,
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index)
 {
-	struct comp_buffer *buf_c;
 	struct sof_ipc_stream_params demuxed_params = *params;
 	const struct ipc4_audio_format *in_fmt = &cd->config.base.audio_fmt;
 	const struct ipc4_audio_format *out_fmt = &cd->config.out_fmt;
@@ -438,15 +437,11 @@ int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 	if (ret < 0)
 		return ret;
 
-	buf_c = buffer_acquire(cd->dd[dai_index]->dma_buffer);
 	for (j = 0; j < SOF_IPC_MAX_CHANNELS; j++)
-		buf_c->chmap[j] = (cd->chan_map[dai_index] >> j * 4) & 0xf;
-	buffer_release(buf_c);
+		cd->dd[dai_index]->dma_buffer->chmap[j] = (cd->chan_map[dai_index] >> j * 4) & 0xf;
 
 	/* set channel copy func */
-	buf_c = buffer_acquire(cd->multi_endpoint_buffer);
-	container_size = audio_stream_sample_bytes(&buf_c->stream);
-	buffer_release(buf_c);
+	container_size = audio_stream_sample_bytes(&cd->multi_endpoint_buffer->stream);
 
 	switch (container_size) {
 	case 2:

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -62,7 +62,6 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 			  struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sink, *source;
-	struct comp_buffer *sink_c, *source_c;
 	struct list_item *sink_list;
 
 	memset(params, 0, sizeof(*params));
@@ -85,13 +84,10 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 		int j;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 
-		j = IPC4_SINK_QUEUE_ID(sink_c->id);
+		j = IPC4_SINK_QUEUE_ID(sink->id);
 
-		ipc4_update_buffer_format(sink_c, &cd->out_fmt[j]);
-
-		buffer_release(sink_c);
+		ipc4_update_buffer_format(sink, &cd->out_fmt[j]);
 	}
 
 	/*
@@ -102,12 +98,9 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 		struct ipc4_audio_format *in_fmt;
 
 		source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-		source_c = buffer_acquire(source);
 
 		in_fmt = &cd->config.base.audio_fmt;
-		ipc4_update_buffer_format(source_c, in_fmt);
-
-		buffer_release(source_c);
+		ipc4_update_buffer_format(source, in_fmt);
 	}
 
 	/* update params for the DMA buffer */
@@ -140,7 +133,6 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	enum sof_ipc_frame valid_fmt;
 	struct sof_ipc_buffer ipc_buf;
 	struct comp_buffer *buffer;
-	struct comp_buffer *buffer_c;
 	uint32_t buf_size;
 	uint32_t chan_map;
 	int i;
@@ -209,19 +201,17 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	if (!buffer)
 		return -ENOMEM;
 
-	buffer_c = buffer_acquire(buffer);
-	audio_stream_set_channels(&buffer_c->stream, copier_cfg->base.audio_fmt.channels_count);
-	audio_stream_set_rate(&buffer_c->stream, copier_cfg->base.audio_fmt.sampling_frequency);
-	audio_stream_set_frm_fmt(&buffer_c->stream, config->frame_fmt);
-	audio_stream_set_valid_fmt(&buffer_c->stream, valid_fmt);
-	audio_stream_set_buffer_fmt(&buffer_c->stream,
+	audio_stream_set_channels(&buffer->stream, copier_cfg->base.audio_fmt.channels_count);
+	audio_stream_set_rate(&buffer->stream, copier_cfg->base.audio_fmt.sampling_frequency);
+	audio_stream_set_frm_fmt(&buffer->stream, config->frame_fmt);
+	audio_stream_set_valid_fmt(&buffer->stream, valid_fmt);
+	audio_stream_set_buffer_fmt(&buffer->stream,
 				    copier_cfg->base.audio_fmt.interleaving_style);
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		buffer_c->chmap[i] = (chan_map >> i * 4) & 0xf;
+		buffer->chmap[i] = (chan_map >> i * 4) & 0xf;
 
-	buffer_c->hw_params_configured = true;
-	buffer_release(buffer_c);
+	buffer->hw_params_configured = true;
 
 	if (create_multi_endpoint_buffer)
 		cd->multi_endpoint_buffer = buffer;

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -246,7 +246,6 @@ void copier_host_dma_cb(struct comp_dev *dev, size_t bytes)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	struct comp_buffer *sink, *source;
 	int ret, frames;
 
 	comp_dbg(dev, "copier_host_dma_cb() %p", dev);
@@ -263,18 +262,13 @@ void copier_host_dma_cb(struct comp_dev *dev, size_t bytes)
 	 * playback scenario.
 	 */
 	if (cd->attenuation && dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		source = buffer_acquire(cd->hd->dma_buffer);
-		sink = buffer_acquire(cd->hd->local_buffer);
-		frames = bytes / audio_stream_frame_bytes(&source->stream);
+		frames = bytes / audio_stream_frame_bytes(&cd->hd->dma_buffer->stream);
 
-		ret = apply_attenuation(dev, cd, sink, frames);
+		ret = apply_attenuation(dev, cd, cd->hd->local_buffer, frames);
 		if (ret < 0)
 			comp_dbg(dev, "copier_host_dma_cb() apply attenuation failed! %d", ret);
 
-		buffer_stream_writeback(sink, bytes);
-
-		buffer_release(source);
-		buffer_release(sink);
+		buffer_stream_writeback(cd->hd->local_buffer, bytes);
 	}
 }
 

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -93,7 +93,6 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 	const struct ipc4_ipc_gateway_cmd_data *in;
 	struct comp_dev *dev;
 	struct comp_buffer *buf;
-	struct comp_buffer *buf_c;
 	uint32_t data_size;
 	struct ipc4_ipc_gateway_cmd_data_reply *out;
 
@@ -110,15 +109,12 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	buf = get_buffer(dev);
 
-	if (buf) {
-		buf_c = buffer_acquire(buf);
-	} else {
+	if (!buf) {
 		/* NOTE: this func is called from IPC processing task and can be potentially
 		 * called before pipeline start even before buffer has been attached. In such
 		 * case do not report error but return 0 bytes available for GET_DATA and
 		 * 0 bytes free for SET_DATA.
 		 */
-		buf_c = NULL;
 		comp_warn(dev, "copier_ipcgtw_process(): no buffer found");
 	}
 
@@ -126,13 +122,13 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	switch (cmd->primary.r.cmd) {
 	case IPC4_IPCGWCMD_GET_DATA:
-		if (buf_c) {
+		if (buf) {
 			data_size = MIN(cmd->extension.r.data_size, SOF_IPC_MSG_MAX_SIZE - 4);
-			data_size = MIN(data_size, audio_stream_get_avail_bytes(&buf_c->stream));
-			buffer_stream_invalidate(buf_c, data_size);
-			audio_stream_copy_bytes_to_linear(&buf_c->stream, out->payload, data_size);
-			comp_update_buffer_consume(buf_c, data_size);
-			out->u.size_avail = audio_stream_get_avail_bytes(&buf_c->stream);
+			data_size = MIN(data_size, audio_stream_get_avail_bytes(&buf->stream));
+			buffer_stream_invalidate(buf, data_size);
+			audio_stream_copy_bytes_to_linear(&buf->stream, out->payload, data_size);
+			comp_update_buffer_consume(buf, data_size);
+			out->u.size_avail = audio_stream_get_avail_bytes(&buf->stream);
 			*reply_payload_size = data_size + 4;
 		} else {
 			out->u.size_avail = 0;
@@ -141,18 +137,18 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 		break;
 
 	case IPC4_IPCGWCMD_SET_DATA:
-		if (buf_c) {
+		if (buf) {
 			data_size = MIN(cmd->extension.r.data_size,
-					audio_stream_get_free_bytes(&buf_c->stream));
+					audio_stream_get_free_bytes(&buf->stream));
 			dcache_invalidate_region((__sparse_force void __sparse_cache *)
 						 MAILBOX_HOSTBOX_BASE,
 						 data_size +
 						 offsetof(struct ipc4_ipc_gateway_cmd_data,
 							  payload));
-			audio_stream_copy_bytes_from_linear(in->payload, &buf_c->stream,
+			audio_stream_copy_bytes_from_linear(in->payload, &buf->stream,
 							    data_size);
-			buffer_stream_writeback(buf_c, data_size);
-			comp_update_buffer_produce(buf_c, data_size);
+			buffer_stream_writeback(buf, data_size);
+			comp_update_buffer_produce(buf, data_size);
 			out->u.size_consumed = data_size;
 			*reply_payload_size = 4;
 		} else {
@@ -163,20 +159,16 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 
 	case IPC4_IPCGWCMD_FLUSH_DATA:
 		*reply_payload_size = 0;
-		if (buf_c)
-			audio_stream_reset(&buf_c->stream);
+		if (buf)
+			audio_stream_reset(&buf->stream);
 		break;
 
 	default:
 		comp_err(dev, "copier_ipcgtw_process(): unexpected cmd: %u",
 			 (unsigned int)cmd->primary.r.cmd);
-		if (buf_c)
-			buffer_release(buf_c);
 		return -EINVAL;
 	}
 
-	if (buf_c)
-		buffer_release(buf_c);
 	return 0;
 }
 
@@ -184,7 +176,6 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 			 struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer *buf_c;
 	int err;
 
 	comp_dbg(dev, "ipcgtw_params()");
@@ -196,9 +187,7 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 	}
 
 	/* resize buffer to size specified in IPC gateway config blob */
-	buf_c = buffer_acquire(buf);
-	err = buffer_set_size(buf_c, ipcgtw_data->buf_size, 0);
-	buffer_release(buf_c);
+	err = buffer_set_size(buf, ipcgtw_data->buf_size, 0);
 
 	if (err < 0) {
 		comp_err(dev, "ipcgtw_params(): failed to resize buffer to %u bytes",
@@ -214,10 +203,7 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	struct comp_buffer *buf = get_buffer(dev);
 
 	if (buf) {
-		struct comp_buffer *buf_c = buffer_acquire(buf);
-
-		audio_stream_reset(&buf_c->stream);
-		buffer_release(buf_c);
+		audio_stream_reset(&buf->stream);
 	} else {
 		comp_warn(dev, "ipcgtw_reset(): no buffer found");
 	}

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -174,13 +174,11 @@ static int mixer_reset(struct processing_module *mod)
 			/* FIXME: this is racy and implicitly protected by serialised IPCs */
 			struct comp_buffer *source = container_of(blist, struct comp_buffer,
 								  sink_list);
-			struct comp_buffer *source_c = buffer_acquire(source);
 			bool stop = false;
 
-			if (source_c->source && source_c->source->state > COMP_STATE_READY)
+			if (source->source && source->source->state > COMP_STATE_READY)
 				stop = true;
 
-			buffer_release(source_c);
 			/* only mix the sources with the same state with mixer */
 			if (stop)
 				/* should not reset the downstream components */
@@ -224,22 +222,18 @@ static int mixer_prepare(struct processing_module *mod,
 			 struct sof_sink **sinks, int num_of_sinks)
 {
 	struct mixer_data *md = module_get_private_data(mod);
-	struct comp_buffer *sink_c;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
 	struct list_item *blist;
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
-	sink_c = buffer_acquire(sink);
-	md->mix_func = mixer_get_processing_function(dev, sink_c);
-	mixer_set_frame_alignment(&sink_c->stream);
-	buffer_release(sink_c);
+	md->mix_func = mixer_get_processing_function(dev, sink);
+	mixer_set_frame_alignment(&sink->stream);
 
 	/* check each mixer source state */
 	list_for_item(blist, &dev->bsource_list) {
 		struct comp_buffer *source;
-		struct comp_buffer *source_c;
 		bool stop;
 
 		/*
@@ -251,11 +245,9 @@ static int mixer_prepare(struct processing_module *mod,
 		 * done.
 		 */
 		source = container_of(blist, struct comp_buffer, sink_list);
-		source_c = buffer_acquire(source);
-		mixer_set_frame_alignment(&source_c->stream);
-		stop = source_c->source && (source_c->source->state == COMP_STATE_PAUSED ||
-					    source_c->source->state == COMP_STATE_ACTIVE);
-		buffer_release(source_c);
+		mixer_set_frame_alignment(&source->stream);
+		stop = source->source && (source->source->state == COMP_STATE_PAUSED ||
+					    source->source->state == COMP_STATE_ACTIVE);
 
 		/* only prepare downstream if we have no active sources */
 		if (stop)

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -281,12 +281,11 @@ static int mixin_process(struct processing_module *mod,
 		struct mixout_data *mixout_data;
 		struct processing_module *mixout_mod;
 		struct module_source_info __sparse_cache *mod_source_info;
-		struct comp_buffer *sink_c;
 		uint32_t free_frames, pending_frames;
 
 		/* unused buffer between mixin and mixout */
-		unused_in_between_buf_c = container_of(output_buffers[i].data, struct comp_buffer,
-						       stream);
+		unused_in_between_buf_c = container_of(output_buffers[i].data,
+						       struct comp_buffer, stream);
 		mixout = unused_in_between_buf_c->sink;
 		sink_id = IPC4_SRC_QUEUE_ID(unused_in_between_buf_c->id);
 
@@ -305,20 +304,17 @@ static int mixin_process(struct processing_module *mod,
 			return -EINVAL;
 		}
 
-		sink_c = buffer_acquire(sink);
-
 		/* Normally this should never happen as we checked above
 		 * that mixout is in active state and so its sink buffer
 		 * should be already initialized in mixout .params().
 		 */
-		if (!sink_c->hw_params_configured) {
+		if (!sink->hw_params_configured) {
 			comp_err(dev, "Uninitialized mixout sink buffer!");
-			buffer_release(sink_c);
 			module_source_info_release(mod_source_info);
 			return -EINVAL;
 		}
 
-		free_frames = audio_stream_get_free_frames(&sink_c->stream);
+		free_frames = audio_stream_get_free_frames(&sink->stream);
 
 		/* mixout sink buffer may still have not yet produced data -- data
 		 * consumed and written there by mixin on previous mixin_process() run.
@@ -328,7 +324,6 @@ static int mixin_process(struct processing_module *mod,
 		assert(free_frames >= pending_frames);
 		sinks_free_frames = MIN(sinks_free_frames, free_frames - pending_frames);
 
-		buffer_release(sink_c);
 		module_source_info_release(mod_source_info);
 	}
 
@@ -361,7 +356,6 @@ static int mixin_process(struct processing_module *mod,
 		struct module_source_info __sparse_cache *mod_source_info;
 		struct processing_module *mixout_mod;
 		uint32_t start_frame;
-		struct comp_buffer *sink_c;
 		uint32_t writeback_size;
 
 		mixout = active_mixouts[i];
@@ -383,25 +377,22 @@ static int mixin_process(struct processing_module *mod,
 		 */
 		start_frame = mixout_data->pending_frames[source_index];
 
-		sink_c = buffer_acquire(sink);
-
 		/* if source does not produce any data but mixin is in active state -- generate
 		 * silence instead of that source data
 		 */
 		if (source_avail_frames == 0) {
 			/* generate silence */
-			silence(&sink_c->stream, start_frame, mixout_data->mixed_frames,
+			silence(&sink->stream, start_frame, mixout_data->mixed_frames,
 				frames_to_copy);
 		} else {
 			/* basically, if sink buffer has no data -- copy source data there, if
 			 * sink buffer has some data (written by another mixin) mix that data
 			 * with source data.
 			 */
-			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink_c->stream,
+			ret = mix_and_remap(dev, mixin_data, sinks_ids[i], &sink->stream,
 					    start_frame, mixout_data->mixed_frames,
 					    input_buffers[0].data, frames_to_copy);
 			if (ret < 0) {
-				buffer_release(sink_c);
 				module_source_info_release(mod_source_info);
 				return ret;
 			}
@@ -411,11 +402,10 @@ static int mixin_process(struct processing_module *mod,
 		 * of frames_to_copy size (converted to bytes, of course). However, seems
 		 * there is no appropreate API. Anyway, start_frame would be 0 most of the time.
 		 */
-		writeback_size = audio_stream_period_bytes(&sink_c->stream,
+		writeback_size = audio_stream_period_bytes(&sink->stream,
 							   frames_to_copy + start_frame);
 		if (writeback_size > 0)
-			buffer_stream_writeback(sink_c, writeback_size);
-		buffer_release(sink_c);
+			buffer_stream_writeback(sink, writeback_size);
 
 		mixout_data->pending_frames[source_index] += frames_to_copy;
 
@@ -543,15 +533,12 @@ static int mixout_reset(struct processing_module *mod)
 	if (dev->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK) {
 		list_for_item(blist, &dev->bsource_list) {
 			struct comp_buffer *source;
-			struct comp_buffer *source_c;
 			bool stop;
 
 			/* FIXME: this is racy and implicitly protected by serialised IPCs */
 			source = container_of(blist, struct comp_buffer, sink_list);
-			source_c = buffer_acquire(source);
-			stop = (dev->pipeline == source_c->source->pipeline &&
-					source_c->source->state > COMP_STATE_PAUSED);
-			buffer_release(source_c);
+			stop = (dev->pipeline == source->source->pipeline &&
+					source->source->state > COMP_STATE_PAUSED);
 
 			if (stop)
 				/* should not reset the downstream components */
@@ -580,28 +567,25 @@ static int mixin_params(struct processing_module *mod)
 	 */
 	list_for_item(blist, &dev->bsink_list) {
 		struct comp_buffer *sink;
-		struct comp_buffer *sink_c;
 		enum sof_ipc_frame frame_fmt, valid_fmt;
 		uint16_t sink_id;
 
 		sink = buffer_from_list(blist, PPL_DIR_DOWNSTREAM);
-		sink_c = buffer_acquire(sink);
 
-		audio_stream_set_channels(&sink_c->stream,
+		audio_stream_set_channels(&sink->stream,
 					  mod->priv.cfg.base_cfg.audio_fmt.channels_count);
 
 		/* Applying channel remapping may produce sink stream with channel count
 		 * different from source channel count.
 		 */
-		sink_id = IPC4_SRC_QUEUE_ID(sink_c->id);
+		sink_id = IPC4_SRC_QUEUE_ID(sink->id);
 		if (sink_id >= MIXIN_MAX_SINKS) {
 			comp_err(dev, "Sink index out of range: %u, max sink count: %u",
 				 (uint32_t)sink_id, MIXIN_MAX_SINKS);
-			buffer_release(sink_c);
 			return -EINVAL;
 		}
 		if (md->sink_config[sink_id].mixer_mode == IPC4_MIXER_CHANNEL_REMAPPING_MODE)
-			audio_stream_set_channels(&sink_c->stream,
+			audio_stream_set_channels(&sink->stream,
 						  md->sink_config[sink_id].output_channel_count);
 
 		/* comp_verify_params() does not modify valid_sample_fmt (a BUG?),
@@ -612,10 +596,8 @@ static int mixin_params(struct processing_module *mod)
 					    &frame_fmt, &valid_fmt,
 					    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-		audio_stream_set_frm_fmt(&sink_c->stream, frame_fmt);
-		audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
-
-		buffer_release(sink_c);
+		audio_stream_set_frm_fmt(&sink->stream, frame_fmt);
+		audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
 	}
 
 	/* use BUFF_PARAMS_CHANNELS to skip updating channel count */
@@ -643,7 +625,6 @@ static int mixin_prepare(struct processing_module *mod,
 	struct mixin_data *md = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	enum sof_ipc_frame fmt;
 	int ret;
 
@@ -654,9 +635,7 @@ static int mixin_prepare(struct processing_module *mod,
 		return ret;
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
-	fmt = audio_stream_get_valid_fmt(&sink_c->stream);
-	buffer_release(sink_c);
+	fmt = audio_stream_get_valid_fmt(&sink->stream);
 
 	/* currently inactive so setup mixer */
 	switch (fmt) {
@@ -683,7 +662,6 @@ static int mixout_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt, valid_fmt;
 	uint32_t sink_period_bytes, sink_stream_size;
@@ -700,7 +678,6 @@ static int mixout_params(struct processing_module *mod)
 	}
 
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sink);
 
 	/* comp_verify_params() does not modify valid_sample_fmt (a BUG?), let's do this here */
 	audio_stream_fmt_conversion(mod->priv.cfg.base_cfg.audio_fmt.depth,
@@ -708,15 +685,14 @@ static int mixout_params(struct processing_module *mod)
 				    &frame_fmt, &valid_fmt,
 				    mod->priv.cfg.base_cfg.audio_fmt.s_type);
 
-	audio_stream_set_valid_fmt(&sink_c->stream, valid_fmt);
-	audio_stream_set_channels(&sink_c->stream, params->channels);
+	audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
+	audio_stream_set_channels(&sink->stream, params->channels);
 
-	sink_stream_size = audio_stream_get_size(&sink_c->stream);
+	sink_stream_size = audio_stream_get_size(&sink->stream);
 
 	/* calculate period size based on config */
-	sink_period_bytes = audio_stream_period_bytes(&sink_c->stream,
+	sink_period_bytes = audio_stream_period_bytes(&sink->stream,
 						      dev->frames);
-	buffer_release(sink_c);
 
 	if (sink_period_bytes == 0) {
 		comp_err(dev, "mixout_params(): period_bytes = 0");


### PR DESCRIPTION
This is step 4 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

Remove usage of buffer_acquire and buffer_release from a number of files.

next part: https://github.com/thesofproject/sof/pull/8218