### PR TITLE
sof_ri_info: fix imr size for cnl

### DIFF
--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -1546,7 +1546,7 @@ APL_MEMORY_SPACE = DspMemory('Intel Apollolake',
 
 CNL_MEMORY_SPACE = DspMemory('Intel Cannonlake',
     [
-        DspMemorySegment('imr', 0xb0000000, 8*0x1024*0x1024),
+        DspMemorySegment('imr', 0xb0000000, 8*1024*1024),
         DspMemorySegment('l2 hpsram', 0xbe000000, 48*64*1024),
         DspMemorySegment('l2 lpsram', 0xbe800000, 1*64*1024)
     ])


### PR DESCRIPTION
Fix the typo for 8MB imr size.