### PR TITLE
samples: change smart_amp_test prefix `smart_amp_` to `smart_amp_test_`

### DIFF
--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -21,10 +21,10 @@ static const struct comp_driver comp_smart_amp;
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_comp_uuid, 0x167a961e, 0x8ae4,
+DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
-DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(smart_amp_comp_uuid),
+DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),
 	       LOG_LEVEL_INFO);
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
@@ -537,8 +537,8 @@ static int smart_amp_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_smart_amp = {
 	.type = SOF_COMP_SMART_AMP,
-	.uid = SOF_RT_UUID(smart_amp_comp_uuid),
-	.tctx = &smart_amp_comp_tr,
+	.uid = SOF_RT_UUID(smart_amp_test_comp_uuid),
+	.tctx = &smart_amp_test_comp_tr,
 	.ops = {
 		.create			= smart_amp_new,
 		.free			= smart_amp_free,
@@ -555,11 +555,11 @@ static SHARED_DATA struct comp_driver_info comp_smart_amp_info = {
 	.drv = &comp_smart_amp,
 };
 
-UT_STATIC void sys_comp_smart_amp_init(void)
+UT_STATIC void sys_comp_smart_amp_test_init(void)
 {
 	comp_register(platform_shared_get(&comp_smart_amp_info,
 					  sizeof(comp_smart_amp_info)));
 }
 
-DECLARE_MODULE(sys_comp_smart_amp_init);
-SOF_MODULE_INIT(smart_amp_test, sys_comp_smart_amp_init);
+DECLARE_MODULE(sys_comp_smart_amp_test_init);
+SOF_MODULE_INIT(smart_amp_test, sys_comp_smart_amp_test_init);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -20,10 +20,10 @@
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_comp_uuid, 0x167a961e, 0x8ae4,
+DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
-DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(smart_amp_comp_uuid),
+DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),
 	       LOG_LEVEL_INFO);
 typedef int(*smart_amp_proc)(struct processing_module *mod,
 			     struct input_stream_buffer *bsource,
@@ -376,7 +376,7 @@ static int smart_amp_prepare(struct processing_module *mod,
 	return ret;
 }
 
-static const struct module_interface smart_amp_interface = {
+static const struct module_interface smart_amp_test_interface = {
 	.init = smart_amp_init,
 	.prepare = smart_amp_prepare,
 	.process_audio_stream = smart_amp_process,
@@ -385,5 +385,9 @@ static const struct module_interface smart_amp_interface = {
 	.reset = smart_amp_reset,
 	.free = smart_amp_free
 };
-DECLARE_MODULE_ADAPTER(smart_amp_interface, smart_amp_comp_uuid, smart_amp_comp_tr);
-SOF_MODULE_INIT(smart_amp_test, sys_comp_module_smart_amp_interface_init);
+
+DECLARE_MODULE_ADAPTER(smart_amp_test_interface, smart_amp_test_comp_uuid, smart_amp_test_comp_tr);
+/* DECLARE_MODULE_ADAPTER() creates
+ * "sys_comp_module_<smart_amp_test_interface>_init()" (and a lot more)
+ */
+SOF_MODULE_INIT(smart_amp_test, sys_comp_module_smart_amp_test_interface_init);


### PR DESCRIPTION
Avoids conflicts with the "real" smart_amp.c when the "stub" compilation check enables everything and compiles everything.

Also makes `git grep smart_thing` a bit more convenient in some cases.

Only the IPC3 sample clashed because the real code does not use MODULE_ADAPTER(). Pre-emptively rename the IPC4 sample too for consistency and in case the real code changes its mind later.

Only global symbols are renamed; no need to git churn private symbols.

Fixes commit ba2cfe3daa55 ("app/stub*.conf: add
CONFIG_SAMPLE_SMART_AMP=y") which clashed with commit d4d0a0ca134f ("smart_amp: fix code and re-enable it on stub builds")

CI did not detect the clash because these two commits were merged at the same time.

In case anyone is interested, the CI "fix" to prevent this type of race is a GitHub feature called "merge queue" (resp. "merge train" in Gitlab, "commit queue" in the older Chrome infrastructure, etc.)  It would be a heavy lift, overkill for the small size and concurrency of the sof git repo and how rarely these accidents happen (a couple times/year)