### PR TITLE
iadk: module_adapter: Check return code for sink/source api

### DIFF
--- a/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
+++ b/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
@@ -57,6 +57,9 @@ uint32_t IadkModuleAdapter::IadkModuleAdapter_Process(struct sof_source **source
 			i_size = source_get_data_available(sources[i]);
 			ret = source_get_data(sources[i], i_size, (const void **)&input,
 					      (const void **)&input_start, &input_end);
+			if (ret != 0)
+				return ret;
+
 			const intel_adsp::InputStreamBuffer isb_data(
 				(uint8_t *)input, i_size, flags);
 			new (&input_stream_buffers[i]) intel_adsp::InputStreamBuffer(isb_data);
@@ -69,6 +72,9 @@ uint32_t IadkModuleAdapter::IadkModuleAdapter_Process(struct sof_source **source
 			o_size = sink_get_free_size(sinks[i]);
 			ret = sink_get_buffer(sinks[i], o_size, (void **)&output,
 					(void **)&output_start, &output_end);
+			if (ret != 0)
+				return ret;
+
 			const intel_adsp::OutputStreamBuffer osb_data(
 					(uint8_t *)output, o_size);
 			new (&output_stream_buffers[i]) intel_adsp::OutputStreamBuffer(osb_data);

--- a/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
+++ b/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
@@ -64,10 +64,10 @@ namespace dsp_fw
 		 * samples provided by the codec_adapter and produce/output the processed
 		 * ones back to codec_adapter.
 		 */
-		uint32_t IadkModuleAdapter_Process(struct sof_source **sources,
-						   int num_of_sources,
-						   struct sof_sink **sinks,
-						   int num_of_sinks);
+		int IadkModuleAdapter_Process(struct sof_source **sources,
+					      int num_of_sources,
+					      struct sof_sink **sinks,
+					      int num_of_sinks);
 
 		/**
 		 * Module specific apply config procedure, called by codec_adapter every time


### PR DESCRIPTION
Add check of return code for sink/source API functions.
The IADK processing module interface uses uint32_t return code
while cSOF is using int type. Checks return value
from processing() method and returns -ENODATA in case of
failure.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>