### PR TITLE
smart_amp: fix code and re-enable it on stub builds

### DIFF
--- a/app/stub_build_all_ipc3.conf
+++ b/app/stub_build_all_ipc3.conf
@@ -9,9 +9,5 @@ CONFIG_WAVES_CODEC=y
 CONFIG_DTS_CODEC=y
 CONFIG_COMP_IGO_NR=y
 CONFIG_COMP_RTNR=y
-# temporarily disabled until it compiles:
-# sof/src/audio/smart_amp/smart_amp.c:748:9: error:
-#    no member named 'in_channels' in 'struct smart_amp_data'
-#              sad->in_channels = audio_stream_get_channels(&source_buffer->stream);
-CONFIG_COMP_SMART_AMP=n
+CONFIG_COMP_SMART_AMP=y
 CONFIG_MAXIM_DSM=y

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -741,12 +741,10 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		struct comp_buffer *source_buffer = container_of(blist, struct comp_buffer,
 								 sink_list);
 
-		if (source_buffer->source->ipc_config.type == SOF_COMP_DEMUX) {
+		if (source_buffer->source->ipc_config.type == SOF_COMP_DEMUX)
 			sad->feedback_buf = source_buffer;
-		} else {
+		else
 			sad->source_buf = source_buffer;
-			sad->in_channels = audio_stream_get_channels(&source_buffer->stream);
-		}
 	}
 
 	/* sink buffer */


### PR DESCRIPTION
Fixes smart_amp.c
@marc-hb 