### PR TITLE
Fix compilation errors / warnings

### DIFF
--- a/src/audio/drc/drc_hifi4.c
+++ b/src/audio/drc/drc_hifi4.c
@@ -577,8 +577,8 @@ static void drc_delay_input_sample_s16(struct drc_state *state,
 		drc_pre_delay_index_inc(&state->pre_delay_read_index, nfrm);
 	}
 
-	*x = x0;
-	*y = y0;
+	*x = (int16_t *)x0;
+	*y = (int16_t *)y0;
 }
 
 static void drc_s16_default(struct processing_module *mod,
@@ -715,8 +715,8 @@ static void drc_delay_input_sample_s32(struct drc_state *state,
 		drc_pre_delay_index_inc(&state->pre_delay_read_index, nfrm);
 	}
 
-	*x = x0;
-	*y = y0;
+	*x = (int32_t *)x0;
+	*y = (int32_t *)y0;
 }
 #endif
 

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -27,6 +27,7 @@
 #if !defined(__ASSEMBLER__) && defined(__XTENSA__)
 
 #include <ipc/trace.h>
+#include <rtos/panic.h>
 #define VERIFY_ALIGN
 
 #endif


### PR DESCRIPTION
Commit 16d126a36fd821 ("audio: Header files cleanup") removed rtos/panic.h include but this is still needed.

Otherwise, we get the following compilation error:

/work/repos/sof/src/lib/lib.c: In function ‘memset’:
/work/repos/sof/src/lib/lib.c:31: warning: implicit declaration of function ‘sof_panic’

Fixes: 16d126a36fd821 ("audio: Header files cleanup")