### PR TITLE
dai_zephyr: Silence benign warnings

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1286,8 +1286,6 @@ int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 
 	/* return if nothing to copy */
 	if (!frames) {
-		comp_warn(dev, "dai_zephyr_multi_endpoint_copy(): nothing to copy");
-
 		for (i = 0; i < num_endpoints; i++) {
 			ret = dma_reload(dd[i]->chan->dma->z_dev, dd[i]->chan->index, 0, 0, 0);
 			if (ret < 0) {
@@ -1460,19 +1458,8 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 	comp_dbg(dev, "dai_common_copy(), dir: %d copy_bytes= 0x%x",
 		 dev->direction, copy_bytes);
 
-	/* Check possibility of glitch occurrence */
-	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&
-	    copy_bytes + avail_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_common_copy(): Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
-			  copy_bytes, avail_bytes, dd->period_bytes);
-	else if (dev->direction == SOF_IPC_STREAM_CAPTURE &&
-		 copy_bytes + free_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_common_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
-			  copy_bytes, free_bytes, dd->period_bytes);
-
 	/* return if nothing to copy */
 	if (!copy_bytes) {
-		comp_warn(dev, "dai_zephyr_copy(): nothing to copy");
 		dma_reload(dd->chan->dma->z_dev, dd->chan->index, 0, 0, 0);
 		return 0;
 	}


### PR DESCRIPTION
[A more limited version of this patch was submitted in #8571]

The DAI emits a flood of warnings when presented with empty buffers at copy time.  That's not really a reasonable warning condition.  There are multiple situations where components upstream may be paused or asynchronous, leading to starvation in any given cycle.

Earlier code has hit this with paused components, where the log messages are merely annoying.

One new situation is that when using the DP scheduler, updates are async and may happen at a different cadence than the pipeline the DAI is on; the upstream component will be presented with data in a (for example) 1ms pipeline tick, but then send it to a different component (echo cancellation, say) that batches it up into larger buffers (10ms) and releases it downstream only at the slower cadence.

In that situation the flood of messages is being emitted during an active stream, and tends to cause glitches all by itself after a few seconds (and even where it doesn't, it floods the Zephyr log backend to the extent that literally every message is dropped).

(I don't know that all such warnigns are removed by this patch.  These are only the ones I've seen in practice.)

Fixes #4672