### PR TITLE
scripts/xtensa-build-zephyr.py: Correct XTENSA_SYSTEM path

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -699,9 +699,12 @@ def build_platforms():
 			# Set variables expected by xcc toolchain. CMake cannot set (evil) build-time
 			# environment variables at configure time:
 			# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-get-or-set-environment-variables
-			XTENSA_BUILDS_DIR=str(pathlib.Path(xtensa_tools_root_dir, "install", "builds",
-				TOOLCHAIN_VER).absolute())
-			XTENSA_SYSTEM = str(pathlib.Path(XTENSA_BUILDS_DIR, XTENSA_CORE, "config").absolute())
+			XTENSA_SYSTEM = str(pathlib.Path(xtensa_tools_root_dir,
+							 "install",
+							 "tools",
+							 TOOLCHAIN_VER,
+							 "XtensaTools",
+							 "config").absolute())
 			platf_build_environ["XTENSA_SYSTEM"] = XTENSA_SYSTEM
 
 		platform_build_dir_name = f"build-{platform}"


### PR DESCRIPTION
When XTENSA_TOOLS_ROOT is set in the environment (which is a standard way for the user to specify the SDK installation directory), this script was setting the XTENSA_SYSTEM variable (the location of the registry of cores in a specific toolchain) to:

    $XTENSA_TOOLS_ROOT/install/builds/<toolchain_ver>/

But that seems to be incorrect, and causes the compiler to fail with a fairly reasonable runtime error that it can't find the requested core. (And THAT then causes the initial Zephyr cmake compiler check to fail in weird ways, as it tries to run "xt-clang" with no arguments and eats the output, reporting that you have no compiler installed).

The correct $XTENSA_SYSTEM path that works is:

    $XTENSA_TOOLS_ROOT/install/tools/<toolchain_ver>/XtensaTools/config

I'm guessing most builds run the tools from standard locations and don't set XTENSA_TOOLS_ROOT?