### PR TITLE
cache: remove buffer_acquire/buffer_release stubs

### DIFF
--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -220,16 +220,6 @@ static inline void buffer_stream_writeback(struct comp_buffer *buffer, uint32_t 
 		audio_stream_writeback(&buffer->stream, bytes);
 }
 
-/* stubs for acquire/release for compilation, to be removed at last step */
-__must_check static inline struct comp_buffer *buffer_acquire(struct comp_buffer *buffer)
-{
-	return (struct comp_buffer *)buffer;
-}
-
-static inline void buffer_release(struct comp_buffer *buffer)
-{
-	(void)buffer;
-}
 
 /*
  * Attach a new buffer at the beginning of the list. Note, that "head" must


### PR DESCRIPTION
This is step 9 of implementation of #8006
This PR is a result of splitting https://github.com/thesofproject/sof/pull/8106 into parts.

buffer_acquire and buffer_release are no longer in use
remove stubs from the code