### PR TITLE
drivers: imx: micfil: Change loglevel to info

### DIFF
--- a/src/drivers/imx/micfil.c
+++ b/src/drivers/imx/micfil.c
@@ -52,7 +52,7 @@ static int micfil_get_hw_params(struct dai *dai,
 {
 	struct micfil_pdata *micfil = dai_get_drvdata(dai);
 
-	dai_err(dai, "micfil_get_hw_params()");
+	dai_info(dai, "micfil_get_hw_params()");
 
 	params->rate = micfil->params.pdm_rate;
 	params->channels = micfil->params.pdm_ch;


### PR DESCRIPTION
There is no need to print an error at the beginning of a function. The usual behavior should be to print an info.