### PR TITLE
Support DMIC mute LED and volume mute function on IPC4 firmware/topology

### DIFF
--- a/tools/topology/topology2/include/components/gain.conf
+++ b/tools/topology/topology2/include/components/gain.conf
@@ -152,6 +152,41 @@ Class.Widget."gain" {
 				}
 			}
 		}
+
+		# mute switch control
+		mixer."2" {
+			Object.Base.channel.1 {
+				name	"flw"
+				reg	2
+				shift	0
+			}
+			Object.Base.channel.2 {
+				name	"fl"
+				reg	2
+				shift	1
+			}
+			Object.Base.channel.3 {
+				name	"fr"
+				reg	2
+				shift	2
+			}
+			Object.Base.channel.4 {
+				name	"frw"
+				reg	2
+				shift	3
+			}
+
+			Object.Base.ops.1 {
+				name	"ctl"
+				info 	"volsw"
+				## get = 259 binds the mixer control to switch get/put handlers
+				get 	259
+				put 	259
+			}
+
+			#max 1 indicates switch type control
+			max 1
+		}
 	}
 
 	# Default attribute values for gain widget

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -140,7 +140,7 @@ IncludeByKey.PASSTHROUGH {
 						}
 					]
 					Object.Control.mixer.1 {
-						name '$DMIC0_PCM_NAME Capture Volume'
+						name 'Dmic0 Capture Volume'
 					}
 					Object.Control.mixer.2 {
 						name 'Dmic0 Capture Switch'

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -142,6 +142,12 @@ IncludeByKey.PASSTHROUGH {
 					Object.Control.mixer.1 {
 						name '$DMIC0_PCM_NAME Capture Volume'
 					}
+					Object.Control.mixer.2 {
+						name 'Dmic0 Capture Switch'
+
+						mute_led_use 		1
+						mute_led_direction	1
+					}
 				}
 
 				Object.Widget.module-copier."2" {


### PR DESCRIPTION
I'm asked to add a mixer switch for MIC LED mute control so I studied how it is supported on IPC3 then add missing code to IPC4 firmware and topology.

Three missing parts are identified and restored:
1. add volume mute support to IPC4 firmware. (FW)
2. add a switch to gain widget for the mute control. (TPLG)
3. crate this switch with led mute function in dmic topology. (TPLG)

FW and TPLG are tested on MTL chromebook with chrome-v6.6 kernel. DMIC recording could be mute/unmute by mixer switch.

A side effect is the gain widget is default muted. Machines using PCH DMIC need to update UCM config to control 'Dmic0 Capture Switch' mixer properly.
