### PR TITLE
[SKIP SOF-TEST] Run all workflows in daily tests

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -6,7 +6,7 @@ name: Build test all components
 # 'Actions' tab
 
 # yamllint disable-line rule:truthy
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch, workflow_call]
 
 jobs:
 

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -12,7 +12,7 @@
 name: codestyle
 
 # yamllint disable-line rule:truthy
-on: [pull_request]
+on: [pull_request, workflow_call, workflow_dispatch]
 
 jobs:
   checkpatch:

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -14,9 +14,44 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-all-main-actions:
+
+  # Keep in .yml alphabetical order
+
+  zephyr-stub-all:
+    uses: ./.github/workflows/build_all.yml
+
+  # TODO: separate "fetchPRcommits" which can't work in daily tests
+  # uses: ./.github/workflows/codestyle.yml
+
+  XTOS-make-install:
+    uses: ./.github/workflows/installer.yml
+
+  zephyr-fuzz-IPC:
+    uses: ./.github/workflows/ipc_fuzzer.yml
+    with:
+      fuzzing_duration_s: 300
+
+  # A legacy, semi-random mix
+  main-PR-workflows:
     uses: ./.github/workflows/pull-request.yml
-  run-zephyr-builds:
-    uses: ./.github/workflows/zephyr.yml
-  sparse-zephyr:
+
+  XTOS-reproducible:
+    uses: ./.github/workflows/repro-build.yml
+
+  rimage:
+    uses: ./.github/workflows/rimage.yml
+
+  zephyr-sparse-analyzer:
     uses: ./.github/workflows/sparse-zephyr.yml
+
+  user-space-testbench:
+    uses: ./.github/workflows/testbench.yml
+
+  user-space-other-tools:
+    uses: ./.github/workflows/tools.yml
+
+  cmocka-unit-tests:
+    uses: ./.github/workflows/unit-tests.yml
+
+  zephyr-builds:
+    uses: ./.github/workflows/zephyr.yml

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -13,7 +13,7 @@ name: installer
 # 'workflow_dispatch' allows running this workflow manually from the
 # 'Actions' tab
 # yamllint disable-line rule:truthy
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   checktree:

--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -6,7 +6,21 @@ name: IPC fuzzing
 # 'Actions' tab
 
 # yamllint disable-line rule:truthy
-on: [pull_request, workflow_dispatch]
+on:
+  workflow_call:
+    inputs:
+      fuzzing_duration_s:
+        type: number
+        default: 300  # 5 minutes
+
+  workflow_dispatch:
+    inputs:
+      fuzzing_duration_s:
+        type: number
+        default: 300
+
+  pull_request:
+  # TODO: can we provide a default inputs here too?
 
 jobs:
 
@@ -66,7 +80,9 @@ jobs:
             IPC3) cmake_arg='-DCONFIG_IPC_MAJOR_3=y' ;;
             IPC4) cmake_arg='-DCONFIG_IPC_MAJOR_4=y' ;;
           esac
-          sof/scripts/fuzz.sh -o fuzz-stdout.txt -t 300 -- "$cmake_arg"
+          duration="${{inputs.fuzzing_duration_s}}"
+          duration="${duration:-301}"  # pull_request has not 'inputs.' :-(
+          sof/scripts/fuzz.sh -o fuzz-stdout.txt -t "$duration" -- "$cmake_arg"
 
       - name: Upload stdout
         uses: actions/upload-artifact@v3

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -12,7 +12,7 @@
 name: Reproducible builds
 
 # yamllint disable-line rule:truthy
-on: [pull_request]
+on: [pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   main:

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -13,6 +13,7 @@ name: rimage
 
 # yamllint disable-line rule:truthy
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -26,6 +26,7 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -5,7 +5,7 @@ name: User space tools/ directory
 # 'Actions' tab
 
 # yamllint disable-line rule:truthy
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   # This is not the same as building every ./build-tools.sh option.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ name: Unit tests
 # 'Actions' tab
 
 # yamllint disable-line rule:truthy
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   cmocka_utests:


### PR DESCRIPTION
~Also fuzz for longer in daily tests: 30 minutes instead of 5 minutes~

3 commits.

It's sometimes hard to find whether a check failure is due to the PR in which it fails. 

It also happens that two passing PRs are merged around the same time and conflict with each other[*] (recent example: #8560).

Running all checks daily on a "pure" main branch without any PR helps with these problems.

[*] "Merge trains / merge queues" solve this problem but they would a lot of work and overkill considering how rarely this happens.