### PR TITLE
topology: Add support for buffer flags

### DIFF
--- a/src/include/kernel/tokens.h
+++ b/src/include/kernel/tokens.h
@@ -33,6 +33,7 @@
 /* buffers */
 #define SOF_TKN_BUF_SIZE			100
 #define SOF_TKN_BUF_CAPS			101
+#define SOF_TKN_BUF_FLAGS			102
 
 /* DAI */
 /* Token retired with ABI 3.2, do not use for new capabilities

--- a/tools/topology/topology1/m4/buffer.m4
+++ b/tools/topology/topology1/m4/buffer.m4
@@ -5,13 +5,16 @@ dnl Define the macro for buffer widget
 dnl N_BUFFER(name)
 define(`N_BUFFER', `BUF'PIPELINE_ID`.'$1)
 
-dnl W_BUFFER(name, size, capabilities)
+dnl W_BUFFER(name, size, capabilities, [core], [flags])
 define(`W_BUFFER',
 `SectionVendorTuples."'N_BUFFER($1)`_tuples" {'
 `	tokens "sof_buffer_tokens"'
 `	tuples."word" {'
 `		SOF_TKN_BUF_SIZE'	STR($2)
 `		SOF_TKN_BUF_CAPS'	STR($3)
+`ifelse(`$#', `5',
+`		SOF_TKN_BUF_FLAGS'	STR($5)
+,` ')'
 `	}'
 `}'
 `SectionData."'N_BUFFER($1)`_data" {'

--- a/tools/tplg_parser/buffer.c
+++ b/tools/tplg_parser/buffer.c
@@ -30,6 +30,8 @@ static const struct sof_topology_token buffer_tokens[] = {
 		offsetof(struct sof_ipc_buffer, size), 0},
 	{SOF_TKN_BUF_CAPS, SND_SOC_TPLG_TUPLE_TYPE_WORD, tplg_token_get_uint32_t,
 		offsetof(struct sof_ipc_buffer, caps), 0},
+	{SOF_TKN_BUF_FLAGS, SND_SOC_TPLG_TUPLE_TYPE_WORD, tplg_token_get_uint32_t,
+		offsetof(struct sof_ipc_buffer, flags), 0},
 };
 
 static const struct sof_topology_token buffer_comp_tokens[] = {


### PR DESCRIPTION
Flags have been a part of IPC3 for ages, add support for them in the topology.