### PR TITLE
[cavs2.5-001] topology1: sof-hda-generic: enable dts playback

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TPLGS
 	"sof-hda-generic\;sof-hda-generic-2ch\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic\;sof-hda-generic-3ch\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic\;sof-hda-generic-4ch\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
+	"sof-hda-generic\;sof-hda-generic-4ch-dts\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1\;-DDTS=`DTS'"
 	## end HDaudio codec topologies
 
 	"sof-hda-generic-idisp\;sof-hda-generic-idisp\;-DCHANNELS=0\;-DDYNAMIC=1"

--- a/tools/topology/topology1/sof-hda-generic.m4
+++ b/tools/topology/topology1/sof-hda-generic.m4
@@ -97,12 +97,21 @@ DAI_ADD(PIPE_HEADSET_PLAYBACK,
 
 # Low Latency playback pipeline 1 on PCM 30 using max 2 channels of s32le.
 # 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
+PIPELINE_PCM_ADD(
+	ifdef(`DTS', sof/pipe-eq-iir-dts-codec-playback.m4, sof/pipe-host-volume-playback.m4),
 	30, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000,
 	SCHEDULE_TIME_DOMAIN_TIMER,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
+
+ifdef(`DTS',
+`
+# Because there is no dai pipeline.30 for HDA0.OUT in pipe-eq-iir-dts-codec-playback.m4, so
+# using macro defined W_PIPELINE_TOP() to add missing dai pipeline back. Instead of
+# modifying in pipe-eq-iir-dts-codec-playback.m4, these changes are not necessary for all others.
+W_PIPELINE_TOP(30, HDA0.OUT, 1000, 0, 0, 1, pipe_dai_schedule_plat)
+')
 
 # Deep buffer playback pipeline 31 on PCM 31 using max 2 channels of s32le
 # Set 1000us deadline on core 0 with priority 0.


### PR DESCRIPTION
Enabling dts pipeline on HDA0 speaker/headphone playaback.
In this case, using defined macro W_PIPELINE_TOP() to add missing dai pipeline is due to topology not found it for PCM0P.
Verified dts test blobs via sof-ctl.