### PR TITLE
dp: Eearliest deadline first scheduling policy

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -281,6 +281,7 @@ static int module_adapter_dp_queue_prepare(struct comp_dev *dev)
 		i++;
 	}
 	mod->num_of_sources = i;
+	unsigned int period = UINT32_MAX;
 
 	i = 0;
 	list_init(&mod->dp_queue_dp_to_ll_list);
@@ -311,10 +312,27 @@ static int module_adapter_dp_queue_prepare(struct comp_dev *dev)
 			 sizeof(dp_queue->audio_stream_params),
 			 &sink_buffer->stream.runtime_stream_params,
 			 sizeof(sink_buffer->stream.runtime_stream_params));
+		/* calculate time required the module to provide OBS data portion - a period */
+		unsigned int sink_period = 1000000 * sink_get_min_free_space(mod->sinks[i]) /
+					   (sink_get_frame_bytes(mod->sinks[i]) *
+					   sink_get_rate(mod->sinks[i]));
+		/* note the minimal period for the module */
+		if (period > sink_period)
+			period = sink_period;
 
 		i++;
 	}
 	mod->num_of_sinks = i;
+	/* set the period for the module unless it has already been calculated by the
+	 * module itself during prepare
+	 * It may happen i.e. for modules like phrase detect that do not produce audio data
+	 * but events and therefore don't have any deadline for processing
+	 * Second example is a module with variable data rate on output (like MPEG encoder)
+	 */
+	if (!dev->period) {
+		comp_info(dev, "DP Module period set to %u", period);
+		dev->period = period;
+	}
 
 	return 0;
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -260,7 +260,14 @@ static int pipeline_comp_complete(struct comp_dev *current,
 
 	/* complete component init */
 	current->pipeline = ppl_data->p;
-	current->period = ppl_data->p->period;
+	/* LL module has its period always eq period of the pipeline
+	 * DP period is set to 0 as sink format may not yet been set
+	 * It will be calculated during module prepare operation
+	 * either by the module or to default value based on module's OBS
+	 */
+	if (current->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL)
+		current->period = ppl_data->p->period;
+
 	current->priority = ppl_data->p->priority;
 
 	return pipeline_for_each_comp(current, ctx, dir);

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -581,7 +581,12 @@ struct comp_dev {
 				  *  2) for all DP tasks
 				  */
 	uint32_t size;		/**< component's allocated size */
-	uint32_t period;	/**< component's processing period */
+	uint32_t period;	/**< component's processing period
+				  *  for LL modules is set to LL pipeline's period
+				  *  for DP module its meaning is "the time the module MUST
+				  *  provide data that allows the following module to perform
+				  *  without glitches"
+				  */
 	uint32_t priority;	/**< component's processing priority */
 	bool is_shared;		/**< indicates whether component is shared
 				  *  across cores


### PR DESCRIPTION
This PR introduces a Earlier Deadline First scheduling policy for DP processing

currently there's a limitation - DP module must be surrounded by LL modules.
it simplifies algorithm - there's no need to browse through DP chains calculating
deadlines for each module in function of all modules execution status.
Now is simple - modules deadline is its start + tick time.

example:
 Lets assume we do have a pipeline:

 LL1 -> DP1 -> LL2 -> DP2 -> LL3 -> DP3 -> LL4

 all LLs starts in 1ms tick

 for simplification lets assume
  - all LLs are on primary core, all DPs on secondary (100% CPU is for DP)
  - context switching requires 0 cycles

 DP1 - starts every 1ms, needs 0.5ms to finish processing
 DP2 - starts every 2ms, needs 0.6ms to finish processing
 DP3 - starts every 10ms, needs 0.3ms to finish processing

TICK0
	only LL1 is ready to run
		LL1 processing (producing data chunk for DP1)

TICK1
	LL1 is ready to run
	DP1 is ready tu run (has data from LL1) set deadline to TICK2
	  LL1 processing (producing second data chunk for DP1)
	  DP1 processing for 0.5ms (consuming first data chunk, producing data chunk for LL2)
	CPU is idle for 0.5ms

TICK2
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK3
	LL2 is ready to run
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing 50% data chunk for DP2)
		DP1 processing for 0.5ms (producing data chunk for LL2)
	CPU is idle for 0.5ms

TICK3
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK4
	LL2 is ready to run
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing rest of data chunk for DP2)
		DP1 processing for 0.5ms (producing data chunk for LL2)
	CPU is idle for 0.5ms

TICK4
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK5
	LL2 is ready to run
	DP2 is ready to run set deadline to TICK6
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing 50% of second data chunk for DP2)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.5ms (no data produced as DP2 has 0.1ms to go)
	100% CPU used

	!!!!!! Note here - DP1 must do before DP2 as it MUST finish in this tick. DP2 can wait
		>>>>>>> this is what we call EDF - EARIEST DEADLINE FIRST <<<<<<

TICK5
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK6
	LL2 is ready to run
	DP2 is in progress, deadline is set to TICK6
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing rest of second data chunk for DP2)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.1ms (producing TWO data chunks for LL3)
	CPU is idle for 0.4ms (60% used)

TICK6
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK7
	LL2 is ready to run
	DP2 is ready to run set deadline to TICK8
	LL3 is ready to run
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing 50% of second data chunk for DP2)
		LL3 processing (producing 10% of first data chunk for DP3)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.5ms (no data produced as DP2 has 0.1ms to go)
	100% CPU used



  (........ 9 more cycles - LL3 procuces 100% of data for DP3......)


TICK15
	LL1 is ready to run
	DP1 is ready tu run set deadline to TICK16
	LL2 is ready to run
	DP2 is ready to run set deadline to TICK17
	LL3 is ready to run
	DP3 is ready to run set deadline to TICK25
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing 50% of data chunk for DP2)
		LL3 processing (producing 10% of second data chunk for DP3)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.5ms (no data produced as DP2 has 0.1ms to go)
	100% CPU used -
	!!! note that DP3 is ready but has no chance to get CPU in this cycle

TICK16
	LL1 is ready to run set deadline to TICK17
	DP1 is ready tu run
	LL2 is ready to run
	DP2 is in progress, deadline is set to TICK17
	LL3 is ready to run
	DP3 is in progress, deadline is set to TICK25
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing rest of data chunk for DP2)
		LL3 processing (producing 10% of second data chunk for DP3)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.1ms (producing data)
		DP3 processing for 0.2ms (producing 10 data chunks for LL4)
	90% CPU used

TICK17
	LL1 is ready to run
	DP1 is ready tu run
	LL2 is ready to run
	DP2 is ready to run
	LL3 is ready to run
	LL4 is ready to run
			!! NOTE that DP3 is not ready - it will be ready again in TICK25
		LL1 processing (producing data chunk for DP1)
		LL2 processing (producing rest of data chunk for DP2)
		LL3 processing (producing next 10% of second data chunk for DP3)
		LL4 processing (consuming 10% of data prepared by DP3)
		DP1 processing for 0.5ms (producing data chunk for LL2)
		DP2 processing for 0.5ms (no data produced as DP2 has 0.1ms to go)
		100% CPU used


Now - pipeline is in stable state, CPU used almost in 100% (it would be 100% if DP3
needed 1.2ms for processing - but the example would be too complicated)
