### PR TITLE
west.yml: update zephyr to main branch commit 53c121381f1a

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d7af6f371034f31b9440b27c694b0be3c87491d3
+      revision: 53c121381f1a26153002e133ab4dd656cec0e592
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
530 Zephyr commits in total including:

```
4204ca9bcb3f ace: fix DSP panic during startup  (fixes c3a6274bf5e4)
d4b0273ab0c4 cmake: sparse.template: add COMMAND_ERROR_IS_FATAL
ca12fd13c6d3 xtensa: intel_adsp: fix a cache handling error
0ee1e28a2f5f xtensa: polish doxygen and add to missing doc
035c8d8ceb4b xtensa: remove sys_define_gpr_with_alias()
a64eec6aaeec xtensa: remove XTENSA_ERR_NORET
1c0c900cbbc3 intel_adsp: ace15: Enhance HST domain power-down sequence
c3a6274bf5e4 intel_adsp: ace: power: Prevent HST domain power gating
4aa0e7af6834 west: sign.py: add "REM" support to pass comments through cpp
a27e8f9a1976 west: sign.py: explain why `-P` is passed to cpp
2ee6c26d15a0 west: sign.py: rename new `generated/platf.toml` to `rimage_config.toml`
991a85361ee0 llext: use generic attributes instead of GCC's
5993192ec1ac llext: fix incorrect elf64_sym structure
```