### PR TITLE
ipc4: handler: maintain IPC set_pipeline_state order

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -630,6 +630,17 @@ static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 			ipc_compound_pre_start(state.primary.r.type);
 			ret = ipc4_pipeline_trigger(ppl_icd, cmd, &delayed);
 			ipc_compound_post_start(state.primary.r.type, ret, delayed);
+			if (delayed) {
+				/* To maintain pipeline order for triggers, we must
+				 * do a blocking wait until trigger is processed.
+				 * This will add a max delay of 'ppl_count' LL ticks
+				 * to process the full trigger list.
+				 */
+				if (ipc_wait_for_compound_msg() != 0) {
+					ipc_cmd_err(&ipc_tr, "ipc4: fail with delayed trigger");
+					return IPC4_FAILURE;
+				}
+			}
 		}
 
 		if (ret != 0)


### PR DESCRIPTION
Fix a side-effect of commit 068f14381026 ("ipc4: handler: Use separate loops for pipeline state phases") where the order of pipeline triggers was changed when the trigger handling was delayed to the pipeline thread. If host asked for pipelines to be triggered in order 0, 1, 2, the actual trigger order might end up as 2, 1, 0 based on how the pipes were connected.

Fix the issue by adding a blocking wait to the IPC thread between each delayed trigger.

Link: https://github.com/thesofproject/sof/issues/8481