### PR TITLE
topology2: mtl: Add HDMI-in capture support for SSP-based nocodec products.

### DIFF
--- a/tools/topology/topology2/cavs-hdmi-in-ssp.conf
+++ b/tools/topology/topology2/cavs-hdmi-in-ssp.conf
@@ -1,0 +1,76 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<pdm_config.conf>
+<tokens.conf>
+<virtual.conf>
+<host-gateway-playback.conf>
+<host-gateway-capture.conf>
+<io-gateway.conf>
+<io-gateway-capture.conf>
+<host-copier-gain-mixin-playback.conf>
+<mixout-gain-dai-copier-playback.conf>
+<deepbuffer-playback.conf>
+<dai-copier-be.conf>
+<dai-copier-eqiir-module-copier-capture.conf>
+<gain-capture.conf>
+<gain-module-copier.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<dmic.conf>
+<hda.conf>
+<intel/hw_config_cardinal_clk.conf>
+<manifest.conf>
+<route.conf>
+<intel/common_definitions.conf>
+<dai-copier.conf>
+<module-copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+<dmic-default.conf>
+<hdmi-default.conf>
+<hdmi-in-default.conf>
+<input_pin_binding.conf>
+<output_pin_binding.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+
+Define {
+	# override HDMI-IN/DMIC default definitions
+	HDMI_IN_1_ID		0
+	HDMI_IN_2_ID		1
+	DMIC0_ID			3
+	DMIC1_ID			4
+	# override HDMI BE link ids
+	NUM_HDMIS			3
+	HDMI1_ID			5
+	HDMI2_ID			6
+	HDMI3_ID			7
+	PLATFORM 			"none"
+}
+
+# override defaults with platform-specific config
+IncludeByKey.PLATFORM {
+	"mtl"	"platform/intel/mtl.conf"
+}
+
+# include HDMI-in capture config.
+IncludeByKey.HDMI_IN_CAPTURE {
+	"true"	"platform/intel/hdmi-in-capture.conf"
+}
+
+# include HDMI config if needed.
+IncludeByKey.NUM_HDMIS {
+	"[3-4]"	"platform/intel/hdmi-generic.conf"
+}

--- a/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
+++ b/tools/topology/topology2/sof-ace-tplg/tplg-targets.cmake
@@ -84,6 +84,10 @@ GOOGLE_RTC_AEC_SUPPORT=1,DEEP_BUF_SPK=true,PLAYBACK_PIPELINE_SRC=dts"
 NHLT_BIN=nhlt-sof-mtl-es83x6-ssp1-hdmi-ssp02.bin,HEADSET_SSP_DAI_INDEX=1,\
 HEADSET_CODEC_NAME=SSP1-Codec,HDMI_IN_CAPTURE=true"
 
+#Nocodec + HDMI-IN + HDMI
+"cavs-hdmi-in-ssp\;sof-mtl-hdmi-ssp02\;PLATFORM=mtl,PREPROCESS_PLUGINS=nhlt,\
+NHLT_BIN=nhlt-sof-mtl-hdmi-ssp02.bin,HDMI_IN_CAPTURE=true"
+
 # SDW + DMIC + HDMI
 "cavs-sdw\;sof-mtl-sdw-cs42l42-l0-max98363-l2\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\
 PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,\


### PR DESCRIPTION
Adding support for the product which doesn't have no ssp codec but need to support HDMI audio playback and HDMI-in capture via I2S.