### PR TITLE
[imx-stable-v2.7] Update west.yml for imx-stable-v2.7 to point to zephyr v.3.5 rc2

### DIFF
--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -23,7 +23,6 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/sys_clock.h>
-#include <zephyr/timeout_q.h>
 
 LOG_MODULE_DECLARE(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
@@ -112,7 +111,7 @@ static void zephyr_domain_timer_fn(struct k_timer *timer)
 	 * registered again next time.
 	 */
 	if (!zephyr_domain) {
-		z_abort_timeout(&timer->timeout);
+		k_timer_stop(timer);
 		return;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 5689916a70ad5c363bd7d5511b772ada90067d51
+      revision: c1b1dd78e2a83285f6cf5780fa1fcf4089e0367b
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Also, backport 98e8f8fdc zephyr: ll-schedule: stop using zephyr/timeout_q.h  to get rid of a compilation issue.