### PR TITLE
[SKIP SOF-TEST] fuzz.sh: add -Werror in GitHub workflow

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -56,9 +56,13 @@ jobs:
           west init -l
           west update --narrow --fetch-opt=--filter=tree:0
 
-      - name: build
+      # This is not fuzzing. Fuzzing just happens to require stubbing
+      # which provides be a great solution to compile-check many CONFIG_*
+      # at once.
+      - name: stubs build
         run: |
           cd workspace
           clang --verbose
           set -x
-          sof/scripts/fuzz.sh -b -- -DOVERLAY_CONFIG=stub_build_all_${{ matrix.IPC }}.conf
+          sof/scripts/fuzz.sh -b -- -DEXTRA_CFLAGS='-Werror' -DEXTRA_CXXFLAGS='-Werror' \
+              -DOVERLAY_CONFIG=stub_build_all_${{ matrix.IPC }}.conf

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -4,28 +4,50 @@ set -e
 print_help()
 {
     cat <<EOFHELP
-# Simple wrapper around a libfuzzer test run, as much for
-# documentation as direct use.  The idea here is really simple: build
-# for the Zephyr "native_posix" board (which is a just a x86
-# executable for the build host, not an emulated device) and run the
-# resulting zephyr.exe file.  This specifies a "fuzz_corpus" directory
-# to save the seeds that produce useful coverage output for use in
-# repeated runs (these are not particularly large, we might consider
-# curating and commiting such a seed directory to the tree).
-#
-# The tool will run until it finds a failure condition.  You will see
-# MANY errors on stdout from all the randomized input.  Don't try to
-# capture this, either let it output to a terminal or arrange to keep
-# only the last XXX lines after the tool exits.
-#
-# The only prerequisite to install is a clang compiler on the host.
-# Versions 12+ have all been observed to work.
-#
-# You will need the kconfigs specified below for correct operation,
-# but can add more at the end of this script's command line to
-# duplicate configurations as needed.  Alternatively you can pass
-# overlay files in kconfig syntax via:
-#    fuzz.sh  -t 300 -- -DOVERLAY_CONFIG=..., etc...
+
+Usage:
+
+      $0 -b      -- -DOVERLAY_CONFIG=stub_build_all_ipc4.conf -DEXTRA_CFLAGS=...
+      $0 -t 500  -- -DOVERLAY_CONFIG=stub_build_all_ipc3.conf ...
+
+
+  -b         Do not run/fuzz: stop after the build.
+  -t n       Fuzz for n seconds.
+  -o ofile   Redirect the fuzzer's extremely verbose stdout. The
+             relatively verbose stderr is not redirected by -o.
+
+Arguments after -- are passed as is to CMake (through west).
+When passing conflicting -DVAR='VAL UE1' -DVAR='VAL UE2' to CMake,
+the last 'VAL UE2' wins; previous values are silently ignored.
+
+Fuzzing happens to require stubbing which provides a great solution to
+compile-check many CONFIG_* at once. So you can stop after the build
+with the -b option.
+
+Simple wrapper around a libfuzzer test run, as much for
+documentation as direct use.  The idea here is really simple: build
+for the Zephyr "native_posix" board (which is a just a x86
+executable for the build host, not an emulated device) and run the
+resulting zephyr.exe file.  This specifies a "fuzz_corpus" directory
+to save the seeds that produce useful coverage output for use in
+repeated runs (these are not particularly large, we might consider
+curating and committing such a seed directory to the tree).
+
+The tool will run until it finds a failure condition.  You will see
+MANY errors on stdout from all the randomized input.  Don't try to
+capture this, either let it output to a terminal or arrange to keep
+only the last XXX lines after the tool exits.
+
+The only prerequisite to install is a clang compiler on the host.
+Versions 12+ have all been observed to work.
+
+You will need the kconfigs specified below for correct operation,
+but can add more at the end of this script's command line to
+duplicate configurations as needed.  Alternatively you can pass
+overlay files in kconfig syntax via:
+
+   fuzz.sh  -t 300 -- -DOVERLAY_CONFIG=... -DEXTRA_CFLAGS='-Wone -Wtwo' ...
+
 EOFHELP
 }
 

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -80,8 +80,12 @@ main()
     -DCONFIG_ASAN=y
   )
 
+  (set -x
+   # When passing conflicting -DVAR='VAL UE1' -DVAR='VAL UE2' to CMake,
+   # the last 'VAL UE2' wins. Previous ones are silently ignored.
   west build -d build-fuzz -b native_posix "$SOF_TOP"/app/ -- \
       "${fuzz_configs[@]}" "$@"
+  )
 
   if $BUILD_ONLY; then
       exit 0


### PR DESCRIPTION
3 commits.

Main ones:
- add -Werror to catch warnings like 3f572b8cb67ede1e47719d49fa29d451ae0f3887 / #8631 
- add a proper -h text