### PR TITLE
disable CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT in performance build

### DIFF
--- a/app/perf_overlay.conf
+++ b/app/perf_overlay.conf
@@ -1,3 +1,6 @@
 CONFIG_PERFORMANCE_COUNTERS=y
 CONFIG_SYS_HEAP_RUNTIME_STATS=y
 CONFIG_TIMING_FUNCTIONS=y
+# Disable L1 EXIT DMA logic in performance build as
+# it add much extra cycles for module performance measurement.
+CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT=n


### PR DESCRIPTION
Due to there is very high peak mcps during performance test(7X+), further investigation shows it may caused by some isr routine, in order to get a more clean module peak performance data, disable this config in performance build only.