### PR TITLE
Update Zephyr to include CONFIG_MODULES support

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9852e8e15bc8536aa1a49cc2697c1e8f802e331f
+      revision: 9183ceaf911965fd1e30f4172e0518c176ed644a
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9183ceaf911965fd1e30f4172e0518c176ed644a
+      revision: 9d1df132b1ccf28e8a8a216781ca52c6c47ed1fe
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9d1df132b1ccf28e8a8a216781ca52c6c47ed1fe
+      revision: pull/69547/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -233,7 +233,7 @@ static void __sparse_cache *heap_alloc_aligned_cached(struct k_heap *h,
 
 #ifdef CONFIG_SOF_ZEPHYR_HEAP_CACHED
 	if (ptr)
-		ptr = z_soc_cached_ptr((__sparse_force void *)ptr);
+		ptr = sys_cache_cached_ptr_get((__sparse_force void *)ptr);
 #endif
 
 	return ptr;
@@ -246,7 +246,7 @@ static void heap_free(struct k_heap *h, void *mem)
 	void *mem_uncached;
 
 	if (is_cached(mem)) {
-		mem_uncached = z_soc_uncached_ptr((__sparse_force void __sparse_cache *)mem);
+		mem_uncached = sys_cache_uncached_ptr_get((__sparse_force void __sparse_cache *)mem);
 		sys_cache_data_flush_and_invd_range(mem,
 				sys_heap_usable_size(&h->heap, mem_uncached));
 

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -19,6 +19,7 @@
 /* Zephyr includes */
 #include <version.h>
 #include <zephyr/kernel.h>
+#include <zephyr/kernel/smp.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>
 
@@ -27,36 +28,9 @@
 extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
-static atomic_t start_flag;
-static atomic_t ready_flag;
-
-/* Zephyr kernel_internal.h interface */
-extern void smp_timer_init(void);
-
-static FUNC_NORETURN void secondary_init(void *arg)
+static void secondary_init(void *arg)
 {
-	struct k_thread dummy_thread;
-
-	/*
-	 * This is an open-coded version of zephyr/kernel/smp.c
-	 * smp_init_top(). We do this so that we can call SOF
-	 * secondary_core_init() for each core.
-	 */
-
-	atomic_set(&ready_flag, 1);
-	z_smp_thread_init(arg, &dummy_thread);
-
 	secondary_core_init(sof_get());
-
-#ifdef CONFIG_THREAD_STACK_INFO
-	dummy_thread.stack_info.start = (uintptr_t)z_interrupt_stacks +
-		arch_curr_cpu()->id * Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
-	dummy_thread.stack_info.size = Z_KERNEL_STACK_LEN(CONFIG_ISR_STACK_SIZE);
-#endif
-
-	z_smp_thread_swap();
-
-	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
@@ -118,7 +92,6 @@ void cpu_notify_state_exit(enum pm_state state)
 			/* Notifying primary core that secondary core successfully exit the D3
 			 * state and is back in the Idle thread.
 			 */
-			atomic_set(&ready_flag, 1);
 			return;
 		}
 #endif
@@ -147,31 +120,17 @@ int cpu_enable_core(int id)
 	if (arch_cpu_active(id))
 		return 0;
 
-#if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
 	/* During kernel initialization, the next pm state is set to ACTIVE. By checking this
 	 * value, we determine if this is the first core boot, if not, we need to skip idle thread
 	 * initialization. By reinitializing the idle thread, we would overwrite the kernel structs
 	 * and the idle thread stack.
 	 */
-	if (pm_state_next_get(id)->state == PM_STATE_ACTIVE)
-		z_init_cpu(id);
-#endif
+	if (pm_state_next_get(id)->state == PM_STATE_ACTIVE) {
+		k_smp_cpu_start(id, secondary_init, NULL);
+		return 0;
+	}
 
-	atomic_clear(&start_flag);
-	atomic_clear(&ready_flag);
-
-	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
-		       secondary_init, &start_flag);
-
-	unsigned int retry;
-
-	for (retry = 100; !atomic_get(&ready_flag) && retry; retry--)
-		k_busy_wait(100);
-
-	if (!retry)
-		return -ETIMEDOUT;
-
-	atomic_set(&start_flag, 1);
+	k_smp_cpu_resume(id, secondary_init, NULL, true, false);
 
 	return 0;
 }
@@ -249,34 +208,20 @@ int cpu_enable_core(int id)
 
 int cpu_enable_secondary_core(int id)
 {
-	/*
-	 * This is an open-coded version of zephyr/kernel/smp.c
-	 * z_smp_start_cpu(). We do this, so we can use a customized
-	 * secondary_init() for SOF.
-	 */
-
 	if (arch_cpu_active(id))
 		return 0;
 
-#if ZEPHYR_VERSION(3, 0, 99) <= ZEPHYR_VERSION_CODE
-	z_init_cpu(id);
-#endif
+	/* During kernel initialization, the next pm state is set to ACTIVE. By checking this
+	 * value, we determine if this is the first core boot, if not, we need to skip idle thread
+	 * initialization. By reinitializing the idle thread, we would overwrite the kernel structs
+	 * and the idle thread stack.
+	 */
+	if (pm_state_next_get(id)->state == PM_STATE_ACTIVE) {
+		k_smp_cpu_start(id, secondary_init, NULL);
+		return 0;
+	}
 
-	atomic_clear(&start_flag);
-	atomic_clear(&ready_flag);
-
-	arch_start_cpu(id, z_interrupt_stacks[id], CONFIG_ISR_STACK_SIZE,
-		       secondary_init, &start_flag);
-
-	unsigned int retry;
-
-	for (retry = 100; !atomic_get(&ready_flag) && retry; retry--)
-		k_busy_wait(100);
-
-	if (!retry)
-		return -ETIMEDOUT;
-
-	atomic_set(&start_flag, 1);
+	k_smp_cpu_resume(id, secondary_init, NULL, true, false);
 
 	return 0;
 }


### PR DESCRIPTION
Update to a Zephyr version, including CONFIG_MODULES support. This is needed for #8180, but is now also a general long overdue Zephyr upgrade

cc:
- #8818