### PR TITLE
build: namespace the generated `version.h` - take 2

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -38,7 +38,7 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <user/abi_dbg.h>
 #include <sof_versions.h>
-#include <version.h>
+#include <zephyr/version.h>
 #endif
 #include <sof/lib/ams.h>
 

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -29,7 +29,7 @@
 #include <sof_versions.h>
 
 #ifdef __ZEPHYR__
-#include <version.h>
+#include <zephyr/version.h>
 #endif
 
 #include <errno.h>

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -23,7 +23,7 @@
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/cache.h>
 

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -17,7 +17,7 @@
 #include <rtos/alloc.h>
 
 /* Zephyr includes */
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -29,7 +29,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Zephyr's build time generated `version.h` is now in the `zephyr` to provide proper namespace, update the includes of this module accordingly.

See ZephyrProject upstream PR at:
https://github.com/zephyrproject-rtos/zephyr/pull/63973

Take 1: #8459