### PR TITLE
Rename IS_ALIGN() to SOF_IS_ALIGN()

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -633,7 +633,7 @@ static int dai_set_sg_config(struct dai_data *dd, struct comp_dev *dev, uint32_t
 				 period_count);
 			buf_size = period_count * period_bytes;
 			do {
-				if (IS_ALIGNED(buf_size, max_block_count)) {
+				if (SOF_IS_ALIGNED(buf_size, max_block_count)) {
 					period_count = max_block_count;
 					period_bytes = buf_size / period_count;
 					break;

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1895,7 +1895,7 @@ static void kpb_convert_24b_to_32b(const void *linear_source, int ioffset,
 	int i = 0;
 	ae_int24x2 d24 = AE_ZERO24();
 
-	if (!IS_ALIGNED((uintptr_t)out_ptr, 8)) {
+	if (!SOF_IS_ALIGNED((uintptr_t)out_ptr, 8)) {
 		AE_LA24_IP(d24, align_in, in);
 		ae_int32x2 d320 = d24;
 		int higher = AE_MOVAD32_H(d320);
@@ -1996,7 +1996,7 @@ static void kpb_convert_32b_to_24b(const struct audio_stream *source, int ioffse
 	ae_f24x2 vs = AE_ZERO24();
 	ae_valign align_out = AE_ZALIGN64();
 
-	if (!IS_ALIGNED((uintptr_t)sin, 8)) {
+	if (!SOF_IS_ALIGNED((uintptr_t)sin, 8)) {
 		AE_L32F24_XC(vs, (const ae_f24 *)sin, 4);
 		AE_SA24_IP(vs, align_out, sout);
 		n_samples--;
@@ -2154,7 +2154,7 @@ static void kpb_copy_24b_in_32b(const struct audio_stream *source, uint32_t ioff
 	ae_int32x2 *sout = (ae_int32x2 *)out;
 	ae_int32x2 vs = AE_ZERO32();
 
-	if (!IS_ALIGNED((uintptr_t)sin, 8)) {
+	if (!SOF_IS_ALIGNED((uintptr_t)sin, 8)) {
 		AE_L32_IP(vs, (const ae_int32 *)sin, 4);
 		AE_S32_L_IP(vs, (ae_int32 *)sout, 4);
 		n_samples--;

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -14,14 +14,8 @@
 /* callers must check/use the return value */
 #define __must_check __attribute__((warn_unused_result))
 
-#ifdef __ZEPHYR__
-#include <zephyr/sys/util.h>
-#endif
-
 /* Align the number to the nearest alignment value */
-#ifndef IS_ALIGNED
 #define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
-#endif
 
 /* Treat zero as a special case because it wraps around */
 #define is_power_of_2(x) ((x) && !((x) & ((x) - 1)))

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -15,7 +15,7 @@
 #define __must_check __attribute__((warn_unused_result))
 
 /* Align the number to the nearest alignment value */
-#define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
+#define SOF_IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
 
 /* Treat zero as a special case because it wraps around */
 #define is_power_of_2(x) ((x) && !((x) & ((x) - 1)))


### PR DESCRIPTION
This is the simplest, cheapest and safest to avoid the collision with
the incoming Zephyr macro IS_ALIGN() submitted in
https://github.com/zephyrproject-rtos/zephyr/pull/67243

As SOF depends on Zephyr, most SOF symbols should be prefixed SOF_ or
something specific.

This is compliant with:
https://docs.zephyrproject.org/latest/contribute/coding_guidelines/index.html#rule-a-3-macro-name-collisions

Signed-off-by: Marc Herbert <marc.herbert@intel.com>