### PR TITLE
[stable-2.7] west.yml: update Zephyr to sofproject stable-v2.7

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -133,7 +133,7 @@ jobs:
       - name: west clones
 
         run: pip3 install west && cd workspace/sof/ && west init -l &&
-               west update --narrow --fetch-opt=--filter=tree:0
+               time west update --narrow --fetch-opt=--filter=tree:0
 
       - name: select zephyr revision
         run: |
@@ -149,7 +149,7 @@ jobs:
                sed -e "s#=sof_zephyr_revision_override=#${rem_rev}#" \
                  sof-ci-jenkins/zephyr-override-template.yml > test-zephyr-main.yml
              )
-             west update --narrow  --fetch-opt=--filter=tree:0
+             time west update --narrow  --fetch-opt=--filter=tree:0
           fi
 
           # Because we used git tricks to speed things up, we now have two git
@@ -167,7 +167,7 @@ jobs:
           #     both issues in no time.
 
           cd zephyr
-          git fetch --filter=tree:0 "$(git remote |head -n1)" "$rem_rev":_branch_placeholder
+          time git fetch --filter=tree:0 "$(git remote |head -n1)" "$rem_rev":_branch_placeholder
           git branch -D _branch_placeholder
 
           set -x

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -167,7 +167,7 @@ jobs:
           #     both issues in no time.
 
           cd zephyr
-          git fetch --filter=tree:0 zephyrproject "$rem_rev":_branch_placeholder
+          git fetch --filter=tree:0 "$(git remote |head -n1)" "$rem_rev":_branch_placeholder
           git branch -D _branch_placeholder
 
           set -x

--- a/versions.json
+++ b/versions.json
@@ -2,6 +2,6 @@
   "SOF": {
     "MAJOR": "2",
     "MINOR": "7",
-    "MICRO": "0"
+    "MICRO": "1"
   }
 }

--- a/west.yml
+++ b/west.yml
@@ -45,8 +45,8 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 5689916a70ad5c363bd7d5511b772ada90067d51
-      remote: zephyrproject
+      revision: feaa6281b7fc8af6ed6099b2bc1955e3f9925493
+      remote: thesofproject
 
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
commit 335c51b98c2eaa390df1435f1f8b8a026e70abd2 (HEAD -> stable-v2.7)
Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
Date:   Thu Oct 19 17:59:52 2023 +0300

    versions.json: bump version to 2.7.1
    
    Set version to 2.7.1 as we start merging bugfixes.
    
    Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>

commit f6b74afe4e471431c4fa30168253100a43e628cf
Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
Date:   Thu Oct 19 17:56:49 2023 +0300

    west.yml: update Zephyr to sofproject stable-v2.7
    
    Update Zephyr to use thesofproject/zephyr/stable-v2.7 with
    following one commit backported from Zephyr main.
    
    3c58926487eb drivers: dma: intel-adsp-hda: Correct DGCS:SCS bit for
    
    Link: https://github.com/thesofproject/sof/issues/8236
    Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
