### PR TITLE
cache: remove buffer_acquire/release part 4

### DIFF
--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -221,7 +221,6 @@ static inline void dcblock_set_frame_alignment(struct audio_stream *source,
 static void dcblock_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -231,14 +230,10 @@ static void dcblock_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(sink_c);
+	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
 
@@ -253,7 +248,6 @@ static int dcblock_prepare(struct processing_module *mod,
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 
 	comp_info(dev, "dcblock_prepare()");
@@ -266,18 +260,13 @@ static int dcblock_prepare(struct processing_module *mod,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
+	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
 
-	dcblock_set_frame_alignment(&source_c->stream, &sink_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	dcblock_set_frame_alignment(&sourceb->stream, &sinkb->stream);
 
 	dcblock_init_state(cd);
 	cd->dcblock_func = dcblock_find_func(cd->source_format);

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -458,7 +458,6 @@ static int multiband_drc_params(struct processing_module *mod)
 	struct sof_ipc_stream_params comp_params;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb;
-	struct comp_buffer *sink_c;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
 	int i, ret;
 
@@ -481,9 +480,8 @@ static int multiband_drc_params(struct processing_module *mod)
 
 	component_set_nearest_period_frames(dev, comp_params.rate);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ret = buffer_set_params(sink_c, &comp_params, true);
-	buffer_release(sink_c);
+	ret = buffer_set_params(sinkb, &comp_params, true);
+
 	return ret;
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
@@ -495,7 +493,6 @@ static int multiband_drc_prepare(struct processing_module *mod,
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer *source_c, *sink_c;
 	int channels;
 	int rate;
 	int ret = 0;
@@ -512,17 +509,12 @@ static int multiband_drc_prepare(struct processing_module *mod,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	multiband_drc_set_alignment(&source_c->stream, &sink_c->stream);
+	multiband_drc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	channels = audio_stream_get_channels(&source_c->stream);
-	rate = audio_stream_get_rate(&source_c->stream);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	channels = audio_stream_get_channels(&sourceb->stream);
+	rate = audio_stream_get_rate(&sourceb->stream);
 
 	/* Initialize DRC */
 	comp_dbg(dev, "multiband_drc_prepare(), source_format=%d, sink_format=%d",

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -530,8 +530,7 @@ mux_func mux_get_processing_function(struct processing_module *mod)
 				source_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer *sink_c = buffer_acquire(sinkb);
-		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sink_c->stream);
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sinkb->stream);
 
 
 		if (fmt == mux_func_map[i].frame_format)
@@ -554,10 +553,7 @@ demux_func demux_get_processing_function(struct processing_module *mod)
 				sink_list);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
-		struct comp_buffer *source_c = buffer_acquire(sourceb);
-		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&source_c->stream);
-
-		buffer_release(source_c);
+		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sourceb->stream);
 
 		if (fmt == mux_func_map[i].frame_format)
 			return mux_func_map[i].demux_proc_func;


### PR DESCRIPTION
This is step 6 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

Remove usage of buffer_acquire and buffer_release from a number of files.

next part: https://github.com/thesofproject/sof/pull/8220