### PR TITLE
module: Add support for saving and retrieving the base config extension

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -148,6 +148,22 @@ int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *valu
 		memcpy_s(value, sizeof(struct ipc4_base_module_cfg),
 			 &mod->priv.cfg.base_cfg, sizeof(mod->priv.cfg.base_cfg));
 		break;
+	case COMP_ATTR_BASE_CONFIG_EXT:
+	{
+		struct ipc4_base_module_cfg_ext *basecfg_ext = mod->priv.cfg.basecfg_ext;
+		size_t size;
+
+		if (!basecfg_ext) {
+			comp_err(mod->dev, "No base config extn set for module");
+			return -EINVAL;
+		}
+
+		size = basecfg_ext->nb_input_pins * sizeof(struct ipc4_input_pin_format) +
+				basecfg_ext->nb_output_pins * sizeof(struct ipc4_output_pin_format);
+		memcpy_s(value, sizeof(*basecfg_ext) + size,
+			 basecfg_ext, sizeof(*basecfg_ext) + size);
+		break;
+	}
 	default:
 		return -EINVAL;
 	}

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -30,6 +30,7 @@ struct module_config {
 	const void *init_data; /**< Initial IPC configuration. */
 #if CONFIG_IPC_MAJOR_4
 	struct ipc4_base_module_cfg base_cfg;
+	struct ipc4_base_module_cfg_ext *basecfg_ext;
 #endif
 };
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -117,6 +117,7 @@ enum {
 #define COMP_ATTR_COPY_DIR	2	/**< Comp copy direction */
 #define COMP_ATTR_VDMA_INDEX	3	/**< Comp index of the virtual DMA at the gateway. */
 #define COMP_ATTR_BASE_CONFIG	4	/**< Component base config */
+#define COMP_ATTR_BASE_CONFIG_EXT 5	/**< Component base config extension */
 /** @}*/
 
 /** \name Trace macros

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -16,6 +16,7 @@
 #ifndef __SOF_AUDIO_COMPONENT_INT_H__
 #define __SOF_AUDIO_COMPONENT_INT_H__
 
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/component.h>
 #include <ipc/topology.h>
 
@@ -216,31 +217,59 @@ struct get_attribute_remote_payload {
 static inline int comp_ipc4_get_attribute_remote(struct comp_dev *dev, uint32_t type,
 						 void *value)
 {
+	struct ipc4_base_module_cfg_ext *basecfg_ext;
 	struct ipc4_base_module_cfg *base_cfg;
 	struct get_attribute_remote_payload payload = {};
 	struct idc_msg msg = { IDC_MSG_GET_ATTRIBUTE,
 		IDC_EXTENSION(dev->ipc_config.id), dev->ipc_config.core,
 		sizeof(payload), &payload};
+	size_t size = MODULE_MAX_SINKS * sizeof(struct ipc4_output_pin_format) +
+			MODULE_MAX_SOURCES * sizeof(struct ipc4_input_pin_format);
 	int ret;
 
-	/* Only COMP_ATTR_BASE_CONFIG is supported for remote access */
-	if (type != COMP_ATTR_BASE_CONFIG)
-		return -EINVAL;
-
-	base_cfg = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*base_cfg));
-	if (!base_cfg)
-		return -ENOMEM;
-
 	payload.type = type;
-	payload.value = base_cfg;
+
+	/*
+	 * Only COMP_ATTR_BASE_CONFIG and COMP_ATTR_BASE_CONFIG_EXT are supported for
+	 * remote access
+	 */
+	switch (type) {
+	case COMP_ATTR_BASE_CONFIG:
+		base_cfg = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+				   sizeof(*base_cfg));
+		if (!base_cfg)
+			return -ENOMEM;
+
+		payload.value = base_cfg;
+		break;
+	case COMP_ATTR_BASE_CONFIG_EXT:
+		basecfg_ext = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM,
+					  sizeof(*basecfg_ext) + size);
+		if (!basecfg_ext)
+			return -ENOMEM;
+
+		payload.value = basecfg_ext;
+		break;
+	default:
+		return -EINVAL;
+	}
 
 	ret = idc_send_msg(&msg, IDC_BLOCKING);
 
-	if (ret == 0)
-		memcpy_s(value, sizeof(struct ipc4_base_module_cfg),
-			 base_cfg, sizeof(struct ipc4_base_module_cfg));
+	if (!ret) {
+		switch (type) {
+		case COMP_ATTR_BASE_CONFIG:
+			memcpy_s(value, sizeof(struct ipc4_base_module_cfg),
+				 base_cfg, sizeof(struct ipc4_base_module_cfg));
+			rfree(base_cfg);
+			break;
+		case COMP_ATTR_BASE_CONFIG_EXT:
+			memcpy_s(value, size, basecfg_ext, size);
+			rfree(basecfg_ext);
+			break;
+		}
+	}
 
-	rfree(base_cfg);
 	return ret;
 }
 #endif	/* CONFIG_IPC_MAJOR_4 */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -36,6 +36,7 @@
 
 #define MAX_BLOB_SIZE 8192
 #define MODULE_MAX_SOURCES 8
+#define MODULE_MAX_SINKS 8
 
 #define API_CALL(cd, cmd, sub_cmd, value, ret) \
 	do { \


### PR DESCRIPTION
Modules are bound with one another with a buffer in between. Today, this buffer's size is based on the source module's base config obs and sink module's base config ibs. But this is incorrect because this assumes that the connection is always from output pin 0 of the source module and input pin 0 of the sink module.

To determine the buffer size correctly, the buffer size should be based on the pin-based obs/ibs of the source/sink module. To allow this, save the base config extension for the module during init so that it can be retrieved during module binding to get the obs/ibs based on the source/sink pin ID.

Modify the google rtc and smart amp modules to save the base config extension during their init.