### PR TITLE
[SKIP CI]github action: remove duplicate build for TGL/TGL-H

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -107,7 +107,6 @@ jobs:
         IPC_platforms: [
           # - IPC3 default
           imx8 imx8x imx8m,
-          tgl tgl-h,  # UNSUPPORTED! Will be removed
           # - IPC4 default
           mtl, lnl,
           # Temporary testbed for Zephyr development.
@@ -213,10 +212,8 @@ jobs:
         platforms: [
           # - IPC3 default
           imx8 imx8x imx8m,
-          tgl tgl-h,  # UNSUPPORTED! Will be removed
           # - IPC4 default
           mtl,
-          # Very few IPC3 platforms support IPC4 too.
           tgl tgl-h,
         ]
         build_opts: [""]


### PR DESCRIPTION
At the beginning, we have two build jobs in github action to build IPC3 and IPC4 firmware for TGL/TGL-H.

The PR https://github.com/thesofproject/sof/pull/8048 switches cAVS2.5 configs to use IPC4 by default and empties the cAVS2.5 overlay files. After the change, the xtensa-build-zephyr.py script is building the
same IPC4 firmware with or without '-i IPC4' option. So we have two jobs running different build command but build the same IPC4 firmware.

Recently, commit 5004d0fe1e74 ("zephyr.yml: remove ipc option for zephyr build") removes '-i IPC4' option in github action for TGL/TGL-H IPC4 build. So we have duplicated jobs to build firmware for TGL and TGL-H now.

This patch removes the duplicated build job which previously is used to build IPC3 firmware for TGL/TGL-H.