### PR TITLE
rimage: mtl/lnl: fix key slot setup based on imr type

### DIFF
--- a/tools/rimage/config/lnl.toml
+++ b/tools/rimage/config/lnl.toml
@@ -44,7 +44,6 @@ length = "0x0"  # calculated by rimage
 
 [signed_pkg]
 name = "ADSP"
-partition_usage = "0x23"
 [[signed_pkg.module]]
 name = "ADSP.met"
 

--- a/tools/rimage/config/mtl.toml
+++ b/tools/rimage/config/mtl.toml
@@ -44,7 +44,6 @@ length = "0x0"  # calculated by rimage
 
 [signed_pkg]
 name = "ADSP"
-partition_usage = "0x23"
 [[signed_pkg.module]]
 name = "ADSP.met"
 

--- a/tools/rimage/src/adsp_config.c
+++ b/tools/rimage/src/adsp_config.c
@@ -1087,9 +1087,7 @@ static int parse_signed_pkg_ace_v1_5(const toml_table_t *toml, struct parse_ctx 
 	if (ret < 0)
 		return ret;
 
-	out->partition_usage = parse_uint32_hex_key(signed_pkg, &ctx, "partition_usage", 0, &ret);
-	if (ret < 0)
-		return ret;
+	out->partition_usage = 0x20 + image->imr_type;
 
 	/* check everything parsed, expect 1 more array */
 	ctx.array_cnt += 1;

--- a/tools/rimage/src/rimage.c
+++ b/tools/rimage/src/rimage.c
@@ -191,8 +191,6 @@ int main(int argc, char *argv[])
 	}
 
 	if (image.adsp->man_ace_v1_5) {
-		if (imr_type_override)
-			image.adsp->man_ace_v1_5->adsp_file_ext.imr_type = image.imr_type;
 		image.adsp->man_ace_v1_5->css.reserved0 = pv_bit;
 	}
 


### PR DESCRIPTION
Clean cherry-picks of two commits from separate rimage repo https://github.com/thesofproject/rimage/commits/stable-v2.7

This will properly setup partition_usage field
and remove fixed 0x23 value from MTL toml

Signed-off-by: Adrian Bonislawski <adrian.bonislawski@intel.com>
(cherry picked from commit fbea59358d06ffa86645cdf4ce0996e352742eb5)

Second, squashed LNL commit:

config/lnl.toml: drop now invalid signed_pkg.partition_usage

Fixes commit fbea59358d06 ("rimage: mtl: fix key slot setup based on imr type") which broke LNL compilation like this:

```
error: 1 unparsed keys left in 'signed_pkg'
error: key 'signed_pkg' parsing error
```

This commit does not change the final image (compared to before rimage commit fbea59358d06) because the default value is now 0x20 + IMR type.

Fixes are normally submitted to the main branch first and then cherry picked to stable branches. However MTL fbea59358d06 has been made in stable-v2.7 first so the LNL change was also in stable-v2.7 first for consistency.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
(cherry picked from commit 469102a8f6052ce6a374b870ea945a84d04c3b1a)