### PR TITLE
include: sof: common.h Fix compilation error

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -27,6 +27,7 @@
 #if !defined(__ASSEMBLER__) && defined(__XTENSA__)
 
 #include <ipc/trace.h>
+#include <rtos/panic.h>
 #define VERIFY_ALIGN
 
 #endif


### PR DESCRIPTION
Commit 16d126a36fd821 ("audio: Header files cleanup") removed rtos/panic.h include but this is still needed.

Otherwise, we get the following compilation error:

/work/repos/sof/src/lib/lib.c: In function ‘memset’:
/work/repos/sof/src/lib/lib.c:31: warning: implicit declaration of function ‘sof_panic’

Fixes: 16d126a36fd821 ("audio: Header files cleanup")
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>
(cherry picked from commit a4a3b3aed9c9a78087a0c796827ec608d0cd621c)