### PR TITLE
lnl: memory: expand HEAPMEM_SIZE for KPB

### DIFF
--- a/src/platform/lunarlake/include/platform/lib/memory.h
+++ b/src/platform/lunarlake/include/platform/lib/memory.h
@@ -56,7 +56,7 @@
 /**
  * size of HPSRAM system heap
  */
-#define HEAPMEM_SIZE 0x40000
+#define HEAPMEM_SIZE 0xD0000
 
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 


### PR DESCRIPTION
FW infrastructure shall support buffering of historic data from 1ch up to 6 channels 24bit samples in 24bit container. For this reason, the heap should be extended. Increase HEAPMEM_SIZE by 0x90000 because for audio format 16000Hz/6ch/24bit history_buffer_size = 16 * 6 * 3 * 2100s = 604800 bytes (0x93A80)
The same change was applied to MTL previously.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>