### PR TITLE
zephyr/cmake: move math/*.c files to now common math/CMakeLists.txt

### DIFF
--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -5,9 +5,13 @@ if(BUILD_LIBRARY)
 	return()
 endif()
 
+is_zephyr(it_is_zephyr)
+
 add_local_sources(sof numbers.c)
 
-if(CONFIG_CORDIC_FIXED)
+# Up to now, trig.c has never been optional in Zephyr.
+# Maybe it should be in the future.
+if(CONFIG_CORDIC_FIXED OR it_is_zephyr)
         add_local_sources(sof trig.c)
 endif()
 
@@ -15,10 +19,13 @@ add_local_sources_ifdef(CONFIG_SQRT_FIXED sof sqrt_int16.c)
 
 add_local_sources_ifdef(CONFIG_MATH_EXP sof exp_fcn.c exp_fcn_hifi.c)
 
-if(CONFIG_MATH_DECIBELS)
+# Up to now, decibels.c has never been optional in Zephyr.
+# Maybe it should be in the future.
+if(CONFIG_MATH_DECIBELS OR it_is_zephyr)
         add_local_sources(sof decibels.c)
 endif()
 
+if(NOT it_is_zephyr) # So far none of these has ever been enabled in Zephyr.
 add_local_sources_ifdef(CONFIG_NATURAL_LOGARITHM_FIXED sof log_e.c)
 
 add_local_sources_ifdef(CONFIG_COMMON_LOGARITHM_FIXED sof log_10.c)
@@ -26,10 +33,12 @@ add_local_sources_ifdef(CONFIG_COMMON_LOGARITHM_FIXED sof log_10.c)
 add_local_sources_ifdef(CONFIG_POWER_FIXED sof power.c)
 
 add_local_sources_ifdef(CONFIG_BINARY_LOGARITHM_FIXED sof base2log.c)
+endif()
 
 add_local_sources_ifdef(CONFIG_MATH_FIR sof fir_generic.c fir_hifi2ep.c fir_hifi3.c)
 
-if(CONFIG_MATH_FFT)
+# So far this directory has never been enabled in Zephyr.
+if(CONFIG_MATH_FFT AND NOT it_is_zephyr)
 	add_subdirectory(fft)
 endif()
 
@@ -39,6 +48,7 @@ add_local_sources_ifdef(CONFIG_MATH_IIR_DF2T sof
 add_local_sources_ifdef(CONFIG_MATH_IIR_DF1 sof
 	iir_df1_generic.c iir_df1_hifi3.c iir_df1.c)
 
+if(NOT it_is_zephyr) # So far none of these has ever been enabled in Zephyr.
 if(CONFIG_MATH_WINDOW)
 	 add_local_sources(sof window.c)
 endif()
@@ -54,3 +64,4 @@ endif()
 if(CONFIG_MATH_DCT)
 	 add_local_sources(sof dct.c)
 endif()
+endif() # not Zephyr

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -56,7 +56,6 @@ set(SOF_SAMPLES_PATH "${SOF_SRC_PATH}/samples")
 set(SOF_LIB_PATH "${SOF_SRC_PATH}/lib")
 set(SOF_DRIVERS_PATH "${SOF_SRC_PATH}/drivers")
 set(SOF_DEBUG_PATH "${SOF_SRC_PATH}/debug")
-set(SOF_MATH_PATH "${SOF_SRC_PATH}/math")
 set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
 set(RIMAGE_TOP ${sof_top_dir}/tools/rimage)
@@ -146,6 +145,7 @@ endmacro()
 
 add_subdirectory(../src/init/ init_unused_install/)
 add_subdirectory(../src/ipc/  ipc_unused_install/)
+add_subdirectory(../src/math/ math_unused_install/)
 
 
 
@@ -366,11 +366,6 @@ zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
 # Commented files will be added/removed as integration dictates.
 zephyr_library_sources(
 
-	# SOF math utilities
-	${SOF_MATH_PATH}/decibels.c
-	${SOF_MATH_PATH}/numbers.c
-	${SOF_MATH_PATH}/trig.c
-
 	# SOF library - parts to transition to Zephyr over time
 	${SOF_LIB_PATH}/clk.c
 	${SOF_LIB_PATH}/notifier.c
@@ -484,24 +479,6 @@ elseif(CONFIG_IPC_MAJOR_4)
 		${SOF_AUDIO_PATH}/eq_iir/eq_iir_generic.c
 	)
 endif()
-
-zephyr_library_sources_ifdef(CONFIG_MATH_FIR
-	${SOF_MATH_PATH}/fir_generic.c
-	${SOF_MATH_PATH}/fir_hifi2ep.c
-	${SOF_MATH_PATH}/fir_hifi3.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_MATH_IIR_DF1
-	${SOF_MATH_PATH}/iir_df1_generic.c
-	${SOF_MATH_PATH}/iir_df1_hifi3.c
-	${SOF_MATH_PATH}/iir_df1.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_MATH_IIR_DF2T
-	${SOF_MATH_PATH}/iir_df2t_generic.c
-	${SOF_MATH_PATH}/iir_df2t_hifi3.c
-	${SOF_MATH_PATH}/iir_df2t.c
-)
 
 zephyr_library_sources_ifdef(CONFIG_COMP_ASRC
 	${SOF_AUDIO_PATH}/asrc/asrc.c
@@ -783,15 +760,6 @@ zephyr_library_sources_ifdef(CONFIG_COMP_TDFB
 	${SOF_AUDIO_PATH}/tdfb/tdfb_generic.c
 	${SOF_AUDIO_PATH}/tdfb/tdfb_hifiep.c
 	${SOF_AUDIO_PATH}/tdfb/tdfb_hifi3.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_SQRT_FIXED
-	${SOF_MATH_PATH}/sqrt_int16.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_MATH_EXP
-	${SOF_MATH_PATH}/exp_fcn.c
-	${SOF_MATH_PATH}/exp_fcn_hifi.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_UP_DOWN_MIXER


### PR DESCRIPTION
CMake decentralization per #8260

EDIT: There seems to be some confusion happening in the review comments right now.

Clarification: this CMake PR is BUG-FOR-BUG compatible.

There are Cmake and CONFIG bugs in zephyr/CMakeLists.txt right now that this https://github.com/thesofproject/sof/issues/8260 effort is exposing. The purpose of this PR is to carefully NOT fix any of these bugs. The commits in this PR and all other 8260 commits in general are way too big to hide small functional changes inside. You really don't want your git bisect to land on a giant CONFIG_ commit like these. So this PR is strictly "bug-preserving". Garbage in, exact same garbage out.

If this PR made you discover some existing CMake or CONFIG bug, then please submit a smaller PR either before this PR is merged (and I will rebase and adjust), or after this PR. But please stop asking for bug fixes here.