### PR TITLE
set_xtensa_params.sh: add missing LNL, ACP_6_3 and vangogh, remove duplication with xtensa-build-all.sh

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -196,82 +196,15 @@ CURDIR="$(pwd)"
 # build platforms
 for platform in "${PLATFORMS[@]}"
 do
+
+	printf '\n   ------\n   %s\n   ------\n' "$platform"
+
 	HAVE_ROM='no'
 	DEFCONFIG_PATCH=''
 	PLATFORM_PRIVATE_KEY=''
 
-	case $platform in
-		imx8)
-			PLATFORM="imx8"
-			XTENSA_CORE="hifi4_nxp_v3_3_1_2_2017"
-			HOST="xtensa-imx-elf"
-			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-			;;
-		imx8x)
-			PLATFORM="imx8x"
-			XTENSA_CORE="hifi4_nxp_v3_3_1_2_2017"
-			HOST="xtensa-imx-elf"
-			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-			;;
-		imx8m)
-			PLATFORM="imx8m"
-			XTENSA_CORE="hifi4_mscale_v0_0_2_2017"
-			HOST="xtensa-imx8m-elf"
-			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-			;;
-		imx8ulp)
-			PLATFORM="imx8ulp"
-			XTENSA_CORE="hifi4_nxp2_ulp_prod"
-			HOST="xtensa-imx8ulp-elf"
-			XTENSA_TOOLS_VERSION="RG-2017.8-linux"
-			;;
-		rn)
-			PLATFORM="renoir"
-			XTENSA_CORE="ACP_3_1_001_PROD_2019_1"
-			HOST="xtensa-rn-elf"
-			XTENSA_TOOLS_VERSION="RI-2019.1-linux"
-			;;
-		rmb)
-			PLATFORM="rembrandt"
-			ARCH="xtensa"
-			XTENSA_CORE="LX7_HiFi5_PROD"
-			HOST="xtensa-rmb-elf"
-			XTENSA_TOOLS_VERSION="RI-2019.1-linux"
-			;;
-		vangogh)
-			PLATFORM="vangogh"
-			ARCH="xtensa"
-			XTENSA_CORE="ACP_5_0_001_PROD"
-			HOST="xtensa-vangogh-elf"
-			XTENSA_TOOLS_VERSION="RI-2019.1-linux"
-			;;
-		acp_6_3)
-			PLATFORM="acp_6_3"
-			ARCH="xtensa"
-			XTENSA_CORE="ACP_6_3_HiFi5_PROD_Linux"
-			HOST="xtensa-acp_6_3-elf"
-			XTENSA_TOOLS_VERSION="RI-2021.6-linux"
-			;;
-		mt8186)
-			PLATFORM="mt8186"
-			XTENSA_CORE="hifi5_7stg_I64D128"
-			HOST="xtensa-mt8186-elf"
-			XTENSA_TOOLS_VERSION="RI-2020.5-linux"
-			;;
-		mt8188)
-			PLATFORM="mt8188"
-			XTENSA_CORE="hifi5_7stg_I64D128"
-			HOST="xtensa-mt8188-elf"
-			XTENSA_TOOLS_VERSION="RI-2020.5-linux"
-			;;
-		mt8195)
-			PLATFORM="mt8195"
-			XTENSA_CORE="hifi4_8195_PROD"
-			HOST="xtensa-mt8195-elf"
-			XTENSA_TOOLS_VERSION="RI-2019.1-linux"
-			;;
-
-	esac
+	source "${SOF_TOP}"/scripts/set_xtensa_params.sh "$platform" ||
+            die 'set_xtensa_params.sh failed'
 
 	test -z "${PRIVATE_KEY_OPTION}" || PLATFORM_PRIVATE_KEY="${PRIVATE_KEY_OPTION}"
 

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -87,6 +87,7 @@ class PlatformConfig:
 	aliases: list = dataclasses.field(default_factory=list)
 
 # These can all be built out of the box. --all builds all these.
+# Some of these values are duplicated in sof/scripts/set_xtensa_param.sh: keep them in sync.
 platform_configs_all = {
 	#  Intel platforms
 	"tgl" : PlatformConfig(


### PR DESCRIPTION
2 commits.

Main one: set_xtensa_params.sh: add missing LNL, ACP_6_3 and vangogh

This adds support for:
```
   ./scripts/rebuild-testbench.sh -p lnl
```

But the real motivation is to re-use `set_xtensa_params.sh` before `west build` and `twister`. More commits about that after this PR.