### PR TITLE
[SKIP SOF-TEST] rebuild-testbench.sh: cosmetic improvements

### DIFF
--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -136,7 +136,16 @@ main()
         esac
     done
 
+    # This automagically removes the -- sentinel itself if any.
+    shift "$((OPTIND -1))"
+    # Error on spurious arguments.
+    test $# -eq 0 || {
+        print_usage
+        die "Unknown arguments: %s\n" "$*"
+    }
+
     rebuild_testbench
+
     printf '\n'
     testbench_usage
 }

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -10,6 +10,7 @@ SOF_REPO=$(dirname "$SCRIPT_DIR")
 TESTBENCH_DIR="$SOF_REPO"/tools/testbench
 
 # Defaults
+BUILD_BACKEND='make'
 BUILD_TYPE=native
 BUILD_DIR_NAME=build_testbench
 BUILD_TARGET=install
@@ -23,7 +24,7 @@ usage: $0 [-f] [-p <platform>]
           When omitted, perform a BUILD_TYPE=native, compile-only check.
        -f Build testbench with compiler provided by fuzzer
           (default path: $HOME/sof/work/AFL/afl-gcc)
-       -j number of parallel make/ninja jobs. Defaults to /usr/bin/nproc.
+       -j number of parallel $BUILD_BACKEND jobs. Defaults to /usr/bin/nproc.
           You MUST re-run with -j1 when something is failing!
 EOFUSAGE
 }
@@ -100,11 +101,32 @@ EOFSETUP
 
 testbench_usage()
 {
+    local src_env_msg
+    if [ "$BUILD_TYPE" = 'xt' ]; then
+        export_xtensa_setup
+        src_env_msg="source $export_script"
+    fi
+
+cat <<EOF0
+Success!
+
+For temporary, interactive Kconfiguration use:
+
+   $BUILD_BACKEND -C $TESTBENCH_DIR/$BUILD_DIR_NAME/sof_ep/build/  menuconfig
+
+Permanent configuration is "src/arch/host/configs/library_defconfig".
+
+For instant, incremental build:
+
+   $src_env_msg
+   $BUILD_BACKEND -C $TESTBENCH_DIR/$BUILD_DIR_NAME/ -j$(nproc)
+
+EOF0
+
     case "$BUILD_TYPE" in
         xt)
-            export_xtensa_setup
             cat <<EOFUSAGE
-Success! Testbench binary for $BUILD_PLATFORM is in $xtbench
+Testbench binary for $BUILD_PLATFORM is in $xtbench
 it can be run with command:
 
 $xtbench_run -h

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -40,15 +40,12 @@ die()
 
 rebuild_testbench()
 {
+    local bdir="$BUILD_DIR_NAME"
     cd "$TESTBENCH_DIR"
 
-    rm -rf "$BUILD_DIR_NAME"
-    mkdir "$BUILD_DIR_NAME"
-    cd "$BUILD_DIR_NAME"
-
-    cmake -DCMAKE_INSTALL_PREFIX=install  ..
-
-    cmake --build .  --  -j"${jobs}" $BUILD_TARGET
+    rm -rf "$bdir"
+    cmake -B "$bdir" -DCMAKE_INSTALL_PREFIX="$bdir"/install
+    cmake --build "$bdir"  --  -j"${jobs}" $BUILD_TARGET
 }
 
 export_CC_with_afl()

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -5,10 +5,15 @@
 # stop on most errors
 set -e
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+SOF_REPO=$(dirname "$SCRIPT_DIR")
+BUILD_TESTBENCH_DIR="$SOF_REPO"/tools/testbench
+
 # Defaults
 BUILD_TYPE=native
 BUILD_DIR_NAME=build_testbench
 BUILD_TARGET=install
+: "${SOF_AFL:=$HOME/sof/work/AFL/afl-gcc}"
 
 print_usage()
 {
@@ -120,11 +125,6 @@ EOFUSAGE
 
 main()
 {
-    SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
-    SOF_REPO=$(dirname "$SCRIPT_DIR")
-    BUILD_TESTBENCH_DIR="$SOF_REPO"/tools/testbench
-    : "${SOF_AFL:=$HOME/sof/work/AFL/afl-gcc}"
-
     jobs=$(nproc)
     while getopts "fhj:p:" OPTION; do
         case "$OPTION" in
@@ -134,7 +134,7 @@ main()
                 ;;
             f) export_CC_with_afl;;
             j) jobs=$(printf '%d' "$OPTARG") ;;
-            h) print_usage; exit 1;;
+            h) print_usage; exit 0;;
             *) print_usage; exit 1;;
         esac
     done

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -7,7 +7,7 @@ set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 SOF_REPO=$(dirname "$SCRIPT_DIR")
-BUILD_TESTBENCH_DIR="$SOF_REPO"/tools/testbench
+TESTBENCH_DIR="$SOF_REPO"/tools/testbench
 
 # Defaults
 BUILD_TYPE=native
@@ -40,7 +40,7 @@ die()
 
 rebuild_testbench()
 {
-    cd "$BUILD_TESTBENCH_DIR"
+    cd "$TESTBENCH_DIR"
 
     rm -rf "$BUILD_DIR_NAME"
     mkdir "$BUILD_DIR_NAME"
@@ -80,7 +80,7 @@ setup_xtensa_tools_build()
 
     install_bin=install/tools/$XTENSA_TOOLS_VERSION/XtensaTools/bin
     tools_bin=$XTENSA_TOOLS_ROOT/$install_bin
-    testbench_sections="-Wl,--sections-placement $BUILD_TESTBENCH_DIR/testbench_xcc_sections.txt"
+    testbench_sections="-Wl,--sections-placement $TESTBENCH_DIR/testbench_xcc_sections.txt"
     export CC=$tools_bin/$COMPILER
     export LD=$tools_bin/xt-ld
     export OBJDUMP=$tools_bin/xt-objdump
@@ -90,7 +90,7 @@ setup_xtensa_tools_build()
 
 export_xtensa_setup()
 {
-    export_dir=$BUILD_TESTBENCH_DIR/$BUILD_DIR_NAME
+    export_dir=$TESTBENCH_DIR/$BUILD_DIR_NAME
     export_script=$export_dir/xtrun_env.sh
     xtbench=$export_dir/testbench
     xtbench_run="XTENSA_CORE=$XTENSA_CORE \$XTENSA_TOOLS_ROOT/$install_bin/xt-run $xtbench"

--- a/tools/testbench/CMakeLists.txt
+++ b/tools/testbench/CMakeLists.txt
@@ -50,6 +50,8 @@ install(TARGETS testbench DESTINATION bin)
 
 include(ExternalProject)
 
+# Should we do this? Only for sof_ep, not for parser_ep?
+# https://stackoverflow.com/questions/12021448/how-can-cmake-arguments-be-forwarded-to-externalproject
 ExternalProject_Add(sof_ep
 	DOWNLOAD_COMMAND ""
 	SOURCE_DIR "${sof_source_directory}"


### PR DESCRIPTION
Minor cleanups spotted when looking at past issue 240cc9786ae245c

5 commits, please review separately.

The only really visible addition is this:

```
[100%] Linking C executable testbench
[100%] Built target testbench

Success!

For temporary, interactive Kconfiguration use:

   make -C /home/me/SOF/sof/tools/testbench/build_xt_testbench/sof_ep/build/  menuconfig

Permanent configuration is "src/arch/host/configs/library_defconfig".

For instant, incremental build:

   source  /home/me/SOF/sof/tools/testbench/build_xt_testbench/xtrun_env.sh
   make -C /home/me/SOF/sof/tools/testbench/build_xt_testbench/ -j8


....
```