### PR TITLE
topology2: google-rtc-aec: Add Byte control

### DIFF
--- a/tools/topology/topology2/include/components/google-rtc-aec.conf
+++ b/tools/topology/topology2/include/components/google-rtc-aec.conf
@@ -47,6 +47,15 @@ Class.Widget."google-rtc-aec" {
 		token_ref	"comp.word"
 	}
 
+	Object.Control.bytes."1" {
+		access [
+			tlv_write
+			tlv_callback
+		]
+		name 'Config'
+		max 2048
+	}
+
 	# Attribute categories
 	attributes {
 		#


### PR DESCRIPTION
Add binary controls for AEC tuning data with
max size set to 2048.