### PR TITLE
dai: add error log for failed path

### DIFF
--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -208,8 +208,11 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 	struct dai *d;
 
 	dev = dai_get_zephyr_device(type, index);
-	if (!dev)
+	if (!dev) {
+		tr_err(&dai_tr, "dai_get: failed to get dai with index %d type %d",
+		       index, type);
 		return NULL;
+	}
 
 	d = rzalloc(SOF_MEM_ZONE_RUNTIME_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(struct dai));
 	if (!d)
@@ -222,6 +225,8 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 	dai_set_device_params(d);
 
 	if (dai_probe(d->dev)) {
+		tr_err(&dai_tr, "dai_get: failed to probe dai with index %d type %d",
+		       index, type);
 		rfree(d);
 		return NULL;
 	}


### PR DESCRIPTION
The error log is convenient for developer to check failed case in stress test.

We have a bug : https://github.com/thesofproject/sof/issues/8056. The failed log provided limited information.
````
[  766.013925] <err> dai_comp: dai_common_new: comp:1 0x10004 dai_new(): dai_get() failed to create DAI.
[  766.013945] <err> copier: copier_dai_create: comp:1 0x10004 failed to create dai
[  766.013978] <err> copier: copier_init: comp:1 0x10004 unable to create dai
````
It is hard to be reproduced in private environment, so add error log for CI to catch it