### PR TITLE
nxp: imx93_a55: Switch to timer domain and Zephyr native drivers

### DIFF
--- a/app/boards/imx93_evk_mimx9352_a55.conf
+++ b/app/boards/imx93_evk_mimx9352_a55.conf
@@ -26,3 +26,5 @@ CONFIG_DMA_NXP_EDMA_ENABLE_HALFMAJOR_IRQ=y
 # needed because EDMA uses same interrupt for multiple
 # channels.
 CONFIG_SHARED_INTERRUPTS=y
+
+CONFIG_ZEPHYR_NATIVE_DRIVERS=y

--- a/app/boards/imx93_evk_mimx9352_a55.conf
+++ b/app/boards/imx93_evk_mimx9352_a55.conf
@@ -14,3 +14,15 @@ CONFIG_DCACHE_LINE_SIZE=64
 
 CONFIG_IMX93_A55=y
 CONFIG_TRACE=n
+
+# DAI-related configurations
+CONFIG_SAI_HAS_MCLK_CONFIG_OPTION=y
+CONFIG_SAI_IMX93_ERRATA_051421=y
+
+# DMA-related configurations
+CONFIG_DMA=y
+CONFIG_DMA_NXP_EDMA_ENABLE_HALFMAJOR_IRQ=y
+
+# needed because EDMA uses same interrupt for multiple
+# channels.
+CONFIG_SHARED_INTERRUPTS=y

--- a/app/boards/imx93_evk_mimx9352_a55.overlay
+++ b/app/boards/imx93_evk_mimx9352_a55.overlay
@@ -24,18 +24,6 @@
 		reg = <0x42430000 DT_SIZE_K(64)>;
 	};
 
-	sai3: memory@42660000 {
-		reg = <0x42660000 DT_SIZE_K(64)>;
-	};
-
-	edma2_ch0: memory@42010000 {
-		reg = <0x42010000 DT_SIZE_K(32)>;
-	};
-
-	edma2_ch1: memory@42018000 {
-		reg = <0x42018000 DT_SIZE_K(32)>;
-	};
-
 	outbox: memory@ce100000 {
 		reg = <0xce100000 DT_SIZE_K(4)>;
 	};
@@ -58,4 +46,22 @@
 	host_ram: memory@80000000 {
 		reg = <0x80000000 DT_SIZE_M(1024)>;
 	};
+
+	host_dma: dma {
+		compatible = "nxp,sof-host-dma";
+		dma-channels = <32>;
+		#dma-cells = <0>;
+	};
+};
+
+&sai3 {
+	tx-fifo-watermark = <2>;
+	rx-fifo-watermark = <96>;
+	fifo-depth = <96>;
+	rx-sync-mode = <1>;
+	status = "okay";
+};
+
+&edma4 {
+	status = "okay";
 };

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -128,7 +128,6 @@ config IMX93_A55
 	select BUILD_OUTPUT_BIN
 	select ZEPHYR_LOG
 	select HOST_PTABLE
-	select DMA_DOMAIN
 	help
 	 Select if your target platform is imx93-compatible.
 

--- a/src/platform/imx93_a55/platform.c
+++ b/src/platform/imx93_a55/platform.c
@@ -118,12 +118,6 @@ int platform_init(struct sof *sof)
 	if (ret < 0)
 		return -ENODEV;
 
-	/* Initialize DMA domain */
-	sof->platform_dma_domain = zephyr_dma_domain_init(&sof->dma_info->dma_array[0],
-							  1,
-							  PLATFORM_DEFAULT_CLOCK);
-	zephyr_ll_scheduler_init(sof->platform_dma_domain);
-
 	/* Initialize IPC */
 	ipc_init(sof);
 

--- a/tools/topology/topology1/sof-imx93-wm8962.m4
+++ b/tools/topology/topology1/sof-imx93-wm8962.m4
@@ -58,14 +58,14 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, 3, sai3-wm8962,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI is SAI1 using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, 3, sai3-wm8962,
 	PIPELINE_SINK_2, 2, s32le,
-	1000, 0, 0)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 
 # PCM Low Latency, id 0

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 8858a024c0151e3b4cd35262bed935248211d6b1
+      revision: 66b475a3aa4d73f4ddd5be5a7a1e0f3c7028e539
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -323,16 +323,12 @@ if (CONFIG_SOC_MIMX9352_A55)
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/imx93_a55/platform.c
 		${SOF_PLATFORM_PATH}/imx93_a55/lib/clk.c
-		${SOF_PLATFORM_PATH}/imx93_a55/lib/dma.c
-		${SOF_PLATFORM_PATH}/imx93_a55/lib/dai.c
+		lib/dma.c
 	)
 
 	# Drivers
 	zephyr_library_sources(
-		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
 		${SOF_DRIVERS_PATH}/imx/ipc.c
-		${SOF_DRIVERS_PATH}/imx/edma.c
-		${SOF_DRIVERS_PATH}/imx/sai.c
 	)
 
 	zephyr_library_sources(


### PR DESCRIPTION
With this PR, the i.MX93 platform will now start using the timer domain in conjunction with the Zephyr native drivers.

Zephyr dependencies:

1. https://github.com/zephyrproject-rtos/zephyr/pull/65671 (EDMA)
2. https://github.com/zephyrproject-rtos/zephyr/pull/65187 (DAI)
3. https://github.com/zephyrproject-rtos/zephyr/pull/65679 (removal of SAI3 and EDMA static mappings)
4. https://github.com/zephyrproject-rtos/zephyr/pull/65684 (DAI_DIR_{TX/RX} value adjustment)

**Important notes**:

1. Currently, the PR is split in multiple commits. This is done to ease the reviewing process, but most of the commits will be squashed into a single one to avoid breaking git bisect.
2. If git dependency 3 is merged before this PR and the Zephyr revision is bumped up this will lead to SOF no longer working on i.MX93 because the SAI and EDMA address spaces will no longer have any mappings, leading to translation faults.
3. The transition to timer domain is mandatory because the DMA domain is unusable with the Zephyr native drivers ATM.