### PR TITLE
DP: fix DP thread priority

### DIFF
--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -48,7 +48,7 @@ DECLARE_SOF_UUID("dp-task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
 /**
  * \brief a priority of the DP threads in the system.
  */
-#define ZEPHYR_DP_THREAD_PRIORITY (CONFIG_NUM_PREEMPT_PRIORITIES - 1)
+#define ZEPHYR_DP_THREAD_PRIORITY (CONFIG_NUM_PREEMPT_PRIORITIES - 2)
 
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 


### PR DESCRIPTION
After enabling deadline calculation DP threads began to lose priority in relation to logger thread which currently is set to the same priority but has zeroed deadline.
Since processing should be not disturbed by logging operations, the ZEPHYR_DP_THREAD_PRIORITY must be set to lower value than logger.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>