### PR TITLE
[stable-v2.2] backport all sof-logger updates from main

### DIFF
--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+# https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-To-Write-Platform-Checks
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES(sys/inotify.h HAS_INOTIFY)
+
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(sof-logger
 	logger.c
 	convert.c

--- a/tools/logger/config.h.in
+++ b/tools/logger/config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine01 HAS_INOTIFY

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -65,9 +65,6 @@ static const char *BAD_PTR_STR = "<bad uid ptr 0x%.8x>";
 #define UUID_LOWER "%s%s%s<%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x>%s%s%s"
 #define UUID_UPPER "%s%s%s<%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X>%s%s%s"
 
-/* pointer to config for global context */
-struct convert_config *global_config;
-
 static int read_entry_from_ldc_file(struct ldc_entry *entry, uint32_t log_entry_address);
 
 char *format_uid_raw(const struct sof_uuid_entry *uid_entry, int use_colors, int name_first,
@@ -1037,14 +1034,20 @@ static int dump_ldc_info(void)
 	return 0;
 }
 
-int convert(struct convert_config *config)
+int convert(void)
 {
 	struct snd_sof_logs_header snd;
 	struct snd_sof_uids_header uids_hdr;
 	int count, ret = 0;
 
+	/* const pointer initialized at build time */
+	if (!global_config)
+		abort();
+
+	/* just a shorter alias */
+	struct convert_config * const config = global_config;
+
 	config->logs_header = &snd;
-	global_config = config;
 
 	count = fread(&snd, sizeof(snd), 1, config->ldc_fd);
 	if (!count) {

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -131,6 +131,10 @@ static const char *format_uid(uint32_t uid_ptr, int use_colors, bool be, bool up
 	if (uid_ptr < uids_dict->base_address ||
 	    uid_ptr >= uids_dict->base_address + uids_dict->data_length) {
 		str = calloc(1, strlen(BAD_PTR_STR) + 1 + 6);
+		if (!str) {
+			log_err("can't allocate memory\n");
+			exit(EXIT_FAILURE);
+		}
 		sprintf(str, BAD_PTR_STR, uid_ptr);
 	} else {
 		uid_entry = get_uuid_entry(uid_ptr);

--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -356,11 +356,14 @@ static inline void print_table_header(void)
 	fprintf(out_fd, "%s", "CONTENT");
 
 	if (global_config->time_precision >= 0) {
+		struct tm *ltime = localtime(&epoc_secs);
+
 		/* e.g.: ktime=4263.487s @ 2021-04-27 14:21:13 -0700 PDT */
 		fprintf(out_fd, "\tktime=%lu.%03lus",
 			ktime.tv_sec, ktime.tv_nsec / 1000000);
-		if (strftime(date_string, sizeof(date_string),
-			     "%F %X %z %Z", localtime(&epoc_secs)))
+
+		if (ltime && strftime(date_string, sizeof(date_string),
+			     "%F %X %z %Z", ltime))
 			fprintf(out_fd, "  @  %s", date_string);
 	}
 

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -47,4 +47,8 @@ struct convert_config {
 };
 
 uint32_t get_uuid_key(const struct sof_uuid_entry *entry);
-int convert(struct convert_config *config);
+
+/* pointer to config for global context */
+extern struct convert_config * const global_config;
+
+int convert(void);

--- a/tools/logger/filter.c
+++ b/tools/logger/filter.c
@@ -22,8 +22,6 @@
 #define COMPONENTS_SEPARATOR ','
 #define COMPONENT_NAME_SCAN_STRING_LENGTH 32
 
-extern struct convert_config *global_config;
-
 /** map between log level given by user and enum value */
 static const struct {
 	const char name[16];

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -282,6 +282,8 @@ cleanup:
 }
 #endif // HAS_INOTIFY
 
+static struct convert_config _global_config;
+struct convert_config * const global_config = &_global_config;
 
 int main(int argc, char *argv[])
 {
@@ -498,7 +500,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	ret = -convert(&config);
+	_global_config = config;
+	ret = -convert();
 
 out:
 	/* free memory */

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -441,6 +441,11 @@ int main(int argc, char *argv[])
 	if (!config.in_file && !config.dump_ldc)
 		config.in_file = "/sys/kernel/debug/sof/etrace";
 
+	if (!config.in_file && baud) {
+		fprintf(stderr, "error: No UART device specified\n");
+		usage();
+	}
+
 	if (config.input_std) {
 		config.in_fd = stdin;
 	} else if (baud) {

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -304,17 +304,6 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	if (config.version_fw) {
-		config.version_fd = fopen(config.version_file, "rb");
-		if (!config.version_fd && !config.dump_ldc) {
-			ret = errno;
-			fprintf(stderr,
-				"error: Unable to open version file %s: %s\n",
-				config.version_file, strerror(ret));
-			goto out;
-		}
-	}
-
 	if (config.out_file) {
 		config.out_fd = fopen(config.out_file, "w");
 		if (!config.out_fd) {
@@ -359,6 +348,17 @@ int main(int argc, char *argv[])
 	}
 	if (isatty(fileno(config.out_fd)) != 1)
 		config.use_colors = 0;
+
+	if (config.version_fw) {
+		config.version_fd = fopen(config.version_file, "rb");
+		if (!config.version_fd && !config.dump_ldc) {
+			ret = errno;
+			fprintf(stderr,
+				"error: Unable to open version file %s: %s\n",
+				config.version_file, strerror(ret));
+			goto out;
+		}
+	}
 
 	ret = -convert(&config);
 

--- a/tools/logger/logger.c
+++ b/tools/logger/logger.c
@@ -223,6 +223,11 @@ static void *wait_open(const char *watched_dir, const char *expected_file)
 
 	char * const fpath = malloc(strlen(watched_dir) + 1 + strlen(expected_file) + 1);
 
+	if (!fpath) {
+		fprintf(stderr, "error: can't allocate memory\n");
+		exit(EXIT_FAILURE);
+	}
+
 	strcpy(fpath, watched_dir);
 	strcat(fpath, "/");
 	strcat(fpath, expected_file);

--- a/tools/logger/misc.c
+++ b/tools/logger/misc.c
@@ -41,8 +41,6 @@ char *log_asprintf(const char *format, ...)
 	return result;
 }
 
-extern struct convert_config *global_config;
-
 /** Prints 1. once to stderr. 2. a second time to the global out_fd if
  * out_fd is neither stderr nor stdout (because the -o option was used).
  */


### PR DESCRIPTION
Preparation for backporting #8216 release fixes.

Zero conflict, fully automated backport with just:
```
git log --oneline --format=%h  2c1f089d3965..origin/main -- tools/logger/*.c  |
  tac | git cherry-pick -x --stdin
```