### PR TITLE
Revert "ipc4: relax the IPC timeout checks and be nicer to other thre…

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -510,13 +510,12 @@ static void ipc_compound_msg_done(uint32_t msg_id, int error)
 	}
 }
 
-/* wait for IPCs to complete on other cores and be nice to any LL work */
 static int ipc_wait_for_compound_msg(void)
 {
-	int try_count = 30; /* timeout out is 30 x 10ms so 300ms for IPC */
+	int try_count = 30;
 
 	while (atomic_read(&msg_data.delayed_reply)) {
-		k_sleep(Z_TIMEOUT_MS(10));
+		k_sleep(Z_TIMEOUT_US(250));
 
 		if (!try_count--) {
 			atomic_set(&msg_data.delayed_reply, 0);


### PR DESCRIPTION
…ads"

When a stream is triggered to start, host kernel first sendis trigger start ipc message to fw and then start host dma for this stream. Ipc_wait_for_compound_msg is used to wait for all pipelines in the stream to be complete and need to be done fast since it blocks host to start hda dma. The reverted commit adds a 10 ms delay and results to host copier xrun warning for it can't get data from host dma. And this commit also makes a negative effect for stream_start_offset calculation, so revert it.

This reverts commit 909a3277f1271d91314736fc1eaff35f362176d1.

one fix for https://github.com/thesofproject/linux/issues/4781