### PR TITLE
topology2: host-gateway-capture: Replace audio_format objects

### DIFF
--- a/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
+++ b/tools/topology/topology2/cavs-sdw-src-gain-mixin.conf
@@ -120,11 +120,6 @@ Object.Pipeline {
 			Object.Widget.host-copier.1 {
 				stream_name	"Passthrough Capture 0"
 				pcm_id	1
-				Object.Base.audio_format.1 {
-					# 32 -> 16 bits conversion is done here,
-					# so in_bit_depth is 32 (and out_bit_depth is 16).
-					in_bit_depth	32
-				}
 			}
 		}
 	]

--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
@@ -16,7 +16,8 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
-<include/common/audio_format.conf>
+<include/common/input_audio_format.conf>
+<include/common/output_audio_format.conf>
 <include/components/host-copier.conf>
 <include/components/pipeline.conf>
 
@@ -45,64 +46,57 @@ Class.Pipeline."host-gateway-capture" {
 			type	"aif_out"
 			node_type $HDA_HOST_INPUT_CLASS
 			num_input_pins 1
-			num_input_audio_formats 6
+			num_input_audio_formats 2
 			num_output_audio_formats 6
-			# 16-bit output format 48KHz 2ch. Input sample format is always 32-bit for capture
-			Object.Base.audio_format.1 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-			}
-			# 24-bit 48KHz 2ch
-			Object.Base.audio_format.2 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	24
-			}
-			# 32-bit 48KHz 2ch
-			Object.Base.audio_format.3 {
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-			}
-			# 16-bit output format 48KHz 4ch. Input sample format is always 32-bit for capture
-			Object.Base.audio_format.4 {
-				in_channels		4
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_channels		4
-				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				in_ch_map	$CHANNEL_MAP_3_POINT_1
-				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				out_ch_map	$CHANNEL_MAP_3_POINT_1
-			}
-			# 24-bit 48KHz 2ch
-			Object.Base.audio_format.5 {
-				in_channels		4
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	24
-				out_channels		4
-				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				in_ch_map	$CHANNEL_MAP_3_POINT_1
-				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				out_ch_map	$CHANNEL_MAP_3_POINT_1
-			}
-			# 32-bit 48KHz 4ch
-			Object.Base.audio_format.6 {
-				in_channels		4
-				in_bit_depth		32
-				in_valid_bit_depth	32
-				out_bit_depth		32
-				out_valid_bit_depth	32
-				out_channels		4
-				in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				in_ch_map	$CHANNEL_MAP_3_POINT_1
-				out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-				out_ch_map	$CHANNEL_MAP_3_POINT_1
-			}
+			# Input sample format is always 32-bit for capture
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth 32
+					in_valid_bit_depth 32
+				}
+				{
+					in_bit_depth 32
+					in_valid_bit_depth 32
+					in_channels 4
+					in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
+					in_ch_map	$CHANNEL_MAP_3_POINT_1
+				}
+			]
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	24
+				}
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+				}
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	24
+					out_channels 		4
+					out_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map		$CHANNEL_MAP_3_POINT_1
+				}
+				{
+					out_bit_depth		32
+					out_valid_bit_depth	32
+					out_channels 		4
+					out_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map		$CHANNEL_MAP_3_POINT_1
+				}
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+					out_channels 		4
+					out_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+					out_ch_map		$CHANNEL_MAP_3_POINT_1
+				}
+			]
 		}
 
 		pipeline."1" {


### PR DESCRIPTION
With input_audio_format/output_audio_format objects in preparation to deprecate the audio_format class.