### PR TITLE
xtensa-build-zephyr.py: Update platform aliases and a small help print improvement

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -94,19 +94,20 @@ platform_configs_all = {
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
-		aliases = ['adl', 'ehl']
+		aliases = ['adl', 'adl-n', 'ehl', 'rpl']
 	),
 	"tgl-h" : PlatformConfig(
 		"tgl-h", "intel_adsp_cavs25_tgph",
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
-		aliases = ['adl-s']
+		aliases = ['adl-s', 'rpl-s']
 	),
 	"mtl" : PlatformConfig(
 		"mtl", "intel_adsp_ace15_mtpm",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
+		aliases = ['arl']
 	),
 	"lnl" : PlatformConfig(
 		"lnl", "intel_adsp_ace20_lnl",

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -179,8 +179,10 @@ def parse_args():
 				"               └── RG-2017.8{}/\n".format(xtensa_tools_version_postfix) +
 				"                   └── XtensaTools/\n" +
 			"$XTENSA_TOOLS_ROOT=/path/to/myXtensa ...\n" +
-			f"Supported platforms: {list(platform_configs)}"))
 
+			f"\nSupported platforms: {list(platform_configs)}"), add_help=False)
+
+	parser.add_argument('-h', '--help', action='store_true', help='show help')
 	parser.add_argument("-a", "--all", required=False, action="store_true",
 						help="Build all currently supported platforms")
 	parser.add_argument("platforms", nargs="*", action=validate_platforms_arguments,
@@ -265,9 +267,14 @@ This should be used with programmatic script invocations (eg. Continuous Integra
 		args.platforms = list(platform_configs_all)
 
 	# print help message if no arguments provided
-	if len(sys.argv) == 1:
-			parser.print_help()
-			sys.exit(0)
+	if len(sys.argv) == 1 or args.help:
+		for platform in platform_configs:
+			if platform_configs[platform].aliases:
+				parser.epilog += "\nPlatform aliases for '" + platform + "':\t"
+				parser.epilog += f"{list(platform_configs[platform].aliases)}"
+
+		parser.print_help()
+		sys.exit(0)
 
 	if args.fw_naming == 'AVS':
 		if not args.use_platform_subdir:


### PR DESCRIPTION
Hi,

Add the following missing platform aliases:
tgl: adl-n, rpl
tgl-h: rpl-s
mtl: arl

In the help output print out the aliases for platforms:
```
Supported platforms: ['tgl', 'tgl-h', 'mtl', 'lnl', 'imx8', 'imx8x', 'imx8m', 'imx8ulp']
Platform aliases for 'tgl':     ['adl', 'adl-n', 'ehl', 'rpl']
Platform aliases for 'tgl-h':   ['adl-s', 'rpl-s']
Platform aliases for 'mtl':     ['arl']
```
In this way we can stop guessing which 'platform' should be built to have the firmware for an aliased platform.