### PR TITLE
copier: store gateway config in copier_data

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -64,6 +64,8 @@ static int copier_init(struct processing_module *mod)
 	struct module_data *md = &mod->priv;
 	struct ipc4_copier_module_cfg *copier = (struct ipc4_copier_module_cfg *)md->cfg.init_data;
 	struct comp_ipc_config *config = &dev->ipc_config;
+	void *gtw_cfg = NULL;
+	size_t gtw_cfg_size;
 	int i, ret = 0;
 
 	cd = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, sizeof(*cd));
@@ -78,7 +80,31 @@ static int copier_init(struct processing_module *mod)
 	 */
 	if (memcpy_s(&cd->config, sizeof(cd->config), copier, sizeof(*copier)) < 0) {
 		ret = -EINVAL;
-		goto error;
+		goto error_cd;
+	}
+
+	/* Allocate memory and store gateway_cfg in runtime. Gateway cfg has to
+	 * be kept even after copier is created e.g. during SET_PIPELINE_STATE
+	 * IPC when dai_config_dma_channel() is called second time and DMA
+	 * config is used to assign dma_channel_id value.
+	 */
+	if (copier->gtw_cfg.config_length) {
+		gtw_cfg_size = copier->gtw_cfg.config_length << 2;
+		gtw_cfg = rmalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM,
+				  gtw_cfg_size);
+		if (!gtw_cfg) {
+			ret = -ENOMEM;
+			goto error_cd;
+		}
+
+		ret = memcpy_s(gtw_cfg, gtw_cfg_size, &copier->gtw_cfg.config_data,
+			       gtw_cfg_size);
+		if (ret) {
+			comp_err(dev, "Unable to copy gateway config from copier blob");
+			goto error;
+		}
+
+		cd->gtw_cfg = gtw_cfg;
 	}
 
 	for (i = 0; i < IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT; i++)
@@ -148,6 +174,8 @@ static int copier_init(struct processing_module *mod)
 	dev->state = COMP_STATE_READY;
 	return 0;
 error:
+	rfree(gtw_cfg);
+error_cd:
 	rfree(cd);
 	return ret;
 }
@@ -172,6 +200,8 @@ static int copier_free(struct processing_module *mod)
 		break;
 	}
 
+	if (cd)
+		rfree(cd->gtw_cfg);
 	rfree(cd);
 
 	return 0;

--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -155,7 +155,7 @@ struct ipc4_copier_module_cfg {
 	/* audio format for output pin 0 */
 	struct ipc4_audio_format out_fmt;
 	uint32_t copier_feature_mask;
-	struct ipc4_copier_gateway_cfg  gtw_cfg;
+	struct ipc4_copier_gateway_cfg gtw_cfg;
 } __attribute__((packed, aligned(4)));
 
 enum ipc4_copier_module_config_params {
@@ -242,6 +242,7 @@ struct copier_data {
 	 * from the IPC data.
 	 */
 	struct ipc4_copier_module_cfg config;
+	void *gtw_cfg;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint32_t endpoint_num;

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -231,8 +231,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_dmic;
-
-		ret = ipc4_find_dma_config(&dai, (uint8_t *)copier->gtw_cfg.config_data,
+		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
 					   copier->gtw_cfg.config_length * 4);
 		if (ret != 0) {
 			comp_err(dev, "No dmic dma_config found in blob!");

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -172,7 +172,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.type = SOF_DAI_INTEL_SSP;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_ssp;
-		ret = ipc4_find_dma_config(&dai, (uint8_t *)copier->gtw_cfg.config_data,
+		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
 					   copier->gtw_cfg.config_length * 4);
 		if (ret != 0) {
 			comp_err(dev, "No ssp dma_config found in blob!");


### PR DESCRIPTION
We need to keep `gtw_cfg.config_data` during Copier lifetime to be able to retrieve dma_channel_id when process SET_PIPELINE_STATE(RUN) IPC. Please refer to the detailed explanation below:
https://github.com/thesofproject/sof/issues/8275#issuecomment-1822333476

Use previously saved gateway config to find DMA config and assign correct pointer to `host_dma_config` for SSP and DMIC.
This PR should fix issues reported in https://github.com/thesofproject/sof/issues/8275 for SSP and DMIC interfaces.