### PR TITLE
topology/cmake: skip all topologies when alsatplg < 1.2.5

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -25,6 +25,25 @@ ${stdout}")
 endfunction()
 
 
+# Being written in C, `alsatplg` silently ignores some invalid inputs
+# and produces an corrupt .tplg file instead of returning an error code
+# that fails the build.  For instance, alsatplg versions < 1.2.5 silently
+# corrupt `codec_consumer` and turn it into `codec_master` instead.
+# Longer story in #5192.
+alsatplg_version(STATUS ALSATPLG_VERSION_NUMBER)
+if(NOT STATUS EQUAL 0)
+	message(WARNING "alsatplg failed: ${STATUS}; all topologies skipped")
+	return()
+else()
+	if(${ALSATPLG_VERSION_NUMBER} VERSION_LESS "1.2.5")
+		message(WARNING "All topologies skipped: minimum alsatplg version 1.2.5,\
+ found ${ALSATPLG_VERSION_NUMBER}.")
+		return()
+	endif()
+	# success
+endif()
+
+
 # This use of VERBOSE relies on original CMake behavior.
 # From the add_custom_command() manual:
 #

--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -1,5 +1,30 @@
 set(SOF_TOPOLOGY_BINARY_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
+
+function(alsatplg_version  OUT_STATUS  OUT_VERSION)
+	execute_process(COMMAND alsatplg --version
+	  RESULT_VARIABLE status
+	  OUTPUT_VARIABLE stdout
+	  OUTPUT_STRIP_TRAILING_WHITESPACE)
+	message(DEBUG "alsatplg --version: status=${status}, output=${stdout}")
+
+	set(${OUT_STATUS} "${status}" PARENT_SCOPE)
+
+        # Some error messages have already been printed on stderr
+	if(NOT status EQUAL 0)
+	  message(WARNING "alsatplg --version returned status: ${status},
+${stdout}")
+	  return()
+	endif()
+
+	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${stdout})
+	list(GET ALSA_VERSION_LIST 0 ALSATPLG_VERSION)
+	string(REGEX MATCH "[0-9]\.[0-9]\.*[0-9]*" ALSATPLG_VERSION_NUMBER ${ALSATPLG_VERSION})
+
+	set(${OUT_VERSION} "${ALSATPLG_VERSION_NUMBER}" PARENT_SCOPE)
+endfunction()
+
+
 # This use of VERBOSE relies on original CMake behavior.
 # From the add_custom_command() manual:
 #

--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -3,30 +3,6 @@ add_custom_target(topologies2)
 
 # Check alsatplg version and build topology2 if alsatplg version is
 # 1.2.7 or greater, see https://github.com/thesofproject/sof/issues/5323
-
-function(alsatplg_version  OUT_STATUS  OUT_VERSION)
-	execute_process(COMMAND alsatplg --version
-	  RESULT_VARIABLE status
-	  OUTPUT_VARIABLE stdout
-	  OUTPUT_STRIP_TRAILING_WHITESPACE)
-	message(DEBUG "alsatplg --version: status=${status}, output=${stdout}")
-
-	set(${OUT_STATUS} "${status}" PARENT_SCOPE)
-
-        # Some error messages have already been printed on stderr
-	if(NOT status EQUAL 0)
-	  message(WARNING "alsatplg --version returned status: ${status},
-${stdout}")
-	  return()
-	endif()
-
-	string(REPLACE "\n" ";" ALSA_VERSION_LIST ${stdout})
-	list(GET ALSA_VERSION_LIST 0 ALSATPLG_VERSION)
-	string(REGEX MATCH "[0-9]\.[0-9]\.*[0-9]*" ALSATPLG_VERSION_NUMBER ${ALSATPLG_VERSION})
-
-	set(${OUT_VERSION} "${ALSATPLG_VERSION_NUMBER}" PARENT_SCOPE)
-endfunction()
-
 alsatplg_version(STATUS ALSATPLG_VERSION_NUMBER)
 
 if(NOT STATUS EQUAL 0)


### PR DESCRIPTION
Stop producing corrupted .tplg files when using `codec_consumer` (e.g.:
sof-imx8mp-btsco-dual-8ch.tplg, sof-imx8ulp-9x9-btsco-16k.tplg, ...)

Then we'll be able to finally search/replace "codec_master", see revert