### PR TITLE
[cavs2.5-001] intel: ssp: check mclk always-on quirk in ssp_remove: backport to cavs2.5-001

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -1190,9 +1190,18 @@ static int ssp_probe(struct dai *dai)
 
 static int ssp_remove(struct dai *dai)
 {
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
-	ssp_mclk_disable_unprepare(dai);
+	/*
+	 * dai comp will be freed during HW_FREE stage if dynamic pipeline is
+	 * enabled; need to check the MCLK_AON quirk to see if we need to keep
+	 * MCLK on even when dai comp is going to be freed
+	 */
+	if (!(ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON))
+		ssp_mclk_disable_unprepare(dai);
+
 	ssp_bclk_disable_unprepare(dai);
 
 	/* Disable SSP power */

--- a/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98357a-rt5682.m4
@@ -510,7 +510,7 @@ ifelse(
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))',
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, eval(SSP_CC_BCLK_ES | SSP_CC_MCLK_AON))))',
 	HEADPHONE, `RT5650', `
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, MCLK_RATE, codec_mclk_in),
 		SSP_CLOCK(bclk, 3072000, codec_slave),

--- a/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
+++ b/tools/topology/topology1/sof-tgl-max98373-rt5682.m4
@@ -242,7 +242,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
                       SSP_CLOCK(bclk, 3072000, codec_slave),
                       SSP_CLOCK(fsync, 48000, codec_slave),
                       SSP_TDM(2, 32, 3, 3),
-                      SSP_CONFIG_DATA(SSP, 0, 32)))
+                      SSP_CONFIG_DATA(SSP, 0, 32, 0, 0, 0, SSP_CC_MCLK_AON)))
 
 # 4 HDMI/DP outputs (ID: 3,4,5,6)
 DAI_CONFIG(HDA, 0, 3, iDisp1,


### PR DESCRIPTION
Backport PR https://github.com/thesofproject/sof/pull/8505 cavs2.5-001-drop-stable branch.