### PR TITLE
intel: ssp: check mclk always-on quirk in ssp_remove

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -1195,9 +1195,18 @@ static int ssp_probe(struct dai *dai)
 
 static int ssp_remove(struct dai *dai)
 {
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
-	ssp_mclk_disable_unprepare(dai);
+	/*
+	 * dai comp will be freed during HW_FREE stage if dynamic pipeline is
+	 * enabled; need to check the MCLK_AON quirk to see if we need to keep
+	 * MCLK on even when dai comp is going to be freed
+	 */
+	if (!(ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON))
+		ssp_mclk_disable_unprepare(dai);
+
 	ssp_bclk_disable_unprepare(dai);
 
 	/* Disable SSP power */

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -499,7 +499,7 @@ ifelse(
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))',
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, eval(SSP_CC_BCLK_ES | SSP_CC_MCLK_AON))))',
 	HEADPHONE, `RT5650', `
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, MCLK_RATE, codec_mclk_in),
 		SSP_CLOCK(bclk, 3072000, codec_slave),

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -238,7 +238,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
                       SSP_CLOCK(bclk, 3072000, codec_slave),
                       SSP_CLOCK(fsync, 48000, codec_slave),
                       SSP_TDM(2, 32, 3, 3),
-                      SSP_CONFIG_DATA(SSP, 0, 32)))
+                      SSP_CONFIG_DATA(SSP, 0, 32, 0, 0, 0, SSP_CC_MCLK_AON)))
 
 # 4 HDMI/DP outputs (ID: 3,4,5,6)
 DAI_CONFIG(HDA, 0, 3, iDisp1,


### PR DESCRIPTION
Dynamic pipeline breaks mclk always-on feature by freeing dai component in HW_FREE stage; the ssp_remove() will be called and disables mclk unconditionally. Check mclk always-on quirk in ssp_remove() to avoid releasing mclk when external codec (i.e. ALC5682)  still needs it.

Linux log:
[  102.479240] sound pcmC0D1p: snd_pcm_common_ioctl: HW_FREE
[  102.479257]  Headset: ASoC: hw_free FE Headset
[  102.479351] sof-audio-pci-intel-tgl 0000:00:1f.3: pcm: free stream 1 dir 0
[  102.479383] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30020000: GLB_TPLG_MSG: COMP_FREE
[  102.479746] sof-audio-pci-intel-tgl 0000:00:1f.3: widget PCM1P freed
[  102.479764] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30210000: GLB_TPLG_MSG: BUFFER_FREE
[  102.480007] sof-audio-pci-intel-tgl 0000:00:1f.3: widget BUF2.0 freed
[  102.480024] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30020000: GLB_TPLG_MSG: COMP_FREE
[  102.480217] sof-audio-pci-intel-tgl 0000:00:1f.3: widget PGA2.0 freed
[  102.480226] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30210000: GLB_TPLG_MSG: BUFFER_FREE
[  102.480422] sof-audio-pci-intel-tgl 0000:00:1f.3: widget BUF2.1 freed
[  102.480432] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30020000: GLB_TPLG_MSG: COMP_FREE
=> DAI component free IPC sent
[  102.480793] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x30110000: GLB_TPLG_MSG: PIPE_FREE
[  102.481688] sof-audio-pci-intel-tgl 0000:00:1f.3: widget PIPELINE.2.SSP0.OUT freed
[  102.481700] sof-audio-pci-intel-tgl 0000:00:1f.3: widget SSP0.OUT freed
[  102.481724]  SSP0-Codec: ASoC: hw_free BE SSP0-Codec

SOF log:
[    51892225.177572] (        1161.093750) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30020000
[    51892245.698404] (          20.520832) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 8 -> free
[    51892266.167153] (          20.468750) c0 host         2.8           src/audio/host.c:682  INFO host_free()
[    51892285.385903] (          19.218750) c0 hda-dma            ..../intel/hda/hda-dma.c:932  INFO hda-dmac :5 -> remove
[    51892382.417149] (          97.031242) c0 dma                           src/lib/dma.c:143  INFO dma_put(), dma = 0x9e07f1c0, sref = 0
[    51892946.479626] (         564.062500) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30210000
[    51892966.167125] (          19.687500) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 10 -> free
[    51893467.208772] (         501.041656) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30020000
[    51893487.104605] (          19.895832) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 9 -> free
[    51893882.885839] (         395.781219) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30210000
[    51893902.521255] (          19.635416) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 11 -> free
[    51894296.114989] (         393.593719) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30020000
=> DAI component free IPC received
[    51894315.958738] (          19.843750) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 12 -> free
[    51894408.406651] (          92.447914) c0 dma                           src/lib/dma.c:143  INFO dma_put(), dma = 0x9e07f100, sref = 0
[    51894428.042067] (          19.635416) c0 ssp-dai      1.0   /drivers/intel/ssp/ssp.c:1197 INFO ssp_remove(): SSP0
[    51894449.656650] (          21.614582) c0 ssp-dai      1.0   /drivers/intel/ssp/ssp.c:174  INFO ssp_mclk_disable_unprepare(): SSP0
=> ssp_removed() is called, mclk is disabled
[    51894471.271232] (          21.614582) c0 power              ../cavs/lib/pm_runtime.c:204  INFO dis_ssp_power index 0
[    51894490.125398] (          18.854166) c0 power              ../cavs/lib/pm_runtime.c:213  INFO dis_ssp_power I2SLCTL 00000000
[    51894517.625397] (          27.499998) c0 dai                           src/lib/dai.c:190  INFO dai_put type 1 index 0 new sref 0
[    51895004.604544] (         486.979156) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x30110000
[    51895024.969127] (          20.364582) c0 ipc                  src/ipc/ipc3/handler.c:1386 INFO ipc: comp 13 -> free
[    51895044.187876] (          19.218750) c0 pipe         2.13  ......./pipeline-graph.c:199  INFO pipeline_free()

