### PR TITLE
topology2: sdw-amp-generic: Remove incorrect audio format

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -350,11 +350,6 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					Object.Widget.host-copier.1 {
 						stream_name	"amp feedback"
 						pcm_id 3
-						Object.Base.audio_format.1 {
-							# 32 -> 16 bits conversion is done here,
-							# so in_bit_depth is 32 (and out_bit_depth is 16).
-							in_bit_depth	32
-						}
 					}
 				}
 			]

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -30,11 +30,6 @@ Object.Pipeline {
 			Object.Widget.host-copier.1 {
 				stream_name	"sdw dmic"
 				pcm_id 4
-				Object.Base.audio_format.1 {
-					# 32 -> 16 bits conversion is done here,
-					# so in_bit_depth is 32 (and out_bit_depth is 16).
-					in_bit_depth	32
-				}
 			}
 		}
 	]


### PR DESCRIPTION
Setting the in bit depth for the second audio format in the host-gateway-capture object results in resetting the channel count to 4. The in_bit_depth is set to 32-bit by default for all audio formats in host-gateway-capture class already.


Fixes: 7a11e27bf2a19e9acf643d416fc079f479fd2748 ('topology2: host-gateway-capture: Replace audio_format objects')
Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>