### PR TITLE
module_adapter: build params first then verify it

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -581,6 +581,8 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 	int ret;
 	struct processing_module *mod = comp_get_drvdata(dev);
 
+	module_adapter_set_params(mod, params);
+
 	ret = comp_verify_params(dev, mod->verify_params_flags, params);
 	if (ret < 0) {
 		comp_err(dev, "module_adapter_params(): comp_verify_params() failed.");
@@ -610,7 +612,6 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 			return ret;
 	}
 
-	module_adapter_set_params(mod, params);
 	return 0;
 }
 

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -67,7 +67,6 @@ void module_adapter_check_data(struct processing_module *mod, struct comp_dev *d
 void module_adapter_set_params(struct processing_module *mod, struct sof_ipc_stream_params *params)
 {
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
-	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, mod->stream_params);
 }
 
 int module_adapter_set_state(struct processing_module *mod, struct comp_dev *dev,


### PR DESCRIPTION
We need to build params based on module base config first then we can verify it since the income params is built for the source of the this module . In comp_verify_params the params is applied to buffer so the sequence is vital. And also remove redundant stream_param set.