### PR TITLE
Work round Fix for noise issue when playback and capturer in parallel.

### DIFF
--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -336,6 +336,7 @@ static bool dma_multi_chan_domain_is_pending(struct ll_schedule_domain *domain,
 			/* clear interrupt */
 			if (pipe_task->registrable) {
 				dma_interrupt_legacy(&dmas[i].chan[j], DMA_IRQ_CLEAR);
+				dma_data_copied_clear(&dmas[i].chan[j]);
 				interrupt_clear_mask(dma_domain->data[i][j].irq,
 						     BIT(j));
 			}

--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -169,8 +169,10 @@ static void dma_irq_handler(void *data)
 	list_for_item(i, &irq_data->channels) {
 		chan_data = container_of(i, struct zephyr_dma_domain_channel, list);
 
-		if (dma_interrupt_legacy(chan_data->channel, DMA_IRQ_STATUS_GET))
+		if (dma_interrupt_legacy(chan_data->channel, DMA_IRQ_STATUS_GET)) {
 			dma_interrupt_legacy(chan_data->channel, DMA_IRQ_CLEAR);
+			dma_data_copied_clear(chan_data->channel);
+		}
 	}
 
 	/* clear IRQ - the mask argument is unused ATM */

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -198,6 +198,8 @@ struct dma_ops {
 	int (*get_data_size)(struct dma_chan_data *channel, uint32_t *avail,
 			     uint32_t *free);
 
+	int (*clear_data_copied)(struct dma_chan_data *channel);
+
 	int (*get_attribute)(struct dma *dma, uint32_t type, uint32_t *value);
 
 	int (*interrupt)(struct dma_chan_data *channel, enum dma_irq_cmd cmd);
@@ -421,6 +423,13 @@ static inline int dma_interrupt_legacy(struct dma_chan_data *channel,
 				       enum dma_irq_cmd cmd)
 {
 	return channel->dma->ops->interrupt(channel, cmd);
+}
+
+static inline int dma_data_copied_clear(struct dma_chan_data *channel)
+{
+	if (channel->dma->ops->clear_data_copied)
+		return channel->dma->ops->clear_data_copied(channel);
+	return 0;
 }
 
 /* DMA hardware register operations */


### PR DESCRIPTION
Did basic tests(playback&record in parallel, with suspend) in i.MX8QM/i.MX8ULP platform. The fix changed edma driver behavior, so need check not only zephyr but also xtensa build.
@dbaluta Please tell me if you think the fix still impact some tests, I will do the tests you mentioned. Thanks a lot!