### PR TITLE
[SKIP SOF-TEST] rebuild-testbench.sh: drop no-op LDFLAGS=-Wl,-LE

### DIFF
--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -78,7 +78,7 @@ setup_xtensa_tools_build()
     export CC=$tools_bin/$compiler
     export LD=$tools_bin/xt-ld
     export OBJDUMP=$tools_bin/xt-objdump
-    export LDFLAGS="-mlsp=sim -Wl,-LE $testbench_sections"
+    export LDFLAGS="-mlsp=sim $testbench_sections"
     export XTENSA_CORE
 }
 

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020, Mohana Datta Yelugoti
 
-# fail on any errors
+# stop on most errors
 set -e
 
 # Defaults
@@ -15,6 +15,7 @@ print_usage()
     cat <<EOFUSAGE
 usage: $0 [-f] [-p <platform>]
        -p Build testbench binary for xt-run for selected platform, e.g. -p tgl
+          When omitted, perform a BUILD_TYPE=native, compile-only check.
        -f Build testbench with compiler provided by fuzzer
           (default path: $HOME/sof/work/AFL/afl-gcc)
        -j number of parallel make/ninja jobs. Defaults to /usr/bin/nproc.
@@ -139,7 +140,7 @@ main()
     done
 
     rebuild_testbench
-
+    printf '\n'
     testbench_usage
 }
 


### PR DESCRIPTION
It's not clear why `LDFLAGS=-Wl,-LE` was added in
commit https://github.com/thesofproject/sof/commit/10d0b3b5e107506583f1a8b6d16ef1f14f30a233 ("Scripts: Add xt-run build target for
rebuild-testbench.sh"). Maybe it was supposed to be `-Wl,-EL`?

Either way this flag has always been interpreted as adding the directory
`./E/` to the search library path, which obviously never had any
effect; proof below. So it can safely be removed.

Here's the proof:

```
mv ~/XCC/install/builds/RG-2017.8-linux/cavs2x_LX6HiFi3_2017_8/xtensa-elf/lib/libm.a .

./scripts/rebuild-testbench.sh -p tgl

  # Fails as expected
  # => XCC/install/tools/RG-2017.8-linux/XtensaTools/bin/xt-ld: cannot find -lm

cmake --build tools/testbench/build_xt_testbench/ -- testbench

  # Same again
  # => XCC/install/tools/RG-2017.8-linux/XtensaTools/bin/xt-ld: cannot find -lm

mkdir tools/testbench/build_xt_testbench/E/
cp libm.a  tools/testbench/build_xt_testbench/E/
cmake --build tools/testbench/build_xt_testbench/ -- testbench

  # => now compiles!
```

Remember: the best way to test software is always to break it.

Don't forget to fix XCC:

```
mv libm.a ~/XCC/install/builds/RG-2017.8-linux/cavs2x_LX6HiFi3_2017_8/xtensa-elf/lib/
```