### PR TITLE
topology2: google-rtc-aec: adjust the IBS/OBS size based on process needs

### DIFF
--- a/tools/topology/topology2/include/components/google-rtc-aec.conf
+++ b/tools/topology/topology2/include/components/google-rtc-aec.conf
@@ -14,6 +14,8 @@
 # Where N is the unique instance number for the google-rtc-aec object within the same alsaconf node.
 Define {
 	AEC_UUID	"a6:a0:80:b7:9f:26:6f:46:b4:77:23:df:a0:5a:f7:58"
+	# AEC requires 10ms buffers for processing
+	BUFFER_PERIOD_MS	10
 }
 
 Class.Widget."google-rtc-aec" {
@@ -96,6 +98,7 @@ Class.Widget."google-rtc-aec" {
 			input_pin_index		0
 			in_bit_depth            16
 			in_valid_bit_depth      16
+			ibs "$[(($in_channels * ($[($in_rate + 999)] / 1000)) * ($in_bit_depth / 8)) * $BUFFER_PERIOD_MS ]"
 		}
 		# 4ch 16-bit on Pin 0
 		{
@@ -105,12 +108,14 @@ Class.Widget."google-rtc-aec" {
 			in_channels		4
 			in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
 			in_ch_map		$CHANNEL_MAP_3_POINT_1
+			ibs "$[(($in_channels * ($[($in_rate + 999)] / 1000)) * ($in_bit_depth / 8)) * $BUFFER_PERIOD_MS]"
 		}
 		# 2ch 16-bit on Pin 1
 		{
 			input_pin_index		1
 			in_bit_depth            16
 			in_valid_bit_depth      16
+			ibs "$[(($in_channels * ($[($in_rate + 999)] / 1000)) * ($in_bit_depth / 8)) * $BUFFER_PERIOD_MS]"
 		}
 	]
 
@@ -118,6 +123,8 @@ Class.Widget."google-rtc-aec" {
 		{
 			out_bit_depth           16
 			out_valid_bit_depth     16
+			obs "$[(($out_channels * ($[($out_rate + 999)] / 1000)) * ($out_bit_depth / 8)) * $BUFFER_PERIOD_MS]"
+
 		}
 		# 4ch 16-bit
 		{
@@ -126,6 +133,8 @@ Class.Widget."google-rtc-aec" {
 			out_channels		4
 			out_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
 			out_ch_map		$CHANNEL_MAP_3_POINT_1
+			obs "$[(($out_channels * ($[($out_rate + 999)] / 1000)) * ($out_bit_depth / 8)) * $BUFFER_PERIOD_MS]"
+
 		}
 	]
 


### PR DESCRIPTION
Add new token to adjust the input/output buffer size for process modules.