### PR TITLE
cache: remove buffer_acquire/release part 6

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -97,7 +97,6 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 	struct comp_dev *dev = arg;
 	struct dai_data *dd = comp_get_drvdata(dev);
 	uint32_t bytes = next->elem.size;
-	struct comp_buffer *local_buf, *dma_buf;
 	int ret;
 
 	comp_dbg(dev, "dai_dma_cb()");
@@ -113,26 +112,21 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		next->status = DMA_CB_STATUS_END;
 	}
 
-	dma_buf = buffer_acquire(dd->dma_buffer);
-
 	/* is our pipeline handling an XRUN ? */
 	if (dd->xrun) {
 		/* make sure we only playback silence during an XRUN */
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			/* fill buffer with silence */
-			buffer_zero(dma_buf);
-		buffer_release(dma_buf);
+			buffer_zero(dd->dma_buffer);
 
 		return;
 	}
 
-	local_buf = buffer_acquire(dd->local_buffer);
-
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		ret = dma_buffer_copy_to(local_buf, dma_buf,
+		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
 					 dd->process, bytes);
 	} else {
-		ret = dma_buffer_copy_from(dma_buf, local_buf,
+		ret = dma_buffer_copy_from(dd->dma_buffer, dd->local_buffer,
 					   dd->process, bytes);
 	}
 
@@ -141,9 +135,9 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		struct comp_buffer *source_c, *sink_c;
 
 		source_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					local_buf : dma_buf;
+					dd->local_buffer : dd->dma_buffer;
 		sink_c = dev->direction == SOF_IPC_STREAM_PLAYBACK ?
-					dma_buf : local_buf;
+					dd->dma_buffer : dd->local_buffer;
 		comp_err(dev, "dai_dma_cb() dma buffer copy failed, dir %d bytes %d avail %d free %d",
 			 dev->direction, bytes,
 			 audio_stream_get_avail_samples(&source_c->stream) *
@@ -154,9 +148,6 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 		/* update host position (in bytes offset) for drivers */
 		dd->total_data_processed += bytes;
 	}
-
-	buffer_release(local_buf);
-	buffer_release(dma_buf);
 }
 
 int dai_common_new(struct dai_data *dd, struct comp_dev *dev, const struct ipc_config_dai *dai)
@@ -357,23 +348,18 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo;
 	int err = 0;
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
 
-	buffer_release(local_buf);
-
 	if (!dd->process) {
 		comp_err(dev, "dai_playback_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
-		err = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* set up DMA configuration */
@@ -401,15 +387,12 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
+				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
-
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -419,23 +402,18 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
 	struct dma_sg_config *config = &dd->config;
-	struct comp_buffer *dma_buf = buffer_acquire(dd->dma_buffer),
-		*local_buf = buffer_acquire(dd->local_buffer);
-	uint32_t local_fmt = audio_stream_get_frm_fmt(&local_buf->stream);
-	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dma_buf->stream);
+	uint32_t local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
+	uint32_t dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	uint32_t fifo;
 	int err = 0;
 
 	/* set processing function */
 	dd->process = pcm_get_conversion_function(dma_fmt, local_fmt);
 
-	buffer_release(local_buf);
-
 	if (!dd->process) {
 		comp_err(dev, "dai_capture_params(): converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
-		err = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	/* set up DMA configuration */
@@ -474,15 +452,12 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   config->direction,
 				   period_count,
 				   period_bytes,
-				   (uintptr_t)(audio_stream_get_addr(&dma_buf->stream)),
+				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
 			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
-
-out:
-	buffer_release(dma_buf);
 
 	return err;
 }
@@ -491,7 +466,6 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params)
 {
 	struct sof_ipc_stream_params hw_params = *params;
-	struct comp_buffer *buffer_c;
 	uint32_t frame_size;
 	uint32_t period_count;
 	uint32_t period_bytes;
@@ -565,13 +539,9 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	buffer_c = buffer_acquire(dd->local_buffer);
-
 	/* calculate frame size */
 	frame_size = get_frame_bytes(dev->ipc_config.frame_fmt,
-				     audio_stream_get_channels(&buffer_c->stream));
-
-	buffer_release(buffer_c);
+				     audio_stream_get_channels(&dd->local_buffer->stream));
 
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
@@ -589,9 +559,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		err = buffer_set_size(buffer_c, buffer_size, addr_align);
-		buffer_release(buffer_c);
+		err = buffer_set_size(dd->dma_buffer, buffer_size, addr_align);
 
 		if (err < 0) {
 			comp_err(dev, "dai_params(): buffer_set_size() failed, buffer_size = %u",
@@ -613,10 +581,8 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		 * frame_fmt's (using pcm converter).
 		 */
 		hw_params.frame_fmt = dev->ipc_config.frame_fmt;
-		buffer_c = buffer_acquire(dd->dma_buffer);
-		buffer_set_params(buffer_c, &hw_params,
+		buffer_set_params(dd->dma_buffer, &hw_params,
 				  BUFFER_UPDATE_FORCE);
-		buffer_release(buffer_c);
 	}
 
 	return dev->direction == SOF_IPC_STREAM_PLAYBACK ?
@@ -685,7 +651,6 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 
 int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 {
-	struct comp_buffer *buffer_c;
 	int ret;
 
 	dd->total_data_processed = 0;
@@ -703,9 +668,7 @@ int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	/* clear dma buffer to avoid pop noise */
-	buffer_c = buffer_acquire(dd->dma_buffer);
-	buffer_zero(buffer_c);
-	buffer_release(buffer_c);
+	buffer_zero(dd->dma_buffer);
 
 	/* dma reconfig not required if XRUN handling */
 	if (dd->xrun) {
@@ -815,11 +778,7 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 		 * this is only supported at capture mode.
 		 */
 		if (dev->direction == SOF_IPC_STREAM_CAPTURE) {
-			struct comp_buffer *buffer_c =
-				buffer_acquire(dd->dma_buffer);
-
-			buffer_zero(buffer_c);
-			buffer_release(buffer_c);
+			buffer_zero(dd->dma_buffer);
 		}
 
 		/* only start the DAI if we are not XRUN handling */
@@ -947,17 +906,14 @@ static int dai_comp_trigger(struct comp_dev *dev, int cmd)
 static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
-	struct comp_buffer *buf_c = buffer_acquire(dd->local_buffer);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
-		comp_underrun(dev, buf_c, bytes);
+		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
 		comp_err(dev, "dai_report_xrun(): overrun due to no space available");
-		comp_overrun(dev, buf_c, bytes);
+		comp_overrun(dev, dd->local_buffer, bytes);
 	}
-
-	buffer_release(buf_c);
 }
 
 /* copy and process stream data from source to sink buffers */
@@ -965,7 +921,6 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 {
 	uint32_t dma_fmt;
 	uint32_t sampling;
-	struct comp_buffer *buf_c;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
@@ -981,23 +936,17 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		return ret;
 	}
 
-	buf_c = buffer_acquire(dd->dma_buffer);
-
-	dma_fmt = audio_stream_get_frm_fmt(&buf_c->stream);
+	dma_fmt = audio_stream_get_frm_fmt(&dd->dma_buffer->stream);
 	sampling = get_sample_bytes(dma_fmt);
-
-	buffer_release(buf_c);
-
-	buf_c = buffer_acquire(dd->local_buffer);
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		src_samples = audio_stream_get_avail_samples(&buf_c->stream);
+		src_samples = audio_stream_get_avail_samples(&dd->local_buffer->stream);
 		sink_samples = free_bytes / sampling;
 		samples = MIN(src_samples, sink_samples);
 	} else {
 		src_samples = avail_bytes / sampling;
-		sink_samples = audio_stream_get_free_samples(&buf_c->stream);
+		sink_samples = audio_stream_get_free_samples(&dd->local_buffer->stream);
 		samples = MIN(src_samples, sink_samples);
 	}
 
@@ -1010,9 +959,7 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 
 	comp_dbg(dev, "dai_common_copy(), dir: %d copy_bytes= 0x%x, frames= %d",
 		 dev->direction, copy_bytes,
-		 samples / audio_stream_get_channels(&buf_c->stream));
-
-	buffer_release(buf_c);
+		 samples / audio_stream_get_channels(&dd->local_buffer->stream));
 
 	/* Check possibility of glitch occurrence */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -105,16 +105,13 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
  */
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -168,17 +165,14 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd, struct comp_dev *dev)
 {
 	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
-	struct comp_buffer *buffer_c = buffer_acquire(hd->local_buffer);
 	uint32_t copy_bytes;
 	uint32_t split_value;
 
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		copy_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		copy_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 	else
-		copy_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
-
-	buffer_release(buffer_c);
+		copy_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -239,12 +233,12 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 	bool send_ipc = false;
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		source = buffer_acquire(hd->dma_buffer);
-		sink = buffer_acquire(hd->local_buffer);
+		source = hd->dma_buffer;
+		sink = hd->local_buffer;
 		ret = dma_buffer_copy_from(source, sink, hd->process, bytes);
 	} else {
-		source = buffer_acquire(hd->local_buffer);
-		sink = buffer_acquire(hd->dma_buffer);
+		source = hd->local_buffer;
+		sink = hd->dma_buffer;
 		ret = dma_buffer_copy_to(source, sink, hd->process, bytes);
 	}
 
@@ -256,9 +250,6 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 				audio_stream_frame_bytes(&source->stream),
 			 audio_stream_get_free_samples(&sink->stream) *
 				audio_stream_frame_bytes(&sink->stream));
-
-	buffer_release(sink);
-	buffer_release(source);
 
 	if (ret < 0)
 		return;
@@ -372,7 +363,6 @@ static void host_dma_cb(void *arg, enum notify_id type, void *data)
  */
 static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev *dev)
 {
-	struct comp_buffer *buffer_c;
 	uint32_t avail_bytes = 0;
 	uint32_t free_bytes = 0;
 	uint32_t copy_bytes = 0;
@@ -387,27 +377,23 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 		return 0;
 	}
 
-	buffer_c = buffer_acquire(hd->local_buffer);
-
 	/* calculate minimum size to copy */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		/* limit bytes per copy to one period for the whole pipeline
 		 * in order to avoid high load spike
 		 */
-		free_bytes = audio_stream_get_free_bytes(&buffer_c->stream);
+		free_bytes = audio_stream_get_free_bytes(&hd->local_buffer->stream);
 		copy_bytes = MIN(hd->period_bytes, MIN(avail_bytes, free_bytes));
 		if (!copy_bytes)
 			comp_info(dev, "no bytes to copy, %d free in buffer, %d available in DMA",
 				  free_bytes, avail_bytes);
 	} else {
-		avail_bytes = audio_stream_get_avail_bytes(&buffer_c->stream);
+		avail_bytes = audio_stream_get_avail_bytes(&hd->local_buffer->stream);
 		copy_bytes = MIN(avail_bytes, free_bytes);
 		if (!copy_bytes)
 			comp_info(dev, "no bytes to copy, %d avail in buffer, %d free in DMA",
 				  avail_bytes, free_bytes);
 	}
-
-	buffer_release(buffer_c);
 
 	/* copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
@@ -446,7 +432,6 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
 			      uint32_t buffer_bytes)
 {
-	struct comp_buffer *dma_buf_c;
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
 	int err;
@@ -469,11 +454,9 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		elem_array = &hd->config.elem_array;
 	}
 
-	dma_buf_c = buffer_acquire(hd->dma_buffer);
 	err = dma_sg_alloc(elem_array, SOF_MEM_ZONE_RUNTIME, dir, buffer_count,
 			   buffer_bytes,
-			   (uintptr_t)(audio_stream_get_addr(&dma_buf_c->stream)), 0);
-	buffer_release(dma_buf_c);
+			   (uintptr_t)(audio_stream_get_addr(&hd->dma_buffer->stream)), 0);
 	if (err < 0) {
 		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
 		return err;
@@ -690,8 +673,6 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params, notifier_callback_t cb)
 {
 	struct dma_sg_config *config = &hd->config;
-	struct comp_buffer *host_buf_c;
-	struct comp_buffer *dma_buf_c;
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;
@@ -740,10 +721,9 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,
 						   sink_list);
-	host_buf_c = buffer_acquire(hd->local_buffer);
 
 	period_bytes = dev->frames *
-		audio_stream_frame_bytes(&host_buf_c->stream);
+		audio_stream_frame_bytes(&hd->local_buffer->stream);
 
 	if (!period_bytes) {
 		comp_err(dev, "host_params(): invalid period_bytes");
@@ -778,9 +758,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	 * but we have to write back caches after we finish anyway
 	 */
 	if (hd->dma_buffer) {
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		err = buffer_set_size(dma_buf_c, buffer_size, addr_align);
-		buffer_release(dma_buf_c);
+		err = buffer_set_size(hd->dma_buffer, buffer_size, addr_align);
 		if (err < 0) {
 			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
@@ -795,9 +773,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 			goto out;
 		}
 
-		dma_buf_c = buffer_acquire(hd->dma_buffer);
-		buffer_set_params(dma_buf_c, params, BUFFER_UPDATE_FORCE);
-		buffer_release(dma_buf_c);
+		buffer_set_params(hd->dma_buffer, params, BUFFER_UPDATE_FORCE);
 	}
 
 	/* create SG DMA elems for local DMA buffer */
@@ -806,8 +782,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		goto out;
 
 	/* set up DMA configuration - copy in sample bytes. */
-	config->src_width = audio_stream_sample_bytes(&host_buf_c->stream);
-	config->dest_width = audio_stream_sample_bytes(&host_buf_c->stream);
+	config->src_width = audio_stream_sample_bytes(&hd->local_buffer->stream);
+	config->dest_width = audio_stream_sample_bytes(&hd->local_buffer->stream);
 	config->cyclic = 0;
 	config->irq_disabled = pipeline_is_timer_driven(dev->pipeline);
 	config->is_scheduling_source = comp_is_scheduling_source(dev);
@@ -851,11 +827,11 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		host_copy_normal;
 
 	/* set processing function */
-	hd->process = pcm_get_conversion_function(audio_stream_get_frm_fmt(&host_buf_c->stream),
-						  audio_stream_get_frm_fmt(&host_buf_c->stream));
+	hd->process =
+		pcm_get_conversion_function(audio_stream_get_frm_fmt(&hd->local_buffer->stream),
+					    audio_stream_get_frm_fmt(&hd->local_buffer->stream));
 
 out:
-	buffer_release(host_buf_c);
 
 	hd->cb_dev = dev;
 
@@ -886,11 +862,7 @@ static int host_params(struct comp_dev *dev,
 
 int host_common_prepare(struct host_data *hd)
 {
-	struct comp_buffer *buf_c = buffer_acquire(hd->dma_buffer);
-
-	buffer_zero(buf_c);
-	buffer_release(buf_c);
-
+	buffer_zero(hd->dma_buffer);
 	return 0;
 }
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -249,8 +249,7 @@ void buffer_detach(struct comp_buffer *buffer, struct list_item *head, int dir);
 
 static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int dir)
 {
-	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer->sink :
-		buffer->source;
+	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer->sink : buffer->source;
 	return comp;
 }
 

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -107,7 +107,6 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 {
 	struct ipc_config_dai *dai = &dd->ipc_config;
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
-	struct comp_buffer *buffer_c;
 
 	if (!config) {
 		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",
@@ -149,11 +148,10 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		 * all formats, such as 8/16/24/32 bits.
 		 */
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		if (dd->dma_buffer) {
-			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
-			buffer_release(buffer_c);
-		}
+		if (dd->dma_buffer)
+			audio_stream_set_frm_fmt(&dd->dma_buffer->stream,
+						 dev->ipc_config.frame_fmt);
+
 		dd->config.burst_elems = dai_get_fifo_depth(dd->dai, dai->direction);
 		/* As with HDA, the DMA channel is assigned in runtime,
 		 * not during topology parsing.
@@ -174,11 +172,9 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		break;
 	case SOF_DAI_AMD_DMIC:
 		dev->ipc_config.frame_fmt = SOF_IPC_FRAME_S32_LE;
-		if (dd->dma_buffer) {
-			buffer_c = buffer_acquire(dd->dma_buffer);
-			audio_stream_set_frm_fmt(&buffer_c->stream, dev->ipc_config.frame_fmt);
-			buffer_release(buffer_c);
-		}
+		if (dd->dma_buffer)
+			audio_stream_set_frm_fmt(&dd->dma_buffer->stream,
+						 dev->ipc_config.frame_fmt);
 		break;
 	case SOF_DAI_AMD_HS:
 	case SOF_DAI_AMD_HS_VIRTUAL:

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -797,7 +797,6 @@ static int test_keyword_params(struct comp_dev *dev,
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb;
-	struct comp_buffer *source_c;
 	unsigned int channels, rate;
 	enum sof_ipc_frame frame_fmt;
 	int err;
@@ -815,11 +814,9 @@ static int test_keyword_params(struct comp_dev *dev,
 	/* keyword components will only ever have 1 source */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	source_c = buffer_acquire(sourceb);
-	channels = audio_stream_get_channels(&source_c->stream);
-	frame_fmt = audio_stream_get_frm_fmt(&source_c->stream);
-	rate = audio_stream_get_rate(&source_c->stream);
-	buffer_release(source_c);
+	channels = audio_stream_get_channels(&sourceb->stream);
+	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
+	rate = audio_stream_get_rate(&sourceb->stream);
 
 	if (channels != 1) {
 		comp_err(dev, "test_keyword_params(): only single-channel supported");
@@ -881,7 +878,6 @@ static int test_keyword_copy(struct comp_dev *dev)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *source;
-	struct comp_buffer *source_c;
 	uint32_t frames;
 
 	comp_dbg(dev, "test_keyword_copy()");
@@ -889,23 +885,18 @@ static int test_keyword_copy(struct comp_dev *dev)
 	/* keyword components will only ever have 1 source */
 	source = list_first_item(&dev->bsource_list,
 				 struct comp_buffer, sink_list);
-	source_c = buffer_acquire(source);
 
-	if (!audio_stream_get_avail(&source_c->stream)) {
-		buffer_release(source_c);
+	if (!audio_stream_get_avail(&source->stream))
 		return PPL_STATUS_PATH_STOP;
-	}
 
-	frames = audio_stream_get_avail_frames(&source_c->stream);
+	frames = audio_stream_get_avail_frames(&source->stream);
 
 	/* copy and perform detection */
-	buffer_stream_invalidate(source_c, audio_stream_get_avail_bytes(&source_c->stream));
-	cd->detect_func(dev, &source_c->stream, frames);
+	buffer_stream_invalidate(source, audio_stream_get_avail_bytes(&source->stream));
+	cd->detect_func(dev, &source->stream, frames);
 
 	/* calc new available */
-	comp_update_buffer_consume(source_c, audio_stream_get_avail_bytes(&source_c->stream));
-
-	buffer_release(source_c);
+	comp_update_buffer_consume(source, audio_stream_get_avail_bytes(&source->stream));
 
 	return 0;
 }


### PR DESCRIPTION
This is step 8 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

Remove usage of buffer_acquire and buffer_release from a number of files.