### PR TITLE
audio: perf: add module ibs and obs for performance profiling log

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -354,7 +354,20 @@ int comp_copy(struct comp_dev *dev)
 		ret = dev->drv->ops.copy(dev);
 
 #if CONFIG_PERFORMANCE_COUNTERS
+		struct ipc4_base_module_cfg dev_cfg;
+
 		perf_cnt_stamp(&dev->pcd, perf_trace_null, dev);
+
+		ret = comp_get_attribute(dev, COMP_ATTR_BASE_CONFIG, &dev_cfg);
+		if (ret < 0) {
+			comp_err(dev, "perf failed to get base config for module %#x",
+				 dev_comp_id(dev));
+			return ret;
+		}
+
+		dev->pcd.ibs = dev_cfg.ibs;
+		dev->pcd.obs = dev_cfg.obs;
+
 		perf_cnt_average(&dev->pcd, comp_perf_avg_info, dev);
 #endif
 	}

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -236,12 +236,13 @@ enum {
 		  (uint32_t)((pcd)->cpu_delta_peak))
 
 #define comp_perf_avg_info(pcd, comp_p)					\
-	comp_info(comp_p, "perf comp_copy samples %u period %u cpu avg %u peak %u %u",\
+	comp_info(comp_p, "perf comp_copy samples %u period %u cpu avg %u peak %u ibs %u obs %u",\
 		  (uint32_t)((comp_p)->frames),            \
 		  (uint32_t)((comp_p)->period),			    \
 		  (uint32_t)((pcd)->cpu_delta_sum),			\
 		  (uint32_t)((pcd)->cpu_delta_peak),			\
-		  (uint32_t)((pcd)->peak_mcps_period_cnt))
+		  (uint32_t)((pcd)->ibs),				\
+		  (uint32_t)((pcd)->obs))
 
 /** @}*/
 

--- a/xtos/include/sof/lib/perf_cnt.h
+++ b/xtos/include/sof/lib/perf_cnt.h
@@ -33,8 +33,6 @@ struct perf_cnt_data {
 	uint32_t cpu_delta_sum;
 	/* accumulate period passed and calculate avg cycles */
 	uint32_t period_cnt;
-	/* indicate which period have peak mcps in current module */
-	uint32_t peak_mcps_period_cnt;
 	/* indicate module input buffer size and output buffer size */
 	uint32_t ibs;
 	uint32_t obs;
@@ -124,7 +122,6 @@ struct perf_cnt_data {
 			(pcd)->period_cnt = 0;                               \
 			(pcd)->plat_delta_peak = 0;                          \
 			(pcd)->cpu_delta_peak = 0;                           \
-			(pcd)->peak_mcps_period_cnt = 0;			     \
 		}                                                            \
 	} while (0)
 
@@ -143,10 +140,8 @@ struct perf_cnt_data {
 			(uint32_t)perf_cnt_get_cpu_ts();			\
 		(pcd)->plat_delta_last = plat_ts - (pcd)->plat_ts;		\
 		(pcd)->cpu_delta_last = cpu_ts - (pcd)->cpu_ts;			\
-		if ((pcd)->plat_delta_last > (pcd)->plat_delta_peak) {		\
+		if ((pcd)->plat_delta_last > (pcd)->plat_delta_peak)		\
 			(pcd)->plat_delta_peak = (pcd)->plat_delta_last;	\
-			(pcd)->peak_mcps_period_cnt = (pcd)->period_cnt;		\
-		}								\
 		if ((pcd)->cpu_delta_last > (pcd)->cpu_delta_peak) {		\
 			(pcd)->cpu_delta_peak = (pcd)->cpu_delta_last;		\
 			trace_m(pcd, arg);					\

--- a/xtos/include/sof/lib/perf_cnt.h
+++ b/xtos/include/sof/lib/perf_cnt.h
@@ -35,6 +35,9 @@ struct perf_cnt_data {
 	uint32_t period_cnt;
 	/* indicate which period have peak mcps in current module */
 	uint32_t peak_mcps_period_cnt;
+	/* indicate module input buffer size and output buffer size */
+	uint32_t ibs;
+	uint32_t obs;
 };
 
 #if CONFIG_PERFORMANCE_COUNTERS


### PR DESCRIPTION
Add ibs and obs information to performance logs, they will be used for update module CPC based on different ibs and obs.