### PR TITLE
Tools: Topology2: Remove bytes control from cavs-nocodec-rtcaec.conf

### DIFF
--- a/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
+++ b/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
@@ -346,11 +346,6 @@ Object.Widget.google-rtc-aec [
 		Object.Base.input_pin_binding.2 {
 			input_pin_binding_name "dai-copier.SSP.NoCodec-2.capture"
 		}
-
-		Object.Control.bytes."1" {
-			name 'google-rtc-aec bytes'
-			<include/components/google-rtc-aec/rtc-aec-blob.conf>
-		}
 	}
 ]
 


### PR DESCRIPTION
It was confirmed that the IPC4 version of Google RTC AEC is not using the bytes control, so it can be safely removed from topology.

This fixes topologies build error:

ALSA lib conf.c:838:(get_char_skip_comments)
Cannot access file include/components/google-rtc-aec/rtc-aec-blob.conf

Fixes: 	64fcebbd64bf8e8be4ec7098215d7281fa6a4791
	("Tools: Topology2: Add nocodec topology to test google-rtc-aec")

Fixes:	#8357