### PR TITLE
.github/zephyr: Add imx8ulp target to CI

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -106,7 +106,7 @@ jobs:
         # many lines. Pay attention to COMMAS.
         IPC_platforms: [
           # - IPC3 default
-          imx8 imx8x imx8m,
+          imx8 imx8x imx8m imx8ulp,
           # - IPC4 default
           mtl, lnl,
           # Temporary testbed for Zephyr development.
@@ -211,7 +211,7 @@ jobs:
         # many lines. Pay attention to COMMAS.
         platforms: [
           # - IPC3 default
-          imx8 imx8x imx8m,
+          imx8 imx8x imx8m imx8ulp,
           # - IPC4 default
           mtl,
           tgl tgl-h,


### PR DESCRIPTION
Now that imx8ulp support is ready with Zephyr add it as compilation target for CI.