### PR TITLE
Backport to imx-stable-v2.7

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -130,8 +130,6 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 			goto err;
 		}
 		dst->init_data = dst->data;
-	} else {
-		goto err;
 	}
 #else
 	if (drv->type == SOF_COMP_MODULE_ADAPTER) {

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -408,7 +408,7 @@ struct ipc4_module_load_library {
 } __packed __aligned(4);
 
 #define IPC4_COMP_ID(x, y)	((y) << 16 | (x))
-#define IPC4_MOD_ID(x)	((x) & 0xffff)
+#define IPC4_MOD_ID(x)	(IS_ENABLED(CONFIG_IPC_MAJOR_4) ? ((x) & 0xffff) : 0)
 #define IPC4_INST_ID(x)	((x) >> 16)
 #define IPC4_SRC_QUEUE_ID(x)	((x) & 0xffff)
 #define IPC4_SINK_QUEUE_ID(x)	(((x) >> 16) & 0xffff)


### PR DESCRIPTION
Backport mixer fixes on imx-stable-v2.7

Second commit is not the one from main, is the revert of e847c8b27 ("module_adapter: avoid module init crash in case of ipc data invalid").
That's because, on main, there is a split of module_adapter into module_adapter_ipc3 and module_adapter_ipc4, and the fix applies  only to ipc3.