### PR TITLE
topology2: google-rtc-aec: expose component core_id for override

### DIFF
--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -96,7 +96,10 @@ Define {
 	BT_PB_DAI_PIPELINE_SRC "copier.host.9.1"
 	BT_PB_PIPELINE_STREAM_NAME "dai-copier.SSP.10.1"
 	GOOGLE_RTC_AEC_SUPPORT		0
+	# assign core for AEC LL pipelines
 	GOOGLE_AEC_CORE_ID		0
+	# assign core for RTC_AE DP task
+	GOOGLE_AEC_DP_CORE_ID		0
 	HEADSET_PCM_NAME		"Headset"
 	HEADSET_PCM_ID			0
 	SPEAKER_PCM_NAME		"Speakers"

--- a/tools/topology/topology2/platform/intel/google-rtc-aec-reference.conf
+++ b/tools/topology/topology2/platform/intel/google-rtc-aec-reference.conf
@@ -10,6 +10,7 @@ Object.Pipeline.google-rtc-aec-capture [
 		}
 
 		Object.Widget.google-rtc-aec.1 {
+			core_id $GOOGLE_AEC_DP_CORE_ID
 			Object.Base.input_pin_binding.1 {
 				input_pin_binding_name	"module-copier.18.1"
 			}


### PR DESCRIPTION
RTC AEC module is using DP and rest of echo ref pipeline is LL, and both can run on secondary cores.
In order to assign RTC_AEC DP alone on secondary core, add new macro GOOGLE_AEC_DP_CORE_ID.