### PR TITLE
cache: remove buffer_acquire/release part 3

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -153,19 +153,14 @@ static int aria_free(struct processing_module *mod)
 static void aria_set_stream_params(struct comp_buffer *buffer,
 				   struct processing_module *mod)
 {
-	struct comp_buffer *buffer_c;
 	const struct ipc4_audio_format *audio_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
 
-	buffer_c = buffer_acquire(buffer);
-
-	ipc4_update_buffer_format(buffer_c, audio_fmt);
+	ipc4_update_buffer_format(buffer, audio_fmt);
 #ifdef ARIA_GENERIC
-	audio_stream_init_alignment_constants(1, 1, &buffer_c->stream);
+	audio_stream_init_alignment_constants(1, 1, &buffer->stream);
 #else
-	audio_stream_init_alignment_constants(8, 1, &buffer_c->stream);
+	audio_stream_init_alignment_constants(8, 1, &buffer->stream);
 #endif
-
-	buffer_release(buffer_c);
 }
 
 static int aria_prepare(struct processing_module *mod,

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -238,11 +238,8 @@ static enum task_state chain_task_run(void *data)
 		 * mode task will update read position based on transferred data size to avoid
 		 * overwriting valid data and write position by half buffer size.
 		 */
-		struct comp_buffer *buffer_c = buffer_acquire(cd->dma_buffer);
-		const size_t buff_size = audio_stream_get_size(&buffer_c->stream);
+		const size_t buff_size = audio_stream_get_size(&cd->dma_buffer->stream);
 		const size_t half_buff_size = buff_size / 2;
-
-		buffer_release(buffer_c);
 
 		if (!cd->first_data_received && host_avail_bytes > half_buff_size) {
 			ret = dma_reload(cd->chan_link->dma->z_dev,
@@ -510,7 +507,6 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 		    uint32_t fifo_size)
 {
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer *buffer_c;
 	uint32_t addr_align;
 	size_t buff_size;
 	void *buff_addr;
@@ -598,11 +594,9 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	}
 
 	/* clear dma buffer */
-	buffer_c = buffer_acquire(cd->dma_buffer);
-	buffer_zero(buffer_c);
-	buff_addr = audio_stream_get_addr(&buffer_c->stream);
-	buff_size = audio_stream_get_size(&buffer_c->stream);
-	buffer_release(buffer_c);
+	buffer_zero(cd->dma_buffer);
+	buff_addr = audio_stream_get_addr(&cd->dma_buffer->stream);
+	buff_size = audio_stream_get_size(&cd->dma_buffer->stream);
 
 	ret = chain_init(dev, buff_addr, buff_size);
 	if (ret < 0) {

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -133,7 +133,6 @@ static int crossover_assign_sinks(struct processing_module *mod,
 	struct sof_crossover_config *config = cd->config;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	int num_sinks = 0;
 	int i;
@@ -143,14 +142,12 @@ static int crossover_assign_sinks(struct processing_module *mod,
 		unsigned int sink_id, state;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
 #if CONFIG_IPC_MAJOR_4
 		sink_id = cd->output_pin_index[j];
 #else
-		sink_id = sink_c->pipeline_id;
+		sink_id = sink->pipeline_id;
 #endif
-		state = sink_c->sink->state;
-		buffer_release(sink_c);
+		state = sink->sink->state;
 		if (state != dev->state) {
 			j++;
 			continue;
@@ -486,7 +483,6 @@ static int crossover_check_sink_assign(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	struct list_item *sink_list;
 	int num_assigned_sinks = 0;
 	uint8_t assigned_sinks[SOF_CROSSOVER_MAX_STREAMS] = {0};
@@ -496,9 +492,7 @@ static int crossover_check_sink_assign(struct processing_module *mod,
 		unsigned int pipeline_id;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		pipeline_id = sink_c->pipeline_id;
-		buffer_release(sink_c);
+		pipeline_id = sink->pipeline_id;
 
 		i = crossover_get_stream_index(mod, config, pipeline_id);
 		if (i < 0) {
@@ -691,7 +685,6 @@ static int crossover_process_audio_stream(struct processing_module *mod,
 static void crossover_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct list_item *sink_list;
 	struct comp_dev *dev = mod->dev;
@@ -702,15 +695,11 @@ static void crossover_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	list_for_item(sink_list, &dev->bsink_list) {
 		sinkb = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sinkb);
-		ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-		buffer_release(sink_c);
+		ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 	}
 }
 #endif
@@ -727,7 +716,6 @@ static int crossover_prepare(struct processing_module *mod,
 	struct comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source, *sink;
-	struct comp_buffer *source_c, *sink_c;
 	struct list_item *sink_list;
 	int channels;
 	int ret = 0;
@@ -741,27 +729,23 @@ static int crossover_prepare(struct processing_module *mod,
 	/* Crossover has a variable number of sinks */
 	mod->max_sinks = SOF_CROSSOVER_MAX_STREAMS;
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(source);
 
 	/* Get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	channels = audio_stream_get_channels(&source_c->stream);
-	audio_stream_init_alignment_constants(1, 1, &source_c->stream);
-	buffer_release(source_c);
+	cd->source_format = audio_stream_get_frm_fmt(&source->stream);
+	channels = audio_stream_get_channels(&source->stream);
+	audio_stream_init_alignment_constants(1, 1, &source->stream);
 
 	/* Validate frame format and buffer size of sinks */
 	list_for_item(sink_list, &dev->bsink_list) {
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		if (cd->source_format == audio_stream_get_frm_fmt(&sink_c->stream)) {
-			audio_stream_init_alignment_constants(1, 1, &sink_c->stream);
+		if (cd->source_format == audio_stream_get_frm_fmt(&sink->stream)) {
+			audio_stream_init_alignment_constants(1, 1, &sink->stream);
 		} else {
 			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different.",
-				 cd->source_format, audio_stream_get_frm_fmt(&sink_c->stream));
+				 cd->source_format, audio_stream_get_frm_fmt(&sink->stream));
 			ret = -EINVAL;
 		}
 
-		buffer_release(sink_c);
 		if (ret < 0)
 			return ret;
 	}

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -37,7 +37,6 @@ LOG_MODULE_DECLARE(volume, CONFIG_SOF_LOG_LEVEL);
 void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_or_sink)
 {
 	struct comp_buffer *bufferb;
-	struct comp_buffer *buffer_c;
 
 	if (source_or_sink)
 		bufferb = list_first_item(&dev->bsource_list,
@@ -46,10 +45,7 @@ void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_o
 		bufferb = list_first_item(&dev->bsink_list,
 					  struct comp_buffer, source_list);
 
-	buffer_c = buffer_acquire(bufferb);
-	cd->scale_vol = vol_get_processing_function(dev, buffer_c, cd);
-
-	buffer_release(buffer_c);
+	cd->scale_vol = vol_get_processing_function(dev, bufferb, cd);
 }
 
 /**

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -366,7 +366,6 @@ int volume_get_config(struct processing_module *mod,
 static int volume_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -378,14 +377,10 @@ static int volume_params(struct processing_module *mod)
 
 	/* volume component will only ever have 1 sink buffer */
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(sink_c);
+	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	return 0;
 }


### PR DESCRIPTION
This is step 5 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

Remove usage of buffer_acquire and buffer_release from a number of files.

next part:https://github.com/thesofproject/sof/pull/8219