### PR TITLE
Tools: Topology2: Remove 50 ms curve duration set from nocodec

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-multicore.conf
+++ b/tools/topology/topology2/cavs-nocodec-multicore.conf
@@ -335,7 +335,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -397,7 +396,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -456,7 +454,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -275,7 +275,6 @@ IncludeByKey.PASSTHROUGH {
 					pcm_id $SSP0_PCM_ID
 				}
 				Object.Widget.gain.1 {
-					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_PCM_NAME Capture Volume'
 					}
@@ -290,7 +289,6 @@ IncludeByKey.PASSTHROUGH {
 					pcm_id $SSP0_CAPTURE_PCM_ID
 				}
 				Object.Widget.gain.1 {
-					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_CAPTURE_PCM Volume'
 					}
@@ -331,7 +329,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -397,7 +394,6 @@ IncludeByKey.PASSTHROUGH {
 					}
 				}
 				Object.Widget.gain.1 {
-					curve_duration 500000
 					Object.Control.mixer.1 {
 						name 'Pre Demux $SSP0_PCM_NAME Capture Volume'
 					}
@@ -703,7 +699,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {
@@ -760,7 +755,6 @@ IncludeByKey.PASSTHROUGH {
 							}
 						}
 						Object.Widget.gain.1 {
-							curve_duration 500000
 							num_input_audio_formats 2
 							num_output_audio_formats 2
 							Object.Base.audio_format.1 {


### PR DESCRIPTION
We need to care about audio user experience and peak MCPS usage in production topologies.

The alsabat test is disturbed by longer ramp so it can be removed from nocodec topologies since the codec is never used by end users and also the peak MCPS mitigation is not relevant for a test topology, as long as higher MCPS is not triggering error reports. The curve duration becomes without explicit set the default 20 ms.

Fixes: #8238
Fixes: d0d74a477f64a83654bccb3905175584d05d9257
       ("Tools: Topology2: Change in capture gain
       curve_duration to 50 m")