### PR TITLE
Zephyr: Fix path to google_hotword_detect.c

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -705,7 +705,7 @@ zephyr_library_sources_ifdef(CONFIG_COMP_MUX
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_GOOGLE_HOTWORD_DETECT
-	${SOF_AUDIO_PATH}/google_hotword_detect.c
+	${SOF_AUDIO_PATH}/google/google_hotword_detect.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_DTS_CODEC


### PR DESCRIPTION
The file is found from subdirectory src/audio/google. Without fix if CONFIG_COMP_GOOGLE_HOTWORD_DETECT is enabled build fails:

CMake Error at sof/zephyr/cmake/modules/extensions.cmake:424 (add_library):
Cannot find source file:
/src/audio/google_hotword_detect.c