### PR TITLE
west.yml: update Zephyr to 460c2167e4f3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: a6eef0ba3755f2530c5ce93524e5ac4f5be30194
+      revision: 460c2167e4f3f6489ff0d3f519466a5682d8146b
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 800+ commits merged after 3.5.0 release, including following directly affecting SOF targets:

f4cb487b79f9 modules: sof: Options only when module is available
02deea0e806a ace: alh: Only ACE1.5 has OSEL feature
f0326f72498c tests: dma_loopback: Intel ADSP ACE15 disable PM
adf6d0e3d80e soc: intel_adsp: lpsram enable retention mode
eeb4f2f76d6d soc: intel_adsp: hpsram enable retention mode
16f729214b50 soc: intel_adsp: lpsram init refactor
112611378f85 soc: intel_adsp: hpsram init refactor
cdd4d8470323 xtensa: add custom mem range check functions