### PR TITLE
schedule: zephyr_ll: Fix schedule bug for multi instances

### DIFF
--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -222,7 +222,8 @@ static inline bool domain_is_pending(struct ll_schedule_domain *domain,
 {
 	bool ret;
 
-	assert(domain->ops->domain_is_pending);
+	if (!domain->ops->domain_is_pending)
+		return true;
 
 	ret = domain->ops->domain_is_pending(domain, task, comp);
 


### PR DESCRIPTION
When run two instances at same time the sound has noise, for example: playback and record in i.MX8QM or i.MX8ULP platform.

The reason is one dma interrupt will process two task cause the schedule have no mechanism to make sure only handle the task needed to process.

Fix this issue by adding check if task is in pending state.