### PR TITLE
C++ & AEC support for Zephyr builds

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -751,6 +751,17 @@ zephyr_library_sources_ifdef(CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK
 	${SOF_AUDIO_PATH}/google/google_rtc_audio_processing_mock.c
 )
 
+if(CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING AND NOT CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK)
+	zephyr_include_directories(../third_party/include)
+	target_link_directories(SOF INTERFACE ../third_party/lib)
+	target_link_libraries(SOF INTERFACE google_rtc_audio_processing)
+	target_link_libraries(SOF INTERFACE c++)
+	target_link_libraries(SOF INTERFACE c++abi)
+	target_link_libraries(SOF INTERFACE m)
+	target_link_libraries(SOF INTERFACE c)
+	target_link_libraries(SOF INTERFACE gcc)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_COMP_IGO_NR
 	${SOF_AUDIO_PATH}/igo_nr/igo_nr.c
 )

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -367,4 +367,16 @@ static int heap_init(void)
 	return 0;
 }
 
+/* This is a weak stub for the Cadence libc's allocator (which is just
+ * a newlib build).  It's traditionally been provided like this in SOF
+ * for the benefit of C++ code where the standard library needs to
+ * link to a working malloc() even if it will never call it.
+ */
+struct _reent;
+__weak void *_sbrk_r(struct _reent *ptr, ptrdiff_t incr)
+{
+	k_panic();
+	return NULL;
+}
+
 SYS_INIT(heap_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);


### PR DESCRIPTION
Split out from #8571 as it should be relatively uncontroversial.

See commit messages, basically this just forward ports some pre-existing trickery to make Google AEC (which is a C++ library) build with existing toolchains.  As the commit message indicates, really this is something the Zephyr toolchain layer should be prepared to provide, but it doesn't (yet).