### PR TITLE
Convert #if XCHAL_HIFI logic to new CONFIG_DCBLOCK_HIFI

### DIFF
--- a/src/audio/dcblock/Kconfig
+++ b/src/audio/dcblock/Kconfig
@@ -6,3 +6,24 @@ config COMP_DCBLOCK
 	help
 	  Select for DC Blocking Filter component. This component filters out
 	  the DC offset which often originates from a microphone's output.
+
+choice
+	prompt "DC Blocking Filter HIFI level"
+	depends on COMP_DCBLOCK
+
+# The first valid one seems to be the default.
+# If not reliably, this can also be achieved with 3
+# explicit `default` lines above.
+config DCBLOCK_HIFI4
+       bool "HIFI4 DCBLOCK"
+       depends on XTENSA_ARCH_HAS_HIFI4
+
+config DCBLOCK_HIFI3
+       bool "HIFI3 DCBLOCK"
+       depends on XTENSA_ARCH_HAS_HIFI3
+
+config DCBLOCK_GENERIC
+       bool "Generic DCBLOCK, no HIFI"
+
+
+endchoice

--- a/src/audio/dcblock/dcblock.h
+++ b/src/audio/dcblock/dcblock.h
@@ -15,20 +15,6 @@
 #include <module/module/base.h>
 #include <module/module/interface.h>
 
-/* __XCC__ is both for xt_xcc and xt_clang */
-#if defined(__XCC__)
-# include <xtensa/config/core-isa.h>
-# if XCHAL_HAVE_HIFI4
-#  define DCBLOCK_HIFI4
-# elif XCHAL_HAVE_HIFI3
-#  define DCBLOCK_HIFI3
-# else
-#  define DCBLOCK_GENERIC
-# endif
-#else
-# define DCBLOCK_GENERIC
-#endif
-
 struct audio_stream;
 struct comp_dev;
 

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_GENERIC
+#if CONFIG_DCBLOCK_GENERIC
 
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI3
+#if CONFIG_DCBLOCK_HIFI3
 
 #include <xtensa/tie/xt_hifi3.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI4
+#if CONFIG_DCBLOCK_HIFI4
 
 #include <xtensa/tie/xt_hifi4.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,8 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d7af6f371034f31b9440b27c694b0be3c87491d3
+      # TEST hack https://github.com/zephyrproject-rtos/zephyr/pull/67513
+      revision: 512407edc9d8cffe80d7fb9a75cc923b49b2f2fb
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
The `if XCHAL_HAVE_HIFI4` macro logic is duplicated across many source files. Starting with dcblock.h, make it generic and move it to Kconfig

This adds the ability to override the max available HIFI level using Kconfig

EDIT: this is what was (I think) requested in alternative https://github.com/thesofproject/sof/pull/8720#discussion_r1447686269