### PR TITLE
west.yml: update Zephyr to ca3310145f8f

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2f90ef488a4e97c94c2cc5b95dacd1b15de32216
+      revision: ca3310145f8f1bbf932cd04ed83536dff14fd620
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 1131 commits, including the NXP hal update.