### PR TITLE
topology2: remove duplicated pipeline index attribute definition

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -22,8 +22,6 @@
 
 Class.Pipeline."dai-copier-be" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -25,8 +25,6 @@
 
 Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."dai-copier-gain-mixin-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -23,8 +23,6 @@
 
 Class.Pipeline."dai-copier-gain-module-copier-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."dai-kpb-be" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."deepbuffer-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."gain-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."gain-copier-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
@@ -23,8 +23,6 @@
 
 Class.Pipeline."gain-module-copier" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -23,8 +23,6 @@
 
 Class.Pipeline."gain-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/google-rtc-aec-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/google-rtc-aec-capture.conf
@@ -25,8 +25,6 @@
 
 Class.Pipeline."google-rtc-aec-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
@@ -25,8 +25,6 @@
 
 Class.Pipeline."highpass-capture-be" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."host-copier-gain-mixin-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
@@ -26,8 +26,6 @@
 
 Class.Pipeline."host-copier-gain-src-mixin-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
@@ -22,8 +22,6 @@
 
 Class.Pipeline."host-gateway-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-playback.conf
@@ -22,8 +22,6 @@
 
 Class.Pipeline."host-gateway-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway-capture.conf
@@ -23,8 +23,6 @@
 
 Class.Pipeline."io-gateway-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."io-gateway" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
@@ -25,8 +25,6 @@
 
 Class.Pipeline."mixout-aria-gain-mixin-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
@@ -23,8 +23,6 @@
 
 Class.Pipeline."mixout-dai-copier-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
@@ -22,8 +22,6 @@
 
 Class.Pipeline."mixout-gain-alh-dai-copier-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."mixout-gain-dai-copier-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -29,8 +29,6 @@
 
 Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
@@ -29,8 +29,6 @@
 
 Class.Pipeline."mixout-gain-efx-mbdrc-dai-copier-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
@@ -24,8 +24,6 @@
 
 Class.Pipeline."mixout-gain-host-copier-capture" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
@@ -20,8 +20,6 @@
 
 Class.Pipeline."mixout-mixin" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -26,8 +26,6 @@
 
 Class.Pipeline."src-gain-mixin-playback" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {

--- a/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
@@ -26,8 +26,6 @@
 
 Class.Pipeline."wov-detect" {
 
-	DefineAttribute."index" {}
-
 	<include/pipelines/pipeline-common.conf>
 
 	attributes {


### PR DESCRIPTION
The pipeline-common.conf helps us to define several common pipeline attributes
include pipeline index, there is no need to define pipeline index in each
pipeline class definition if pipeline-common.conf is included.