### PR TITLE
topology2: pipeline: document pipeline.priority attribute

### DIFF
--- a/tools/topology/topology2/include/components/pipeline.conf
+++ b/tools/topology/topology2/include/components/pipeline.conf
@@ -57,10 +57,14 @@ Class.Widget."pipeline" {
 		}
 	}
 
-	# pipeline priority
+	# pipeline priority (0 = highest priority, 7 = lowest)
 	DefineAttribute."priority" {
 		# Token reference and type
 		token_ref	"scheduler.word"
+		constraints {
+			min	0
+			max	7
+		}
 	}
 
 	# core that the pipeline should be scheduled on


### PR DESCRIPTION
Add a note that priority 0 is the highest priority and indicates pipeline that should be run first. This matches with the SOF scheduler implementation.