### PR TITLE
.github/sparse-zephyr: add -DCONFIG_MINIMAL_LIBC to avoid picolibc

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -57,12 +57,15 @@ jobs:
       # --pristine is important to reproduce _warnings_. It makes no
       # difference for github but it's useful for anyone trying to
       # reproduce and copying the command from the logs.
+      # "sparse" is currently incompatible with PICOLIBC (the new Zephyr default),
+      # see https://github.com/zephyrproject-rtos/zephyr/issues/63003
       - name: analyze zephyr
         working-directory: ./workspace
         run: |
              ./sof/zephyr/docker-run.sh                          \
              ./sof/zephyr/docker-build.sh ${{ matrix.platform }}          \
              --cmake-args=-DZEPHYR_SCA_VARIANT=sparse --cmake-args=-DCONFIG_LOG_USE_VLA=n  \
+             --cmake-args=-DCONFIG_MINIMAL_LIBC=y  \
              --pristine 2>&1 | tee _.log
 
              printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -14,9 +14,8 @@ CONFIG_OUTPUT_DISASSEMBLY=y
 
 CONFIG_HAVE_AGENT=n
 
-# PICOLIBC does not seem compatible with the "sparse" static analyzer
-# yet, see https://github.com/zephyrproject-rtos/zephyr/issues/63003
-# Plus the paint on it is still wet.
+# Since Zephyr commit f0daf904bb0202c PICOLIBC is the new default.
+# We need more time to test and evaluate.
 CONFIG_MINIMAL_LIBC=y
 
 CONFIG_LOG=y


### PR DESCRIPTION
Add a sparse-specific workaround for the incompatibility with picolibc (the new Zephyr default)
- https://github.com/zephyrproject-rtos/zephyr/issues/63003

Also fix comment in commit 2a9473a17be4 ("app/prj.conf: disable PICOLIBC with CONFIG_MINIMAL_LIBC=y"): we don't need to disable PICOLIBC _everywhere_; we only need to disable it when using sparse.