### PR TITLE
west.yml: update Zephyr to efc32081893

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: efc32081893dd607dfc51938ef93787872008fe2
+      revision: a47aa23129747f15dee6b528f84cd983c7750b40
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to pull in imx8ulp support. This includes following zephyr commits:

- cfb68f827202 ("boards: xtensa: adsp: add support for imx8ulp board")
- a9a0c28282c3 ("dts/xtensa/nxp: Add dtsi for imx8ulp")
- 4b33c65f7108 ("soc: xtensa: adsp: add support for NXP ADSP for i.MX8ULP")
- ceae1d83ca4b ("west: sign: add support for NXP i.MX8ULP board")