### PR TITLE
schedule: Fix input/output error when using zephyr dma domain

### DIFF
--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -273,6 +273,9 @@ static int register_dma_irq(struct zephyr_dma_domain *domain,
 			if (core != crt_chan->core)
 				continue;
 
+			if (dma_chan_is_registered(crt_chan))
+				continue;
+
 			/* get IRQ number for current channel */
 			irq = interrupt_get_irq(dma_chan_irq(crt_dma, j),
 						dma_chan_irq_name(crt_dma, j));
@@ -308,6 +311,8 @@ static int register_dma_irq(struct zephyr_dma_domain *domain,
 			/* bind registrable ptask to channel */
 			chan_data->pipe_task = pipe_task;
 			chan_data->irq_data = crt_irq_data;
+
+			dma_chan_register(crt_chan);
 
 			list_item_append(&chan_data->list, &crt_irq_data->channels);
 
@@ -557,6 +562,8 @@ static int zephyr_dma_domain_unregister(struct ll_schedule_domain *domain,
 		tr_warn(&ll_tr, "trying to unregister ptask %p while channel still active.",
 			pipe_task);
 	}
+
+	dma_chan_unregister(chan_data->channel);
 
 	/* remove channel from parent IRQ's list */
 	list_item_del(&chan_data->list);

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -243,6 +243,8 @@ struct dma_chan_data {
 	/* true if this DMA channel is the scheduling source */
 	bool is_scheduling_source;
 
+	bool registered;
+
 	/* device specific data set by the device that requests the DMA channel */
 	void *dev_data;
 
@@ -493,6 +495,21 @@ static inline void dma_chan_reg_update_bits16(struct dma_chan_data *channel,
 static inline bool dma_is_scheduling_source(struct dma_chan_data *channel)
 {
 	return channel->is_scheduling_source;
+}
+
+static inline void dma_chan_register(struct dma_chan_data *channel)
+{
+	channel->registered = true;
+}
+
+static inline void dma_chan_unregister(struct dma_chan_data *channel)
+{
+	channel->registered = false;
+}
+
+static inline bool dma_chan_is_registered(struct dma_chan_data *channel)
+{
+	return channel->registered;
 }
 
 static inline void dma_sg_init(struct dma_sg_elem_array *ea)


### PR DESCRIPTION
Run cmd: "arecord -Dhw:1,0 -f S16_LE -r 48000 -c 2 -d 4 rec.wav & sleep 2; aplay -Dhw:1,0 S168K2C.wav" on imx8qxp, we get input output error issue.

The issue caused by try to free playback dma chan when stopping record, causing playback can't get right dma chan at begainning only according to the dma_chan status.

Add registerd flag for dma chan and correct this issue.