### PR TITLE
Revert "module_adapter: avoid module init crash in case of ipc data invalid"

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -79,8 +79,6 @@ int module_adapter_init_data(struct comp_dev *dev,
 			return ret;
 		}
 		dst->init_data = dst->data;
-	} else {
-		return -EINVAL;
 	}
 
 	return 0;


### PR DESCRIPTION
Revert "module_adapter: avoid module init crash in case of ipc data invalid"

This reverts 'commit https://github.com/thesofproject/sof/commit/e847c8b270150353551d4720e382502c9a916496 ("module_adapter: avoid module
init crash in case of ipc data invalid")'.

No data is not an invalid case for mixer, for example.

Fixes: https://github.com/thesofproject/sof/issues/8265
Signed-off-by: Iuliana Prodan <iuliana.prodan@nxp.com>