### PR TITLE
sink_src: add ipc4 update format functions

### DIFF
--- a/src/audio/source_api_helper.c
+++ b/src/audio/source_api_helper.c
@@ -96,6 +96,14 @@ bool source_get_underrun(struct sof_source *source)
 	return source->audio_stream_params->underrun_permitted;
 }
 
+int source_set_frm_fmt(struct sof_source *source, enum sof_ipc_frame frm_fmt)
+{
+	source->audio_stream_params->frame_fmt = frm_fmt;
+	if (source->ops->on_audio_format_set)
+		return source->ops->on_audio_format_set(source);
+	return 0;
+}
+
 int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt)
 {

--- a/src/include/ipc4/base-config.h
+++ b/src/include/ipc4/base-config.h
@@ -244,5 +244,11 @@ void ipc4_base_module_cfg_to_stream_params(const struct ipc4_base_module_cfg *ba
 struct comp_buffer;
 void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 			       const struct ipc4_audio_format *fmt);
+struct sof_source;
+void ipc4_update_source_format(struct sof_source *source,
+			       const struct ipc4_audio_format *fmt);
+struct sof_sink;
+void ipc4_update_sink_format(struct sof_sink *sink,
+			     const struct ipc4_audio_format *fmt);
 
 #endif

--- a/src/include/sof/audio/source_api.h
+++ b/src/include/sof/audio/source_api.h
@@ -134,6 +134,7 @@ uint32_t source_get_buffer_fmt(struct sof_source *source);
 bool source_get_underrun(struct sof_source *source);
 
 /** set of functions for setting audio parameters */
+int source_set_frm_fmt(struct sof_source *source, enum sof_ipc_frame frm_fmt);
 int source_set_valid_fmt(struct sof_source *source,
 			 enum sof_ipc_frame valid_sample_fmt);
 int source_set_rate(struct sof_source *source, unsigned int rate);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1053,3 +1053,37 @@ void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 
 	buf_c->hw_params_configured = true;
 }
+
+void ipc4_update_source_format(struct sof_source *source,
+			       const struct ipc4_audio_format *fmt)
+{
+	enum sof_ipc_frame valid_fmt, frame_fmt;
+
+	source_set_channels(source, fmt->channels_count);
+	source_set_rate(source, fmt->sampling_frequency);
+	audio_stream_fmt_conversion(fmt->depth,
+				    fmt->valid_bit_depth,
+				    &frame_fmt, &valid_fmt,
+				    fmt->s_type);
+
+	source_set_frm_fmt(source, frame_fmt);
+	source_set_valid_fmt(source, valid_fmt);
+	source_set_buffer_fmt(source, fmt->interleaving_style);
+}
+
+void ipc4_update_sink_format(struct sof_sink *sink,
+			     const struct ipc4_audio_format *fmt)
+{
+	enum sof_ipc_frame valid_fmt, frame_fmt;
+
+	sink_set_channels(sink, fmt->channels_count);
+	sink_set_rate(sink, fmt->sampling_frequency);
+	audio_stream_fmt_conversion(fmt->depth,
+				    fmt->valid_bit_depth,
+				    &frame_fmt, &valid_fmt,
+				    fmt->s_type);
+
+	sink_set_frm_fmt(sink, frame_fmt);
+	sink_set_valid_fmt(sink, valid_fmt);
+	sink_set_buffer_fmt(sink, fmt->interleaving_style);
+}


### PR DESCRIPTION
sink/src API must grow to provide similar functionality to comp_buffers.

This commit adds 2 helpers for IPC4 format set