### PR TITLE
audio: google_rtc_audio_processing: fixup undeclared identifier

### DIFF
--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -97,7 +97,7 @@ static void google_rtc_audio_processing_params(struct processing_module *mod)
 
 	list_for_item(source_list, &dev->bsource_list) {
 		sourceb = container_of(source_list, struct comp_buffer, sink_list);
-		if (IPC4_SINK_QUEUE_ID(source->id) == SOF_AEC_FEEDBACK_QUEUE_ID)
+		if (IPC4_SINK_QUEUE_ID(sourceb->id) == SOF_AEC_FEEDBACK_QUEUE_ID)
 			ipc4_update_buffer_format(sourceb, &cd->config.reference_fmt);
 		else
 			ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);


### PR DESCRIPTION
This is fixup for d4b27bfa8ba2b8deb88ec3bb1c9ab4b935535487