### PR TITLE
Trace: Rename UNUSED() macro to SOF_TRACE_UNUSED()

### DIFF
--- a/src/include/sof/trace/preproc.h
+++ b/src/include/sof/trace/preproc.h
@@ -158,7 +158,7 @@
 		return_t META_CONCAT(prefix, postfix) (args)
 
 /* counteract compiler warning about unused variables */
-#define UNUSED(arg1, ...) do { META_RECURSE( \
+#define SOF_TRACE_UNUSED(arg1, ...) do { META_RECURSE( \
 	META_MAP_AGGREGATE(1, _META_VOID2, _META_VOID(arg1), __VA_ARGS__)); \
 	} while (0)
 

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -93,7 +93,7 @@ static inline struct trace *trace_get(void)
 
 /* Silences compiler warnings about unused variables */
 #define trace_unused(class, ctx, id_1, id_2, format, ...) \
-	UNUSED(ctx, id_1, id_2, ##__VA_ARGS__)
+	SOF_TRACE_UNUSED(ctx, id_1, id_2, ##__VA_ARGS__)
 
 struct trace_filter {
 	uint32_t uuid_id;	/**< type id, or 0 when not important */


### PR DESCRIPTION
The xt-clang RI-2022.10 compiler headers define UNUSED. The rename of the macro for trace fixes in testbench build this error:

  In file included sof/tools/tplg_parser/pga.c:17:
  In file included sof/tools/tplg_parser/
  ../../src/include/sof/lib/uuid.h:11:
  In file included sof/tools/tplg_parser/
  ../../src/include/sof/common.h:105:
  /home/singalsu/work/current/sof/sof/tools/tplg_parser/
  ../../src/include/sof/trace/preproc.h:162:9: error:
  'UNUSED' macro redefined [-Werror,-Wmacro-redefined]
  #define UNUSED(arg1, ...) do { META_RECURSE(
  xtensa/XtDevTools/install/tools/RI-2022.10-linux/XtensaTools/
  xtensa-elf/include/xtensa/xtensa-types.h:60:9:
  note: previous definition is here
  #define UNUSED(x)       ((void)(x))