### PR TITLE
Topology: Topology2: Add sof-hda-benchmark-src32-<platform>

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -32,11 +32,15 @@ Object.PCM.pcm [
 			direction	"playback"
 			name $ANALOG_PLAYBACK_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
+			rate_min 8000
+			rate_max 192000
 		}
 		Object.PCM.pcm_caps.2 {
 			direction	"capture"
 			name $ANALOG_CAPTURE_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
+			rate_min 8000
+			rate_max 192000
 		}
 		direction duplex
 	}
@@ -317,5 +321,13 @@ IncludeByKey.BENCH_CONFIG {
 
 	"rtnr32" {
 		<include/bench/rtnr_s32.conf>
+	}
+
+	#
+	# SRC component
+	#
+
+	"src32" {
+		<include/bench/src_s32.conf>
 	}
 }

--- a/tools/topology/topology2/development/tplg-targets-bench.cmake
+++ b/tools/topology/topology2/development/tplg-targets-bench.cmake
@@ -32,10 +32,12 @@ set(component_parameters
 
 set(components_s32
 	"aria"
+	"src"
 )
 
 set(component_parameters_s32
 	"BENCH_ARIA_PARAMS=default"
+	"BENCH_SRC_PARAMS=default"
 )
 
 foreach(p ${platforms})

--- a/tools/topology/topology2/include/bench/host_io_gateway_pipelines_src.conf
+++ b/tools/topology/topology2/include/bench/host_io_gateway_pipelines_src.conf
@@ -1,0 +1,84 @@
+                Object.Pipeline {
+                        host-gateway-playback [
+                                {
+                                        index 1
+
+                                        Object.Widget.host-copier.1 {
+                                                stream_name $ANALOG_PLAYBACK_PCM
+                                                pcm_id 0
+                                                <include/components/src_format_sxx_to_s32_convert.conf>
+                                        }
+                                }
+                        ]
+
+                        io-gateway [
+                                {
+                                        index 2
+                                        direction playback
+
+                                        Object.Widget.dai-copier.1 {
+                                                node_type $HDA_LINK_OUTPUT_CLASS
+                                                stream_name $HDA_ANALOG_DAI_NAME
+                                                dai_type "HDA"
+                                                copier_type "HDA"
+                                                num_input_pins 1
+                                                num_input_audio_formats 1
+                                                num_output_audio_formats 1
+                                                Object.Base.input_audio_format [
+                                                        {
+                                                                in_bit_depth		32
+                                                                in_valid_bit_depth	32
+                                                        }
+                                                ]
+                                                Object.Base.output_audio_format [
+                                                        {
+                                                                out_bit_depth		32
+                                                                out_valid_bit_depth	32
+                                                        }
+                                                ]
+                                        }
+                                }
+                        ]
+
+                        host-gateway-capture [
+                                {
+                                        index 	3
+                                        Object.Widget.host-copier.1 {
+                                                stream_name $ANALOG_CAPTURE_PCM
+                                                pcm_id 0
+                                                <include/components/src_format_s32_to_sxx_convert.conf>
+                                        }
+                                }
+                        ]
+
+                        io-gateway-capture [
+                                {
+                                        index		4
+                                        direction	capture
+
+                                        Object.Widget.dai-copier."1" {
+                                                dai_type 	"HDA"
+                                                type		"dai_out"
+                                                copier_type	"HDA"
+                                                stream_name	$HDA_ANALOG_DAI_NAME
+                                                node_type	$HDA_LINK_INPUT_CLASS
+                                                num_output_pins 1
+                                                num_input_audio_formats 1
+                                                num_output_audio_formats 1
+                                                Object.Base.input_audio_format [
+                                                        {
+                                                                in_bit_depth		32
+                                                                in_valid_bit_depth	32
+                                                        }
+                                                ]
+                                                Object.Base.output_audio_format [
+                                                        {
+                                                                out_bit_depth		32
+                                                                out_valid_bit_depth	32
+                                                        }
+                                                ]
+                                        }
+                                }
+                        ]
+                }
+

--- a/tools/topology/topology2/include/bench/src_hda_route.conf
+++ b/tools/topology/topology2/include/bench/src_hda_route.conf
@@ -1,0 +1,19 @@
+		# Created with script "./bench_comp_generate.sh src"
+		Object.Base.route [
+			{
+				sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+				source 'src.1.1'
+			}
+			{
+				sink 'src.1.1'
+				source 'host-copier.0.playback'
+			}
+			{
+				source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+				sink 'src.3.2'
+			}
+			{
+				source 'src.3.2'
+				sink 'host-copier.0.capture'
+			}
+		]

--- a/tools/topology/topology2/include/bench/src_s32.conf
+++ b/tools/topology/topology2/include/bench/src_s32.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh src"
+		Object.Widget.src.1 {
+			index 1
+			rate_out 48000
+			<include/components/src_format_s32_convert_to_48k.conf>
+		}
+		Object.Widget.src.2 {
+			index 3
+			rate_in 48000
+			<include/components/src_format_s32_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src.conf>
+		<include/bench/src_hda_route.conf>


### PR DESCRIPTION
This patch adds build of hda-generic development topologies to test SRC component with s32 format.