### PR TITLE
[SOF-v2.7] backport fixes for CI builds

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -310,7 +310,7 @@ jobs:
           # Get some tags to fix `git describe`, see build-linux comments above.
           cd zephyr
           $_rev = "$(git rev-parse HEAD)"
-          git fetch --filter=tree:0 zephyrproject "${_rev}:_branch_placeholder"
+          git fetch --filter=tree:0 "$(west list -f '{url}' zephyr)" "${_rev}:_branch_placeholder"
           git branch -D _branch_placeholder
 
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -176,9 +176,6 @@ def parse_args():
 						help="List of platforms to build")
 	parser.add_argument("-d", "--debug", required=False, action="store_true",
 						help="Shortcut for: -o sof/app/debug_overlay.conf")
-	parser.add_argument("-i", "--ipc", required=False, choices=["IPC4"],
-			    help="""Applies --overlay <platform>/ipc4_overlay.conf
-and a different rimage config. Valid only for IPC3 platforms supporting IPC4 too.""")
     # NO SOF release will ever user the option --fw-naming.
     # This option is only for disguising SOF IPC4 as CAVS IPC4 and only in cases where
     # the kernel 'ipc_type' expects CAVS IPC4. In this way, developers and CI can test
@@ -265,10 +262,6 @@ This should be used with programmatic script invocations (eg. Continuous Integra
 		if not args.use_platform_subdir:
 			args.use_platform_subdir=True
 			warnings.warn("The option '--fw-naming AVS' has to be used with '--use-platform-subdir'. Enable '--use-platform-subdir' automatically.")
-		if args.ipc != "IPC4":
-			args.ipc="IPC4"
-			warnings.warn("The option '--fw-naming AVS' has to be used with '-i IPC4'. Enable '-i IPC4' automatically.")
-
 
 def execute_command(*run_args, **run_kwargs):
 	"""[summary] Provides wrapper for subprocess.run that prints
@@ -626,7 +619,7 @@ def rimage_options(platform_dict):
 	#                         test_00_01_load_fw_and_check_version
 	opts.append(("-b", "1"))
 
-	if args.ipc == "IPC4":
+	if platform_dict.get("IPC4_RIMAGE_DESC", None) is not None:
 		rimage_desc = platform_dict["IPC4_RIMAGE_DESC"]
 	else:
 		rimage_desc = platform_dict["name"] + ".toml"
@@ -724,13 +717,6 @@ def build_platforms():
 		# if both are provided, because it's no harm to merge the same overlay twice.
 		if args.debug:
 			overlays.append(str(pathlib.Path(SOF_TOP, "app", "debug_overlay.conf")))
-
-		# The '-i IPC4' is a shortcut for '-o path_to_ipc4_overlay' (and more), we
-		# are good if both are provided, because it's no harm to merge the same
-		# overlay twice.
-		if args.ipc == "IPC4":
-			overlays.append(str(pathlib.Path(SOF_TOP, "app", "overlays", platform,
-                            platform_dict["IPC4_CONFIG_OVERLAY"])))
 
 		if overlays:
 			overlays = ";".join(overlays)


### PR DESCRIPTION
Fix the Zephyr Windows build and Intel QB TGL build with following backports:

ec0667a2b4f  xtensa-build-zephyr: remove ipc option
4e74d2b606 .github/zephyr: de-hardcode the remote name in the Windows build too

No changes to functionality.