### PR TITLE
rimage: module: Fix section order in output image

### DIFF
--- a/tools/rimage/src/include/rimage/module.h
+++ b/tools/rimage/src/include/rimage/module.h
@@ -63,8 +63,9 @@ struct module_sections_info {
 	/* sections count */
 	unsigned int count;
 
-	/* First section */
+	/* sections list */
 	struct module_section *first_section;
+	struct module_section *last_section;
 };
 
 /*


### PR DESCRIPTION
Fixed the order in which sections are placed in the output firmware image for platforms using a simple manifest.

Fixes: #8336