### PR TITLE
dai-zephyr: Do not skip dma_reload() when sink if full

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1287,6 +1287,15 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 	/* return if nothing to copy */
 	if (!frames) {
 		comp_warn(dev, "dai_zephyr_multi_endpoint_copy(): nothing to copy");
+
+		for (i = 0; i < num_endpoints; i++) {
+			ret = dma_reload(dd[i]->chan->dma->z_dev, dd[i]->chan->index, 0, 0, 0);
+			if (ret < 0) {
+				dai_report_xrun(dd[i], dev, 0);
+				return ret;
+			}
+		}
+
 		return 0;
 	}
 


### PR DESCRIPTION
If sink is full and so no bytes were copied, reload DMA anyway as otherwise xrun may happen if reload is skipped for a long time.

This is a back port from mtl-006-drop-stable. It fixes the issue https://github.com/thesofproject/sof/issues/8224.

This fixes dai_zephyr_multi_endpoint_copy() (multi-gateway DAI case). Normal (single gateway DAI) case has been already fixed some time ago by this commit 5ad5da5bc7.