### PR TITLE
[SKIP SOF-TEST] .github: add ninja to MSYS2 downloads

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -330,11 +330,17 @@ jobs:
         run: pip install -r zephyr/scripts/requirements.txt
 
       # MSYS2 provides gcc x64_86 toolchain & openssl
+      # Installs in D:/a/_temp/msys64
+      #
+      # Note there is already C:/msys64/ provided by
+      # https://github.com/actions/runner-images/blob/win22/20230918.1/images/win/Windows2022-Readme.md
+      # Is it not good enough? Maybe it could save 20-30s.
       - name: Initialize MSYS2
         uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
-          install: gcc openssl-devel
+          # Ninja has been coming and going, see #8250
+          install: gcc openssl-devel ninja
           path-type: inherit
 
       - name: Build


### PR DESCRIPTION
Ninja seems to have just mysteriously disappeared from https://github.com/actions/runner-images/blob/win22/20230918.1/images/win/Windows2022-Readme.md See #8250 for more details.

Let's try to get it from MSYS2 instead.