### PR TITLE
[SKIP SOF-TEST] .github/sparse: switch sparse version back to the upstream main branch

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -26,22 +26,23 @@ jobs:
 
     steps:
       - name: git clone sparse analyzer
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 10
           # TODO: switch to thesofproject/sparse
           repository: marc-hb/sparse
+          fetch-depth: 0
+          filter: 'tree:0'
           path: workspace/sparse
 
       - name: build sparse analyzer
         run: cd workspace/sparse && make -j4
 
       - name: git clone sof
-        uses: actions/checkout@v3
-        # From time to time this will catch a git tag and change SOF_VERSION
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 10
           path: ./workspace/sof
+          fetch-depth: 0  # fix git describe
+          filter: 'tree:0'
 
       - name: west clones
         run: pip3 install west && cd workspace/sof/ && west init -l &&

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -28,14 +28,17 @@ jobs:
       - name: git clone sparse analyzer
         uses: actions/checkout@v4
         with:
-          # TODO: switch to thesofproject/sparse
-          repository: marc-hb/sparse
+          repository: thesofproject/sparse
           fetch-depth: 0
           filter: 'tree:0'
           path: workspace/sparse
 
+      # As of its 2023 commit 98b203419679, sparse-llvm.c uses symbols
+      # (LLVMConstGEP, LLVMBuildLoad, LLVMBuildCall,...) which are:
+      #   -  -Wdeprecated in LLVM v14
+      #   -  Removed in LLVM v16
       - name: build sparse analyzer
-        run: cd workspace/sparse && make -j4
+        run: cd workspace/sparse && make -j4  # HAVE_LLVM=no
 
       - name: git clone sof
         uses: actions/checkout@v4


### PR DESCRIPTION
This should work now that Guennadi's endianness fix 98b20341967 has been
merged.

EDIT: it does work https://github.com/thesofproject/sof/actions/runs/7350497231