### PR TITLE
topolog2: nocodec: set output_pin number

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -375,6 +375,7 @@ IncludeByKey.PASSTHROUGH {
 						out_valid_bit_depth	32
 					}
 
+					num_output_pins 2
 					Object.Base.output_pin_binding.1 {
 						output_pin_binding_name "gain.8.1"
 					}

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -307,48 +307,67 @@ IncludeByKey.PASSTHROUGH {
 						}
 						Object.Widget.module-copier.1 {
 							stream_name 'Gain Capture 19'
+
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
 						}
 						Object.Widget.gain.1 {
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
 							Object.Control.mixer.1 {
 								name 'Pre Demux $DMIC0_PCM_0_NAME Capture Volume'
 							}
@@ -368,12 +387,22 @@ IncludeByKey.PASSTHROUGH {
 					copier_type	"SSP"
 					stream_name	"NoCodec-0"
 					node_type	$I2S_LINK_INPUT_CLASS
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
+
+					num_input_audio_formats 1
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
 
 					num_output_pins 2
 					Object.Base.output_pin_binding.1 {
@@ -387,12 +416,21 @@ IncludeByKey.PASSTHROUGH {
 
 				Object.Widget.module-copier."2" {
 					stream_name	"NoCodec-0"
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
+
+					num_input_audio_formats 1
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
@@ -634,12 +672,21 @@ Object.Pipeline.io-gateway-capture [
 			copier_type	"SSP"
 			stream_name	"NoCodec-2"
 			node_type	$I2S_LINK_INPUT_CLASS
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
+
+			num_input_audio_formats	1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	32
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+			]
 		}
 	}
 ]
@@ -679,47 +726,66 @@ IncludeByKey.PASSTHROUGH {
 							stream_name "Gain Capture 18"
 							pcm_id	27
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
 						}
 						Object.Widget.gain.1 {
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							Object.Control.mixer.1 {
 								name 'Post Demux $DMIC0_PCM_0_NAME Capture Volume'
 							}
@@ -735,47 +801,66 @@ IncludeByKey.PASSTHROUGH {
 							stream_name "Gain Capture 20"
 							pcm_id 28
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
 						}
 						Object.Widget.gain.1 {
 							num_input_audio_formats 2
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+								{
+									in_channels		4
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									in_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							num_output_audio_formats 2
-							Object.Base.audio_format.1 {
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_bit_depth		32
-								out_valid_bit_depth	32
-							}
-							Object.Base.audio_format.2 {
-								in_channels		4
-								in_bit_depth		32
-								in_valid_bit_depth	32
-								out_channels		4
-								out_bit_depth		32
-								out_valid_bit_depth	32
-								in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								in_ch_map	$CHANNEL_MAP_3_POINT_1
-								out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-								out_ch_map	$CHANNEL_MAP_3_POINT_1
-							}
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+								{
+									out_channels		4
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+							]
+
 							Object.Control.mixer.1 {
 								name 'Post Demux $DMIC0_PCM_1_NAME Capture Volume'
 							}
@@ -1070,12 +1155,21 @@ IncludeByKey.SSP1_ENABLED {
 					copier_type	"SSP"
 					stream_name	"NoCodec-1"
 					node_type	$I2S_LINK_INPUT_CLASS
-					Object.Base.audio_format.1 {
-						in_bit_depth		32
-						in_valid_bit_depth	32
-						out_bit_depth		32
-						out_valid_bit_depth	32
-					}
+
+					num_input_audio_formats 1
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
 				}
 			}
 		]


### PR DESCRIPTION
The num_output_pins was set for pass-through path but missed in normal path. Without it Linux kernel driver wouldn't set second output pin format for dai copier which connects smart amp and gain module.