### PR TITLE
topology2: Remove obsolete rate and channels properties from pipeline objects

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-be.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.dai-copier-be."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -103,10 +101,4 @@ Class.Pipeline."dai-copier-be" {
 
 	time_domain		"timer"
 	dynamic_pipeline	1
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-eqiir-module-copier-capture.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.dai-copier-eqiir-module-copier-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -169,10 +167,4 @@ Class.Pipeline."dai-copier-eqiir-module-copier-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	4
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-mixin-capture.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.dai-copier-gain-mixin-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -101,10 +99,4 @@ Class.Pipeline."dai-copier-gain-mixin-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-module-copier-capture.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.dai-copier-gain-module-copier-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -116,10 +114,4 @@ Class.Pipeline."dai-copier-gain-module-copier-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-kpb-be.conf
@@ -10,8 +10,6 @@
 #	direction	"playback"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -135,10 +133,4 @@ Class.Pipeline."dai-kpb-be" {
 
 	time_domain	"timer"
 	dynamic_pipeline 1
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/deepbuffer-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.deepbuffer-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -110,10 +108,4 @@ Class.Pipeline."deepbuffer-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-capture.conf
@@ -10,8 +10,6 @@
 # 	format		"s16le"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -223,10 +221,4 @@ Class.Pipeline."gain-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-copier-capture.conf
@@ -10,8 +10,6 @@
 # 	format		"s16le"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -147,10 +145,4 @@ Class.Pipeline."gain-copier-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-module-copier.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.gain-module-copier."N" {
 #	direction	"capture"
 # 	period		1000
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -110,10 +108,4 @@ Class.Pipeline."gain-module-copier" {
 
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/gain-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.gain-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -105,10 +103,4 @@ Class.Pipeline."gain-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/google-rtc-aec-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/google-rtc-aec-capture.conf
@@ -10,8 +10,6 @@
 # 	format		"s16le"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -138,10 +136,4 @@ Class.Pipeline."google-rtc-aec-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	16000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/highpass-capture-be.conf
@@ -10,8 +10,6 @@
 #	direction	"capture"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -87,10 +85,4 @@ Class.Pipeline."highpass-capture-be" {
 
 	time_domain	"timer"
 	dynamic_pipeline 1
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-mixin-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.host-copier-gain-mixin-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -109,10 +107,4 @@ Class.Pipeline."host-copier-gain-mixin-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-copier-gain-src-mixin-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.host-copier-gain-src-mixin-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -85,10 +83,4 @@ Class.Pipeline."host-copier-gain-src-mixin-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	8000
-	rate_max	192000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-capture.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.host-gateway-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -108,10 +106,4 @@ Class.Pipeline."host-gateway-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.host-gateway-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -80,10 +78,4 @@ Class.Pipeline."host-gateway-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway-capture.conf
@@ -10,8 +10,6 @@
 #	direction	"capture"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -64,10 +62,4 @@ Class.Pipeline."io-gateway-capture" {
 	time_domain	"timer"
 	direction	"capture"
 	dynamic_pipeline 1
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/io-gateway.conf
@@ -10,8 +10,6 @@
 #	direction	"playback"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -91,10 +89,4 @@ Class.Pipeline."io-gateway" {
 
 	time_domain	"timer"
 	dynamic_pipeline 1
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-aria-gain-mixin-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-aria-gain-mixin-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -91,10 +89,4 @@ Class.Pipeline."mixout-aria-gain-mixin-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -74,10 +72,4 @@ Class.Pipeline."mixout-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf
@@ -8,7 +8,6 @@
 #
 # Object.Pipeline.mixout-gain-alh-dai-copier-playback."N" {
 # 	time_domain	"timer"
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -102,10 +101,4 @@ Class.Pipeline."mixout-gain-alh-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -99,10 +97,4 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-efx-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -190,10 +188,4 @@ Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-efx-mbdrc-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -188,10 +186,4 @@ Class.Pipeline."mixout-gain-efx-mbdrc-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-dts-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-dts-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-dts-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -130,10 +128,4 @@ Class.Pipeline."mixout-gain-eqiir-dts-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-host-copier-capture.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-host-copier-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -118,10 +116,4 @@ Class.Pipeline."mixout-gain-host-copier-capture" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-smart-amp-dai-copier-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.mixout-gain-smart-amp-dai-copier-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -131,10 +129,4 @@ Class.Pipeline."mixout-gain-smart-amp-dai-copier-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-mixin.conf
@@ -8,8 +8,6 @@
 # Object.Pipeline.mixout-mixin."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -58,10 +56,4 @@ Class.Pipeline."mixout-mixin" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	48000
-	rate_max	48000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/src-gain-mixin-playback.conf
@@ -9,8 +9,6 @@
 # Object.Pipeline.src-gain-mixin-playback."N" {
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -112,10 +110,4 @@ Class.Pipeline."src-gain-mixin-playback" {
 	direction	"playback"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		48000
-	rate_min	8000
-	rate_max	192000
 }

--- a/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/wov-detect.conf
@@ -10,8 +10,6 @@
 # 	format		"s16le"
 # 	period		1000
 # 	time_domain	"timer"
-# 	channels	2
-# 	rate		48000
 # }
 #
 # Where N is the unique pipeline ID within the same alsaconf node.
@@ -126,10 +124,4 @@ Class.Pipeline."wov-detect" {
 	direction	"capture"
 	dynamic_pipeline 1
 	time_domain	"timer"
-	channels	2
-	channels_min	2
-	channels_max	2
-	rate		16000
-	rate_min	16000
-	rate_max	16000
 }

--- a/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/eq-iir-volume-capture.conf
@@ -10,8 +10,6 @@
 #		format		"s16le"
 #		period		1000
 #		time_domain	"timer"
-#		channels	2
-#		rate		48000
 #	}
 #
 # Where N is a unique integer for pipeline ID in the same alsaconf node.
@@ -117,8 +115,6 @@ Class.Pipeline."eq-iir-volume-capture" {
 	direction 	"capture"
 	time_domain	"timer"
 	period		1000
-	channels	2
-	rate		48000
 	priority	0
 	core 		0
 	frames		0

--- a/tools/topology/topology2/include/pipelines/passthrough-capture.conf
+++ b/tools/topology/topology2/include/pipelines/passthrough-capture.conf
@@ -10,8 +10,6 @@
 #		format		"s16le"
 #		period		1000
 #		time_domain	"timer"
-#		channels	2
-#		rate		48000
 #	}
 #
 # and N is the unique pipeline_id for this pipeline object within the same alsaconf node.
@@ -69,8 +67,6 @@ Class.Pipeline."passthrough-capture" {
 	direction 	"capture"
 	time_domain	"timer"
 	period		1000
-	channels	2
-	rate		48000
 	priority	0
 	core 		0
 	frames		0

--- a/tools/topology/topology2/include/pipelines/pipeline-common.conf
+++ b/tools/topology/topology2/include/pipelines/pipeline-common.conf
@@ -29,14 +29,6 @@ DefineAttribute."format" {
 	}
 }
 
-# Sampling rate
-DefineAttribute."rate" {
-	constraints {
-		min	16000
-		max	196000
-	}
-}
-
 # Pipeline direction
 DefineAttribute."direction" {
 	type	"string"

--- a/tools/topology/topology2/include/pipelines/volume-capture.conf
+++ b/tools/topology/topology2/include/pipelines/volume-capture.conf
@@ -10,8 +10,6 @@
 #		format		"s16le"
 #		period		1000
 #		time_domain	"timer"
-#		channels	2
-#		rate		48000
 #	}
 #
 # and N is the unique pipeline_id for this pipeline object within the same alsaconf node.
@@ -101,8 +99,6 @@ Class.Pipeline."volume-capture" {
 	direction 	"capture"
 	time_domain	"timer"
 	period		1000
-	channels	2
-	rate		48000
 	priority	0
 	core 		0
 	frames		0

--- a/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-demux-playback.conf
@@ -10,8 +10,6 @@
 #		format		"s16le"
 #		period		1000
 #		time_domain	"timer"
-#		channels	2
-#		rate		48000
 #	}
 #
 # Where N is a unique integer for pipeline ID in the same alsaconf node.
@@ -117,8 +115,6 @@ Class.Pipeline."volume-demux-playback" {
 	direction 	"playback"
 	time_domain	"timer"
 	period		1000
-	channels	2
-	rate		48000
 	priority	0
 	core 		0
 	frames		0

--- a/tools/topology/topology2/include/pipelines/volume-playback.conf
+++ b/tools/topology/topology2/include/pipelines/volume-playback.conf
@@ -12,8 +12,6 @@
 ##			format		"s16le"
 ##			period		1000
 ##			time_domain	"timer"
-##			channels	2
-##			rate		48000
 ##		}
 ##
 ## where N is the unique pipeline_id for this pipeline object within the same alsaconf node.
@@ -102,8 +100,6 @@ Class.Pipeline."volume-playback" {
 	direction 	"playback"
 	time_domain	"timer"
 	period		1000
-	channels	2
-	rate		48000
 	priority	0
 	core 		0
 	frames		0


### PR DESCRIPTION
The channels, channels_min, channels_max, rate, rate_min, and rate_max pipeline object properties are obsolete and not used. Let's get rid of them,