### PR TITLE
topology2: sof-mtl-rt713-l0-rt1316-l12-rt1713-l3: use default stream name

### DIFF
--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -35,10 +35,7 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 USE_CHAIN_DMA=true,NUM_SDW_AMP_LINKS=2,SDW_SPK_STREAM=SDW1-Playback,SDW_SPK_IN_STREAM=SDW1-Capture,\
 SDW_DMIC_STREAM=SDW0-Capture"
 
-"cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
-SDW_SPK_STREAM=Playback-SmartAmp,SDW_SPK_IN_STREAM=Capture-SmartAmp,\
-SDW_DMIC_STREAM=Capture-SmartMic,SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
-SDW_JACK_IN_STREAM=Capture-SimpleJack"
+"cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 # Below topologies are used on Chromebooks
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\


### PR DESCRIPTION

rt713 and rt1713 are in different SoundWire links. So, no DAI type will be appended to DAI link name. We should use default stream name in the topology.