### PR TITLE
Better handling of module base_config_ext data

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1333,6 +1333,10 @@ int module_adapter_reset(struct comp_dev *dev)
 	rfree(mod->stream_params);
 	mod->stream_params = NULL;
 
+#if CONFIG_IPC_MAJOR_4
+	rfree(mod->priv.cfg.input_pins);
+#endif
+
 	comp_dbg(dev, "module_adapter_reset(): done");
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -30,6 +30,10 @@ struct module_config {
 	const void *init_data; /**< Initial IPC configuration. */
 #if CONFIG_IPC_MAJOR_4
 	struct ipc4_base_module_cfg base_cfg;
+	uint8_t nb_input_pins;
+	uint8_t nb_output_pins;
+	struct ipc4_input_pin_format *input_pins;
+	struct ipc4_output_pin_format *output_pins;
 #endif
 };
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -8,7 +8,9 @@
 #include <sof/audio/buffer.h>
 #include <sof/audio/component.h>
 #include <sof/audio/component_ext.h>
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/pipeline.h>
+#include <module/module/base.h>
 #include <sof/common.h>
 #include <rtos/interrupt.h>
 #include <sof/ipc/topology.h>
@@ -431,6 +433,9 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	struct ipc4_base_module_cfg source_src_cfg;
 	struct ipc4_base_module_cfg sink_src_cfg;
 	uint32_t flags;
+	uint32_t ibs = 0;
+	uint32_t obs = 0;
+	uint32_t buf_size;
 	int src_id, sink_id;
 	int ret;
 
@@ -453,17 +458,42 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	if (!cpu_is_me(source->ipc_config.core) && !cross_core_bind)
 		return ipc4_process_on_core(source->ipc_config.core, false);
 
-	/* these might call comp_ipc4_get_attribute_remote() if necessary */
-	ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &source_src_cfg);
-	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to get base config for module %#x", dev_comp_id(source));
-		return IPC4_FAILURE;
+	struct processing_module *srcmod = comp_get_drvdata(source);
+	struct processing_module *dstmod = comp_get_drvdata(sink);
+	struct module_config *dstcfg = &dstmod->priv.cfg;
+	struct module_config *srccfg = &srcmod->priv.cfg;
+
+	/* get obs from the base config extension if the src queue ID is non-zero */
+	if (bu->extension.r.src_queue && bu->extension.r.src_queue < srccfg->nb_output_pins)
+		obs = srccfg->output_pins[bu->extension.r.src_queue].obs;
+
+	/* get obs from base config if src queue ID is 0 or if base config extn is missing */
+	if (!obs) {
+		/* these might call comp_ipc4_get_attribute_remote() if necessary */
+		ret = comp_get_attribute(source, COMP_ATTR_BASE_CONFIG, &source_src_cfg);
+
+		if (ret < 0) {
+			tr_err(&ipc_tr, "failed to get base config for src module %#x",
+			       dev_comp_id(source));
+			return IPC4_FAILURE;
+		}
+		obs = source_src_cfg.obs;
 	}
 
-	ret = comp_get_attribute(sink, COMP_ATTR_BASE_CONFIG, &sink_src_cfg);
-	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to get base config for module %#x", dev_comp_id(sink));
-		return IPC4_FAILURE;
+	/* get ibs from the base config extension if the sink queue ID is non-zero */
+	if (bu->extension.r.dst_queue && bu->extension.r.dst_queue < dstcfg->nb_input_pins)
+		ibs = dstcfg->input_pins[bu->extension.r.dst_queue].ibs;
+
+	/* get ibs from base config if sink queue ID is 0 or if base config extn is missing */
+	if (!ibs) {
+		ret = comp_get_attribute(sink, COMP_ATTR_BASE_CONFIG, &sink_src_cfg);
+		if (ret < 0) {
+			tr_err(&ipc_tr, "failed to get base config for sink module %#x",
+			       dev_comp_id(sink));
+			return IPC4_FAILURE;
+		}
+
+		ibs = sink_src_cfg.ibs;
 	}
 
 	/* create a buffer
@@ -472,12 +502,10 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	 * in case of DP -> LL
 	 *	size = 2*ibs of destination (LL) module. DP queue will handle obs of DP module
 	 */
-	uint32_t buf_size;
-
 	if (source->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL)
-		buf_size = source_src_cfg.obs * 2;
+		buf_size = obs * 2;
 	else
-		buf_size = sink_src_cfg.ibs * 2;
+		buf_size = ibs * 2;
 
 	buffer = ipc4_create_buffer(source, cross_core_bind, buf_size, bu->extension.r.src_queue,
 				    bu->extension.r.dst_queue);
@@ -496,8 +524,8 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	 *	sink_module needs to set its IBS (input buffer size)
 	 *		as min_available in buffer's source ifc
 	 */
-	sink_set_min_free_space(audio_stream_get_sink(&buffer->stream), source_src_cfg.obs);
-	source_set_min_available(audio_stream_get_source(&buffer->stream), sink_src_cfg.ibs);
+	sink_set_min_free_space(audio_stream_get_sink(&buffer->stream), obs);
+	source_set_min_available(audio_stream_get_source(&buffer->stream), ibs);
 
 	/*
 	 * Connect and bind the buffer to both source and sink components with LL processing been


### PR DESCRIPTION
This is a different take on a fix for #8639 than the workaround in #8575 on which it was originally coded.  It removes the requirement for components to have to muck with module internals[1] and places the complicated byte-offset math into just one place (in the module code that owns the struct format).  Really I think this is a lot cleaner.  If you guys want to merge the first version for clarity (given it's already "shipped"[2]), I can submit this as cleanup on top of that instead (which, again, is how this was written originally anyway).

With this, the big IPC4 workaround patch at the end of the AEC work is down to just one line, hope to have that cleaned up by tomorrow.  (see https://github.com/andyross/sof/commits/mtl-aec-tmp/ for the current status of my working tree).

[1] Basically, the first version: (1) requires every module to make a copy of the untyped "init_data" field of module_config, then (2) store that pointer **back** into a different field of module_config (because the first one points into the IPC command buffer and won't survive) where (3) it will be eventually used, **not** by the module code itself but by the ipc4/module layer that created it in the first place.  This avoids all that by having the module_adapter init code just parse and store the data at the start.

[2] In the MTL "stable" branch, where it's already been merged.  Can I just whine a bit about how frustrating it is to have to work across branches like this?  I didn't realize until I was about to submit that the code I was modifying wasn't actually upstream!
