### PR TITLE
Zephyr: Only print memory information with performance build

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -158,15 +158,14 @@ static void *heap_alloc_aligned(struct k_heap *h, size_t min_align, size_t bytes
 {
 	k_spinlock_key_t key;
 	void *ret;
-#if CONFIG_SYS_HEAP_RUNTIME_STATS && CONFIG_IPC_MAJOR_4
-	struct sys_memory_stats stats;
-#endif
 
 	key = k_spin_lock(&h->lock);
 	ret = sys_heap_aligned_alloc(&h->heap, min_align, bytes);
 	k_spin_unlock(&h->lock, key);
 
-#if CONFIG_SYS_HEAP_RUNTIME_STATS && CONFIG_IPC_MAJOR_4
+#if CONFIG_SYS_HEAP_RUNTIME_STATS && CONFIG_IPC_MAJOR_4 && CONFIG_PERFORMANCE_COUNTERS
+	struct sys_memory_stats stats;
+
 	sys_heap_runtime_stats_get(&h->heap, &stats);
 	tr_info(&zephyr_tr, "heap allocated: %u free: %u max allocated: %u",
 		stats.allocated_bytes, stats.free_bytes, stats.max_allocated_bytes);


### PR DESCRIPTION
Due to CONFIG_SYS_HEAP_RUNTIME_STATS set with yes, this part of heap memory information print are always enabled, however, this log information only be used for memory performance analysis, so add CONFIG_PERFORMANCE_COUNTERS restriction to this log print.