### PR TITLE
debug_overlay.conf: temporarily disable SOF_BOOT_TEST

### DIFF
--- a/app/debug_overlay.conf
+++ b/app/debug_overlay.conf
@@ -1,8 +1,9 @@
 CONFIG_DEBUG=y
 CONFIG_ASSERT=y
 
-CONFIG_ZTEST=y
-CONFIG_SOF_BOOT_TEST=y
+# Disabled until DSP panic #8621 is fixed
+# CONFIG_ZTEST=y
+# CONFIG_SOF_BOOT_TEST=y
 
 # Following options can be enabled additionally,
 # but will incur a higher runtime cost, so are thus


### PR DESCRIPTION

- This test has failed on MTL since it was enabled.  Running tests that
  we systematically ignore the failure of is much worse than not running
  them because it provides a false impression of quality.

- This can cause DSP panics as seen in
  https://github.com/thesofproject/sof/pull/8621

Signed-off-by: Marc Herbert <marc.herbert@intel.com>