### PR TITLE
basefw: add support for fw config query for context save

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -112,6 +112,10 @@ static int basefw_config(uint32_t *data_offset, char *data)
 	tlv_value_set(tuple, IPC4_SCHEDULER_CONFIGURATION, sizeof(sche_cfg), &sche_cfg);
 
 	tuple = tlv_next(tuple);
+	tlv_value_uint32_set(tuple, IPC4_FW_CONTEXT_SAVE,
+			     IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE));
+
+	tuple = tlv_next(tuple);
 	*data_offset = (int)((char *)tuple - data);
 
 	return 0;

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -359,6 +359,12 @@ enum ipc4_fw_config_params {
 	IPC4_TELEMETRY_BUFFER_SIZE = 24,
 	/* HW version information  */
 	IPC4_BUS_HARDWARE_ID = 25,
+	/* Total memory size available in debug window */
+	IPC4_DEBUG_WINDOW_SIZE = 26,
+	/* Number of realtime Key Phrase Buffer (KPB) output pins */
+	IPC4_KPB_RT_SINK_COUNT = 27,
+	/* Manual control of DMI L1 state */
+	IPC4_DMI_FORCE_L1_EXIT = 28,
 	/* Total number of FW config parameters  */
 	IPC4_FW_CFG_PARAMS_COUNT,
 	/* Max config parameter id */

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -365,6 +365,8 @@ enum ipc4_fw_config_params {
 	IPC4_KPB_RT_SINK_COUNT = 27,
 	/* Manual control of DMI L1 state */
 	IPC4_DMI_FORCE_L1_EXIT = 28,
+	/* FW context save on D3 entry */
+	IPC4_FW_CONTEXT_SAVE = 29,
 	/* Total number of FW config parameters  */
 	IPC4_FW_CFG_PARAMS_COUNT,
 	/* Max config parameter id */


### PR DESCRIPTION
If CONFIG_ADSP_IMR_CONTEXT_SAVE is enabled, base fw will report fw_context_save is supported to host

kernel pr: https://github.com/thesofproject/linux/pull/4680