### PR TITLE
dp: look at all sinks and sources in default "is ready"

### DIFF
--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -187,8 +187,15 @@ bool module_is_ready_to_process(struct processing_module *mod,
 	/* default action - the module is ready if there's enough data for processing and enough
 	 * space to store result. IBS/OBS as declared in init_instance
 	 */
-	return (source_get_data_available(sources[0]) >= source_get_min_available(sources[0]) &&
-		sink_get_free_size(sinks[0]) >= sink_get_min_free_space(sinks[0]));
+	for (int i = 0; i < num_of_sources; i++)
+		if (source_get_data_available(sources[i]) < source_get_min_available(sources[i]))
+			return false;
+
+	for (int i = 0; i < num_of_sinks; i++)
+		if (sink_get_free_size(sinks[i]) < sink_get_min_free_space(sinks[i]))
+			return false;
+
+	return true;
 }
 
 int module_process_sink_src(struct processing_module *mod,


### PR DESCRIPTION
The default "is ready to process" implementation used to look at a first sink and first source only.

This change makes it to look at all sinks and sources.

dependency:

- [x] ~~https://github.com/thesofproject/sof/pull/8575~~
OR
- [x] https://github.com/thesofproject/sof/pull/8685

