### PR TITLE
west.yml: update Zephyr to efc32081893d

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 063ce9caf54fa656f02ae48f3c9d537659a10dec
+      revision: efc32081893dd607dfc51938ef93787872008fe2
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to bring in following Zephyr commit: efc32081893d soc: intel_adsp: cavs: mask idc interrupt before halting cpu

Link: https://github.com/thesofproject/sof/issues/8492
Fix github CI failure on cavs platforms.