### PR TITLE
[SKIP SOF-TEST] Delete inherited tools/rimage/.gitignore

### DIFF
--- a/tools/rimage/.gitignore
+++ b/tools/rimage/.gitignore
@@ -1,2 +1,0 @@
-build/
-.checkpatch-camelcase.git.*


### PR DESCRIPTION
rimage is not so special that it needs its personalized .gitignore