### PR TITLE
[stable-v2.2] intel: ssp: implement mclk always-on feature

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -736,6 +736,17 @@ static int ssp_set_config_tplg(struct dai *dai, struct ipc_config_dai *common_co
 	ssp->state[DAI_DIR_CAPTURE] = COMP_STATE_PREPARE;
 
 clk:
+	/* MCLK always-on: turn on mclk and never turn it off */
+	if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON) {
+		ret = ssp_mclk_prepare_enable(dai);
+		if (ret < 0)
+			goto out;
+
+		ssp->clk_active |= SSP_CLK_MCLK_AON_REQ;
+
+		dai_info(dai, "ssp_set_config(): enable MCLK for SSP%d", dai->index);
+	}
+
 	switch (config->flags & SOF_DAI_CONFIG_FLAGS_CMD_MASK) {
 	case SOF_DAI_CONFIG_FLAGS_HW_PARAMS:
 		if (ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES) {
@@ -910,7 +921,8 @@ static int ssp_pre_start(struct dai *dai)
 	 * We will test if mclk/bclk is configured in
 	 * ssp_mclk/bclk_prepare_enable/disable functions
 	 */
-	if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ)) {
+	if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ) &&
+	    !(ssp->clk_active & SSP_CLK_MCLK_AON_REQ)) {
 		/* MCLK config */
 		ret = ssp_mclk_prepare_enable(dai);
 		if (ret < 0)
@@ -940,7 +952,8 @@ static void ssp_post_stop(struct dai *dai)
 				 dai->index);
 			ssp_bclk_disable_unprepare(dai);
 		}
-		if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ)) {
+		if (!(ssp->clk_active & SSP_CLK_MCLK_ES_REQ) &&
+		    !(ssp->clk_active & SSP_CLK_MCLK_AON_REQ)) {
 			dai_info(dai, "ssp_post_stop releasing MCLK clocks for SSP%d...",
 				 dai->index);
 			ssp_mclk_disable_unprepare(dai);

--- a/src/include/ipc/dai-intel.h
+++ b/src/include/ipc/dai-intel.h
@@ -60,6 +60,8 @@
 #define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_ES		BIT(6)
 /* bclk early start */
 #define SOF_DAI_INTEL_SSP_CLKCTRL_BCLK_ES		BIT(7)
+/* mclk always on */
+#define SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON		BIT(8)
 
 /* DMIC max. four controllers for eight microphone channels */
 #define SOF_DAI_INTEL_DMIC_NUM_CTRL			4

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -29,8 +29,8 @@
 
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
-#define SOF_ABI_MINOR 22
-#define SOF_ABI_PATCH 1
+#define SOF_ABI_MINOR 23
+#define SOF_ABI_PATCH 0
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/sof/drivers/ssp.h
+++ b/src/include/sof/drivers/ssp.h
@@ -232,6 +232,7 @@ extern const struct dai_driver ssp_driver;
 #define SSP_CLK_MCLK_ACTIVE	BIT(1)
 #define SSP_CLK_BCLK_ES_REQ	BIT(2)
 #define SSP_CLK_BCLK_ACTIVE	BIT(3)
+#define SSP_CLK_MCLK_AON_REQ	BIT(4)
 
 /* SSP private data */
 struct ssp_pdata {

--- a/tools/topology/topology1/platform/common/ssp.m4
+++ b/tools/topology/topology1/platform/common/ssp.m4
@@ -34,6 +34,8 @@ dnl SSP_CC_MCLK_ES 64 = (1 << 6)
 define(`SSP_CC_MCLK_ES', 64)
 dnl SSP_CC_BCLK_ES 128 = (1 << 7)
 define(`SSP_CC_BCLK_ES', 128)
+dnl SSP_CC_BCLK_ES 256 = (1 << 8)
+define(`SSP_CC_MCLK_AON', 256)
 
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, bclk_delay,
 dnl clks_control, pulse_width, padding)


### PR DESCRIPTION
In the earliest design, mclk is turned on in set_config() and never turned off. The behavior is modified in this commit:

d5840a920073 ("ssp: move mclk request/release to pre_start and post_stop")

Now the mclk is enabled only during audio streaming so some codec may pop. This commit adds the always-on behavior back as an new feature.

Signed-off-by: Brent Lu <brent.lu@intel.com>
(cherry picked from commit 8dfc008b8b99a1bdbe7707739b62714aaa65abf6)