### PR TITLE
[stable-v2.2] sof_ri_info: fix imr size for cnl

### DIFF
--- a/tools/sof_ri_info/sof_ri_info.py
+++ b/tools/sof_ri_info/sof_ri_info.py
@@ -1461,7 +1461,7 @@ APL_MEMORY_SPACE = DspMemory('Intel Apollolake',
 
 CNL_MEMORY_SPACE = DspMemory('Intel Cannonlake',
     [
-        DspMemorySegment('imr', 0xb0000000, 8*0x1024*0x1024),
+        DspMemorySegment('imr', 0xb0000000, 8*1024*1024),
         DspMemorySegment('l2 hpsram', 0xbe000000, 48*64*1024),
         DspMemorySegment('l2 lpsram', 0xbe800000, 1*64*1024)
     ])


### PR DESCRIPTION
Fix the typo for 8MB imr size.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>
(cherry picked from commit 40f6de58da5ceb6d88510a615de23d3e113e7e37)