### PR TITLE
module: sink: source: Prevent division by zero issue

### DIFF
--- a/src/module/audio/source_api.c
+++ b/src/module/audio/source_api.c
@@ -53,6 +53,10 @@ size_t source_get_frame_bytes(struct sof_source *source)
 
 size_t source_get_data_frames_available(struct sof_source *source)
 {
-	return source_get_data_available(source) /
-			source_get_frame_bytes(source);
+	uint32_t frame_bytes = source_get_frame_bytes(source);
+
+	if (frame_bytes > 0)
+		return source_get_data_available(source) / frame_bytes;
+	else
+		return 0;
 }


### PR DESCRIPTION
This patch prevents division by zero, when
source_get_frame_bytes() routine returns 0.

This change fixes issue https://github.com/thesofproject/sof/issues/8414. The problem happens due to race condition during pipeline pause operation. The exact failure mechanism require additional debug, but checking frame_bytes value before division prevents exceptions.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>