### PR TITLE
app/prj.conf: disable PICOLIBC with CONFIG_MINIMAL_LIBC=y

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -14,6 +14,11 @@ CONFIG_OUTPUT_DISASSEMBLY=y
 
 CONFIG_HAVE_AGENT=n
 
+# PICOLIBC does not seem compatible with the "sparse" static analyzer
+# yet, see https://github.com/zephyrproject-rtos/zephyr/issues/63003
+# Plus the paint on it is still wet.
+CONFIG_MINIMAL_LIBC=y
+
 CONFIG_LOG=y
 CONFIG_LOG_PRINTK=y
 # Log processing is offloaded to a low-priority thread.


### PR DESCRIPTION
Starting from Zephyr commit f0daf904bb02, CONFIG_PICOLIBC is on by default.

PICOLIBC does not seem compatible with sparse yet: https://github.com/zephyrproject-rtos/zephyr/issues/63003

Even if it were compatible with sparse, it seems like a pretty big change that we should not immediately and blindly accept.