### PR TITLE
Topology: Topology2: Add sof-hda-benchmark-src_lite32/24/16-<platform>

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -1,6 +1,7 @@
 <include/components/dcblock.conf>
 <include/components/rtnr.conf>
 <include/components/igo_nr.conf>
+<include/components/src_lite.conf>
 
 Define {
 	ANALOG_PLAYBACK_PCM		'Analog Playback'
@@ -337,5 +338,21 @@ IncludeByKey.BENCH_CONFIG {
 
 	"src32" {
 		<include/bench/src_s32.conf>
+	}
+
+	#
+	# src_lite component
+	#
+
+	"src_lite16" {
+		<include/bench/src_lite_s16.conf>
+	}
+
+	"src_lite24" {
+		<include/bench/src_lite_s24.conf>
+	}
+
+	"src_lite32" {
+		<include/bench/src_lite_s32.conf>
 	}
 }

--- a/tools/topology/topology2/development/tplg-targets-bench.cmake
+++ b/tools/topology/topology2/development/tplg-targets-bench.cmake
@@ -18,6 +18,7 @@ set(components
 	"igo_nr"
 	"rtnr"
 	"src"
+	"src_lite"
 )
 
 set(component_parameters
@@ -30,6 +31,7 @@ set(component_parameters
 	"BENCH_IGO_NR_PARAMS=default"
 	"BENCH_RTNR_PARAMS=default"
 	"BENCH_SRC_PARAMS=default"
+	"BENCH_SRC_LITE_PARAMS=default"
 )
 
 set(components_s32

--- a/tools/topology/topology2/include/bench/src_lite_hda_route.conf
+++ b/tools/topology/topology2/include/bench/src_lite_hda_route.conf
@@ -1,0 +1,19 @@
+		# Created with script "./bench_comp_generate.sh src_lite"
+		Object.Base.route [
+			{
+				sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+				source 'src_lite.1.1'
+			}
+			{
+				sink 'src_lite.1.1'
+				source 'host-copier.0.playback'
+			}
+			{
+				source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+				sink 'src_lite.3.2'
+			}
+			{
+				source 'src_lite.3.2'
+				sink 'host-copier.0.capture'
+			}
+		]

--- a/tools/topology/topology2/include/bench/src_lite_s16.conf
+++ b/tools/topology/topology2/include/bench/src_lite_s16.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh src_lite"
+		Object.Widget.src_lite.1 {
+			index 1
+			rate_out 48000
+			<include/components/src_format_s16_convert_to_48k.conf>
+		}
+		Object.Widget.src_lite.2 {
+			index 3
+			rate_in 48000
+			<include/components/src_format_s16_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s16.conf>
+		<include/bench/src_lite_hda_route.conf>

--- a/tools/topology/topology2/include/bench/src_lite_s24.conf
+++ b/tools/topology/topology2/include/bench/src_lite_s24.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh src_lite"
+		Object.Widget.src_lite.1 {
+			index 1
+			rate_out 48000
+			<include/components/src_format_s24_convert_to_48k.conf>
+		}
+		Object.Widget.src_lite.2 {
+			index 3
+			rate_in 48000
+			<include/components/src_format_s24_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s24.conf>
+		<include/bench/src_lite_hda_route.conf>

--- a/tools/topology/topology2/include/bench/src_lite_s32.conf
+++ b/tools/topology/topology2/include/bench/src_lite_s32.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh src_lite"
+		Object.Widget.src_lite.1 {
+			index 1
+			rate_out 48000
+			<include/components/src_format_s32_convert_to_48k.conf>
+		}
+		Object.Widget.src_lite.2 {
+			index 3
+			rate_in 48000
+			<include/components/src_format_s32_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s32.conf>
+		<include/bench/src_lite_hda_route.conf>

--- a/tools/topology/topology2/include/components/src_lite.conf
+++ b/tools/topology/topology2/include/components/src_lite.conf
@@ -1,0 +1,89 @@
+#
+#
+# A generic src_lite component. All attributes defined herein are namespaced
+# by alsatplg to "Object.Widget.src_lite.N.attribute_name"
+#
+# Usage: this component can be used by instantiating it in the parent object. i.e.
+#
+# 	Object.Widget.src_lite."N" {
+#		format			"s24le"
+#		rate_out		48000
+#	}
+#
+# Where N is the unique instance number for the src_lite widget within the same alsaconf node.
+
+Class.Widget."src_lite" {
+	#
+	# Pipeline ID for the src_lite widget object
+	#
+	DefineAttribute."index" {}
+
+	#
+	# src_lite object instance
+	#
+	DefineAttribute."instance" {}
+
+	#include common component definition
+	<include/components/widget-common.conf>
+
+	#
+	# Bespoke attributes for src_lite
+	#
+
+	# Source sample rate
+	DefineAttribute."rate_in" {
+		# Token set reference name and type
+		token_ref	"src.word"
+
+	}
+
+	# Target sample rate
+	DefineAttribute."rate_out" {
+		# Token set reference name and type
+		token_ref	"src.word"
+	}
+
+	attributes {
+		#
+		# The src_lite widget name would be constructed using the index and instance attributes.
+		# For ex: "src_lite.1.1" or "src_lite.10.2" etc.
+		#
+		!constructor [
+			"index"
+			"instance"
+		]
+
+		!mandatory [
+			"num_input_audio_formats"
+			"num_output_audio_formats"
+			"num_input_pins"
+			"num_output_pins"
+		]
+
+		#
+		# immutable attributes cannot be modified in the object instance
+		#
+		!immutable [
+			"uuid"
+			"type"
+		]
+
+		#
+		# deprecated attributes should not be added in the object instance
+		#
+		!deprecated [
+			"preload_count"
+		]
+
+		unique "instance"
+	}
+
+	#
+	# Default attributes for src_lite
+	#
+	type			"src"
+	uuid			"51:10:44:33:cd:44:6a:46:83:a3:17:84:78:70:8a:ea"
+	no_pm			"true"
+	num_input_pins		1
+	num_output_pins		1
+}


### PR DESCRIPTION
This PR adds build of hda-generic development topologies to test SRC LITE component with s32/24/16 format.