### PR TITLE
Tools: Topology2: Add nocodec topology to test google-rtc-aec

### DIFF
--- a/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
+++ b/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
@@ -1,0 +1,378 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<tokens.conf>
+<virtual.conf>
+<host-gateway-capture.conf>
+<host-gateway-playback.conf>
+<io-gateway-capture.conf>
+<io-gateway.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<intel/hw_config_cardinal_clk.conf>
+<manifest.conf>
+<route.conf>
+<intel/common_definitions.conf>
+<dai-copier.conf>
+<module-copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<input_pin_binding.conf>
+<output_pin_binding.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+
+<controls/bytes.conf>
+<google-rtc-aec.conf>
+
+Define {
+	MCLK				24576000
+	PLATFORM			"none"
+	SSP0_PCM_ID			0
+	SSP0_PCM_NAME			"Port0"
+	SSP1_PCM_NAME			"Port1"
+	SSP2_PCM_NAME			"Port2"
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"tgl"	"platform/intel/tgl.conf"
+	"adl"	"platform/intel/tgl.conf"
+	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/mtl.conf"
+}
+
+#
+# List of all DAIs
+#
+Object.Dai.SSP [
+	{
+		id		0
+		dai_index	0
+		direction	"duplex"
+		name		NoCodec-0
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk		$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP0"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+	{
+		id		2
+		dai_index	2
+		direction	"duplex"
+		name		NoCodec-2
+		default_hw_conf_id	0
+		sample_bits		32
+		quirks			"lbm_mode"
+		io_clk		$MCLK
+
+		Object.Base.hw_config.1 {
+			name	"SSP2"
+			id	0
+			bclk_freq	3072000
+			tdm_slot_width	32
+			# TODO: remove this. Needs alsaptlg change.
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+	}
+]
+
+#
+# Pipeline definitions
+#
+# PCM0 --(1)----------------(2)--> SSP0
+#
+# PCM2 --(5)----------------(6)--> SSP2
+#
+# SSP0 --(8)---> RTCAEC ----(7)--> PCM0
+#		   ^
+#		   |
+# SSP2 --(12)------+
+
+Object.Pipeline.io-gateway [
+	{
+		index	2
+		direction	playback
+
+		Object.Widget.dai-copier.1 {
+			dai_index 0
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-0"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_pins 1
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+	}
+	{
+		index	6
+		direction	playback
+
+		Object.Widget.dai-copier.1 {
+			dai_index 2
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-2"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_pins 1
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-playback [
+	{
+		index	1
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP0 Playback'
+			pcm_id 0
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+	{
+		index	5
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP2 Playback'
+			pcm_id 2
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-capture [
+	{
+		index	7
+
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP0 Capture'
+			pcm_id 0
+			num_input_audio_formats	1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats	1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.io-gateway-capture [
+	{
+		index		8
+		direction	capture
+
+		Object.Widget.dai-copier.1 {
+			dai_index	0
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-0"
+			node_type	$I2S_LINK_INPUT_CLASS
+			num_input_audio_formats	1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			num_output_audio_formats	1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+	{
+		index		12
+		direction	capture
+
+		Object.Widget.dai-copier.1 {
+			dai_index	2
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-2"
+			node_type	$I2S_LINK_INPUT_CLASS
+			num_input_audio_formats	1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			num_output_audio_formats	1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.PCM.pcm [
+	{
+		name	"$SSP0_PCM_NAME"
+		id $SSP0_PCM_ID
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	"$SSP0_PCM_NAME"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP0 Playback"
+			formats 'S16_LE'
+		}
+
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name "SSP0 Capture"
+			formats 'S16_LE'
+		}
+	}
+	{
+		name	"$SSP2_PCM_NAME"
+		id 2
+		direction	"playback"
+		Object.Base.fe_dai.1 {
+			name	"$SSP2_PCM_NAME"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP2 Playback"
+			formats 'S16_LE'
+		}
+	}
+]
+
+Object.Widget.google-rtc-aec [
+	{
+		index 7
+		name "google-rtc-aec.7.1"
+
+		Object.Base.input_pin_binding.1 {
+			input_pin_binding_name "dai-copier.SSP.NoCodec-0.capture"
+		}
+
+		Object.Base.input_pin_binding.2 {
+			input_pin_binding_name "dai-copier.SSP.NoCodec-2.capture"
+		}
+
+		Object.Control.bytes."1" {
+			name 'google-rtc-aec bytes'
+			<include/components/google-rtc-aec/rtc-aec-blob.conf>
+		}
+	}
+]
+
+Object.Base.route [
+	{
+		source	"host-copier.0.playback"
+		sink	"dai-copier.SSP.NoCodec-0.playback"
+	}
+	{
+		source	"host-copier.2.playback"
+		sink	"dai-copier.SSP.NoCodec-2.playback"
+	}
+	{
+		source	"dai-copier.SSP.NoCodec-0.capture"
+		sink	"google-rtc-aec.7.1"
+	}
+	{
+		source	"dai-copier.SSP.NoCodec-2.capture"
+		sink	"google-rtc-aec.7.1"
+	}
+	{
+		source	"google-rtc-aec.7.1"
+		sink	"host-copier.0.capture"
+	}
+]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -123,4 +123,8 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-mtl-lbm.bin"
 # Topology to test IPC4 Crossover
 "development/cavs-nocodec-crossover\;sof-tgl-nocodec-crossover-2way\;PLATFORM=tgl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-crossover.bin,EFX_CROSSOVER_PARAMS=2way"
+
+# Topology to test RTC AEC
+"development/cavs-nocodec-rtcaec\;sof-tgl-nocodec-rtcaec\;PLATFORM=tgl,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-rtcaec.bin"
 )


### PR DESCRIPTION
The first playback PCM is for AEC mic input via SSP0 LBM. The second playback PCM is for AEC reference via SSP2 LBM. The first capture PCM is the AEC output.

The AEC (mockup) can be run and tested with the topology like this:

$ aplay -Dhw:0,0 mic_clip.wav &
$ aplay -Dhw:0,2 ref_clip.wav &
$ arecord -Dhw:0,0 -f dat -d 10 output.wav

With AEC mockup version output.wav is mix of microphone and reference.