### PR TITLE
ipc4: mixin/mixout: Switch to use sink/source API

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -695,7 +695,6 @@ static int mixout_params(struct processing_module *mod)
 	struct comp_buffer *sink;
 	struct comp_dev *dev = mod->dev;
 	enum sof_ipc_frame frame_fmt, valid_fmt;
-	uint32_t sink_period_bytes, sink_stream_size;
 	int ret;
 
 	comp_dbg(dev, "mixout_params()");
@@ -718,23 +717,6 @@ static int mixout_params(struct processing_module *mod)
 
 	audio_stream_set_valid_fmt(&sink->stream, valid_fmt);
 	audio_stream_set_channels(&sink->stream, params->channels);
-
-	sink_stream_size = audio_stream_get_size(&sink->stream);
-
-	/* calculate period size based on config */
-	sink_period_bytes = audio_stream_period_bytes(&sink->stream,
-						      dev->frames);
-
-	if (sink_period_bytes == 0) {
-		comp_err(dev, "mixout_params(): period_bytes = 0");
-		return -EINVAL;
-	}
-
-	if (sink_stream_size < sink_period_bytes) {
-		comp_err(dev, "mixout_params(): sink buffer size %d is insufficient < %d",
-			 sink_stream_size, sink_period_bytes);
-		return -ENOMEM;
-	}
 
 	return 0;
 }

--- a/src/audio/mixin_mixout/mixin_mixout.h
+++ b/src/audio/mixin_mixout/mixin_mixout.h
@@ -102,12 +102,19 @@ struct ipc4_mixer_mode_config {
 	struct ipc4_mixer_mode_sink_config mixer_mode_sink_configs[1];
 } __packed __aligned(4);
 
+/* Pointer to data in circular buffer together with buffer boundaries */
+struct cir_buf_ptr {
+	void *buf_start;
+	void *buf_end;
+	void *ptr;
+};
+
 /**
  * \brief mixin processing function interface
  */
-typedef void (*mix_func)(struct audio_stream *sink, int32_t start_sample,
+typedef void (*mix_func)(struct cir_buf_ptr *sink, int32_t start_sample,
 			 int32_t mixed_samples,
-			 const struct audio_stream *source,
+			 const struct cir_buf_ptr *source,
 			 int32_t sample_count, uint16_t gain);
 
 /**

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -12,16 +12,16 @@
 #ifdef MIXIN_MIXOUT_GENERIC
 
 #if CONFIG_FORMAT_S16LE
-static void mix_s16(struct audio_stream *sink, int32_t start_sample, int32_t mixed_samples,
-		    const struct audio_stream *source,
+static void mix_s16(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixed_samples,
+		    const struct cir_buf_ptr *source,
 		    int32_t sample_count, uint16_t gain)
 {
 	int32_t samples_to_mix, samples_to_copy, left_samples;
 	int32_t n, nmax, i;
 
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int16_t *dst = (int16_t *)audio_stream_get_wptr(sink) + start_sample;
-	int16_t *src = audio_stream_get_rptr(source);
+	/* cir_buf_wrap() is required and is done below in a loop */
+	int16_t *dst = (int16_t *)sink->ptr + start_sample;
+	int16_t *src = source->ptr;
 
 	assert(mixed_samples >= start_sample);
 	samples_to_mix = mixed_samples - start_sample;
@@ -29,12 +29,12 @@ static void mix_s16(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	samples_to_copy = sample_count - samples_to_mix;
 
 	for (left_samples = samples_to_mix; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
+		nmax = (int16_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
+		nmax = (int16_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int16(*dst + *src++);
@@ -43,11 +43,11 @@ static void mix_s16(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	}
 
 	for (left_samples = samples_to_copy; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s16(source, src);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
+		nmax = (int16_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, dst);
+		nmax = (int16_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int16_t), src, n * sizeof(int16_t));
 		dst += n;
@@ -57,15 +57,15 @@ static void mix_s16(struct audio_stream *sink, int32_t start_sample, int32_t mix
 #endif	/* CONFIG_FORMAT_S16LE */
 
 #if CONFIG_FORMAT_S24LE
-static void mix_s24(struct audio_stream *sink, int32_t start_sample, int32_t mixed_samples,
-		    const struct audio_stream *source,
+static void mix_s24(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixed_samples,
+		    const struct cir_buf_ptr *source,
 		    int32_t sample_count, uint16_t gain)
 {
 	int32_t samples_to_mix, samples_to_copy, left_samples;
 	int32_t n, nmax, i;
-	/* audio_stream_wrap() is required and is done below in a loop */
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_sample;
-	int32_t *src = audio_stream_get_rptr(source);
+	/* cir_buf_wrap() is required and is done below in a loop */
+	int32_t *dst = (int32_t *)sink->ptr + start_sample;
+	int32_t *src = source->ptr;
 
 	assert(mixed_samples >= start_sample);
 	samples_to_mix = mixed_samples - start_sample;
@@ -73,12 +73,12 @@ static void mix_s24(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	samples_to_copy = sample_count - samples_to_mix;
 
 	for (left_samples = samples_to_mix; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
+		nmax = (int32_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
+		nmax = (int32_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int24(sign_extend_s24(*dst) + sign_extend_s24(*src++));
@@ -87,11 +87,11 @@ static void mix_s24(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	}
 
 	for (left_samples = samples_to_copy; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s24(source, src);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
+		nmax = (int32_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s24(sink, dst);
+		nmax = (int32_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
 		dst += n;
@@ -102,14 +102,14 @@ static void mix_s24(struct audio_stream *sink, int32_t start_sample, int32_t mix
 #endif	/* CONFIG_FORMAT_S24LE */
 
 #if CONFIG_FORMAT_S32LE
-static void mix_s32(struct audio_stream *sink, int32_t start_sample, int32_t mixed_samples,
-		    const struct audio_stream *source,
+static void mix_s32(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixed_samples,
+		    const struct cir_buf_ptr *source,
 		    int32_t sample_count, uint16_t gain)
 {
 	int32_t samples_to_mix, samples_to_copy, left_samples;
 	int32_t n, nmax, i;
-	int32_t *dst = (int32_t *)audio_stream_get_wptr(sink) + start_sample;
-	int32_t *src = audio_stream_get_rptr(source);
+	int32_t *dst = (int32_t *)sink->ptr + start_sample;
+	int32_t *src = source->ptr;
 
 	assert(mixed_samples >= start_sample);
 	samples_to_mix = mixed_samples - start_sample;
@@ -117,12 +117,12 @@ static void mix_s32(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	samples_to_copy = sample_count - samples_to_mix;
 
 	for (left_samples = samples_to_mix; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		/* calculate the remaining samples*/
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
+		nmax = (int32_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
+		nmax = (int32_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int32((int64_t)*dst + (int64_t)*src++);
@@ -131,11 +131,11 @@ static void mix_s32(struct audio_stream *sink, int32_t start_sample, int32_t mix
 	}
 
 	for (left_samples = samples_to_copy; left_samples > 0; left_samples -= n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
+		nmax = (int32_t *)source->buf_end - src;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
+		nmax = (int32_t *)sink->buf_end - dst;
 		n = MIN(n, nmax);
 		memcpy_s(dst, n * sizeof(int32_t), src, n * sizeof(int32_t));
 		dst += n;

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -984,6 +984,29 @@ static inline int audio_stream_set_zero(struct audio_stream *buffer, uint32_t by
 	return 0;
 }
 
+/**
+ * Writes zeros to circular buffer in range [ptr, ptr+bytes] with rollover if necessary.
+ * @param ptr Pointer inside circular biffer to start writing from.
+ * @param buf_addr Start of the circular buffer.
+ * @param buf_end End of the circular buffer.
+ * @param bytes Size of the fragment to write zeros.
+ */
+static inline void cir_buf_set_zero(void *ptr, void *buf_addr, void *buf_end, uint32_t bytes)
+{
+	uint32_t head_size = bytes;
+	uint32_t tail_size = 0;
+
+	/* check for potential wrap */
+	if ((char *)ptr + bytes > (char *)buf_end) {
+		head_size = (char *)buf_end - (char *)ptr;
+		tail_size = bytes - head_size;
+	}
+
+	memset(ptr, 0, head_size);
+	if (tail_size)
+		memset(buf_addr, 0, tail_size);
+}
+
 static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 					       enum ipc4_bit_depth valid,
 					       enum sof_ipc_frame *frame_fmt,


### PR DESCRIPTION
Modifications to mixin/mixout implementation to switch to use sink/source API.