### PR TITLE
topology2: add rt713_rt1316, no sdw_dmic

### DIFF
--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -36,6 +36,10 @@ USE_CHAIN_DMA=true,NUM_SDW_AMP_LINKS=2,SDW_SPK_STREAM=SDW1-Playback,SDW_SPK_IN_S
 SDW_DMIC_STREAM=SDW0-Capture"
 
 "cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
+
+# Jack codec + SmartAmp topology. No SDW_DMIC connection
+"cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2"
+
 # Below topologies are used on Chromebooks
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\


### PR DESCRIPTION
This is additional HW board: No SDW_DMIC configuration

SDW0: rt713 Jack codec
SDW1: rt1316 smart amp l
SDW2: rt1316 smart amp r