### PR TITLE
aria: change to S24_LE format processing

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -186,6 +186,12 @@ static int aria_prepare(struct processing_module *mod,
 	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
 	aria_set_stream_params(sink, mod);
 
+	if (audio_stream_get_valid_fmt(&source->stream) != SOF_IPC_FRAME_S24_4LE ||
+	    audio_stream_get_valid_fmt(&sink->stream) != SOF_IPC_FRAME_S24_4LE) {
+		comp_err(dev, "aria_prepare(): format is not supported");
+		return -EINVAL;
+	}
+
 	if (dev->state == COMP_STATE_ACTIVE) {
 		comp_info(dev, "aria_prepare(): Component is in active state.");
 		return 0;

--- a/src/audio/aria/aria_generic.c
+++ b/src/audio/aria/aria_generic.c
@@ -40,10 +40,9 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 		src = audio_stream_wrap(source, src + n);
 		samples -= n;
 	}
-
 	/*zero check for maxis not needed since att is in range <0;3>*/
-	if (max_data > (0x7fffffff >> att))
-		gain = (0x7fffffffULL << 32) / max_data;
+	if (max_data > (0x007fffff >> att))
+		gain = (0x007fffffULL << 32) / max_data;
 
 	cd->gains[gain_idx] = (int32_t)(gain >> (att + 1));
 }
@@ -83,7 +82,7 @@ void aria_algo_get_data(struct processing_module *mod,
 		for (i = 0; i < n; i += ch_n) {
 			for (ch = 0; ch < ch_n; ch++) {
 				in_sample = *in++;
-				out[ch] = q_multsr_sat_32x32(in_sample, gain, shift);
+				out[ch] = q_multsr_sat_32x32_24(in_sample, gain, shift);
 			}
 			gain += step;
 			out += ch_n;


### PR DESCRIPTION
After the following change:
"copier: add support for windows driver (383d17a19e25f804d2ba37b6b621131918544e6a)"
aria stopped working properly. It is necessary to adapt the module
S24_LE format processing.