### PR TITLE
module_adapter: ModuleInitialSettingsConcrete: Fix possible null refe…

### DIFF
--- a/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
+++ b/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
@@ -49,6 +49,9 @@ ModuleInitialSettingsConcrete::ModuleInitialSettingsConcrete(DwordArray const &c
 		/* It shall contain BaseModuleCfg + BaseModuleCfgExt +       */
 		/* optionally some InputPinFormat[] + OutputPinFormat[] data */
 		CompoundCfg const * unvalidated_compound_cfg = cfg_ipc_msg.dataAs<CompoundCfg>();
+		if (!unvalidated_compound_cfg)
+			return;
+
 		const size_t computed_msg_size =
 			sizeof(CompoundCfg) -
 			/* CompoundCfg already contains one InputPinFormat and


### PR DESCRIPTION
…rence

The dataAs function can return null if the buffer size is smaller than the size of the target structure. Added handler for this situation.

Signed-off-by: Adrian Warecki <adrian.warecki@intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
(cherry picked from commit c9e0fc8c9afdc3d5e87cf3d6cc908603cf5c8b59)