### PR TITLE
Audio: Module adapter: Fix return value when no prepare operation

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -198,7 +198,7 @@ int module_prepare(struct processing_module *mod,
 		   struct sof_source **sources, int num_of_sources,
 		   struct sof_sink **sinks, int num_of_sinks)
 {
-	int ret;
+	int ret = 0;
 	struct module_data *md = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 


### PR DESCRIPTION
The build of testbench for MTL platform simulation causes this build fail (rebuilt-testbench -p mtl):

src/audio/module_adapter/module/generic.c:213:6:
error: variable 'ret' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
        if (md->ops->prepare) {
            ^~~~~~~~~~~~~~~~

src/audio/module_adapter/module/generic.c:236:9:
note: uninitialized use occurs here
        return ret;
               ^~~

Since it's a possibility to have a module without prepare() operation, the initialize to zero is added to avoid the return of undefined value.

Reported-by: Marc Herbert <marc.herbert@intel.com>