### PR TITLE
west.yml: upgrade Zephyr to a1042c40796

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 28d5d23a232b69b213112e723e0a6392cbd5a47e
+      revision: a1042c407964cd9710f544b8ba9a61c15a7de2fb
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to bring in total of 169 commits, including the following related to SOF targets:

dab6f665ca77 xtensa: fix build errors with cache functions
039e5ef1b813 intel_adsp: remove rimage sign() from `west flash`
c7e3ccd51ad4 drivers: dma: intel_adsp_gpdma: fix issue with stop and PM refcounts

Link: https://github.com/thesofproject/sof/issues/8503