### PR TITLE
idc: check if secondary core is down before sending IDC

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -30,6 +30,16 @@
 #include <rtos/alloc.h>
 #include <rtos/spinlock.h>
 #include <ipc/topology.h>
+#include <sof/trace/trace.h>
+#include <sof/lib/uuid.h>
+
+LOG_MODULE_REGISTER(zephyr_idc, CONFIG_SOF_LOG_LEVEL);
+
+/* 5f1ec3f8-faaf-4099-903c-cee98351f169 */
+DECLARE_SOF_UUID("zephyr-idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
+		 0x90, 0x3c, 0xce, 0xe9, 0x83, 0x51, 0xf1, 0x69);
+
+DECLARE_TR_CTX(zephyr_idc_tr, SOF_UUID(zephyr_idc_uuid), LOG_LEVEL_INFO);
 
 /*
  * Inter-CPU communication is only used in
@@ -119,6 +129,10 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	work->handler = idc_handler;
 	work->sync = mode == IDC_BLOCKING;
 
+	if (!cpu_is_core_enabled(target_cpu)) {
+		tr_err(&zephyr_idc_tr, "Core %u is down, cannot sent IDC message", target_cpu);
+		return -EACCES;
+	}
 	if (msg->payload) {
 		idc_send_memcpy_err = memcpy_s(payload->data, sizeof(payload->data),
 					       msg->payload, msg->size);


### PR DESCRIPTION
If for any reason a secondary core is down, IDC message has no chance to be processed. This may lead to process hang in case of blocking calls and to undefined actions in case of non blocking.

This commit adds a check and error log message in case of target core is down.