### PR TITLE
idc: bugfix - exit code was not passed to the caller

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -138,6 +138,9 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	switch (mode) {
 	case IDC_BLOCKING:
 		ret = k_p4wq_wait(work, K_FOREVER);
+		if (!ret)
+			/* message was sent and executed successfully, get status code */
+			ret = idc_msg_status_get(msg->core);
 		break;
 	case IDC_POWER_UP:
 	case IDC_NON_BLOCKING:


### PR DESCRIPTION
When executing a blocking operation on a remote core it is expected that an exit code of the operation is passed to the caller as if the operation was on the same core

In fact, a result of message passing was returned, so in most cases result was success, no matter what operation result was