### PR TITLE
Use Zephyr SDK 0.16.4

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -248,12 +248,12 @@ jobs:
 
       # Keep this SDK version identical to the one in
       # sof/zephyr/docker-run.sh
-      - name: Cache Zephyr SDK 0.16.1
+      - name: Cache Zephyr SDK 0.16.4
         id: cache-zephyr-sdk
         uses: actions/cache@v3.0.11
         with:
-          path: zephyr-sdk-0.16.1_windows-x86_64.7z
-          key: ${{ runner.os }}-cache-zephyr-sdk-0-16-1
+          path: zephyr-sdk-0.16.4_windows-x86_64.7z
+          key: ${{ runner.os }}-cache-zephyr-sdk-0-16-4
 
       # Wget is needed by Zephyr SDK setup.cmd installation script
       - name: Download wget
@@ -261,11 +261,11 @@ jobs:
         run: |
           curl -L -O http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip
 
-      - name: Download Zephyr SDK 0.16.1
+      - name: Download Zephyr SDK 0.16.4
         if: ${{ steps.cache-zephyr-sdk.outputs.cache-hit != 'true' }}
         run: |  # yamllint disable-line rule:line-length
           curl -L -O `
-          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/zephyr-sdk-0.16.1_windows-x86_64.7z
+          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_windows-x86_64.7z
 
       # Unzips every .zip package to directory matching its name without extension
       - name: Unzip downloaded packages
@@ -288,7 +288,7 @@ jobs:
       # setup.cmd may not be called in from msys shell as it does not parse
       # forward slash script input arguments correctly.
       - name: Install Zephyr SDK
-        run: zephyr-sdk-0.16.1_windows-x86_64/zephyr-sdk-0.16.1/setup.cmd /t all /h /c
+        run: zephyr-sdk-0.16.4_windows-x86_64/zephyr-sdk-0.16.4/setup.cmd /t all /h /c
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -18,10 +18,10 @@
 # use this script with a image other than the one officially tagged
 # "latest", simply overwrite the official tag. Example:
 #
-#   docker tag ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.4
+#   docker tag ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.6
 #              ghcr.io/zephyrproject-rtos/zephyr-build:latest
 #
-# "latest" is just a regular tag like "v0.26.4", it may or many not name
+# "latest" is just a regular tag like "v0.26.6", it may or many not name
 # the most recent image.
 #
 # To automatically restore the official "latest" tag, just delete it:
@@ -54,7 +54,7 @@ main()
 
 run_command()
 {
-    # zephyr-build:v0.26.4 has /opt/toolchains/zephyr-sdk-0.16.1
+    # zephyr-build:v0.26.6 has /opt/toolchains/zephyr-sdk-0.16.4
     # https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags
     #
     # Keep this SDK version identical to the one in
@@ -63,7 +63,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.4 \
+           ghcr.io/zephyrproject-rtos/zephyr-build:v0.26.6 \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
This updates docker container version and zephyr workflows to support new Zephyr SDK (0.16.4).