### PR TITLE
[SKIP SOF-TEST] app/sample.yml: add MTL and LNL to Zephyr CI

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -1,3 +1,4 @@
+---
 sample:
   description: Audio with SOF
   name: sof
@@ -9,10 +10,14 @@ tests:
   sample.audio.sof:
     tags: sof
     build_only: true
-    platform_allow: intel_adsp_cavs25 nxp_adsp_imx8 nxp_adsp_imx8x nxp_adsp_imx8m
+    platform_allow:
+      intel_adsp_cavs25 intel_adsp_ace15_mtpm intel_adsp_ace20_lnl
+      nxp_adsp_imx8 nxp_adsp_imx8x nxp_adsp_imx8m
 
     integration_platforms:
-      - intel_adsp_cavs25
+      - intel_adsp_cavs25  # TGL
+      - intel_adsp_ace15_mtpm  # MTL
+      - intel_adsp_ace20_lnl
       - nxp_adsp_imx8
       - nxp_adsp_imx8x
       - nxp_adsp_imx8m


### PR DESCRIPTION
This will catch earlier compile-time regressions like this one: https://github.com/zephyrproject-rtos/zephyr/pull/61166#issuecomment-1789717233

Zephyr commit 06cfbd4159fd ("drivers: power_domain: Introduce a gpio monitor driver")