### PR TITLE
audio_stream: Fix uninitialized data in alignment_constants

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -163,7 +163,7 @@ static void aria_set_stream_params(struct comp_buffer *buffer,
 
 	ipc4_update_buffer_format(buffer, audio_fmt);
 #ifndef ARIA_GENERIC
-	audio_stream_init_alignment_constants(8, 1, &buffer->stream);
+	audio_stream_set_align(8, 1, &buffer->stream);
 #endif
 }
 

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -162,9 +162,7 @@ static void aria_set_stream_params(struct comp_buffer *buffer,
 	const struct ipc4_audio_format *audio_fmt = &mod->priv.cfg.base_cfg.audio_fmt;
 
 	ipc4_update_buffer_format(buffer, audio_fmt);
-#ifdef ARIA_GENERIC
-	audio_stream_init_alignment_constants(1, 1, &buffer->stream);
-#else
+#ifndef ARIA_GENERIC
 	audio_stream_init_alignment_constants(8, 1, &buffer->stream);
 #endif
 }

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -550,9 +550,6 @@ static int asrc_prepare(struct processing_module *mod,
 	sinkb = list_first_item(&dev->bsink_list,
 				struct comp_buffer, source_list);
 
-	audio_stream_init_alignment_constants(1, 1, &sourceb->stream);
-	audio_stream_init_alignment_constants(1, 1, &sinkb->stream);
-
 	/* get source data format and period bytes */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
 	source_period_bytes = audio_stream_period_bytes(&sourceb->stream,

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -93,7 +93,7 @@ void audio_stream_recalc_align(struct audio_stream *stream)
 			(is_power_of_2(process_size) ? 31 : 32) - clz(process_size);
 }
 
-void audio_stream_init_alignment_constants(const uint32_t byte_align,
+void audio_stream_set_align(const uint32_t byte_align,
 					   const uint32_t frame_align_req,
 					   struct audio_stream *stream)
 {
@@ -139,7 +139,7 @@ static int audio_stream_source_set_alignment_constants(struct sof_source *source
 {
 	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
+	audio_stream_set_align(byte_align, frame_align_req, audio_stream);
 
 	return 0;
 }
@@ -150,7 +150,7 @@ static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 {
 	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, audio_stream);
+	audio_stream_set_align(byte_align, frame_align_req, audio_stream);
 
 	return 0;
 }
@@ -195,7 +195,7 @@ void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint3
 	audio_stream->addr = buff_addr;
 	audio_stream->end_addr = (char *)audio_stream->addr + size;
 
-	audio_stream_init_alignment_constants(1, 1, audio_stream);
+	audio_stream_set_align(1, 1, audio_stream);
 	source_init(audio_stream_get_source(audio_stream), &audio_stream_source_ops,
 		    &audio_stream->runtime_stream_params);
 	sink_init(audio_stream_get_sink(audio_stream), &audio_stream_sink_ops,

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -79,10 +79,10 @@ static uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
 }
 
 
-void audio_stream_init_alignment_constants(const uint32_t byte_align,
-					   const uint32_t frame_align_req,
-					   struct audio_stream *stream)
+void audio_stream_recalc_align(struct audio_stream *stream)
 {
+	const uint32_t byte_align = stream->byte_align_req;
+	const uint32_t frame_align_req = stream->frame_align_req;
 	uint32_t process_size;
 	uint32_t frame_size = audio_stream_frame_bytes(stream);
 
@@ -92,6 +92,16 @@ void audio_stream_init_alignment_constants(const uint32_t byte_align,
 	stream->runtime_stream_params.align_shift_idx	=
 			(is_power_of_2(process_size) ? 31 : 32) - clz(process_size);
 }
+
+void audio_stream_init_alignment_constants(const uint32_t byte_align,
+					   const uint32_t frame_align_req,
+					   struct audio_stream *stream)
+{
+	stream->byte_align_req = byte_align;
+	stream->frame_align_req = frame_align_req;
+	audio_stream_recalc_align(stream);
+}
+
 
 static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
@@ -145,11 +155,28 @@ static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 	return 0;
 }
 
+static int source_format_set(struct sof_source *source)
+{
+	struct audio_stream *s = container_of(source, struct audio_stream, source_api);
+
+	audio_stream_recalc_align(s);
+	return 0;
+}
+
+static int sink_format_set(struct sof_sink *sink)
+{
+	struct audio_stream *s = container_of(sink, struct audio_stream, sink_api);
+
+	audio_stream_recalc_align(s);
+	return 0;
+}
+
 static const struct source_ops audio_stream_source_ops = {
 	.get_data_available = audio_stream_get_data_available,
 	.get_data = audio_stream_get_data,
 	.release_data = audio_stream_release_data,
 	.audio_set_ipc_params = audio_stream_set_ipc_params_source,
+	.on_audio_format_set = source_format_set,
 	.set_alignment_constants = audio_stream_source_set_alignment_constants
 };
 
@@ -158,6 +185,7 @@ static const struct sink_ops audio_stream_sink_ops = {
 	.get_buffer = audio_stream_get_buffer,
 	.commit_buffer = audio_stream_commit_buffer,
 	.audio_set_ipc_params = audio_stream_set_ipc_params_sink,
+	.on_audio_format_set = sink_format_set,
 	.set_alignment_constants = audio_stream_sink_set_alignment_constants
 };
 
@@ -167,6 +195,7 @@ void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint3
 	audio_stream->addr = buff_addr;
 	audio_stream->end_addr = (char *)audio_stream->addr + size;
 
+	audio_stream_init_alignment_constants(1, 1, audio_stream);
 	source_init(audio_stream_get_source(audio_stream), &audio_stream_source_ops,
 		    &audio_stream->runtime_stream_params);
 	sink_init(audio_stream_get_sink(audio_stream), &audio_stream_sink_ops,

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -67,6 +67,32 @@ static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 	return 0;
 }
 
+static uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
+					     const uint32_t frame_align_req,
+					     uint32_t frame_size)
+{
+	/* Figure out how many frames are needed to meet the byte_align alignment requirements */
+	uint32_t frame_num = byte_align / gcd(byte_align, frame_size);
+
+	/** return the lcm of frame_num and frame_align_req*/
+	return frame_align_req * frame_num / gcd(frame_num, frame_align_req);
+}
+
+
+void audio_stream_init_alignment_constants(const uint32_t byte_align,
+					   const uint32_t frame_align_req,
+					   struct audio_stream *stream)
+{
+	uint32_t process_size;
+	uint32_t frame_size = audio_stream_frame_bytes(stream);
+
+	stream->runtime_stream_params.align_frame_cnt =
+			audio_stream_frame_align_get(byte_align, frame_align_req, frame_size);
+	process_size = stream->runtime_stream_params.align_frame_cnt * frame_size;
+	stream->runtime_stream_params.align_shift_idx	=
+			(is_power_of_2(process_size) ? 31 : 32) - clz(process_size);
+}
+
 static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
 	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -546,14 +546,11 @@ static int crossover_prepare(struct processing_module *mod,
 	/* Get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&source->stream);
 	channels = audio_stream_get_channels(&source->stream);
-	audio_stream_init_alignment_constants(1, 1, &source->stream);
 
 	/* Validate frame format and buffer size of sinks */
 	list_for_item(sink_list, &dev->bsink_list) {
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		if (cd->source_format == audio_stream_get_frm_fmt(&sink->stream)) {
-			audio_stream_init_alignment_constants(1, 1, &sink->stream);
-		} else {
+		if (cd->source_format != audio_stream_get_frm_fmt(&sink->stream)) {
 			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different.",
 				 cd->source_format, audio_stream_get_frm_fmt(&sink->stream));
 			ret = -EINVAL;

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -183,17 +183,6 @@ static int dcblock_process(struct processing_module *mod,
 	return 0;
 }
 
-/* init and calculate the aligned setting for available frames and free frames retrieve*/
-static inline void dcblock_set_frame_alignment(struct audio_stream *source,
-					       struct audio_stream *sink)
-{
-	const uint32_t byte_align = 1;
-	const uint32_t frame_align_req = 1;
-
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
-}
-
 /**
  * \brief Prepares DC Blocking Filter component for processing.
  * \param[in,out] dev DC Blocking Filter base component device.
@@ -220,8 +209,6 @@ static int dcblock_prepare(struct processing_module *mod,
 
 	/* get sink data format and period bytes */
 	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
-
-	dcblock_set_frame_alignment(&sourceb->stream, &sinkb->stream);
 
 	dcblock_init_state(cd);
 	cd->dcblock_func = dcblock_find_func(cd->source_format);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -260,14 +260,6 @@ static int drc_get_config(struct processing_module *mod,
 	return comp_data_blob_get_cmd(cd->model_handler, cdata, fragment_size);
 }
 
-static void drc_set_alignment(struct audio_stream *source,
-			      struct audio_stream *sink)
-{
-	/* Currently no optimizations those would use wider loads and stores */
-	audio_stream_init_alignment_constants(1, 1, source);
-	audio_stream_init_alignment_constants(1, 1, sink);
-}
-
 static int drc_process(struct processing_module *mod,
 		       struct input_stream_buffer *input_buffers,
 		       int num_input_buffers,
@@ -344,7 +336,6 @@ static int drc_prepare(struct processing_module *mod,
 	/* DRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-	drc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -402,8 +402,8 @@ static void eq_fir_set_alignment(struct audio_stream *source,
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
+	audio_stream_set_align(byte_align, frame_align_req, source);
+	audio_stream_set_align(byte_align, frame_align_req, sink);
 }
 
 static int eq_fir_prepare(struct processing_module *mod,

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -174,8 +174,8 @@ static void eq_iir_set_alignment(struct audio_stream *source,
 	const uint32_t byte_align = 8;
 	const uint32_t frame_align_req = 2;
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
+	audio_stream_set_align(byte_align, frame_align_req, source);
+	audio_stream_set_align(byte_align, frame_align_req, sink);
 }
 
 static int eq_iir_prepare(struct processing_module *mod,

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -576,7 +576,6 @@ static int google_rtc_audio_processing_prepare(struct processing_module *mod,
 				 microphone_stream_channels);
 		}
 
-		audio_stream_init_alignment_constants(1, 1, &source->stream);
 		i++;
 	}
 
@@ -592,7 +591,6 @@ static int google_rtc_audio_processing_prepare(struct processing_module *mod,
 		return -EINVAL;
 	}
 
-	audio_stream_init_alignment_constants(1, 1, &output->stream);
 	frame_fmt = audio_stream_get_frm_fmt(&output->stream);
 	rate = audio_stream_get_rate(&output->stream);
 	output_stream_channels = audio_stream_get_channels(&output->stream);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -893,16 +893,12 @@ static int kpb_prepare(struct comp_dev *dev)
 	 */
 	if (kpb->ipc4_cfg.base_cfg.ibs != kpb->ipc4_cfg.base_cfg.obs) {
 		struct list_item *sink_list;
-		const uint32_t byte_align = 1;
-		const uint32_t frame_align_req = 1;
 		uint32_t sink_id;
 
 		list_for_item(sink_list, &dev->bsink_list) {
 			struct comp_buffer *sink =
 				container_of(sink_list, struct comp_buffer, source_list);
 
-			audio_stream_init_alignment_constants(byte_align, frame_align_req,
-							      &sink->stream);
 			sink_id = buf_get_id(sink);
 
 			if (sink_id == 0)

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -177,15 +177,6 @@ static int mfcc_process(struct processing_module *mod,
 	return 0;
 }
 
-static void mfcc_set_alignment(struct audio_stream *source, struct audio_stream *sink)
-{
-	const uint32_t byte_align = 1;
-	const uint32_t frame_align_req = 1;
-
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
-}
-
 static int mfcc_prepare(struct processing_module *mod,
 			struct sof_source **sources, int num_of_sources,
 			struct sof_sink **sinks, int num_of_sinks)
@@ -207,9 +198,6 @@ static int mfcc_prepare(struct processing_module *mod,
 
 	/* get source data format */
 	source_format = audio_stream_get_frm_fmt(&sourceb->stream);
-
-	/* set align requirements */
-	mfcc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get sink data format and period bytes */
 	sink_format = audio_stream_get_frm_fmt(&sinkb->stream);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -205,17 +205,8 @@ static inline void mixer_set_frame_alignment(struct audio_stream *source)
 	/*There is no limit for frame number, so set it as 1*/
 	const uint32_t frame_align_req = 1;
 
-#else
-
-	/* Since the generic version process signal sample by sample, so there is no
-	 * limit for it, then set the byte_align and frame_align_req to be 1.
-	 */
-	const uint32_t byte_align = 1;
-	const uint32_t frame_align_req = 1;
-
-#endif
-
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
+#endif
 }
 
 static int mixer_prepare(struct processing_module *mod,

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -205,7 +205,7 @@ static inline void mixer_set_frame_alignment(struct audio_stream *source)
 	/*There is no limit for frame number, so set it as 1*/
 	const uint32_t frame_align_req = 1;
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
+	audio_stream_set_align(byte_align, frame_align_req, source);
 #endif
 }
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -310,14 +310,6 @@ static int multiband_drc_get_config(struct processing_module *mod,
 	return multiband_drc_get_ipc_config(mod, cdata, fragment_size);
 }
 
-static void multiband_drc_set_alignment(struct audio_stream *source,
-					struct audio_stream *sink)
-{
-	/* Currently no optimizations those would use wider loads and stores */
-	audio_stream_init_alignment_constants(1, 1, source);
-	audio_stream_init_alignment_constants(1, 1, sink);
-}
-
 static int multiband_drc_process(struct processing_module *mod,
 				 struct input_stream_buffer *input_buffers, int num_input_buffers,
 				 struct output_stream_buffer *output_buffers,
@@ -356,7 +348,7 @@ static int multiband_drc_prepare(struct processing_module *mod,
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct comp_buffer *sourceb, *sinkb;
+	struct comp_buffer *sourceb;
 	int channels;
 	int rate;
 	int ret = 0;
@@ -369,9 +361,6 @@ static int multiband_drc_prepare(struct processing_module *mod,
 
 	/* DRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-
-	multiband_drc_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -378,12 +378,8 @@ static int mux_prepare(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
-	struct list_item *blist;
-	struct comp_buffer *source;
-	struct comp_buffer *sink;
 	struct sof_mux_config *config;
 	size_t blob_size;
-	int state;
 	int ret;
 
 	comp_dbg(dev, "mux_prepare()");
@@ -408,23 +404,6 @@ static int mux_prepare(struct processing_module *mod,
 	if (!cd->mux && !cd->demux) {
 		comp_err(dev, "mux_prepare(): Invalid configuration, couldn't find suitable processing function.");
 		return -EINVAL;
-	}
-
-	/* check each mux source state, set source align to 1 byte, 1 frame */
-	list_for_item(blist, &dev->bsource_list) {
-		source = container_of(blist, struct comp_buffer, sink_list);
-		state = source->source->state;
-		audio_stream_init_alignment_constants(1, 1, &source->stream);
-
-		/* only prepare downstream if we have no active sources */
-		if (state == COMP_STATE_PAUSED || state == COMP_STATE_ACTIVE)
-			return PPL_STATUS_PATH_STOP;
-	}
-
-	/* set sink align to 1 byte, 1 frame */
-	list_for_item(blist, &dev->bsink_list) {
-		sink = container_of(blist, struct comp_buffer, source_list);
-		audio_stream_init_alignment_constants(1, 1, &sink->stream);
 	}
 
 	/* prepare downstream */

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -80,8 +80,6 @@ static void set_mux_params(struct processing_module *mod)
 	struct comp_buffer *sink, *source;
 	struct list_item *source_list;
 	int j;
-	const uint32_t byte_align = 1;
-	const uint32_t frame_align_req = 1;
 
 	params->direction = dev->direction;
 	params->channels =  cd->md.base_cfg.audio_fmt.channels_count;
@@ -101,8 +99,6 @@ static void set_mux_params(struct processing_module *mod)
 	/* update sink format */
 	if (!list_is_empty(&dev->bsink_list)) {
 		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
-		audio_stream_init_alignment_constants(byte_align, frame_align_req,
-						      &sink->stream);
 
 		if (!sink->hw_params_configured) {
 			ipc4_update_buffer_format(sink, &cd->md.output_format);
@@ -117,8 +113,6 @@ static void set_mux_params(struct processing_module *mod)
 		list_for_item(source_list, &dev->bsource_list)
 		{
 			source = container_of(source_list, struct comp_buffer, sink_list);
-			audio_stream_init_alignment_constants(byte_align, frame_align_req,
-							      &source->stream);
 			j = buf_get_id(source);
 			cd->config.streams[j].pipeline_id = source->pipeline_id;
 			if (j == BASE_CFG_QUEUED_ID)

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -847,8 +847,8 @@ static int selector_prepare(struct processing_module *mod,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 
-	audio_stream_init_alignment_constants(4, 1, &sourceb->stream);
-	audio_stream_init_alignment_constants(4, 1, &sinkb->stream);
+	audio_stream_set_align(4, 1, &sourceb->stream);
+	audio_stream_set_align(4, 1, &sinkb->stream);
 
 	/* get source data format and period bytes */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -518,8 +518,8 @@ static void tdfb_set_alignment(struct audio_stream *source,
 	const uint32_t byte_align = 1;
 	const uint32_t frame_align_req = 2; /* Process multiples of 2 frames */
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
+	audio_stream_set_align(byte_align, frame_align_req, source);
+	audio_stream_set_align(byte_align, frame_align_req, sink);
 }
 
 static int tdfb_prepare(struct processing_module *mod,

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -632,8 +632,8 @@ static void volume_set_alignment(struct audio_stream *source,
 	/*There is no limit for frame number, so both source and sink set it to be 1*/
 	const uint32_t frame_align_req = 1;
 
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
-	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
+	audio_stream_set_align(byte_align, frame_align_req, source);
+	audio_stream_set_align(byte_align, frame_align_req, sink);
 #endif
 }
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -623,7 +623,6 @@ static void volume_set_alignment(struct audio_stream *source,
 				 struct audio_stream *sink)
 {
 #if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
-
 	/* Both source and sink buffer in HiFi 3 or HiFi4 processing version,
 	 * xtensa intrinsics ask for 8-byte aligned. 5.1 format SSE audio
 	 * requires 16-byte aligned.
@@ -633,18 +632,9 @@ static void volume_set_alignment(struct audio_stream *source,
 	/*There is no limit for frame number, so both source and sink set it to be 1*/
 	const uint32_t frame_align_req = 1;
 
-#else
-
-	/* Since the generic version process signal sample by sample, so there is no
-	 * limit for it, then set the byte_align and frame_align_req to be 1.
-	 */
-	const uint32_t byte_align = 1;
-	const uint32_t frame_align_req = 1;
-
-#endif
-
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, source);
 	audio_stream_init_alignment_constants(byte_align, frame_align_req, sink);
+#endif
 }
 
 /**

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -332,25 +332,6 @@ static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
 }
 
 /**
- * Return the frames that meet the align requirement of both byte_align and
- * frame_align_req.
- * @param byte_align Processing byte alignment requirement.
- * @param frame_align_req Processing frames alignment requirement.
- * @param frame_size Size of the frame in bytes.
- * @return frame number.
- */
-static inline uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
-						    const uint32_t frame_align_req,
-						    uint32_t frame_size)
-{
-	/* Figure out how many frames are needed to meet the byte_align alignment requirements */
-	uint32_t frame_num = byte_align / gcd(byte_align, frame_size);
-
-	/** return the lcm of frame_num and frame_align_req*/
-	return frame_align_req * frame_num / gcd(frame_num, frame_align_req);
-}
-
-/**
  * Set align_shift_idx and align_frame_cnt of stream according to byte_align and
  * frame_align_req alignment requirement. Once the channel number,frame size
  * are determined，the align_frame_cnt and align_shift_idx are determined too.
@@ -362,19 +343,9 @@ static inline uint32_t audio_stream_frame_align_get(const uint32_t byte_align,
  * @param frame_align_req Processing frames alignment requirement.
  * @param stream Sink or source stream structure which to be set.
  */
-static inline void audio_stream_init_alignment_constants(const uint32_t byte_align,
-							 const uint32_t frame_align_req,
-							 struct audio_stream *stream)
-{
-	uint32_t process_size;
-	uint32_t frame_size = audio_stream_frame_bytes(stream);
-
-	stream->runtime_stream_params.align_frame_cnt =
-			audio_stream_frame_align_get(byte_align, frame_align_req, frame_size);
-	process_size = stream->runtime_stream_params.align_frame_cnt * frame_size;
-	stream->runtime_stream_params.align_shift_idx	=
-			(is_power_of_2(process_size) ? 31 : 32) - clz(process_size);
-}
+void audio_stream_init_alignment_constants(const uint32_t byte_align,
+					   const uint32_t frame_align_req,
+					   struct audio_stream *stream);
 
 /**
  * Applies parameters to the buffer.

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -338,20 +338,20 @@ static inline uint32_t audio_stream_sample_bytes(const struct audio_stream *buf)
 }
 
 /**
- * Set align_shift_idx and align_frame_cnt of stream according to byte_align and
- * frame_align_req alignment requirement. Once the channel number,frame size
- * are determined，the align_frame_cnt and align_shift_idx are determined too.
- * these two feature will be used in audio_stream_get_avail_frames_aligned
- * to calculate the available frames. it should be called in component prepare
- * or param functions only once before stream copy. if someone forgets to call
- * this first, there would be unexampled error such as nothing is copied at all.
+ * @brief Set processing alignment requirements
+ *
+ * Sets the sample byte alignment and aligned frame count required for
+ * processing done on this stream.  This function may be called at any
+ * time, the internal constants are recalculated if the frame/sample
+ * size changes.  @see audio_stream_avail_frames_aligned().
+ *
  * @param byte_align Processing byte alignment requirement.
  * @param frame_align_req Processing frames alignment requirement.
  * @param stream Sink or source stream structure which to be set.
  */
-void audio_stream_init_alignment_constants(const uint32_t byte_align,
-					   const uint32_t frame_align_req,
-					   struct audio_stream *stream);
+void audio_stream_set_align(const uint32_t byte_align,
+			    const uint32_t frame_align_req,
+			    struct audio_stream *stream);
 
 /**
  * Applies parameters to the buffer.

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -61,10 +61,14 @@ struct audio_stream {
 	void *r_ptr;	/**< Buffer read position */
 	void *addr;	/**< Buffer base address */
 	void *end_addr;	/**< Buffer end address */
+	uint8_t byte_align_req;
+	uint8_t frame_align_req;
 
 	/* runtime stream params */
 	struct sof_audio_stream_params runtime_stream_params;
 };
+
+void audio_stream_recalc_align(struct audio_stream *stream);
 
 static inline void *audio_stream_get_rptr(const struct audio_stream *buf)
 {
@@ -175,6 +179,7 @@ static inline void audio_stream_set_frm_fmt(struct audio_stream *buf,
 					    enum sof_ipc_frame val)
 {
 	buf->runtime_stream_params.frame_fmt = val;
+	audio_stream_recalc_align(buf);
 }
 
 static inline void audio_stream_set_valid_fmt(struct audio_stream *buf,
@@ -191,6 +196,7 @@ static inline void audio_stream_set_rate(struct audio_stream *buf, uint32_t val)
 static inline void audio_stream_set_channels(struct audio_stream *buf, uint16_t val)
 {
 	buf->runtime_stream_params.channels = val;
+	audio_stream_recalc_align(buf);
 }
 
 static inline void audio_stream_set_underrun(struct audio_stream *buf,
@@ -363,11 +369,7 @@ static inline int audio_stream_set_params(struct audio_stream *buffer,
 	buffer->runtime_stream_params.rate = params->rate;
 	buffer->runtime_stream_params.channels = params->channels;
 
-	/* set the default alignment info.
-	 * set byte_align as 1 means no alignment limit on byte.
-	 * set frame_align as 1 means no alignment limit on frame.
-	 */
-	audio_stream_init_alignment_constants(1, 1, buffer);
+	audio_stream_recalc_align(buffer);
 
 	return 0;
 }


### PR DESCRIPTION
PR was reworked from the version described in the initial version.  See comments below and commit message.  This text is stale:

Audio stream objects are generally allocated out of zero'd heap memory, but the computed alignment fields need non-zero values to have correct behavior.  These were being left as garbage.

Set them to a byte and frame alignmnt of 1, as this corresponds to pervasive convention in the tree.  But note that a byte alignment of 1 is actually technically incorrect, as all existing DSP targets are on architectures which don't allow misaligned loads.  But existing component code is universally coded correctly anyway.

(It's worth pointing out that "set_alignment_constants()" is now exposed as an API call on abstracted source/sink objects.  But the only current implementation is on audio_stream.  Future implementations will need to correctly initialize themselves.)

This is a partial fix for Issue #8639
