### PR TITLE
[RFC]: zephyr: CMakeLists: disable packed-related warnings

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -830,6 +830,8 @@ if (NOT CONFIG_COMPILER_INLINE_FUNCTION_OPTION)
 target_compile_options(SOF INTERFACE -fno-inline-functions)
 endif()
 
+target_compile_options(SOF INTERFACE -Wno-address-of-packed-member)
+
 # SOF needs `typeof`, `__VA_ARGS__` and maybe other GNU C99
 # extensions. TODO other flags required ?
 target_compile_options(SOF INTERFACE $<$<COMPILE_LANGUAGE:C,ASM>: -std=gnu99>)


### PR DESCRIPTION
This is an attempt to reduce the compilation warnings on i.MX93 which is a 64-bit platform.

Frankly I doubt this fix is the way to go, but it's a good opportunity to open a discussion. There's a couple of questions that I have:

1. Does "struct coherent" actually need to be packed?
2. Why doesn't this issue appear on 32-bit platforms?
3. Can the issue actually happen?

Ideally, we should try and fix this as it's become very difficult to find the compilation warnings caused by the introduction of new features with the incredible amount of already existing compilation warnings.

**EDIT**: example of such a compilation warning:
`warning: taking address of packed member of 'struct coherent' may result in an unaligned pointer value`