### PR TITLE
west.yml: update zephyr to v3.5.0-rc1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 492517b918d267f553688cd6b9d59b92ffc10f91
+      revision: 8c4eec7ac6e37be89af89e021c6f5c96e1ac1e0a
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Zepych update: total of 853 commits.

Changes include:

i8c4eec7ac6 intel_adsp: boot_complete must be done PRE_KERNEL_1
1fc16e6565 release: Zephyr 3.5.0-rc1
c910dc81a6 sys_clock: header: minor cleanup and doxygenization
b9f8b91692 kernel: sys_clock: remove stray z_enable_sys_clock prototype
cc2a558707 kernel: move more internal smp calls into internal domain
a1c7bfbc63 kernel: remove unused z_init_thread_base from kernel.h
209ff606be kernel: move internal smp calls to a internal header
e19f21cb27 kernel: move z_is_thread_essential out of public kernel header
f0c7fbf0f1 kernel: move sched_priq.h to internal/ folder
e6f1090553 kernel: Integrate object core statistics
1d5d674e0d kernel: Add initial k_obj_core_stats infrastructure
6df8efe354 kernel: Integrate object cores into kernel
55db86e512 kernel: Add initial obj_core infrastructure
eb1e5a161d kernel: FIFO and LIFO have their own sections
9bedfd82a2 kernel: Refactor CPU usage
baea37aeb4 kernel: Re-factor sys_mem_blocks definition
2f003e59e4 kernel: Re-factor k_mem_slab definition
41e0a4a371 llext: Linkable loadable extensions
4289359eb2 modules: mcux: fix HAS_CMSIS_CORE selection
1194a35aa2 xtensa: cast char* to void* during stack dump with %p
fcf22e59b8 xtensa: mark arch_switch ALWAYS_INLINE
b2f7ea0523 soc: xtensa/intel_adsp/ace: fix _end location
e560bd6b8c boards: intel_adsp: fix board compatible
b4998c357e mm_drv: tlb: Fix compile time warning
759e07bebe intel_adsp: move memory window setup to PRE_KERNEL_1

Required changes:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/63279
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/63370
