### PR TITLE
Add new CONFIG_DCBLOCK_HIFI and move generic XCHAL_HAVE logic to common.h

### DIFF
--- a/src/audio/dcblock/Kconfig
+++ b/src/audio/dcblock/Kconfig
@@ -6,3 +6,10 @@ config COMP_DCBLOCK
 	help
 	  Select for DC Blocking Filter component. This component filters out
 	  the DC offset which often originates from a microphone's output.
+
+
+config DCBLOCK_HIFI
+	int "DC Blocking Filter HIFI level (-1 = max)"
+	default -1
+	help
+	  0: no HIFI, -1 (default): max available

--- a/src/audio/dcblock/dcblock.h
+++ b/src/audio/dcblock/dcblock.h
@@ -15,20 +15,6 @@
 #include <module/module/base.h>
 #include <module/module/interface.h>
 
-/* __XCC__ is both for xt_xcc and xt_clang */
-#if defined(__XCC__)
-# include <xtensa/config/core-isa.h>
-# if XCHAL_HAVE_HIFI4
-#  define DCBLOCK_HIFI4
-# elif XCHAL_HAVE_HIFI3
-#  define DCBLOCK_HIFI3
-# else
-#  define DCBLOCK_GENERIC
-# endif
-#else
-# define DCBLOCK_GENERIC
-#endif
-
 struct audio_stream;
 struct comp_dev;
 

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_GENERIC
+#if SOF_USE_HIFI(SOF_NO_HIFI, DCBLOCK)
 
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI3
+#if SOF_USE_HIFI(3, DCBLOCK)
 
 #include <xtensa/tie/xt_hifi3.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI4
+#if SOF_USE_HIFI(4, DCBLOCK)
 
 #include <xtensa/tie/xt_hifi4.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);


### PR DESCRIPTION
1. The `if XCHAL_HAVE_HIFI4` macro logic is duplicated across many source files. Starting with dcblock.h, make it generic and move it to common.h

2. Add the ability to override the max available HIFI level using Kconfig