### PR TITLE
topology2/cmake: extract new function "alsatplg_version()" for re-use

### DIFF
--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -4,7 +4,7 @@ add_custom_target(topologies2)
 # Check alsatplg version and build topology2 if alsatplg version is
 # 1.2.7 or greater, see https://github.com/thesofproject/sof/issues/5323
 execute_process(COMMAND alsatplg --version RESULT_VARIABLE STATUS OUTPUT_VARIABLE ALSA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(STATUS AND NOT STATUS EQUAL 0)
+if(NOT STATUS EQUAL 0)
 	message(WARNING "alsatplg error: ${STATUS}, topology2 will be skipped")
 else()
 	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${ALSA_VERSION})

--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -3,15 +3,38 @@ add_custom_target(topologies2)
 
 # Check alsatplg version and build topology2 if alsatplg version is
 # 1.2.7 or greater, see https://github.com/thesofproject/sof/issues/5323
-execute_process(COMMAND alsatplg --version RESULT_VARIABLE STATUS OUTPUT_VARIABLE ALSA_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(NOT STATUS EQUAL 0)
-	message(WARNING "alsatplg error: ${STATUS}, topology2 will be skipped")
-else()
-	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${ALSA_VERSION})
+
+function(alsatplg_version  OUT_STATUS  OUT_VERSION)
+	execute_process(COMMAND alsatplg --version
+	  RESULT_VARIABLE status
+	  OUTPUT_VARIABLE stdout
+	  OUTPUT_STRIP_TRAILING_WHITESPACE)
+	message(DEBUG "alsatplg --version: status=${status}, output=${stdout}")
+
+	set(${OUT_STATUS} "${status}" PARENT_SCOPE)
+
+        # Some error messages have already been printed on stderr
+	if(NOT status EQUAL 0)
+	  message(WARNING "alsatplg --version returned status: ${status},
+${stdout}")
+	  return()
+	endif()
+
+	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${stdout})
 	list(GET ALSA_VERSION_LIST 0 ALSATPLG_VERSION)
 	string(REGEX MATCH "[0-9]\.[0-9]\.*[0-9]*" ALSATPLG_VERSION_NUMBER ${ALSATPLG_VERSION})
+
+	set(${OUT_VERSION} "${ALSATPLG_VERSION_NUMBER}" PARENT_SCOPE)
+endfunction()
+
+alsatplg_version(STATUS ALSATPLG_VERSION_NUMBER)
+
+if(NOT STATUS EQUAL 0)
+	message(WARNING "alsatplg error: ${STATUS}; topology2 will be skipped")
+else()
 	if(${ALSATPLG_VERSION_NUMBER} VERSION_LESS "1.2.7")
-		message(WARNING "topology2 will be skipped. Minimum required version for alsatplg: 1.2.7")
+		message(WARNING "topology2 skipped. Minimum alsatplg version 1.2.7,\
+ found ${ALSATPLG_VERSION_NUMBER}.")
 	else()
 		add_dependencies(topologies topologies2)
 	endif()


### PR DESCRIPTION
We'll use this new function to require ALSA 1.2.5 and finally rename to
"codec_consumer" (see revert discussion https://github.com/thesofproject/sof/pull/5192)