### PR TITLE
west.yml: update Zephyr to 492517b918d26

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2f90ef488a4e97c94c2cc5b95dacd1b15de32216
+      revision: 492517b918d267f553688cd6b9d59b92ffc10f91
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 700+ commits, including following directly affecting SOF with i.MX:

492517b918 west.yml: Update NXP HAL SDK to 2.14

It also pulls in following commits affecting SOF targets:

a5d1fd9857 soc: adsp: clk: update clock switch flow
9656056b19 dts: adsp: ace20: remove lp clock
50f0e223e8 dts: adsp: ace15: remove lp clock
cf6d5f95b6 adsp: clk: ace: select ipll if wovrco is unavailable
2d835e1b29 dts: adsp: ace20: replace hp with ipll clock
dcecda859c dts: adsp: ace15: replace hp with ipll clock
2f2689e3d3 intel_adsp: ace15: shim: update wovrco request bit