### PR TITLE
topology2: cavs-nocodec-bt: fix PCM0 and PCM1 capabilities

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -278,13 +278,13 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			direction "playback"
 			name "SSP0 Playback"
-			formats 'S16_LE,S24_LE,S32_LE'
+			formats 'S32_LE'
 		}
 
 		Object.PCM.pcm_caps.2 {
 			direction "capture"
 			name "SSP0 Capture"
-			formats 'S16_LE,S24_LE,S32_LE'
+			formats 'S32_LE'
 		}
 	}
 	{
@@ -298,13 +298,13 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			direction "playback"
 			name "SSP1 Playback"
-			formats 'S16_LE,S24_LE,S32_LE'
+			formats 'S32_LE'
 		}
 
 		Object.PCM.pcm_caps.2 {
 			direction "capture"
 			name "SSP1 Capture"
-			formats 'S16_LE,S24_LE,S32_LE'
+			formats 'S32_LE'
 		}
 	}
 ]


### PR DESCRIPTION
The pipelines for PCM0 and PCM1 only support S32_LE audio format. Fix the PCM capability descriptions to match the actual pipeline definitions. This allows to run test suites that enumerate all support PCMs and their formats.