### PR TITLE
tools/probe: Fix WAV header creation for extracted audio streams

### DIFF
--- a/tools/probes/probes_demux.c
+++ b/tools/probes/probes_demux.c
@@ -139,8 +139,9 @@ int init_wave(struct dma_frame_parser *p, uint32_t buffer_id, uint32_t format)
 	return i;
 }
 
-void finalize_wave_files(struct wave_files *files)
+void finalize_wave_files(struct dma_frame_parser *p)
 {
+	struct wave_files *files = p->files;
 	uint32_t i, chunk_size;
 
 	/* fill the header at the beginning of each file */

--- a/tools/probes/probes_demux.h
+++ b/tools/probes/probes_demux.h
@@ -24,4 +24,6 @@ void parser_fetch_free_buffer(struct dma_frame_parser *p, uint8_t **d, size_t *l
 
 int parser_parse_data(struct dma_frame_parser *p, size_t d_len);
 
+void finalize_wave_files(struct dma_frame_parser *p);
+
 #endif

--- a/tools/probes/probes_main.c
+++ b/tools/probes/probes_main.c
@@ -66,6 +66,10 @@ void parse_data(const char *file_in, bool log_to_stdout)
 		len = fread(data, 1, len, fd_in);
 		ret = parser_parse_data(p, len);
 	} while (!ret && !feof(fd_in));
+
+	if (!log_to_stdout)
+		finalize_wave_files(p);
+
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
The finalize_wave_files() should be called to update the WAV header to be valid.
This should be only done when demuxing to files.