### PR TITLE
xtensa-build-zephyr.py: Add arl-s alias to mtl platform

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -109,7 +109,7 @@ platform_configs_all = {
 		"intel", "intel_adsp_ace15_mtpm",
 		f"RI-2022.10{xtensa_tools_version_postfix}",
 		"ace10_LX7HiFi4_2022_10",
-		aliases = ['arl'],
+		aliases = ['arl', 'arl-s'],
 		ipc4 = True
 	),
 	"lnl" : PlatformConfig(


### PR DESCRIPTION
ARL-S is using the same debugkey/community key binary as MTL.