### PR TITLE
topology2: Remove pcm cap attributes

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -169,10 +169,4 @@ Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	4
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }


### PR DESCRIPTION
Remove the attributes that do not belong to Pipeline class. There are no changes to compiled binary.