### PR TITLE
topology1: sof-adl-cs35l41: remove pop noise

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -475,7 +475,7 @@ ifelse(
 		SSP_CLOCK(bclk, 6144000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(4, 32, 3, 15),
-		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 24)))',
+		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 24, 0, 0, 0, SSP_CC_BCLK_ES)))',
 	CODEC, `RT5650', `
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, MCLK_RATE, codec_mclk_in),
 		SSP_CLOCK(bclk, 3072000, codec_slave),


### PR DESCRIPTION
Enable bclk early start to remove speaker pop noise when resuming from S3 or switching audio path.

[copy from issue tracker]
What steps will reproduce the problem?
1. Updated Rev8 image via recovery media,went to OOBE and boot into OS.
2. Play audio file with Gallery app.
3. Plug Typec headphone to unit then unplug it.
4. Find Po noise output from speaker.

What is the expected output?
There is no" Po" noise output from speaker when unplug Typec headphone/Rusume unit from S3 with audio playing.

What do you see instead?
Po noise output from speaker when unplug Typec headphone/Rusume unit from S3 with audio playing.
