### PR TITLE
mailbox: use uncached address to write sw regs

### DIFF
--- a/src/platform/intel/ace/include/ace/lib/mailbox.h
+++ b/src/platform/intel/ace/include/ace/lib/mailbox.h
@@ -80,12 +80,12 @@ static inline uint64_t mailbox_sw_reg_read64(size_t offset)
 
 static inline void mailbox_sw_regs_write(size_t offset, const void *src, size_t bytes)
 {
-	int regs_write_err __unused = memcpy_s((void *)(MAILBOX_SW_REG_BASE + offset),
-					       MAILBOX_SW_REG_SIZE - offset, src, bytes);
+	uint32_t __sparse_cache *ptr_c;
+	uint32_t *ptr;
 
-	assert(!regs_write_err);
-	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_SW_REG_BASE +
-								       offset), bytes);
+	ptr_c = (uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache(ptr_c);
+	memcpy_s(ptr, MAILBOX_SW_REG_SIZE - offset, src, bytes);
 }
 
 #endif /* __ACE_LIB_MAILBOX_H__ */

--- a/src/platform/intel/cavs/include/cavs/lib/mailbox.h
+++ b/src/platform/intel/cavs/include/cavs/lib/mailbox.h
@@ -108,12 +108,12 @@ static inline uint64_t mailbox_sw_reg_read64(size_t offset)
 
 static inline void mailbox_sw_regs_write(size_t offset, const void *src, size_t bytes)
 {
-	int regs_write_err __unused = memcpy_s((void *)(MAILBOX_SW_REG_BASE + offset),
-					       MAILBOX_SW_REG_SIZE - offset, src, bytes);
+	uint32_t __sparse_cache *ptr_c;
+	uint32_t *ptr;
 
-	assert(!regs_write_err);
-	dcache_writeback_region((__sparse_force void __sparse_cache *)(MAILBOX_SW_REG_BASE +
-								       offset), bytes);
+	ptr_c = (uint32_t __sparse_cache *)(MAILBOX_SW_REG_BASE + offset);
+	ptr = cache_to_uncache(ptr_c);
+	memcpy_s(ptr, MAILBOX_SW_REG_SIZE - offset, src, bytes);
 }
 
 #endif /* __CAVS_LIB_MAILBOX_H__ */


### PR DESCRIPTION
mailbox_sw_regs_write is used by dai to update llp node. In multi-core test, the updated llp node is invisable to other cores although dcache_writeback_region is used on both cavs & ace platforms. Now use uncached address to write memory directly which is aligned with other mailbox access functions.

Validated on cavs & ace platforms.

multi-core topology: https://github.com/thesofproject/sof/pull/8240