### PR TITLE
Audio: up_down_mixer: move up_down_mixer header files to module folder

### DIFF
--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -5,8 +5,6 @@
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@intel.com>
 // Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
 
-#include <sof/audio/coefficients/up_down_mixer/up_down_mixer.h>
-#include <sof/audio/up_down_mixer/up_down_mixer.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/format.h>
 #include <sof/audio/module_adapter/module/generic.h>
@@ -27,6 +25,9 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "up_down_mixer_coef.h"
+#include "up_down_mixer.h"
 
 LOG_MODULE_REGISTER(up_down_mixer, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/up_down_mixer/up_down_mixer.h
+++ b/src/audio/up_down_mixer/up_down_mixer.h
@@ -12,11 +12,12 @@
 #include <sof/audio/ipc-config.h>
 #include <sof/common.h>
 #include <ipc/stream.h>
-#include <ipc4/up_down_mixer.h>
 #include <ipc4/module.h>
 #include <ipc4/base-config.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "up_down_mixer_ipc4.h"
 
 /** This type is introduced for better readability. */
 typedef const int32_t *downmix_coefficients;

--- a/src/audio/up_down_mixer/up_down_mixer_coef.h
+++ b/src/audio/up_down_mixer/up_down_mixer_coef.h
@@ -5,7 +5,7 @@
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@intel.com>
 // Author: Adrian Bonislawski <adrian.bonislawski@intel.com>
 
-#include <ipc4/up_down_mixer.h>
+#include "up_down_mixer_ipc4.h"
 #include <stdint.h>
 
 #if CONFIG_COMP_UP_DOWN_MIXER

--- a/src/audio/up_down_mixer/up_down_mixer_hifi3.c
+++ b/src/audio/up_down_mixer/up_down_mixer_hifi3.c
@@ -4,7 +4,7 @@
 //
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@intel.com>
 
-#include <sof/audio/up_down_mixer/up_down_mixer.h>
+#include "up_down_mixer.h"
 
 #if defined(__XCC__) && XCHAL_HAVE_HIFI3
 

--- a/src/audio/up_down_mixer/up_down_mixer_ipc4.h
+++ b/src/audio/up_down_mixer/up_down_mixer_ipc4.h
@@ -7,7 +7,7 @@
 #ifndef __SOF_IPC4_UP_DOWN_MIXER_H__
 #define __SOF_IPC4_UP_DOWN_MIXER_H__
 
-#include "base-config.h"
+#include <ipc4/base-config.h>
 
 /**
  *  \brief bits field map which helps to describe each channel location a the data stream buffer


### PR DESCRIPTION
This is a clean up, purpose is de-cluster headers, toml files,
Readme.md etc per module basis, since today everything is scattered
in current code base.