### PR TITLE
Tools: Testbench: Fix ASRC component load

### DIFF
--- a/tools/testbench/topology.c
+++ b/tools/testbench/topology.c
@@ -50,7 +50,7 @@ static int tb_register_asrc(struct testbench_prm *tp, struct tplg_context *ctx)
 		asrc->source_rate = tp->fs_in;
 
 	/* load asrc component */
-	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(&asrc)) < 0) {
+	if (ipc_comp_new(sof->ipc, ipc_to_comp_new(asrc)) < 0) {
 		fprintf(stderr, "error: new asrc comp\n");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Before the fix the comp->core in ipc_comp_new() is garbage and the check for maximum core count fails. The pointer to struct comp should be passed here instead of asrc.

Fixes:	d9f9340e1a8ebc276fb67bf9e0a0c7bd08e4e52b
	("tplg_parser: split out testbench logic and partition
	features per file.")