### PR TITLE
[DO NOT MERGE] topology2: intel: hdmi-generic: use multiple cores

### DIFF
--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -40,16 +40,21 @@ Object.Pipeline {
 			}
 
 			index $HDMI1_HOST_PIPELINE_ID
-			use_chain_dma	$HDMI_USE_CHAIN_DMA
+			core_id 0
+			use_chain_dma	"false"
 		}
 		{
 			Object.Widget.host-copier.1 {
 				stream_name $HDMI2_PCM_CAPS
 				pcm_id $HDMI2_PCM_ID
 			}
+			Object.Widget.pipeline.1 {
+				core	1
+			}
 
 			index $HDMI2_HOST_PIPELINE_ID
-			use_chain_dma	$HDMI_USE_CHAIN_DMA
+			core_id 1
+			use_chain_dma	"false"
 		}
 		{
 			Object.Widget.host-copier.1 {
@@ -57,14 +62,20 @@ Object.Pipeline {
 				pcm_id $HDMI3_PCM_ID
 			}
 
+			Object.Widget.pipeline.1 {
+				core	2
+			}
+
 			index $HDMI3_HOST_PIPELINE_ID
-			use_chain_dma	$HDMI_USE_CHAIN_DMA
+			core_id 2
+			use_chain_dma	"false"
 		}
 	]
 	io-gateway	 [
 		{
 			direction	"playback"
 			index $HDMI1_DAI_PIPELINE_ID
+			core_id 0
 
 			Object.Widget.dai-copier.1 {
 				node_type $HDA_LINK_OUTPUT_CLASS
@@ -94,6 +105,7 @@ Object.Pipeline {
 		{
 			direction	"playback"
 			index $HDMI2_DAI_PIPELINE_ID
+			core_id 1
 
 			Object.Widget.dai-copier.1 {
 				node_type $HDA_LINK_OUTPUT_CLASS
@@ -118,11 +130,15 @@ Object.Pipeline {
 					}
 				]
 			}
-			use_chain_dma	$HDMI_USE_CHAIN_DMA
+			Object.Widget.pipeline.1 {
+				core	1
+			}
+			use_chain_dma	"false"
 		}
 		{
 			direction	"playback"
 			index $HDMI3_DAI_PIPELINE_ID
+			core_id 2
 			Object.Widget.dai-copier.1 {
 				node_type $HDA_LINK_OUTPUT_CLASS
 				stream_name 'iDisp3'
@@ -146,7 +162,10 @@ Object.Pipeline {
 					}
 				]
 			}
-			use_chain_dma	$HDMI_USE_CHAIN_DMA
+			Object.Widget.pipeline.1 {
+				core	2
+			}
+			use_chain_dma	"false"
 		}
 	]
 }


### PR DESCRIPTION
Spread HDMI PCMS to cores 0, 1 and 2, and disable chain-dma by force (so that a full pipeline is created).