### PR TITLE
rimage: loadable_modules: Set correct image type

### DIFF
--- a/tools/rimage/src/adsp_config.c
+++ b/tools/rimage/src/adsp_config.c
@@ -1548,7 +1548,7 @@ static void dump_fw_desc(const struct sof_man_fw_desc *fw_desc)
 		 fw_desc->header.header_id[3]);
 	DUMP_PRINTABLE_BYTES("name", fw_desc->header.name);
 	DUMP_KEY("preload_page_count", "%d", fw_desc->header.preload_page_count);
-	DUMP_KEY("fw_image_flags", "0x%x", fw_desc->header.fw_image_flags);
+	DUMP_KEY("fw_image_flags", "0x%x", fw_desc->header.fw_image_flags.raw);
 	DUMP_KEY("feature_mask", "0x%x", fw_desc->header.feature_mask);
 	DUMP_KEY("hw_buf_base_addr", "0x%x", fw_desc->header.fw_compat);
 	DUMP_KEY("hw_buf_length", "0x%x", fw_desc->header.hw_buf_length);
@@ -1599,7 +1599,7 @@ static int parse_fw_desc(const toml_table_t *toml, struct parse_ctx *pctx,
 	if (ret < 0)
 		return err_key_parse("header", NULL);
 
-	out->header.fw_image_flags =
+	out->header.fw_image_flags.raw =
 		parse_uint32_hex_key(header, &ctx, "fw_image_flags", SOF_MAN_FW_HDR_FLAGS, &ret);
 	if (ret < 0)
 		return err_key_parse("header", NULL);

--- a/tools/rimage/src/include/rimage/sof/user/manifest.h
+++ b/tools/rimage/src/include/rimage/sof/user/manifest.h
@@ -121,6 +121,20 @@ struct sof_man_mod_config {
  * FW Manifest Header
  */
 
+union sof_man_fw_header_image_flags {
+	uint32_t raw;
+	struct {
+		uint32_t tp : 1;
+		uint32_t image_type : 2;
+		uint32_t relocatable_lib : 1;
+		uint32_t _rsvd0 : 28;
+	} fields;
+};
+
+#define SOF_MAN_FW_HDR_IMG_TYPE_ROM_EXT	0
+#define SOF_MAN_FW_HDR_IMG_TYPE_MAIN_FW	1
+#define SOF_MAN_FW_HDR_IMG_TYPE_LIB	2
+
 #define SOF_MAN_FW_HDR_FW_NAME_LEN	8
 #define SOF_MAN_FW_HDR_ID		{'$', 'A', 'M', '1'}
 #define SOF_MAN_FW_HDR_NAME		"ADSPFW"
@@ -139,7 +153,7 @@ struct sof_man_fw_header {
 	uint8_t name[SOF_MAN_FW_HDR_FW_NAME_LEN];
 	/* number of pages of preloaded image loaded by driver */
 	uint32_t preload_page_count;
-	uint32_t fw_image_flags;
+	union sof_man_fw_header_image_flags fw_image_flags;
 	uint32_t feature_mask;
 	uint16_t major_version;
 	uint16_t minor_version;

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -1380,7 +1380,8 @@ int man_write_fw_ace_v1_5(struct image *image)
 	m->desc.header.build_version = image->fw_ver_build;
 
 	m->desc.header.feature_mask = 0x2; // -> should be feature mask - to fix
-	m->desc.header.fw_image_flags = 0x2; // -> should be feature mask - to fix
+	m->desc.header.fw_image_flags.fields.image_type = image->loadable_module ?
+		SOF_MAN_FW_HDR_IMG_TYPE_LIB : SOF_MAN_FW_HDR_IMG_TYPE_MAIN_FW;
 	m->desc.header.fw_compat = 0x100000; // -> PUT PROPER STRUCT
 
 	/* create each module */


### PR DESCRIPTION
The image header contains a bitfield with flags specifying a image type. This commit sets correct image type depending on whether firmware or a loadable module is being signed.