### PR TITLE
lnl: sndw: use HDA DMA to transfer stream data 

### DIFF
--- a/src/include/ipc4/alh.h
+++ b/src/include/ipc4/alh.h
@@ -66,4 +66,12 @@ struct sof_alh_configuration_blob {
 	struct ipc4_alh_multi_gtw_cfg alh_cfg;
 } __attribute__((packed, aligned(4)));
 
+static inline size_t
+get_alh_config_size(const struct sof_alh_configuration_blob *alh_blob)
+{
+	return sizeof(alh_blob->gtw_attributes) +
+	       sizeof(alh_blob->alh_cfg.count) +
+	       sizeof(alh_blob->alh_cfg.mapping[0]) * alh_blob->alh_cfg.count;
+}
+
 #endif

--- a/src/include/sof/audio/ipc-config.h
+++ b/src/include/sof/audio/ipc-config.h
@@ -75,7 +75,8 @@ struct ipc_config_dai {
 	uint32_t feature_mask;		/**< copier feature mask (set directly from
 					  *  ipc4_copier_module_cfg on init)
 					  */
-	struct ipc_dma_config *host_dma_config; /**< DMA config - required for ACE 2.0 and newer */
+	/**< DMA configs - required for ACE 2.0 and newer */
+	struct ipc_dma_config *host_dma_config[GTW_DMA_DEVICE_MAX_COUNT];
 	const struct ipc4_audio_format *out_fmt;/**< audio format for output pin 0 - required
 						  * for ACE 2.0 and newer
 						  */

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -60,6 +60,8 @@ int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id, uint32_t cmd);
 int ipc4_find_dma_config(struct ipc_config_dai *dai, uint8_t *data_buffer, uint32_t size);
 int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd);
 int ipc4_pipeline_trigger(struct ipc_comp_dev *ppl_icd, uint32_t cmd, bool *delayed);
+int ipc4_find_dma_config_multiple(struct ipc_config_dai *dai, uint8_t *data_buffer,
+				  uint32_t size, uint32_t device_id, int dma_cfg_idx);
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -60,7 +60,6 @@ int ipc4_pipeline_complete(struct ipc *ipc, uint32_t comp_id, uint32_t cmd);
 int ipc4_find_dma_config(struct ipc_config_dai *dai, uint8_t *data_buffer, uint32_t size);
 int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd);
 int ipc4_pipeline_trigger(struct ipc_comp_dev *ppl_icd, uint32_t cmd, bool *delayed);
-
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/include/sof/tlv.h
+++ b/src/include/sof/tlv.h
@@ -33,6 +33,9 @@ struct sof_tlv {
  */
 static inline struct sof_tlv *tlv_next(const struct sof_tlv *tlv)
 {
+	if (tlv->length % sizeof(uint32_t) != 0)
+		return NULL;
+
 	return (struct sof_tlv *)((char *)(tlv) + sizeof(*tlv) + tlv->length);
 }
 
@@ -92,6 +95,24 @@ static inline void tlv_value_get(const void *data,
 
 		tlv = tlv_next(tlv);
 	}
+}
+
+/**
+ * @brief Retrieves pointer to the TLV Structure value of the specified type
+ *
+ * @param tlv TLV struct pointer.
+ * @param type Value type.
+ * @return Value pointer
+ */
+static inline void *tlv_value_ptr_get(struct sof_tlv *tlv, uint32_t type)
+{
+	if ((uintptr_t)tlv % sizeof(uint32_t) != 0)
+		return NULL;
+
+	if (tlv->type != type)
+		return NULL;
+
+	return (void *)tlv->value;
 }
 
 #endif /* __SOF_TLV_H__ */

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -44,7 +44,7 @@ void dai_set_link_hda_config(uint16_t *link_config,
 	case SOF_DAI_INTEL_SSP:
 		link_cfg.full = 0;
 		link_cfg.part.dir = common_config->direction;
-		link_cfg.part.stream = common_config->host_dma_config->stream_id;
+		link_cfg.part.stream = common_config->host_dma_config[0]->stream_id;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		link_cfg.full = 0;
@@ -57,7 +57,7 @@ void dai_set_link_hda_config(uint16_t *link_config,
 		} else {
 			link_cfg.part.hchan = out_fmt->channels_count - 1;
 		}
-		link_cfg.part.stream = common_config->host_dma_config->stream_id;
+		link_cfg.part.stream = common_config->host_dma_config[0]->stream_id;
 		break;
 	default:
 		/* other types of DAIs not need link_config */
@@ -79,8 +79,8 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	case SOF_DAI_INTEL_DMIC:
 		channel = 0;
 #if defined(CONFIG_ACE_VERSION_2_0)
-		if (dai->host_dma_config->pre_allocated_by_host)
-			channel = dai->host_dma_config->dma_channel_id;
+		if (dai->host_dma_config[0]->pre_allocated_by_host)
+			channel = dai->host_dma_config[0]->dma_channel_id;
 #endif
 		break;
 	case SOF_DAI_INTEL_HDA:

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1043,7 +1043,7 @@ int ipc4_find_dma_config(struct ipc_config_dai *dai, uint8_t *data_buffer, uint3
 	if (*dma_config_id != GTW_DMA_CONFIG_ID)
 		return IPC4_INVALID_REQUEST;
 
-	dai->host_dma_config = GET_IPC_DMA_CONFIG(data_buffer, size);
+	dai->host_dma_config[0] = GET_IPC_DMA_CONFIG(data_buffer, size);
 #endif
 	return IPC4_SUCCESS;
 }


### PR DESCRIPTION
Since LNL SoundWire interface uses HDA DMA to transfer stream data. 

This approach uses HDA dai and HDA DMA. No changes needed on Zephyr side.
Following solution involves FW based SoundWire link aggregation mechanism which
is also used on MTL for backward compatibility with Windows driver.

This is a working solution. It was tested in E2E scenarios with Windows driver.