### PR TITLE
xtensa-build-zephyr.py: fail on --deployable-build + older options

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -310,12 +310,9 @@ IPC4
 		sys.exit(0)
 
 	if args.deployable_build:
-		if args.fw_naming == 'AVS':
-			args.fw_naming = 'SOF'
-			print("The option '--fw-naming AVS' is ignored for deployable builds.")
-		if args.use_platform_subdir:
-			args.use_platform_subdir = False
-			print("The option '--use-platform-subdir' is ignored for deployable builds.")
+		if args.fw_naming == 'AVS' or args.use_platform_subdir:
+			sys.exit("Options '--fw-naming=AVS' and '--use-platform-subdir'"
+				 " are incompatible with --deployable-build.")
 
 	if args.fw_naming == 'AVS':
 		if not args.use_platform_subdir:

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -198,25 +198,32 @@ def parse_args():
     # the kernel 'ipc_type' expects CAVS IPC4. In this way, developers and CI can test
     # IPC4 on older platforms.
 	parser.add_argument("--fw-naming", required=False, choices=["AVS", "SOF"],
-						default="SOF", help="""
-Determine firmware naming conversion and folder structure
-For SOF:
-    /lib/firmware/intel/sof
-    └───────community
+						default="SOF",
+help="""Determine firmware naming conversion and folder structure.
+See also the newer and better '--deployable-build' for IPC4.
+With "SOF" (default):
+
+build-sof-staging (for /lib/firmware/intel/sof/)
+        ├───community
         │   └── sof-tgl.ri
         ├── dbgkey
         │   └── sof-tgl.ri
-        └── sof-tgl.ri
-For AVS(filename dsp_basefw.bin):
-Noted that with fw_naming set as 'AVS', there will be output subdirectories for each platform
-    /lib/firmware/intel/sof-ipc4
+        ├── sof-tgl.ri
+        └── sof-tgl.ldc
+
+With "AVS"; filename 'dsp_basefw.bin'.
+'AVS' automatically enables --use-platform-subdir which uses one subdirectory for each platform:
+
+build-sof-staging (for old, developer /lib/firmware/intel/sof-ipc4/)
     └── tgl
         ├── community
         │   └── dsp_basefw.bin
         ├── dbgkey
         │   └── dsp_basefw.bin
-        └── dsp_basefw.bin"""
-	)
+        ├── dsp_basefw.bin
+        └── sof-tgl.ldc
+
+""")
 	parser.add_argument("-j", "--jobs", required=False, type=int,
 						help="Number of concurrent jobs. Passed to west build and"
 						" to cmake (for rimage)")


### PR DESCRIPTION
2 commits. Main one:

xtensa-build-zephyr.py: fail on --deployable-build + older options

From experience, no one scrolls up and looks at warnings that are not in the current screen.


There's no reason to use both the old options and the brand new one at the same time, it would be a huge mistake.
