### PR TITLE
rimage: Set of small improvements

### DIFF
--- a/tools/rimage/src/include/rimage/misc_utils.h
+++ b/tools/rimage/src/include/rimage/misc_utils.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #define DIV_ROUND_UP(val, div) (((val) + (div) - 1) / (div))
+#define ALIGN_UP(val, align)   (((val) + (align) - 1) & ~((align) - 1))
 
 /**
  * Reverses the order of bytes in the array

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -438,10 +438,7 @@ static int man_module_create(struct image *image, struct manifest_module *module
 	}
 
 	/* round module end upto nearest page */
-	if (image->image_end % MAN_PAGE_SIZE) {
-		image->image_end = (image->image_end / MAN_PAGE_SIZE) + 1;
-		image->image_end *= MAN_PAGE_SIZE;
-	}
+	image->image_end = ALIGN_UP(image->image_end, MAN_PAGE_SIZE);
 
 out:
 	fprintf(stdout, " Total pages text %d data %d bss %d module file limit: 0x%x\n\n",
@@ -505,10 +502,7 @@ static int man_module_create_reloc(struct image *image, struct manifest_module *
 	image->image_end = module->foffset + module->file.elf.file_size;
 
 	/* round module end up to nearest page */
-	if (image->image_end % MAN_PAGE_SIZE) {
-		image->image_end = (image->image_end / MAN_PAGE_SIZE) + 1;
-		image->image_end *= MAN_PAGE_SIZE;
-	}
+	image->image_end = ALIGN_UP(image->image_end, MAN_PAGE_SIZE);
 
 	fprintf(stdout, " Total pages text %d data %d bss %d module file limit: 0x%x\n\n",
 		man_module->segment[SOF_MAN_SEGMENT_TEXT].flags.r.length,

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -794,8 +794,7 @@ int man_write_fw_v1_5_sue(struct image *image)
 
 	/* write preload page count */
 	preload_size = image->image_end - MAN_DESC_OFFSET_V1_5_SUE;
-	preload_size += MAN_PAGE_SIZE - (preload_size % MAN_PAGE_SIZE);
-	m->desc.header.preload_page_count = preload_size / MAN_PAGE_SIZE;
+	m->desc.header.preload_page_count = DIV_ROUND_UP(preload_size, MAN_PAGE_SIZE);
 
 	fprintf(stdout, "Firmware file size 0x%x page count %d\n",
 		FILE_TEXT_OFFSET_V1_5_SUE - MAN_DESC_OFFSET_V1_5_SUE +
@@ -992,8 +991,7 @@ int man_write_fw_meu_v1_5(struct image *image)
 
 	/* write preload page count */
 	preload_size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_5;
-	preload_size += MAN_PAGE_SIZE - (preload_size % MAN_PAGE_SIZE);
-	desc->header.preload_page_count = preload_size / MAN_PAGE_SIZE;
+	desc->header.preload_page_count = DIV_ROUND_UP(preload_size, MAN_PAGE_SIZE);
 
 	/* calculate hash for each module */
 	man_hash_modules(image, desc);
@@ -1078,8 +1076,7 @@ int man_write_fw_meu_v1_8(struct image *image)
 
 	/* write preload page count */
 	preload_size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
-	preload_size += MAN_PAGE_SIZE - (preload_size % MAN_PAGE_SIZE);
-	desc->header.preload_page_count = preload_size / MAN_PAGE_SIZE;
+	desc->header.preload_page_count = DIV_ROUND_UP(preload_size, MAN_PAGE_SIZE);
 
 	/* calculate hash for each module */
 	man_hash_modules(image, desc);
@@ -1167,8 +1164,7 @@ int man_write_fw_meu_v2_5(struct image *image)
 
 	/* write preload page count */
 	preload_size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
-	preload_size += MAN_PAGE_SIZE - (preload_size % MAN_PAGE_SIZE);
-	desc->header.preload_page_count = preload_size / MAN_PAGE_SIZE;
+	desc->header.preload_page_count = DIV_ROUND_UP(preload_size, MAN_PAGE_SIZE);
 
 	/* calculate hash for each module */
 	man_hash_modules(image, desc);

--- a/tools/rimage/src/module.c
+++ b/tools/rimage/src/module.c
@@ -14,7 +14,7 @@
 #include <rimage/elf_file.h>
 #include <rimage/file_utils.h>
 #include <rimage/rimage.h>
-
+#include <rimage/misc_utils.h>
 
 int module_read_section(const struct module *module, const struct module_section *section,
 			void *buffer, const size_t size)
@@ -249,10 +249,10 @@ static void sections_info_add(struct module_sections_info *info, struct module_s
  */
 static void sections_info_finalize(struct module_sections_info *info)
 {
-	info->file_size = (info->end > info->start) ? info->end - info->start : 0;
+	size_t size = (info->end > info->start) ? info->end - info->start : 0;
 
 	/* file sizes round up to nearest page */
-	info->file_size = (info->file_size + MAN_PAGE_SIZE - 1) & ~(MAN_PAGE_SIZE - 1);
+	info->file_size = ALIGN_UP(size, MAN_PAGE_SIZE);
 }
 
 /**

--- a/tools/rimage/src/plat_auth.c
+++ b/tools/rimage/src/plat_auth.c
@@ -8,6 +8,7 @@
 #include <rimage/rimage.h>
 #include <rimage/manifest.h>
 #include <rimage/plat_auth.h>
+#include <rimage/misc_utils.h>
 
 void ri_adsp_meta_data_create_v1_8(struct image *image, int meta_start_offset,
 				   int meta_end_offset)
@@ -52,7 +53,7 @@ void ri_plat_ext_data_create(struct image *image)
 	fprintf(stdout, " auth: completing authentication manifest\n");
 
 	part->length = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
-	part->length += MAN_PAGE_SIZE - (part->length % MAN_PAGE_SIZE);
+	part->length = ALIGN_UP(part->length, MAN_PAGE_SIZE);
 
 	/* do this here atm */
 	desc->header.preload_page_count = part->length / MAN_PAGE_SIZE;
@@ -69,10 +70,9 @@ void ri_plat_ext_data_create_v2_5(struct image *image)
 	fprintf(stdout, " auth: completing authentication manifest\n");
 
 	size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
-	size += MAN_PAGE_SIZE - (size % MAN_PAGE_SIZE);
 
 	/* do this here atm */
-	desc->header.preload_page_count = size / MAN_PAGE_SIZE;
+	desc->header.preload_page_count = DIV_ROUND_UP(size, MAN_PAGE_SIZE);
 	ext->size = image->image_end;
 }
 
@@ -87,8 +87,7 @@ void ri_plat_ext_data_create_ace_v1_5(struct image *image)
 	fprintf(stdout, " auth: completing authentication manifest\n");
 
 	size = meta->comp_desc[0].limit_offset - MAN_DESC_OFFSET_V1_8;
-	size += MAN_PAGE_SIZE - (size % MAN_PAGE_SIZE);
 
-	desc->header.preload_page_count = size / MAN_PAGE_SIZE;
+	desc->header.preload_page_count = DIV_ROUND_UP(size, MAN_PAGE_SIZE);
 	ext->size = image->image_end;
 }

--- a/tools/rimage/src/rimage.c
+++ b/tools/rimage/src/rimage.c
@@ -204,6 +204,12 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	if (image.num_modules > MAX_MODULES) {
+		fprintf(stderr, "error: Too many input modules\n");
+		ret = -EMFILE;
+		goto out;
+	}
+
 	/* Some platforms dont have modules configuration in toml file */
 	if (image.adsp->modules && image.num_modules > image.adsp->modules->mod_man_count) {
 		fprintf(stderr, "error: Each ELF input module requires entry in toml file.\n");


### PR DESCRIPTION
Added limit of a number of input modules provided in a command line to the maximum number of supported modules (size of module array / MAX_MODULES)

Created ALIGN_UP macro to simplify calculations.
Used DIV_ROUND_UP macro to calculate page count.