### PR TITLE
west.yml: update Zephyr to 26002b060708

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 460c2167e4f3f6489ff0d3f519466a5682d8146b
+      revision: 26002b0607081182cd6183b690dc0f24f1ef7b29
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains 500+ commits, including following directly affecting SOF targets:

0a6fc6f70a25 soc: intel_adsp: cavs: fix dts memory address format
4b02bbc3297f cmake: xtensa: update xtensa SoC to use SOC_LINKER_SCRIPT variable
8bccb645aae8 boards: intel_adsp: fix board flashing
a4b9692155a3 soc: intel_adsp/cavs: add secondary dsp context save support
0891448ac908 soc: intel_adsp: don't enable interrupt before k_cpu_idle
c73e67018d0a power_domain_intel_adsp.c: revert recent INIT_PRIORITY change
385ceb714537 soc: xtensa: nxp_adsp: rt595: move .noinit