### PR TITLE
common.h: Guard definition of IS_ALIGNED for Zephyr builds

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -14,8 +14,14 @@
 /* callers must check/use the return value */
 #define __must_check __attribute__((warn_unused_result))
 
+#ifdef __ZEPHYR__
+#include <zephyr/sys/util.h>
+#endif
+
 /* Align the number to the nearest alignment value */
+#ifndef IS_ALIGNED
 #define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
+#endif
 
 /* Treat zero as a special case because it wraps around */
 #define is_power_of_2(x) ((x) && !((x) & ((x) - 1)))


### PR DESCRIPTION
common.h defines the IS_ALIGNED macro, which conflicts with a Zephyr macro of the same name. Add guards to define it only if it is not already defined by Zephyr.