### PR TITLE
[stable-v2.7] [SKIP SOF-TEST] .github/zephyr: stop trying Zephyr main branch with a stable branch

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -100,7 +100,6 @@ jobs:
         # Search "zephyr_revision" and see below what they expand to.
         zephyr_revision: [
           mnfst,  # special value: don't override sof/west.yml
-          zmain,  # Zephyr's main branch
         ]
         # Using groups to avoid spamming the small results box with too
         # many lines. Pay attention to COMMAS.


### PR DESCRIPTION
It's bold enough with the SOF main branch, it's obviously not going to work with a stable branch of SOF.