### PR TITLE
[cavs2.5-001] topology1: sof-adl-cs35l41: remove pop noise: backport to cavs2.5-001

### DIFF
--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -486,7 +486,7 @@ ifelse(
 		SSP_CLOCK(bclk, 6144000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(4, 32, 3, 15),
-		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 24)))',
+		SSP_CONFIG_DATA(SSP, SPK_SSP_INDEX, 24, 0, 0, 0, SSP_CC_BCLK_ES)))',
 	CODEC, `RT5650', `
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, MCLK_RATE, codec_mclk_in),
 		SSP_CLOCK(bclk, 3072000, codec_slave),


### PR DESCRIPTION
Backport PR https://github.com/thesofproject/sof/pull/8282 cavs2.5-001-drop-stable branch.