### PR TITLE
audio: dai-zephyr: update channel verification logic

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -553,7 +553,7 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 		return -EINVAL;
 	}
 
-	if (hw_params.channels && hw_params.channels != params->channels) {
+	if (hw_params.channels && hw_params.channels < params->channels) {
 		comp_err(dev, "dai_verify_params(): pcm channels parameter %d does not match hardware channels %d",
 			 params->channels, hw_params.channels);
 		return -EINVAL;


### PR DESCRIPTION
This commit updates the channel verification logic in dai-zephyr.c. The previous condition checked for an exact match between hw_params.channels and params->channels.

The new condition allows for hw_params.channels to be greater than or equal to params->channels, providing more flexibility in channel configuration.