### PR TITLE
component: pipeline: Refactor direction testing in pipeline propagation

### DIFF
--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -500,6 +500,18 @@ static inline uint64_t comp_get_total_data_processed(struct comp_dev *dev, uint3
 	return ret;
 }
 
+/** Returns true if the component's pipeline matches the specified direction */
+static inline bool comp_same_dir(struct comp_dev *comp, enum sof_ipc_stream_direction dir)
+{
+	int end_type = comp_get_endpoint_type(comp->pipeline->sink_comp);
+
+	if (dir == SOF_IPC_STREAM_PLAYBACK && end_type != COMP_ENDPOINT_DAI)
+		return false;
+	if (dir == SOF_IPC_STREAM_CAPTURE && end_type != COMP_ENDPOINT_HOST)
+		return false;
+	return true;
+}
+
 /** @}*/
 
 #endif /* __SOF_AUDIO_COMPONENT_INT_H__ */


### PR DESCRIPTION
[Split out from https://github.com/thesofproject/sof/pull/8571 for separate review]

Clean up some cut/paste code that had spread around, replacing it with a simpler "comp_same_dir()" predicate.  No behavioral changes, just refactoring.

Also remove the big comment that was repeated in triplicate.  It explained this as error handling (i.e. it must be broken topology from which we want to recover), but in fact cross-pipeline widget connections in modern SOF do run in opposite directions (c.f. echo cancellation, which need to look at the output stream to process microphone input, or smart amp devices that do the reverse).

So just explain it as policy: we don't propagate across opposite-direction pipelines, period.  Usages that need them need to manage their pipeline lifecycles manually.