### PR TITLE
DRC: math: Replace exponential function for performance

### DIFF
--- a/src/audio/drc/Kconfig
+++ b/src/audio/drc/Kconfig
@@ -4,7 +4,7 @@ config COMP_DRC
 	bool "Dynamic Range Compressor component"
 	select CORDIC_FIXED
 	select NUMBERS_NORM
-	select MATH_DECIBELS
+	select MATH_EXP
 	select COMP_BLOB
 	default n
 	help

--- a/src/audio/drc/drc_math_generic.c
+++ b/src/audio/drc/drc_math_generic.c
@@ -6,6 +6,7 @@
 
 #include <sof/audio/format.h>
 #include <sof/math/decibels.h>
+#include <sof/math/exp_fcn.h>
 #include <sof/math/numbers.h>
 #include <sof/math/trig.h>
 
@@ -234,7 +235,7 @@ inline int32_t drc_pow_fixed(int32_t x, int32_t y)
 		return 0;
 
 	/* x^y = expf(y * log(x)) */
-	return exp_fixed(q_mult(y, drc_log_fixed(x), 30, 26, 27));
+	return sofm_exp_fixed(q_mult(y, drc_log_fixed(x), 30, 26, 27));
 }
 
 #undef q_multq

--- a/src/include/sof/math/exp_fcn.h
+++ b/src/include/sof/math/exp_fcn.h
@@ -59,5 +59,7 @@
 #define SOFM_EXP_LSHIFT_BITS 0x2000
 
 int32_t sofm_exp_int32(int32_t x);
+int32_t sofm_exp_fixed(int32_t x);
+int32_t sofm_db2lin_fixed(int32_t db);
 
 #endif /* __SOFM_EXP_FCN_H__ */

--- a/src/include/sof/math/exp_fcn.h
+++ b/src/include/sof/math/exp_fcn.h
@@ -5,8 +5,8 @@
  * Author: Shriram Shastry <malladi.sastry@linux.intel.com>
  *
  */
-#ifndef __SOFM_EXP_H__
-#define __SOFM_EXP_H__
+#ifndef __SOFM_EXP_FCN_H__
+#define __SOFM_EXP_FCN_H__
 
 #include <stdint.h>
 
@@ -26,6 +26,38 @@
 
 #endif
 
-int32_t sofm_exp_int32(int32_t x);
+/* TODO: Is there a MCPS difference */
+#define USING_QCONVERT	1
+
+#if USING_QCONVERT
+
+#include <sof/audio/format.h>
+#define SOFM_EXP_FIXED_INPUT_MIN	Q_CONVERT_FLOAT(-11.5, 27)		/* Q5.27 */
+#define SOFM_EXP_FIXED_INPUT_MAX	Q_CONVERT_FLOAT(7.6245, 27)		/* Q5.27 */
+#define SOFM_EXP_TWO_Q27		Q_CONVERT_FLOAT(2.0, 27)		/* Q5.27 */
+#define SOFM_EXP_MINUS_TWO_Q27		Q_CONVERT_FLOAT(-2.0, 27)		/* Q5.27 */
+#define SOFM_EXP_ONE_Q20		Q_CONVERT_FLOAT(1.0, 20)		/* Q12.20 */
+#define SOFM_EXP_MINUS_100_Q24		Q_CONVERT_FLOAT(-100.0, 24)		/* Q8.24 */
+#define SOFM_EXP_LOG10_DIV20_Q27	Q_CONVERT_FLOAT(0.1151292546, 27)	/* Q5.27 */
+
+#else
+
+#define SOFM_EXP_FIXED_INPUT_MIN	-1543503872	/* Q_CONVERT_FLOAT(-11.5, 27) */
+#define SOFM_EXP_FIXED_INPUT_MAX	 1023343067	/* Q_CONVERT_FLOAT(7.6245, 27) */
+#define SOFM_EXP_TWO_Q27		 268435456	/* Q_CONVERT_FLOAT(2.0, 27) */
+#define SOFM_EXP_MINUS_TWO_Q27		-268435456	/* Q_CONVERT_FLOAT(-2.0, 27) */
+#define SOFM_EXP_ONE_Q20		 1048576	/* Q_CONVERT_FLOAT(1.0, 20) */
+#define SOFM_EXP_MINUS_100_Q24		-1677721600	/* Q_CONVERT_FLOAT(-100.0, 24) */
+#define SOFM_EXP_LOG10_DIV20_Q27	 15452387	/* Q_CONVERT_FLOAT(0.1151292546, 27) */
 
 #endif
+
+#define SOFM_EXP_BIT_MASK_LOW_Q27P5 0x0000000008000000
+#define SOFM_EXP_BIT_MASK_Q62P2 0x4000000000000000LL
+#define SOFM_EXP_QUOTIENT_SCALE 0x40000000
+#define SOFM_EXP_TERMS_Q23P9 0x800000
+#define SOFM_EXP_LSHIFT_BITS 0x2000
+
+int32_t sofm_exp_int32(int32_t x);
+
+#endif /* __SOFM_EXP_FCN_H__ */

--- a/src/math/exp_fcn_hifi.c
+++ b/src/math/exp_fcn_hifi.c
@@ -85,7 +85,7 @@ static void mul_s64(ae_int64 in_0, ae_int64 in_1, ae_int64 *__restrict__ ptroutb
 		    ae_int64 *__restrict__ ptroutbitslo)
 {
 	ae_int64 producthihi, producthilo, productlolo;
-	ae_int64 producthi, productlo, product_hl_lh_h, product_hl_lh_l, carry;
+	ae_int64 producthi, product_hl_lh_h, product_hl_lh_l, carry;
 
 #if (SOFM_EXPONENTIAL_HIFI4 == 1 || SOFM_EXPONENTIAL_HIFI5 == 1)
 
@@ -126,6 +126,7 @@ static void mul_s64(ae_int64 in_0, ae_int64 in_1, ae_int64 *__restrict__ ptroutb
 	ae_int64 producthi_1c;
 	ae_int64 producthi_2c;
 	ae_int64 productlo_2c;
+	ae_int64 productlo;
 
 	ae_int64 s0 = AE_SRLI64(in_0, 63);
 	ae_int64 s1 = AE_SRLI64(in_1, 63);
@@ -190,7 +191,7 @@ static int64_t lomul_s64_sr_sat_near(int64_t a, int64_t b)
 	return AE_ADD64(temp, roundup);
 }
 
-static ae_int64 onebyfact_Q63[19] = {
+static const int64_t onebyfact_Q63[19] = {
 		4611686018427387904LL,
 		1537228672809129301LL,
 		384307168202282325LL,
@@ -235,7 +236,7 @@ int32_t sofm_exp_int32(int32_t x)
 	ae_int64 onebyfact;
 	ae_int64 temp;
 
-	ae_int64 *ponebyfact_Q63 = &onebyfact_Q63[0];
+	ae_int64 *ponebyfact_Q63 = (ae_int64 *)onebyfact_Q63;
 	ae_int64 ts = SOFM_EXP_TERMS_Q23P9;
 	ae_int64 mp = (x + SOFM_EXP_LSHIFT_BITS) >> 14; /* x in Q50.14 */;
 	xtbool flag;

--- a/src/math/exp_fcn_hifi.c
+++ b/src/math/exp_fcn_hifi.c
@@ -27,11 +27,7 @@
 #endif
 
 #define SOFM_CONVERG_ERROR 28823037624320LL /* error smaller than 1e-4,1/2 ^ -44.7122876209085 */
-#define SOFM_BIT_MASK_LOW_Q27P5 0x0000000008000000
-#define SOFM_BIT_MASK_Q62P2 0x4000000000000000LL
-#define SOFM_QUOTIENT_SCALE BIT(30)
-#define SOFM_TERMS_Q23P9 0x800000
-#define SOFM_LSHIFT_BITS 0x2000
+
 /*
  * Arguments	: int64_t in_0
  *		  int64_t in_1
@@ -186,7 +182,7 @@ static int64_t lomul_s64_sr_sat_near(int64_t a, int64_t b)
 
 	mul_s64(a, b, &u64_chi, &u64_clo);
 
-	ae_int64 roundup = AE_AND64(u64_clo, SOFM_BIT_MASK_LOW_Q27P5);
+	ae_int64 roundup = AE_AND64(u64_clo, SOFM_EXP_BIT_MASK_LOW_Q27P5);
 
 	roundup = AE_SRLI64(roundup, 27);
 	temp = AE_OR64(AE_SLAI64(u64_chi, 36), AE_SRLI64(u64_clo, 28));
@@ -240,15 +236,15 @@ int32_t sofm_exp_int32(int32_t x)
 	ae_int64 temp;
 
 	ae_int64 *ponebyfact_Q63 = &onebyfact_Q63[0];
-	ae_int64 ts = SOFM_TERMS_Q23P9;
-	ae_int64 mp = (x + SOFM_LSHIFT_BITS) >> 14; /* x in Q50.14 */;
+	ae_int64 ts = SOFM_EXP_TERMS_Q23P9;
+	ae_int64 mp = (x + SOFM_EXP_LSHIFT_BITS) >> 14; /* x in Q50.14 */;
 	xtbool flag;
 	int64_t b_n;
 
-	mul_s64(mp, SOFM_BIT_MASK_Q62P2, &outhi, &outlo);
+	mul_s64(mp, SOFM_EXP_BIT_MASK_Q62P2, &outhi, &outlo);
 	qt = AE_OR64(AE_SLAI64(outhi, 46), AE_SRLI64(outlo, 18));
 
-	temp = AE_SRAI64(AE_ADD64(qt, SOFM_QUOTIENT_SCALE), 35);
+	temp = AE_SRAI64(AE_ADD64(qt, SOFM_EXP_QUOTIENT_SCALE), 35);
 
 	ts = AE_ADD64(ts, temp);
 
@@ -260,7 +256,7 @@ int32_t sofm_exp_int32(int32_t x)
 		mul_s64(mp, onebyfact, &outhi, &outlo);
 		qt = AE_OR64(AE_SLAI64(outhi, 45), AE_SRLI64(outlo, 19));
 
-		temp = AE_SRAI64(AE_ADD64(qt, SOFM_QUOTIENT_SCALE), 35);
+		temp = AE_SRAI64(AE_ADD64(qt, SOFM_EXP_QUOTIENT_SCALE), 35);
 		ts = AE_ADD64(ts, temp);
 
 		mp = lomul_s64_sr_sat_near(mp, (int64_t)x);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -370,6 +370,8 @@ zephyr_library_sources(
 	${SOF_MATH_PATH}/decibels.c
 	${SOF_MATH_PATH}/numbers.c
 	${SOF_MATH_PATH}/trig.c
+	${SOF_MATH_PATH}/exp_fcn.c
+	${SOF_MATH_PATH}/exp_fcn_hifi.c
 
 	# SOF library - parts to transition to Zephyr over time
 	${SOF_LIB_PATH}/clk.c


### PR DESCRIPTION
For DRC performance, replace `exp_small_fixed()` with `sofm_exp_int32()`.
Included supporting change to include `sofm_exp_int32()` within `exp_fixed()`
and repositioned `exp_small_fixed()` for future use.