### PR TITLE
[SKIP SOF-TEST] .github/zephyr: de-hardcode the remote name in the Windows build too

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -308,7 +308,7 @@ jobs:
           # Get some tags to fix `git describe`, see build-linux comments above.
           cd zephyr
           $_rev = "$(git rev-parse HEAD)"
-          git fetch --filter=tree:0 zephyrproject "${_rev}:_branch_placeholder"
+          git fetch --filter=tree:0 "$(west list -f '{url}' zephyr)" "${_rev}:_branch_placeholder"
           git branch -D _branch_placeholder
 
 


### PR DESCRIPTION
Fixes commit 4bc6488b24e44 (".github/zephyr: de-hardcode the name of the zephyr remote")

(Yay for duplication)