### PR TITLE
ipc4: Regression FIX: Do not clear sources/sinks on reset

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1328,15 +1328,6 @@ int module_adapter_reset(struct comp_dev *dev)
 		}
 	}
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
-	if (IS_PROCESSING_MODE_SINK_SOURCE(mod)) {
-		/* for both LL and DP processing */
-		for (i = 0; i < mod->num_of_sources; i++)
-			mod->sources[i] = NULL;
-		for (i = 0; i < mod->num_of_sinks; i++)
-			mod->sinks[i] = NULL;
-		mod->num_of_sinks = 0;
-		mod->num_of_sources = 0;
-	}
 
 	mod->total_data_consumed = 0;
 	mod->total_data_produced = 0;


### PR DESCRIPTION
After https://github.com/thesofproject/sof/pull/8594 been merged, sources and sinks are now setup on .bind() and .unbind(). Previously they were setup in .prepare(). However, there were code left in module_adapter_reset() which clears sources and sinks arrays. That broke some tests: modules which use source/sink API stopped working correctly after pipeline reset.