### PR TITLE
ipc: don't propagate commands across pipelines for IPC4

### DIFF
--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -423,7 +423,7 @@ struct ipc4_module_load_library {
 } __packed __aligned(4);
 
 #define IPC4_COMP_ID(x, y)	((y) << 16 | (x))
-#define IPC4_MOD_ID(x)	((x) & 0xffff)
+#define IPC4_MOD_ID(x)	(IS_ENABLED(CONFIG_IPC_MAJOR_4) ? ((x) & 0xffff) : 0)
 #define IPC4_INST_ID(x)	((x) >> 16)
 #define IPC4_SRC_QUEUE_ID(x)	((x) & 0xffff)
 #define IPC4_SINK_QUEUE_ID(x)	(((x) >> 16) & 0xffff)


### PR DESCRIPTION
When IPC4_MOD_ID was introduced it returned a non-zero module ID under IPC4 and 0 under IPC3.
After commit "45ca3d430 (include: ipc4: module: fix component ID macros)", the IPC4_MOD_ID, under IPC3, is not 0 anymore.
Therefore, in order to not propagate the commands across pipelines for IPC4, add them under CONFIG_IPC_MAJOR_4.

This fixes playback with mixer.
Without this patch, with IPC3, we get:
src/audio/component.c:130  ERROR comp_set_state(): wrong state = 1, COMP_TRIGGER_PRE_START ../pipeline-stream.c:436  ERROR pipeline_trigger_run(): ret = -22, host->comp.id = 12, cmd = 7 src/ipc/ipc3/handler.c:540  ERROR ipc: comp 12 trigger 0x40000 failed -22

That's because, at some point, the trigger command is not propagated across pipeline and the component state remains unmodified.