### PR TITLE
Fix i.MX93 compilation warnings related to mis-formatting / casting 64-bit types

### DIFF
--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -184,7 +184,7 @@ int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 	}
 #endif
 
-	comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd() pos = %d, fragment size = %d",
+	comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd() pos = %d, fragment size = %zu",
 		 pos, fragment_size);
 
 	/* Check that there is no work-in-progress previous request */

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -262,7 +262,7 @@ static int eq_fir_init(struct processing_module *mod)
 	 * blob size is sane.
 	 */
 	if (bs > SOF_EQ_FIR_MAX_SIZE) {
-		comp_err(dev, "eq_fir_init(): coefficients blob size = %u > SOF_EQ_FIR_MAX_SIZE",
+		comp_err(dev, "eq_fir_init(): coefficients blob size = %zu > SOF_EQ_FIR_MAX_SIZE",
 			 bs);
 		return -EINVAL;
 	}

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -59,7 +59,7 @@ static int eq_iir_init(struct processing_module *mod)
 
 	/* Check first before proceeding with dev and cd that coefficients blob size is sane */
 	if (bs > SOF_EQ_IIR_MAX_SIZE) {
-		comp_err(dev, "eq_iir_init(), coefficients blob size %u exceeds maximum", bs);
+		comp_err(dev, "eq_iir_init(), coefficients blob size %zu exceeds maximum", bs);
 		return -EINVAL;
 	}
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -414,7 +414,7 @@ static int kpb_set_verify_ipc_params(struct comp_dev *dev,
 		       ipc_config->size);
 
 	if (ret) {
-		comp_err(dev, "kpb_new(): cannot memcpy_s %d bytes into sof_kpb_config (%d)\n",
+		comp_err(dev, "kpb_new(): cannot memcpy_s %d bytes into sof_kpb_config (%zu)\n",
 			 ipc_config->size, sizeof(kpb->config));
 		return -EINVAL;
 	}
@@ -478,7 +478,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 
 	/* make sure data size is not bigger than config space */
 	if (ipc_config_size > kpb_config_size) {
-		comp_cl_err(&comp_kpb, "kpb_new(): ipc config size %u too big",
+		comp_cl_err(&comp_kpb, "kpb_new(): ipc config size %zu too big",
 			    ipc_config_size);
 		return NULL;
 	}
@@ -579,7 +579,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 			/* We managed to allocate a block of ca_size.
 			 * Now we initialize it.
 			 */
-			comp_cl_info(&comp_kpb, "kpb new memory block: %d",
+			comp_cl_info(&comp_kpb, "kpb new memory block: %zu",
 				     ca_size);
 			allocated_size += ca_size;
 			hb->start_addr = new_mem_block;
@@ -628,7 +628,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 		}
 	}
 
-	comp_cl_info(&comp_kpb, "kpb_allocate_history_buffer(): allocated %d bytes",
+	comp_cl_info(&comp_kpb, "kpb_allocate_history_buffer(): allocated %zu bytes",
 		     allocated_size);
 
 	return allocated_size;
@@ -1339,7 +1339,7 @@ static int kpb_copy(struct comp_dev *dev)
 
 			comp_update_buffer_consume(source, copy_bytes);
 		} else {
-			comp_warn(dev, "kpb_copy(): buffering skipped (no data to copy, avail %d, free %d",
+			comp_warn(dev, "kpb_copy(): buffering skipped (no data to copy, avail %d, free %zu",
 				  audio_stream_get_avail_bytes(&source->stream),
 				  kpb->hd.free);
 		}
@@ -1837,7 +1837,7 @@ static enum task_state kpb_draining_task(void *arg)
 		 * while we were draining real time stream could provided
 		 * new data which needs to be copy to host.
 		 */
-			comp_cl_info(&comp_kpb, "kpb: update drain_req by %d",
+			comp_cl_info(&comp_kpb, "kpb: update drain_req by %zu",
 				     *rt_stream_update);
 			kpb_lock(kpb);
 			drain_req += *rt_stream_update;
@@ -2295,7 +2295,7 @@ static inline bool validate_host_params(struct comp_dev *dev,
 
 	if (!host_period_size || !host_buffer_size) {
 		/* Wrong host params */
-		comp_err(dev, "kpb: host_period_size (%d) cannot be 0 and host_buffer_size (%d) cannot be 0",
+		comp_err(dev, "kpb: host_period_size (%zu) cannot be 0 and host_buffer_size (%zu) cannot be 0",
 			 host_period_size, host_buffer_size);
 		return false;
 	} else if (HOST_BUFFER_MIN_SIZE(hb_size_req, kpb->config.channels) >
@@ -2303,7 +2303,7 @@ static inline bool validate_host_params(struct comp_dev *dev,
 		/* Host buffer size is too small - history data
 		 * may get overwritten.
 		 */
-		comp_warn(dev, "kpb: host_buffer_size (%d) must be at least %d",
+		comp_warn(dev, "kpb: host_buffer_size (%zu) must be at least %zu",
 			  host_buffer_size,
 			  HOST_BUFFER_MIN_SIZE(hb_size_req, kpb->config.channels));
 	} else if (kpb->sync_draining_mode) {
@@ -2318,7 +2318,7 @@ static inline bool validate_host_params(struct comp_dev *dev,
 		 */
 		if ((host_period_size / KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE) <
 		    pipeline_period_size) {
-			comp_err(dev, "kpb: host_period_size (%d) must be at least %d * %d",
+			comp_err(dev, "kpb: host_period_size (%zu) must be at least %d * %zu",
 				 host_period_size,
 				 KPB_DRAIN_NUM_OF_PPL_PERIODS_AT_ONCE,
 				 pipeline_period_size);

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -30,8 +30,8 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 	comp_dbg(dev, "module_load_config() start");
 
 	if (!cfg || !size) {
-		comp_err(dev, "module_load_config(): wrong input params! dev %x, cfg %x size %zu",
-			 (uint32_t)dev, (uint32_t)cfg, size);
+		comp_err(dev, "module_load_config(): wrong input params! dev %zx, cfg %zx size %zu",
+			 (size_t)dev, (size_t)cfg, size);
 		return -EINVAL;
 	}
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -30,7 +30,7 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 	comp_dbg(dev, "module_load_config() start");
 
 	if (!cfg || !size) {
-		comp_err(dev, "module_load_config(): wrong input params! dev %x, cfg %x size %d",
+		comp_err(dev, "module_load_config(): wrong input params! dev %x, cfg %x size %zu",
 			 (uint32_t)dev, (uint32_t)cfg, size);
 		return -EINVAL;
 	}
@@ -448,7 +448,7 @@ int module_set_configuration(struct processing_module *mod,
 			return 0;
 
 		if (md->new_cfg_size > MAX_BLOB_SIZE) {
-			comp_err(dev, "module_set_configuration(): error: blob size is too big cfg size %d, allowed %d",
+			comp_err(dev, "module_set_configuration(): error: blob size is too big cfg size %zu, allowed %d",
 				 md->new_cfg_size, MAX_BLOB_SIZE);
 			return -EINVAL;
 		}

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -47,8 +47,8 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	comp_cl_dbg(drv, "module_adapter_new() start");
 
 	if (!config) {
-		comp_cl_err(drv, "module_adapter_new(), wrong input params! drv = %x config = %x",
-			    (uint32_t)drv, (uint32_t)config);
+		comp_cl_err(drv, "module_adapter_new(), wrong input params! drv = %zx config = %zx",
+			    (size_t)drv, (size_t)config);
 		return NULL;
 	}
 

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -215,7 +215,8 @@ static int mux_demux_common_init(struct processing_module *mod)
 	comp_dbg(dev, "mux_init()");
 
 	if (cfg->size > MUX_BLOB_MAX_SIZE) {
-		comp_err(dev, "mux_init(): blob size %d exceeds %d", cfg->size, MUX_BLOB_MAX_SIZE);
+		comp_err(dev, "mux_init(): blob size %zu exceeds %zu",
+			 cfg->size, MUX_BLOB_MAX_SIZE);
 		return -EINVAL;
 	}
 
@@ -575,7 +576,7 @@ static int mux_prepare(struct processing_module *mod,
 
 	config = comp_get_data_blob(cd->model_handler, &blob_size, NULL);
 	if (blob_size > MUX_BLOB_MAX_SIZE) {
-		comp_err(dev, "mux_prepare(): illegal blob size %d", blob_size);
+		comp_err(dev, "mux_prepare(): illegal blob size %zu", blob_size);
 		return -EINVAL;
 	}
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -458,7 +458,7 @@ static int selector_prepare(struct comp_dev *dev)
 	sink_size = audio_stream_get_size(&sinkb->stream);
 
 	if (sink_size < cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",
+		comp_err(dev, "selector_prepare(): sink buffer size %zu is insufficient < %d",
 			 sink_size, cd->sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -568,7 +568,7 @@ int src_params_general(struct processing_module *mod,
 
 	cd->delay_lines = rballoc(0, SOF_MEM_CAPS_RAM, delay_lines_size);
 	if (!cd->delay_lines) {
-		comp_err(dev, "src_params(): failed to alloc cd->delay_lines, delay_lines_size = %u",
+		comp_err(dev, "src_params(): failed to alloc cd->delay_lines, delay_lines_size = %zu",
 			 delay_lines_size);
 		return  -EINVAL;
 	}

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -170,7 +170,7 @@ int src_init(struct processing_module *mod)
 	}
 
 	if (!cfg->init_data || cfg->size != sizeof(cd->ipc_config)) {
-		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
+		comp_err(dev, "src_init(): Missing or bad size (%zu) init data",
 			 cfg->size);
 		return -EINVAL;
 	}

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -357,7 +357,7 @@ static int tdfb_init(struct processing_module *mod)
 
 	/* Check first that configuration blob size is sane */
 	if (bs > SOF_TDFB_MAX_SIZE) {
-		comp_err(dev, "tdfb_init() error: configuration blob size = %u > %d",
+		comp_err(dev, "tdfb_init() error: configuration blob size = %zu > %d",
 			 bs, SOF_TDFB_MAX_SIZE);
 		return -EINVAL;
 	}
@@ -579,7 +579,7 @@ static int tdfb_prepare(struct processing_module *mod,
 	/* Initialize tracking */
 	ret = tdfb_direction_init(cd, rate, source_channels);
 	if (!ret) {
-		comp_info(dev, "max_lag = %d, xcorr_size = %d",
+		comp_info(dev, "max_lag = %d, xcorr_size = %zu",
 			  cd->direction.max_lag, cd->direction.d_size);
 		comp_info(dev, "line_array = %d, a_step = %d, a_offs = %d",
 			  (int)cd->direction.line_array, cd->config->angle_enum_mult,

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -79,7 +79,7 @@ int volume_init(struct processing_module *mod)
 	int i;
 
 	if (!vol || cfg->size != sizeof(*vol)) {
-		comp_err(dev, "volume_init(): No configuration data or bad data size %u",
+		comp_err(dev, "volume_init(): No configuration data or bad data size %zu",
 			 cfg->size);
 		return -EINVAL;
 	}
@@ -95,7 +95,7 @@ int volume_init(struct processing_module *mod)
 	cd->vol = rmalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, vol_size);
 	if (!cd->vol) {
 		rfree(cd);
-		comp_err(dev, "volume_init(): Failed to allocate %d", vol_size);
+		comp_err(dev, "volume_init(): Failed to allocate %zu", vol_size);
 		return -ENOMEM;
 	}
 

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -34,7 +34,7 @@ extern struct tr_ctx ipc_tr;
 
 /* convenience error trace for mismatched internal structures */
 #define IPC_SIZE_ERROR_TRACE(ctx, object)		\
-	tr_err(ctx, "ipc: size %d expected %d",		\
+	tr_err(ctx, "ipc: size %d expected %zu",	\
 	       (object).hdr.size, sizeof(object))
 
 /* Returns pipeline source component */

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -82,12 +82,12 @@ LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 			___ret = memcpy_s(rx, rx_size, tx, tx->size);	\
 			assert(!___ret);				\
 			bzero((char *)rx + tx->size, rx_size - tx->size);\
-			tr_dbg(&ipc_tr, "ipc: hdr 0x%x rx (%d) > tx (%d)",\
+			tr_dbg(&ipc_tr, "ipc: hdr 0x%x rx (%zu) > tx (%d)",\
 			       rx->cmd, rx_size, tx->size);		\
 		} else if (tx->size > rx_size) {			\
 			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
 			assert(!___ret);				\
-			tr_warn(&ipc_tr, "ipc: hdr 0x%x tx (%d) > rx (%d)",\
+			tr_warn(&ipc_tr, "ipc: hdr 0x%x tx (%d) > rx (%zu)",\
 				rx->cmd, tx->size, rx_size);		\
 		} else	{						\
 			___ret = memcpy_s(rx, rx_size, tx, rx_size);	\
@@ -252,7 +252,7 @@ static int ipc_stream_pcm_params(uint32_t stream)
 	}
 
 	if (sizeof(pcm_params) + pcm_params.params.ext_data_length > SOF_IPC_MSG_MAX_SIZE) {
-		ipc_cmd_err(&ipc_tr, "pcm_params ext_data_length invalid size %d max allowed %d",
+		ipc_cmd_err(&ipc_tr, "pcm_params ext_data_length invalid size %d max allowed %zu",
 			    pcm_params.params.ext_data_length,
 			    SOF_IPC_MSG_MAX_SIZE - sizeof(pcm_params));
 		return -EINVAL;

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -45,7 +45,7 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 	elem_array->elems = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
 				    sizeof(struct dma_sg_elem) * ring->pages);
 	if (!elem_array->elems) {
-		tr_err(&ipc_tr, "ipc_parse_page_descriptors(): There is no heap free with this block size: %d",
+		tr_err(&ipc_tr, "ipc_parse_page_descriptors(): There is no heap free with this block size: %zu",
 		       sizeof(struct dma_sg_elem) * ring->pages);
 		return -ENOMEM;
 	}

--- a/src/platform/imx93_a55/include/platform/lib/memory.h
+++ b/src/platform/imx93_a55/include/platform/lib/memory.h
@@ -49,7 +49,7 @@
 #define HEAPMEM_SIZE 0x00010000
 
 /* SOF uses A side of the WAKEUPMIX MU */
-#define MU_BASE 0x42430000
+#define MU_BASE 0x42430000ULL
 
 /* SOF uses EDMA2 (a.k.a EDMA4 in the TRM) */
 #define EDMA2_BASE 0x42010000

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -112,11 +112,11 @@ static int smart_amp_set_config(struct comp_dev *dev,
 	       ASSUME_ALIGNED(&cdata->data->data, sizeof(uint32_t));
 	bs = cfg->size;
 
-	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %u, expected blob size = %u",
+	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %zu, expected blob size = %zu",
 		 bs, sizeof(struct sof_smart_amp_config));
 
 	if (bs != sizeof(struct sof_smart_amp_config)) {
-		comp_err(dev, "smart_amp_set_config(): invalid blob size, actual blob size = %u, expected blob size = %u",
+		comp_err(dev, "smart_amp_set_config(): invalid blob size, actual blob size = %zu, expected blob size = %zu",
 			 bs, sizeof(struct sof_smart_amp_config));
 		return -EINVAL;
 	}
@@ -137,7 +137,7 @@ static int smart_amp_get_config(struct comp_dev *dev,
 	/* Copy back to user space */
 	bs = sad->config.size;
 
-	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %u, expected blob size = %u",
+	comp_dbg(dev, "smart_amp_set_config(), actual blob size = %zu, expected blob size = %zu",
 		 bs, sizeof(struct sof_smart_amp_config));
 
 	if (bs == 0 || bs > size)


### PR DESCRIPTION
Currently, building SOF on a 64-bit system (i.e: i.MX93) leads to compilation warnings such as:

"format '%d' expects argument of type 'int', but argument 5 has type 'long unsigned int'" or

"cast to pointer from integer of different size"

This is because pointers are 64-bit and size_t resolves to a 64-bit type. As such, casting a pointer to uint32_t when printing leads to int-to-pointer-cast warnings. Also, printing a size_t variable using the "%d" or "%u" formats leads to format warnings.

To fix this, cast all size_t variables to uint32_t when printing. Pointers shall also be casted to uintptr_t before casting to uint32_t. This is fine to do because i.MX93 uses 32-bit addresses anyways.

This in conjunction with https://github.com/thesofproject/sof/pull/8528 fixes all compilation warnings for i.MX93.
This fix is not that great since it forces 64-bit types to 32-bit and counts on the fact that you won't have values that need 64-bit encoding, but it's a start I guess.