### PR TITLE
cache: remove buffer_acquire/release part 5

### DIFF
--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -272,7 +272,6 @@ static int drc_process(struct processing_module *mod,
 static void drc_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
-	struct comp_buffer *sink_c, *source_c;
 	struct comp_buffer *sinkb, *sourceb;
 	struct comp_dev *dev = mod->dev;
 
@@ -282,14 +281,10 @@ static void drc_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	sink_c = buffer_acquire(sinkb);
-	ipc4_update_buffer_format(sink_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(sink_c);
+	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	ipc4_update_buffer_format(source_c, &mod->priv.cfg.base_cfg.audio_fmt);
-	buffer_release(source_c);
+	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
 
@@ -299,7 +294,6 @@ static int drc_prepare(struct processing_module *mod,
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	int channels;
 	int rate;
@@ -314,16 +308,12 @@ static int drc_prepare(struct processing_module *mod,
 	/* DRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	drc_set_alignment(&source_c->stream, &sink_c->stream);
+	drc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source data format */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	channels = audio_stream_get_channels(&sink_c->stream);
-	rate = audio_stream_get_rate(&sink_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	channels = audio_stream_get_channels(&sinkb->stream);
+	rate = audio_stream_get_rate(&sinkb->stream);
 
 	/* Initialize DRC */
 	comp_info(dev, "drc_prepare(), source_format=%d", cd->source_format);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -159,7 +159,6 @@ static int ghd_params(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sourceb;
-	struct comp_buffer *source_c;
 	int ret;
 
 	/* Detector is used only in KPB topology. It always requires channels
@@ -176,20 +175,17 @@ static int ghd_params(struct comp_dev *dev,
 	/* This detector component will only ever have 1 source */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	source_c = buffer_acquire(sourceb);
 
-	if (audio_stream_get_channels(source_c->stream) != 1) {
+	if (audio_stream_get_channels(sourceb->stream) != 1) {
 		comp_err(dev, "ghd_params(): Only single-channel supported");
 		ret = -EINVAL;
-	} else if (audio_stream_get_frm_fmt(&source_c->stream) != SOF_IPC_FRAME_S16_LE) {
+	} else if (audio_stream_get_frm_fmt(&sourceb->stream) != SOF_IPC_FRAME_S16_LE) {
 		comp_err(dev, "ghd_params(): Only S16_LE supported");
 		ret = -EINVAL;
-	} else if (source_c->stream.rate != KPB_SAMPLNG_FREQUENCY) {
+	} else if (sourceb->stream.rate != KPB_SAMPLNG_FREQUENCY) {
 		comp_err(dev, "ghd_params(): Only 16KHz supported");
 		ret = -EINVAL;
 	}
-
-	buffer_release(source_c);
 
 	return ret;
 }
@@ -383,7 +379,6 @@ static int ghd_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer *source_c;
 	struct audio_stream *stream;
 	uint32_t bytes, tail_bytes, head_bytes = 0;
 	int ret;
@@ -399,8 +394,7 @@ static int ghd_copy(struct comp_dev *dev)
 	/* keyword components will only ever have 1 source */
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
-	source_c = buffer_acquire(sourceb);
-	stream = &source_c->stream;
+	stream = &sourceb->stream;
 
 	bytes = audio_stream_get_avail_bytes(stream);
 
@@ -411,7 +405,7 @@ static int ghd_copy(struct comp_dev *dev)
 		 (uint32_t)audio_stream_get_end_addr(stream));
 
 	/* copy and perform detection */
-	buffer_stream_invalidate(source_c, bytes);
+	buffer_stream_invalidate(sourceb, bytes);
 
 	tail_bytes = (char *)audio_stream_get_end_addr(stream) -
 		(char *)audio_stream_get_rptr(stream);
@@ -426,9 +420,7 @@ static int ghd_copy(struct comp_dev *dev)
 		ghd_detect(dev, stream, audio_stream_get_addr(stream), head_bytes);
 
 	/* calc new available */
-	comp_update_buffer_consume(source_c, bytes);
-
-	buffer_release(source_c);
+	comp_update_buffer_consume(sourceb, bytes);
 
 	return 0;
 }

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -89,7 +89,6 @@ static int google_rtc_audio_processing_params(
 	int ret;
 #if CONFIG_IPC_MAJOR_4
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer *sink_c;
 	struct comp_buffer *sink;
 
 	/* update sink buffer format */
@@ -108,9 +107,7 @@ static int google_rtc_audio_processing_params(
 		enum sof_ipc_frame valid_fmt, frame_fmt;
 
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-		sink_c = buffer_acquire(sink);
-		ipc4_update_buffer_format(sink_c, out_fmt);
-		buffer_release(sink_c);
+		ipc4_update_buffer_format(sink, out_fmt);
 	}
 #endif
 
@@ -502,7 +499,6 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 {
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
 	struct list_item *source_buffer_list_item;
-	struct comp_buffer *output_c;
 	unsigned int aec_channels = 0, frame_fmt, rate;
 	int ret;
 
@@ -512,19 +508,17 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 	list_for_item(source_buffer_list_item, &dev->bsource_list) {
 		struct comp_buffer *source = container_of(source_buffer_list_item,
 							  struct comp_buffer, sink_list);
-		struct comp_buffer *source_c = buffer_acquire(source);
 
 #if CONFIG_IPC_MAJOR_4
-		if (IPC4_SINK_QUEUE_ID(source_c->id) == SOF_AEC_FEEDBACK_QUEUE_ID) {
+		if (IPC4_SINK_QUEUE_ID(source->id) == SOF_AEC_FEEDBACK_QUEUE_ID) {
 #else
-		if (source_c->source->pipeline->pipeline_id != dev->pipeline->pipeline_id) {
+		if (source->source->pipeline->pipeline_id != dev->pipeline->pipeline_id) {
 #endif
 			cd->aec_reference = source;
-			aec_channels = audio_stream_get_channels(&source_c->stream);
+			aec_channels = audio_stream_get_channels(&source->stream);
 		} else {
 			cd->raw_microphone = source;
 		}
-		buffer_release(source_c);
 	}
 
 	cd->output = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
@@ -539,11 +533,8 @@ static int google_rtc_audio_processing_prepare(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
-	output_c = buffer_acquire(cd->output);
-	frame_fmt = audio_stream_get_frm_fmt(&output_c->stream);
-	rate = audio_stream_get_rate(&output_c->stream);
-	buffer_release(output_c);
-
+	frame_fmt = audio_stream_get_frm_fmt(&cd->output->stream);
+	rate = audio_stream_get_rate(&cd->output->stream);
 
 	if (cd->num_capture_channels > audio_stream_get_channels(&cd->raw_microphone->stream)) {
 		comp_err(dev, "unsupported number of microphone channels: %d",
@@ -592,8 +583,8 @@ static int google_rtc_audio_processing_reset(struct comp_dev *dev)
 static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 {
 	struct google_rtc_audio_processing_comp_data *cd = comp_get_drvdata(dev);
-	struct comp_buffer *buffer_c, *mic_buf, *output_buf;
 	struct comp_copy_limits cl;
+	struct comp_buffer *buffer;
 	int16_t *src, *dst, *ref;
 	uint32_t num_aec_reference_frames;
 	uint32_t num_aec_reference_bytes;
@@ -609,27 +600,26 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 		if (ret)
 			return ret;
 	}
+	buffer = cd->aec_reference;
 
-	buffer_c = buffer_acquire(cd->aec_reference);
+	ref = audio_stream_get_rptr(&buffer->stream);
 
-	ref = audio_stream_get_rptr(&buffer_c->stream);
+	num_aec_reference_frames = audio_stream_get_avail_frames(&buffer->stream);
+	num_aec_reference_bytes = audio_stream_get_avail_bytes(&buffer->stream);
 
-	num_aec_reference_frames = audio_stream_get_avail_frames(&buffer_c->stream);
-	num_aec_reference_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_stream_invalidate(buffer_c, num_aec_reference_bytes);
+	buffer_stream_invalidate(buffer, num_aec_reference_bytes);
 
 	num_samples_remaining = num_aec_reference_frames *
-		audio_stream_get_channels(&buffer_c->stream);
+		audio_stream_get_channels(&buffer->stream);
 	while (num_samples_remaining) {
-		nmax = audio_stream_samples_without_wrap_s16(&buffer_c->stream, ref);
+		nmax = audio_stream_samples_without_wrap_s16(&buffer->stream, ref);
 		n = MIN(num_samples_remaining, nmax);
 		for (i = 0; i < n; i += cd->num_aec_reference_channels) {
 			j = cd->num_aec_reference_channels * cd->aec_reference_frame_index;
 			for (channel = 0; channel < cd->num_aec_reference_channels; ++channel)
 				cd->aec_reference_buffer[j++] = ref[channel];
 
-			ref += audio_stream_get_channels(&buffer_c->stream);
+			ref += audio_stream_get_channels(&buffer->stream);
 			++cd->aec_reference_frame_index;
 
 			if (cd->aec_reference_frame_index == cd->num_frames) {
@@ -639,26 +629,21 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 			}
 		}
 		num_samples_remaining -= n;
-		ref = audio_stream_wrap(&buffer_c->stream, ref);
+		ref = audio_stream_wrap(&buffer->stream, ref);
 	}
-	comp_update_buffer_consume(buffer_c, num_aec_reference_bytes);
+	comp_update_buffer_consume(buffer, num_aec_reference_bytes);
 
-	buffer_release(buffer_c);
+	src = audio_stream_get_rptr(&cd->raw_microphone->stream);
+	dst = audio_stream_get_wptr(&cd->output->stream);
 
-	mic_buf = buffer_acquire(cd->raw_microphone);
-	output_buf = buffer_acquire(cd->output);
-
-	src = audio_stream_get_rptr(&mic_buf->stream);
-	dst = audio_stream_get_wptr(&output_buf->stream);
-
-	comp_get_copy_limits(mic_buf, output_buf, &cl);
-	buffer_stream_invalidate(mic_buf, cl.source_bytes);
+	comp_get_copy_limits(cd->raw_microphone, cd->output, &cl);
+	buffer_stream_invalidate(cd->raw_microphone, cl.source_bytes);
 
 	num_frames_remaining = cl.frames;
 	while (num_frames_remaining) {
-		nmax = audio_stream_frames_without_wrap(&mic_buf->stream, src);
+		nmax = audio_stream_frames_without_wrap(&cd->raw_microphone->stream, src);
 		n = MIN(num_frames_remaining, nmax);
-		nmax = audio_stream_frames_without_wrap(&output_buf->stream, dst);
+		nmax = audio_stream_frames_without_wrap(&cd->output->stream, dst);
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			memcpy_s(&(cd->raw_mic_buffer[cd->raw_mic_buffer_frame_index *
@@ -684,21 +669,18 @@ static int google_rtc_audio_processing_copy(struct comp_dev *dev)
 				cd->raw_mic_buffer_frame_index = 0;
 			}
 
-			src += audio_stream_get_channels(&mic_buf->stream);
-			dst += audio_stream_get_channels(&output_buf->stream);
+			src += audio_stream_get_channels(&cd->raw_microphone->stream);
+			dst += audio_stream_get_channels(&cd->output->stream);
 		}
 		num_frames_remaining -= n;
-		src = audio_stream_wrap(&mic_buf->stream, src);
-		dst = audio_stream_wrap(&output_buf->stream, dst);
+		src = audio_stream_wrap(&cd->raw_microphone->stream, src);
+		dst = audio_stream_wrap(&cd->output->stream, dst);
 	}
 
-	buffer_stream_writeback(output_buf, cl.sink_bytes);
+	buffer_stream_writeback(cd->output, cl.sink_bytes);
 
-	comp_update_buffer_produce(output_buf, cl.sink_bytes);
-	comp_update_buffer_consume(mic_buf, cl.source_bytes);
-
-	buffer_release(output_buf);
-	buffer_release(mic_buf);
+	comp_update_buffer_produce(cd->output, cl.sink_bytes);
+	comp_update_buffer_consume(cd->raw_microphone, cl.source_bytes);
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -716,7 +716,6 @@ cadence_codec_process(struct processing_module *mod,
 		      struct output_stream_buffer *output_buffers, int num_output_buffers)
 {
 	struct comp_buffer *local_buff;
-	struct comp_buffer *buffer_c;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct cadence_codec_data *cd = codec->private;
@@ -747,9 +746,7 @@ cadence_codec_process(struct processing_module *mod,
 
 	/* do not proceed with processing if not enough free space left in the local buffer */
 	local_buff = list_first_item(&mod->sink_buffer_list, struct comp_buffer, sink_list);
-	buffer_c = buffer_acquire(local_buff);
-	free_bytes = audio_stream_get_free(&buffer_c->stream);
-	buffer_release(buffer_c);
+	free_bytes = audio_stream_get_free(&local_buff->stream);
 	if (free_bytes < output_bytes)
 		return -ENOSPC;
 

--- a/src/audio/module_adapter/module/dts/dts.c
+++ b/src/audio/module_adapter/module/dts/dts.c
@@ -78,7 +78,6 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 {
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
-	struct comp_buffer *source_c;
 	const struct audio_stream *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;
@@ -89,15 +88,11 @@ static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	if (!source)
 		return -EINVAL;
 
-	source_c = buffer_acquire(source);
-
-	stream = &source_c->stream;
+	stream = &source->stream;
 	buffer_fmt = audio_stream_get_buffer_fmt(stream);
 	frame_fmt = audio_stream_get_frm_fmt(stream);
 	rate = audio_stream_get_rate(stream);
 	channels = audio_stream_get_channels(stream);
-
-	buffer_release(source_c);
 
 	switch (buffer_fmt) {
 	case SOF_IPC_BUFFER_INTERLEAVED:

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -60,7 +60,6 @@ static int selector_verify_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *buffer, *sinkb;
-	struct comp_buffer *buffer_c, *sink_c;
 	uint32_t in_channels;
 	uint32_t out_channels;
 
@@ -86,15 +85,13 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		in_channels = cd->config.in_channels_count;
 
-		buffer_c = buffer_acquire(buffer);
-
 		/* if cd->config.out_channels_count are equal to 0
 		 * (it can vary), we set params->channels to sink buffer
 		 * channels, which were previously set in
 		 * pipeline_comp_hw_params()
 		 */
 		out_channels = cd->config.out_channels_count ?
-			cd->config.out_channels_count : audio_stream_get_channels(&buffer_c->stream);
+			cd->config.out_channels_count : audio_stream_get_channels(&buffer->stream);
 		params->channels = out_channels;
 	} else {
 		/* fetch source buffer for capture */
@@ -107,27 +104,21 @@ static int selector_verify_params(struct comp_dev *dev,
 		}
 		out_channels = cd->config.out_channels_count;
 
-		buffer_c = buffer_acquire(buffer);
-
 		/* if cd->config.in_channels_count are equal to 0
 		 * (it can vary), we set params->channels to source buffer
 		 * channels, which were previously set in
 		 * pipeline_comp_hw_params()
 		 */
 		in_channels = cd->config.in_channels_count ?
-			cd->config.in_channels_count : audio_stream_get_channels(&buffer_c->stream);
+			cd->config.in_channels_count : audio_stream_get_channels(&buffer->stream);
 		params->channels = in_channels;
 	}
 
 	/* Set buffer params */
-	buffer_set_params(buffer_c, params, BUFFER_UPDATE_FORCE);
-
-	buffer_release(buffer_c);
+	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
 	/* set component period frames */
-	sink_c = buffer_acquire(sinkb);
-	component_set_nearest_period_frames(dev, audio_stream_get_rate(&sink_c->stream));
-	buffer_release(sink_c);
+	component_set_nearest_period_frames(dev, audio_stream_get_rate(&sinkb->stream));
 
 	/* verify input channels */
 	switch (in_channels) {
@@ -358,7 +349,6 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 static int selector_trigger(struct comp_dev *dev, int cmd)
 {
 	struct comp_buffer *sourceb;
-	struct comp_buffer *source_c;
 	enum sof_comp_type type;
 	int ret;
 
@@ -367,17 +357,13 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
 
-	source_c = buffer_acquire(sourceb);
-
 	ret = comp_set_state(dev, cmd);
 
 	/* TODO: remove in the future after adding support for case when
 	 * kpb_init_draining() and kpb_draining_task() are interrupted by
 	 * new pipeline_task()
 	 */
-	type = dev_comp_type(source_c->source);
-
-	buffer_release(source_c);
+	type = dev_comp_type(sourceb->source);
 
 	return type == SOF_COMP_KPB ? PPL_STATUS_PATH_TERMINATE : ret;
 }
@@ -391,7 +377,6 @@ static int selector_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sink, *source;
-	struct comp_buffer *sink_c, *source_c;
 	uint32_t frames;
 	uint32_t source_bytes;
 	uint32_t sink_bytes;
@@ -404,33 +389,24 @@ static int selector_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	source_c = buffer_acquire(source);
-
-	if (!audio_stream_get_avail(&source_c->stream)) {
-		buffer_release(source_c);
+	if (!audio_stream_get_avail(&source->stream))
 		return PPL_STATUS_PATH_STOP;
-	}
 
-	sink_c = buffer_acquire(sink);
-
-	frames = audio_stream_avail_frames(&source_c->stream, &sink_c->stream);
-	source_bytes = frames * audio_stream_frame_bytes(&source_c->stream);
-	sink_bytes = frames * audio_stream_frame_bytes(&sink_c->stream);
+	frames = audio_stream_avail_frames(&source->stream, &sink->stream);
+	source_bytes = frames * audio_stream_frame_bytes(&source->stream);
+	sink_bytes = frames * audio_stream_frame_bytes(&sink->stream);
 
 	comp_dbg(dev, "selector_copy(), source_bytes = 0x%x, sink_bytes = 0x%x",
 		 source_bytes, sink_bytes);
 
 	/* copy selected channels from in to out */
-	buffer_stream_invalidate(source_c, source_bytes);
-	cd->sel_func(dev, &sink_c->stream, &source_c->stream, frames);
-	buffer_stream_writeback(sink_c, sink_bytes);
+	buffer_stream_invalidate(source, source_bytes);
+	cd->sel_func(dev, &sink->stream, &source->stream, frames);
+	buffer_stream_writeback(sink, sink_bytes);
 
 	/* calculate new free and available */
-	comp_update_buffer_produce(sink_c, sink_bytes);
-	comp_update_buffer_consume(source_c, source_bytes);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	comp_update_buffer_produce(sink, sink_bytes);
+	comp_update_buffer_consume(source, source_bytes);
 
 	return 0;
 }
@@ -444,7 +420,6 @@ static int selector_prepare(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer *sink_c, *source_c;
 	size_t sink_size;
 	int ret;
 
@@ -463,30 +438,24 @@ static int selector_prepare(struct comp_dev *dev)
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
 				source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
 	/* get source data format and period bytes */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	cd->source_period_bytes = audio_stream_period_bytes(&source_c->stream, dev->frames);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	cd->source_period_bytes = audio_stream_period_bytes(&sourceb->stream, dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	cd->sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
+	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
+	cd->sink_period_bytes = audio_stream_period_bytes(&sinkb->stream, dev->frames);
 
 	/* There is an assumption that sink component will report out
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
 	comp_dbg(dev, "selector_prepare(): sourceb->schannels = %u",
-		 audio_stream_get_channels(&source_c->stream));
+		 audio_stream_get_channels(&sourceb->stream));
 	comp_dbg(dev, "selector_prepare(): sinkb->channels = %u",
-		 audio_stream_get_channels(&sink_c->stream));
+		 audio_stream_get_channels(&sinkb->stream));
 
-	sink_size = audio_stream_get_size(&sink_c->stream);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	sink_size = audio_stream_get_size(&sinkb->stream);
 
 	if (sink_size < cd->sink_period_bytes) {
 		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",
@@ -673,7 +642,6 @@ static void set_selector_params(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
-	struct comp_buffer *source;
 	const struct sof_selector_ipc4_config *sel_cfg = &cd->sel_ipc4_cfg;
 	const struct ipc4_audio_format *out_fmt = NULL;
 	struct comp_buffer *src_buf;
@@ -700,12 +668,10 @@ static void set_selector_params(struct processing_module *mod,
 	list_for_item(sink_list, &dev->bsink_list) {
 		struct comp_buffer *sink_buf =
 			container_of(sink_list, struct comp_buffer, source_list);
-		struct comp_buffer *sink = buffer_acquire(sink_buf);
 
-		ipc4_update_buffer_format(sink, out_fmt);
-		audio_stream_set_channels(&sink->stream, params->channels);
-		audio_stream_set_rate(&sink->stream, params->rate);
-		buffer_release(sink);
+		ipc4_update_buffer_format(sink_buf, out_fmt);
+		audio_stream_set_channels(&sink_buf->stream, params->channels);
+		audio_stream_set_rate(&sink_buf->stream, params->rate);
 	}
 
 	/* update the source format
@@ -715,12 +681,9 @@ static void set_selector_params(struct processing_module *mod,
 	 * and the first one is not ready yet along with sink buffers params
 	 */
 	src_buf = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	source = buffer_acquire(src_buf);
 
-	if (!source->hw_params_configured)
-		ipc4_update_buffer_format(source, &mod->priv.cfg.base_cfg.audio_fmt);
-
-	buffer_release(source);
+	if (!src_buf->hw_params_configured)
+		ipc4_update_buffer_format(src_buf, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 
 static int selector_verify_params(struct processing_module *mod,
@@ -729,7 +692,6 @@ static int selector_verify_params(struct processing_module *mod,
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *buffer;
-	struct comp_buffer *buffer_c;
 	uint32_t in_channels = cd->config.in_channels_count;
 	uint32_t out_channels = cd->config.out_channels_count;
 
@@ -755,15 +717,11 @@ static int selector_verify_params(struct processing_module *mod,
 		params->channels = in_channels;
 		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	}
-	buffer_c = buffer_acquire(buffer);
-	buffer_set_params(buffer_c, params, BUFFER_UPDATE_FORCE);
-	buffer_release(buffer_c);
+	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
 	/* set component period frames */
 	buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	buffer_c = buffer_acquire(buffer);
-	component_set_nearest_period_frames(dev, audio_stream_get_rate(&buffer_c->stream));
-	buffer_release(buffer_c);
+	component_set_nearest_period_frames(dev, audio_stream_get_rate(&buffer->stream));
 
 	return 0;
 }
@@ -869,7 +827,6 @@ static int selector_prepare(struct processing_module *mod,
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sinkb, *sourceb;
-	struct comp_buffer *sink_c, *source_c;
 	size_t sink_size;
 	int ret;
 
@@ -886,35 +843,29 @@ static int selector_prepare(struct processing_module *mod,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
-	audio_stream_init_alignment_constants(4, 1, &source_c->stream);
-	audio_stream_init_alignment_constants(4, 1, &sink_c->stream);
+	audio_stream_init_alignment_constants(4, 1, &sourceb->stream);
+	audio_stream_init_alignment_constants(4, 1, &sinkb->stream);
 
 	/* get source data format and period bytes */
-	cd->source_format = audio_stream_get_frm_fmt(&source_c->stream);
-	cd->source_period_bytes = audio_stream_period_bytes(&source_c->stream, dev->frames);
+	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
+	cd->source_period_bytes = audio_stream_period_bytes(&sourceb->stream, dev->frames);
 
 	/* get sink data format and period bytes */
-	cd->sink_format = audio_stream_get_frm_fmt(&sink_c->stream);
-	cd->sink_period_bytes = audio_stream_period_bytes(&sink_c->stream, dev->frames);
+	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
+	cd->sink_period_bytes = audio_stream_period_bytes(&sinkb->stream, dev->frames);
 
 	/* There is an assumption that sink component will report out
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
 	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
-		  audio_stream_get_channels(&source_c->stream),
-		  audio_stream_get_channels(&sink_c->stream));
+		  audio_stream_get_channels(&sourceb->stream),
+		  audio_stream_get_channels(&sinkb->stream));
 
-	sink_size = audio_stream_get_size(&sink_c->stream);
+	sink_size = audio_stream_get_size(&sinkb->stream);
 
 	md->mpd.in_buff_size = cd->source_period_bytes;
 	md->mpd.out_buff_size = cd->sink_period_bytes;
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
 
 	if (sink_size < cd->sink_period_bytes) {
 		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -731,7 +731,6 @@ static int tdfb_prepare(struct processing_module *mod,
 {
 	struct tdfb_comp_data *cd = module_get_private_data(mod);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer *source_c, *sink_c;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt;
 	int source_channels;
@@ -744,16 +743,12 @@ static int tdfb_prepare(struct processing_module *mod,
 	/* Find source and sink buffers */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-	tdfb_set_alignment(&source_c->stream, &sink_c->stream);
+	tdfb_set_alignment(&sourceb->stream, &sinkb->stream);
 
-	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	source_channels = audio_stream_get_channels(&source_c->stream);
-	sink_channels = audio_stream_get_channels(&sink_c->stream);
-	rate = audio_stream_get_rate(&source_c->stream);
-	buffer_release(sink_c);
-	buffer_release(source_c);
+	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
+	source_channels = audio_stream_get_channels(&sourceb->stream);
+	sink_channels = audio_stream_get_channels(&sinkb->stream);
+	rate = audio_stream_get_rate(&sourceb->stream);
 
 	/* Initialize filter */
 	cd->config = comp_get_data_blob(cd->model_handler, NULL, NULL);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -429,7 +429,6 @@ static int tone_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
-	struct comp_buffer *source_c, *sink_c;
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
@@ -444,18 +443,12 @@ static int tone_params(struct comp_dev *dev,
 	if (dev->ipc_config.frame_fmt != SOF_IPC_FRAME_S32_LE)
 		return -EINVAL;
 
-	source_c = buffer_acquire(sourceb);
-	sink_c = buffer_acquire(sinkb);
-
-	audio_stream_set_frm_fmt(&source_c->stream, dev->ipc_config.frame_fmt);
-	audio_stream_set_frm_fmt(&sink_c->stream, dev->ipc_config.frame_fmt);
+	audio_stream_set_frm_fmt(&sourceb->stream, dev->ipc_config.frame_fmt);
+	audio_stream_set_frm_fmt(&sinkb->stream, dev->ipc_config.frame_fmt);
 
 	/* calculate period size based on config */
 	cd->period_bytes = dev->frames *
-			   audio_stream_frame_bytes(&source_c->stream);
-
-	buffer_release(sink_c);
-	buffer_release(source_c);
+			   audio_stream_frame_bytes(&sourceb->stream);
 
 	return 0;
 }
@@ -634,7 +627,6 @@ static int tone_trigger(struct comp_dev *dev, int cmd)
 static int tone_copy(struct comp_dev *dev)
 {
 	struct comp_buffer *sink;
-	struct comp_buffer *sink_c;
 	struct comp_data *cd = comp_get_drvdata(dev);
 	uint32_t free;
 	int ret = 0;
@@ -645,24 +637,21 @@ static int tone_copy(struct comp_dev *dev)
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
 			       source_list);
 
-	sink_c = buffer_acquire(sink);
-	free = audio_stream_get_free_bytes(&sink_c->stream);
+	free = audio_stream_get_free_bytes(&sink->stream);
 
 	/* Test that sink has enough free frames. Then run once to maintain
 	 * low latency and steady load for tones.
 	 */
 	if (free >= cd->period_bytes) {
 		/* create tone */
-		cd->tone_func(dev, &sink_c->stream, dev->frames);
-		buffer_stream_writeback(sink_c, cd->period_bytes);
+		cd->tone_func(dev, &sink->stream, dev->frames);
+		buffer_stream_writeback(sink, cd->period_bytes);
 
 		/* calc new free and available */
-		comp_update_buffer_produce(sink_c, cd->period_bytes);
+		comp_update_buffer_produce(sink, cd->period_bytes);
 
 		ret = dev->frames;
 	}
-
-	buffer_release(sink_c);
 
 	return ret;
 }

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1066,7 +1066,6 @@ static bool probe_purpose_needs_ext_dma(uint32_t purpose)
 static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point_id_t probe_point)
 {
 	struct comp_buffer *buf;
-	struct comp_buffer *buf_c;
 	struct list_item *sink_list, *source_list;
 	unsigned int queue_id;
 
@@ -1074,9 +1073,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 	case PROBE_TYPE_INPUT:
 		list_for_item(source_list, &dev->cd->bsource_list) {
 			buf = container_of(source_list, struct comp_buffer, sink_list);
-			buf_c = buffer_acquire(buf);
-			queue_id = IPC4_SRC_QUEUE_ID(buf_c->id);
-			buffer_release(buf_c);
+			queue_id = IPC4_SRC_QUEUE_ID(buf->id);
 
 			if (queue_id == probe_point.fields.index)
 				return buf;
@@ -1085,9 +1082,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 	case PROBE_TYPE_OUTPUT:
 		list_for_item(sink_list, &dev->cd->bsink_list) {
 			buf = container_of(sink_list, struct comp_buffer, source_list);
-			buf_c = buffer_acquire(buf);
-			queue_id = IPC4_SINK_QUEUE_ID(buf_c->id);
-			buffer_release(buf_c);
+			queue_id = IPC4_SINK_QUEUE_ID(buf->id);
 
 			if (queue_id == probe_point.fields.index)
 				return buf;


### PR DESCRIPTION
This is step 7 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

Remove usage of buffer_acquire and buffer_release from a number of files.

next part: https://github.com/thesofproject/sof/pull/8221