### PR TITLE
base_fw: add DMI_FORCE_L1_EXIT FW config (depends on Zephyr 66042)

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -13,6 +13,9 @@
 #include <sof/lib/cpu.h>
 #include <rtos/init.h>
 #include <platform/lib/clk.h>
+#if defined(CONFIG_SOC_SERIES_INTEL_ACE)
+#include <intel_adsp_hda.h>
+#endif
 
 #if CONFIG_ACE_V1X_ART_COUNTER || CONFIG_ACE_V1X_RTC_COUNTER
 #include <zephyr/device.h>
@@ -391,6 +394,42 @@ static int basefw_power_state_info_get(uint32_t *data_offset, char *data)
 	return 0;
 }
 
+static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
+{
+#if defined(CONFIG_SOC_SERIES_INTEL_ACE)
+	const uint32_t force = tlv->value[0];
+
+	if (force) {
+		tr_info(&basefw_comp_tr, "FW config set force dmi l0 state");
+		intel_adsp_force_dmi_l0_state();
+	} else {
+		tr_info(&basefw_comp_tr, "FW config set allow dmi l1 state");
+		intel_adsp_allow_dmi_l1_state();
+	}
+
+	return 0;
+#else
+	return IPC4_UNAVAILABLE;
+#endif
+}
+
+static int basefw_set_fw_config(bool first_block,
+				bool last_block,
+				uint32_t data_offset,
+				const char *data)
+{
+	const struct sof_tlv *tlv = (const struct sof_tlv *)data;
+
+	switch (tlv->type) {
+	case IPC4_DMI_FORCE_L1_EXIT:
+		return fw_config_set_force_l1_exit(tlv);
+	default:
+		break;
+	}
+	tr_warn(&basefw_comp_tr, "returning success for Set FW_CONFIG without handling it");
+	return 0;
+}
+
 static int basefw_get_large_config(struct comp_dev *dev,
 				   uint32_t param_id,
 				   bool first_block,
@@ -457,8 +496,7 @@ static int basefw_set_large_config(struct comp_dev *dev,
 {
 	switch (param_id) {
 	case IPC4_FW_CONFIG:
-		tr_warn(&basefw_comp_tr, "returning success for Set FW_CONFIG without handling it");
-		return 0;
+		return basefw_set_fw_config(first_block, last_block, data_offset, data);
 	case IPC4_SYSTEM_TIME:
 		return basefw_set_system_time(param_id, first_block,
 						last_block, data_offset, data);

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 0a7251e365af14acc40aadb5cf745bec2ed84618
+      revision: 28d5d23a232b69b213112e723e0a6392cbd5a47e
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Add new parameter for SW to force DMI L1 exit on IPC request.
Associated with: https://github.com/zephyrproject-rtos/zephyr/pull/66042

Separating two new functions force and allow l1 to have the current state with separated functions in the power manager so that SOF can call these functions via IPC DMI_FORCE_L1_EXIT. DMA sometimes slows down and does not perform, therefore the workaround is to switch off l1. Change related to the addition of a new parameter to force DMI L1 exit on IPC request.