### PR TITLE
topology2: doc: Fix main page

### DIFF
--- a/tools/topology/topology2/doc/sof.doxygen.in
+++ b/tools/topology/topology2/doc/sof.doxygen.in
@@ -12,7 +12,7 @@ INPUT            = @top_srcdir@ \
 		   @top_bindir@/contents.doxy
 
 RECURSIVE	 = YES
-FILE_PATTERNS    = *.conf
+FILE_PATTERNS    = *.conf,*.doxy
 IMAGE_PATH	 =
 QUIET            = YES
 WARN_LOGFILE     = doxygen_warnings.txt


### PR DESCRIPTION
The main page sources were dropped out from the document sources in the last review rounds of the original PR. Add *.doxy to FILE_PATTERNS to add it back.