### PR TITLE
topology: imx: fix tdm slot width value

### DIFF
--- a/tools/topology/topology1/sof-imx8-compr-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-compr-wm8960-mixer.m4
@@ -134,5 +134,5 @@ DAI_CONFIG(SAI, SAI_INDEX, 0, DAI_BE_NAME,
 	   SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
 		      SAI_CLOCK(bclk, 3072000, codec_master),
 		      SAI_CLOCK(fsync, 48000, codec_master),
-		      SAI_TDM(2, 16, 3, 3),
+		      SAI_TDM(2, 32, 3, 3),
 		      SAI_CONFIG_DATA(SAI, SAI_INDEX, 0)))

--- a/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
@@ -115,12 +115,12 @@ ifelse(
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
 		SAI_CLOCK(bclk, 3072000, codec_master),
 		SAI_CLOCK(fsync, RATE, codec_master),
-		SAI_TDM(2, 16, 3, 3),
+		SAI_TDM(2, 32, 3, 3),
 		SAI_CONFIG_DATA(SAI, SAI_INDEX, 0)))',
 	CODEC, `wm8962', `
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_in),
 		SAI_CLOCK(bclk, 3072000, codec_master),
 		SAI_CLOCK(fsync, RATE, codec_master),
-		SAI_TDM(2, 16, 3, 3),
+		SAI_TDM(2, 32, 3, 3),
 		SAI_CONFIG_DATA(SAI, SAI_INDEX, 0)))',
 	)


### PR DESCRIPTION
Set correct TDM slot width to 32 bits.

The error has been discovered after commit
0ba64e98ec7d ("SAI: use topology params").
We start using the tdm_slot_width from topology,
rather than hardcoded in code.