### PR TITLE
Tools: Tune: TDFB: Add support for IPC4 and tplg2 blobs

### DIFF
--- a/tools/tune/tdfb/bf_blob_pack.m
+++ b/tools/tune/tdfb/bf_blob_pack.m
@@ -1,4 +1,4 @@
-function blob8 = bf_blob_pack(bf)
+function blob8 = bf_blob_pack(bf, ipc_version)
 
 %% Pack TDFB struct to bytes
 %
@@ -143,7 +143,7 @@ end
 nbytes_data = nb16 * 2;
 
 %% Get ABI information
-[abi_bytes, nbytes_abi] = eq_get_abi(nbytes_data);
+[abi_bytes, nbytes_abi] = get_abi(nbytes_data, ipc_version);
 
 %% Initialize uint8 array with correct size
 nbytes = nbytes_abi + nbytes_data;

--- a/tools/tune/tdfb/bf_defaults.m
+++ b/tools/tune/tdfb/bf_defaults.m
@@ -19,8 +19,10 @@ bf.plot_box = 0.20;  % Show 20cm wide plot cube for array geometry
 bf.array_angle = [0 0 0]; % Array rotation angles for xyz
 bf.tplg_fn = '';
 bf.sofctl_fn = '';
-bf.tplg_path = '../../topology/topology1/m4/tdfb';
-bf.sofctl_path = '../../ctl/tdfb';
+bf.tplg1_path = '../../topology/topology1/m4/tdfb';
+bf.tplg2_path = '../../topology/topology2/include/components/tdfb';
+bf.sofctl3_path = '../../ctl/ipc3/tdfb';
+bf.sofctl4_path = '../../ctl/ipc4/tdfb';
 bf.data_path = './data';
 bf.endian = 'little';
 bf.fn = 1;
@@ -56,5 +58,6 @@ bf.sinerot_fn = {''};
 bf.diffuse_fn = {''};
 bf.random_fn = {''};
 bf.mat_fn = {''};
+bf.export_note = '';
 
 end

--- a/tools/tune/tdfb/bf_export.m
+++ b/tools/tune/tdfb/bf_export.m
@@ -1,8 +1,10 @@
 % bf_export(bf)
 %
 % Inputs
-% bf.sofctl_fn ..... filename of ascii text format blob
-% bf.tplg_fn ....... filename of topology m4 format blob
+% bf.sofctl3_fn .... filename of ascii text format blob
+% bf.sofctl4_fn .... filename of ascii text format blob
+% bf.tplg1_fn ...... filename of topology m4 format blob
+% bf.tplg2_fn ...... filename of topology m4 format blob
 % bf ............... the design procedure output
 
 % SPDX-License-Identifier: BSD-3-Clause
@@ -13,7 +15,8 @@
 
 function bf = bf_export(bf)
 
-% Use functionc from EQ tool, test utils
+% Use functionc from common, test utils
+addpath('../common');
 addpath('../eq');
 addpath('../../test/audio/test_utils');
 
@@ -73,23 +76,50 @@ end
 
 %% Build blob
 bf.all_filters = filters;
-bp = bf_blob_pack(bf);
+bp3 = bf_blob_pack(bf, 3);
+bp4 = bf_blob_pack(bf, 4);
 
 %% Export
-if isempty(bf.sofctl_fn)
-	fprintf(1, 'No sof-ctl output file specified.\n');
+if isempty(bf.sofctl3_fn)
+	fprintf(1, 'No sof-ctl3 output file specified.\n');
 else
-	fprintf(1, 'Exporting to %s\n', bf.sofctl_fn);
-	mkdir_check(bf.sofctl_path);
-	eq_alsactl_write(bf.sofctl_fn, bp);
+	fprintf(1, 'Exporting to %s\n', bf.sofctl3_fn);
+	mkdir_check(bf.sofctl3_path);
+	alsactl_write(bf.sofctl3_fn, bp3);
 end
 
-if isempty(bf.tplg_fn)
-	fprintf(1, 'No topology output file specified.\n');
+if isempty(bf.sofctl4_fn)
+	fprintf(1, 'No sof-ctl4 output file specified.\n');
 else
-	fprintf(1, 'Exporting to %s\n', bf.tplg_fn);
-	mkdir_check(bf.tplg_path);
-	eq_tplg_write(bf.tplg_fn, bp, 'DEF_TDFB_PRIV');
+	fprintf(1, 'Exporting to %s\n', bf.sofctl4_fn);
+	mkdir_check(bf.sofctl4_path);
+	alsactl_write(bf.sofctl4_fn, bp4);
 end
+
+if isempty(bf.export_note)
+	export_note = sprintf("Exported with script example_%s_array.m", bf.array);
+else
+	export_note = bf.export_note;
+end
+
+if isempty(bf.tplg1_fn)
+	fprintf(1, 'No topology1 output file specified.\n');
+else
+	fprintf(1, 'Exporting to %s\n', bf.tplg1_fn);
+	mkdir_check(bf.tplg1_path);
+	tplg_write(bf.tplg1_fn, bp3, 'DEF_TDFB_PRIV', export_note);
+end
+
+if isempty(bf.tplg2_fn)
+	fprintf(1, 'No topology2 output file specified.\n');
+else
+	fprintf(1, 'Exporting to %s\n', bf.tplg2_fn);
+	mkdir_check(bf.tplg2_path);
+	tplg2_write(bf.tplg2_fn, bp4, "tdfb_config", export_note);
+end
+
+rmpath('../../test/audio/test_utils');
+rmpath('../eq');
+rmpath('../common');
 
 end

--- a/tools/tune/tdfb/bf_filenames_helper.m
+++ b/tools/tune/tdfb/bf_filenames_helper.m
@@ -34,18 +34,26 @@ end
 [az_str_pm] = angles_to_str(bf.steer_az);
 [el_str_pm] = angles_to_str(bf.steer_el);
 
-if nargin > 1
-    idstr = sprintf('%s_az%sel%sdeg_%dkhz', ...
-                id, az_str_pm, el_str_pm, round(bf.fs/1e3));
+if strcmp(bf.array, 'line')
+	el_str_show = '';
 else
-    idstr = sprintf('%s%s_%smm_az%sel%sdeg_%dkhz', ...
+	el_str_show = sprintf('_el%s', el_str_pm);
+end
+
+if nargin > 1
+    idstr = sprintf('%s_az%s%s_%dkhz', ...
+                id, az_str_pm, el_str_show, round(bf.fs/1e3));
+else
+    idstr = sprintf('%s%s_%smm_az%s%s_%dkhz', ...
                 bf.array, mic_n_str, mic_d_str, ...
-                az_str_pm, el_str_pm, round(bf.fs/1e3));
+                az_str_pm, el_str_show, round(bf.fs/1e3));
 end
 
 % Contain multiple (az, el) angles
-bf.sofctl_fn = fullfile(bf.sofctl_path, sprintf('coef_%s.txt', idstr));
-bf.tplg_fn = fullfile(bf.tplg_path, sprintf('coef_%s.m4', idstr));
+bf.sofctl3_fn = fullfile(bf.sofctl3_path, sprintf('coef_%s.txt', idstr));
+bf.tplg1_fn = fullfile(bf.tplg1_path, sprintf('coef_%s.m4', idstr));
+bf.sofctl4_fn = fullfile(bf.sofctl4_path, sprintf('%s.txt', idstr));
+bf.tplg2_fn = fullfile(bf.tplg2_path, sprintf('%s.conf', idstr));
 
 
 for n = 1:length(bf.steer_az)

--- a/tools/tune/tdfb/example_line_0mm36mm146mm182mm.m
+++ b/tools/tune/tdfb/example_line_0mm36mm146mm182mm.m
@@ -16,8 +16,10 @@ end
 
 function line_xyz(fs, fir_length, az)
 
-tplg_fn = sprintf('coef_line4_0mm36mm146mm182mm_%dkhz.m4', fs/1e3);
-sofctl_fn = sprintf('coef_line4_0mm36mm146mm182mm_%dkhz.txt', fs/1e3);
+tplg1_fn = sprintf('coef_line4_0mm36mm146mm182mm_%dkhz.m4', fs/1e3);
+sofctl3_fn = sprintf('coef_line4_0mm36mm146mm182mm_%dkhz.txt', fs/1e3);
+tplg2_fn = sprintf('line4_0mm36mm146mm182mm_%dkhz.conf', fs/1e3);
+sofctl4_fn = sprintf('line4_0mm36mm146mm182mm_%dkhz.txt', fs/1e3);
 
 % Get defaults
 close all;
@@ -52,6 +54,7 @@ bf = bf_filenames_helper(bf, 'line4_0mm36mm146mm182mm');
 bf = bf_design(bf);
 
 % Export files for topology and sof-ctl
+bf.export_note = 'Created with script example_line_0mm36mm146mm182mm.m';
 bf_export(bf);
 
 end

--- a/tools/tune/tdfb/example_pass_config.m
+++ b/tools/tune/tdfb/example_pass_config.m
@@ -27,8 +27,11 @@ bf.num_filters          = 2;     % Two filters
 bf.w = [1 0 0 0; 1 0 0 0]'; % Two FIR filters with first tap set to one
 
 % Files
-bf.sofctl_fn = fullfile(bf.sofctl_path, 'coef_line2_pass.txt');
-bf.tplg_fn = fullfile(bf.tplg_path, 'coef_line2_pass.m4');
+bf.export_note = 'Exported with script example_pass_config.m';
+bf.sofctl3_fn = fullfile(bf.sofctl3_path, 'coef_line2_pass.txt');
+bf.tplg1_fn = fullfile(bf.tplg1_path, 'coef_line2_pass.m4');
+bf.sofctl4_fn = fullfile(bf.sofctl4_path, 'line2_pass.txt');
+bf.tplg2_fn = fullfile(bf.tplg2_path, 'line2_pass.conf');
 bf_export(bf);
 
 % Setup for four channels
@@ -43,8 +46,10 @@ bf.num_filters = 4;
 bf.w = [1 0 0 0; 1 0 0 0; 1 0 0 0; 1 0 0 0]'; % Four FIR filters with first tap set to one
 
 % Files
-bf.sofctl_fn = fullfile(bf.sofctl_path, 'coef_line4_pass.txt');
-bf.tplg_fn = fullfile(bf.tplg_path, 'coef_line4_pass.m4');
+bf.sofctl3_fn = fullfile(bf.sofctl3_path, 'coef_line4_pass.txt');
+bf.tplg1_fn = fullfile(bf.tplg1_path, 'coef_line4_pass.m4');
+bf.sofctl4_fn = fullfile(bf.sofctl4_path, 'line4_pass.txt');
+bf.tplg2_fn = fullfile(bf.tplg2_path, 'line4_pass.conf');
 bf_export(bf);
 
 end

--- a/tools/tune/tdfb/example_two_beams.m
+++ b/tools/tune/tdfb/example_two_beams.m
@@ -25,44 +25,54 @@ for fs = [16e3 48e3]
 	close all;
 
 	%% 2 mic 50 mm array
-	tplg_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line2_50mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 50e-3;  % 50 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line2_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 1);
+	line2_two_beams(fs, d, a1, a2, fn, 1);
 
 	%% 2 mic 68 mm array
-	tplg_fn = sprintf('coef_line2_68mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line2_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line2_68mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line2_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line2_68mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line2_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 68e-3;  % 68 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line2_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 1);
+	line2_two_beams(fs, d, a1, a2, fn, 1);
 
 	%% 4 mic 28 mm spaced array
-	tplg_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line4_28mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 28e-3;  % 28 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line4_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 1);
+	line4_two_beams(fs, d, a1, a2, fn, 1);
 
 	%% 4 mic 68 mm spaced array
-	tplg_fn = sprintf('coef_line4_68mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line4_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line4_68mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line4_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line4_68mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line4_68mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 68e-3;  % 68 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line4_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 1);
+	line4_two_beams(fs, d, a1, a2, fn, 1);
 
 	%% 4 mic 78 mm spaced array
-	tplg_fn = sprintf('coef_line4_78mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line4_78mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line4_78mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line4_78mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line4_78mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line4_78mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 78e-3;  % 78 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line4_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 1);
+	line4_two_beams(fs, d, a1, a2, fn, 1);
 end
 
 %% Export blob with just +/- 90 deg beams for testbench beampattern check
@@ -71,29 +81,35 @@ az = [90];
 azstr = az_to_string(az);
 for fs = [16e3 48e3]
 	%% 2 mic 50 mm array, disable beam off description in blob to force processing on
-	tplg_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line2_50mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line2_50mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 50e-3;  % 50 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line2_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 0);
+	line2_two_beams(fs, d, a1, a2, fn, 0);
 
 	%% 4 mic 28 mm spaced array, no beam off configuration
-	tplg_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg1_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('line4_28mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('line4_28mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
 	d = 28e-3;  % 28 mm spacing
 	a1 = az;   % Azimuth +az deg
 	a2 = -az;  % Azimuth -az deg
-	line4_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, 0);
+	line4_two_beams(fs, d, a1, a2, fn, 0);
 end
 
 %% Circular array with two beams
 az = 30;
 azstr = az_to_string(az);
 for fs = [48e3 16e3]
-	tplg_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
-	sofctl_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
-	circular_two_beams(fs, 100e-3, 8, az, -az, tplg_fn, sofctl_fn, 0);
+	fn.tplg1_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.m4', azstr, fs/1e3);
+	fn.sofctl3_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	fn.tplg2_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.conf', azstr, fs/1e3);
+	fn.sofctl4_fn = sprintf('coef_circular8_100mm_pm%sdeg_%dkhz.txt', azstr, fs/1e3);
+	circular_two_beams(fs, 100e-3, 8, az, -az, fn, 0);
 end
 
 %% Creates beamformer with two beams for device with device with microphones
@@ -110,7 +126,7 @@ function s = az_to_string(az)
 	end
 end
 
-function line2_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, add_beam_off);
+function line2_two_beams(fs, d, a1, a2, fn, add_beam_off);
 
 % Get defaults
 bf1 = bf_defaults();
@@ -152,15 +168,18 @@ bf2 = bf_design(bf2);
 
 % Merge two beamformers into single description, set file names
 bfm = bf_merge(bf1, bf2);
-bfm.sofctl_fn = fullfile(bfm.sofctl_path, sofctl_fn);
-bfm.tplg_fn = fullfile(bfm.tplg_path, tplg_fn);
+bfm.sofctl3_fn = fullfile(bfm.sofctl3_path, fn.sofctl3_fn);
+bfm.tplg1_fn = fullfile(bfm.tplg1_path, fn.tplg1_fn);
+bfm.sofctl4_fn = fullfile(bfm.sofctl4_path, fn.sofctl4_fn);
+bfm.tplg2_fn = fullfile(bfm.tplg2_path, fn.tplg2_fn);
 
 % Export files for topology and sof-ctl
+bfm.export_note = 'Created with script example_two_beams.m';
 bf_export(bfm);
 
 end
 
-function line4_two_beams(fs, d, a1, a2, tplg_fn, sofctl_fn, add_beam_off);
+function line4_two_beams(fs, d, a1, a2, fn, add_beam_off);
 
 % Get defaults
 bf1 = bf_defaults();
@@ -201,15 +220,18 @@ bf2 = bf_design(bf2);
 
 % Merge two beamformers into single description, set file names
 bfm = bf_merge(bf1, bf2);
-bfm.sofctl_fn = fullfile(bfm.sofctl_path, sofctl_fn);
-bfm.tplg_fn = fullfile(bfm.tplg_path, tplg_fn);
+bfm.sofctl3_fn = fullfile(bfm.sofctl3_path, fn.sofctl3_fn);
+bfm.tplg1_fn = fullfile(bfm.tplg1_path, fn.tplg1_fn);
+bfm.sofctl4_fn = fullfile(bfm.sofctl4_path, fn.sofctl4_fn);
+bfm.tplg2_fn = fullfile(bfm.tplg2_path, fn.tplg2_fn);
 
 % Export files for topology and sof-ctl
+bfm.export_note = 'Created with script example_two_beams.m';
 bf_export(bfm);
 
 end
 
-function circular_two_beams(fs, r, n, a1, a2, tplg_fn, sofctl_fn, add_beam_off)
+function circular_two_beams(fs, r, n, a1, a2, fn, add_beam_off)
 
 % Get defaults and common settings
 bf1 = bf_defaults();
@@ -244,10 +266,13 @@ bf2 = bf_design(bf2);
 
 % Merge two beamformers into single description, set file names
 bfm = bf_merge(bf1, bf2);
-bfm.sofctl_fn = fullfile(bfm.sofctl_path, sofctl_fn);
-bfm.tplg_fn = fullfile(bfm.tplg_path, tplg_fn);
+bfm.sofctl3_fn = fullfile(bfm.sofctl3_path, fn.sofctl3_fn);
+bfm.tplg1_fn = fullfile(bfm.tplg1_path, fn.tplg1_fn);
+bfm.sofctl4_fn = fullfile(bfm.sofctl4_path, fn.sofctl4_fn);
+bfm.tplg2_fn = fullfile(bfm.tplg2_path, fn.tplg2_fn);
 
 % Export files for topology and sof-ctl
+bfm.export_note = 'Created with script example_two_beams.m';
 bf_export(bfm);
 
 end
@@ -273,8 +298,10 @@ switch fs
 end
 
 % Setup array
-tplg_fn = sprintf('coef_line4_0mm36mm146mm182mm_%s_%dkhz.m4', azstr, fs/1e3);
-sofctl_fn = sprintf('coef_line4_0mm36mm146mm182mm_%s_%dkhz.txt', azstr, fs/1e3);
+tplg1_fn = sprintf('coef_line4_0mm36mm146mm182mm_%s_%dkhz.m4', azstr, fs/1e3);
+sofctl3_fn = sprintf('coef_line4_0mm36mm146mm182mm_%s_%dkhz.txt', azstr, fs/1e3);
+tplg2_fn = sprintf('line4_0mm36mm146mm182mm_%s_%dkhz.conf', azstr, fs/1e3);
+sofctl4_fn = sprintf('line4_0mm36mm146mm182mm_%s_%dkhz.txt', azstr, fs/1e3);
 a1 = az;   % Azimuth +az deg
 a2 = -az;  % Azimuth -az deg
 close all;
@@ -317,10 +344,13 @@ bf2 = bf_design(bf2);
 
 % Merge two beamformers into single description, set file names
 bfm = bf_merge(bf1, bf2);
-bfm.sofctl_fn = fullfile(bfm.sofctl_path, sofctl_fn);
-bfm.tplg_fn = fullfile(bfm.tplg_path, tplg_fn);
+bfm.sofctl3_fn = fullfile(bfm.sofctl3_path, sofctl3_fn);
+bfm.tplg1_fn = fullfile(bfm.tplg1_path, tplg1_fn);
+bfm.sofctl4_fn = fullfile(bfm.sofctl4_path, sofctl4_fn);
+bfm.tplg2_fn = fullfile(bfm.tplg2_path, tplg2_fn);
 
 % Export files for topology and sof-ctl
+bfm.export_note = 'Created with script example_two_beams.m';
 bf_export(bfm);
 
 end


### PR DESCRIPTION
This patch adds generation of.conf format blobs for tplg2 with IPC4 format blob. The blob ABI header retrieving is changed to common helper functions path those already have the support.