### PR TITLE
topology2: Tidy up the production target name as topology2_prod

### DIFF
--- a/tools/topology/topology2/production/CMakeLists.txt
+++ b/tools/topology/topology2/production/CMakeLists.txt
@@ -25,6 +25,6 @@ foreach(tplg ${TPLGS})
 	  "${CMAKE_CURRENT_SOURCE_DIR}/../${input}" "${output}"
 	  "${CMAKE_CURRENT_SOURCE_DIR}/../" "${defines}")
 
-	add_custom_target(topology2_${output} DEPENDS ${output}.tplg)
-	add_dependencies(topology2_prod topology2_${output})
+	add_custom_target(topology2_prod_${output} DEPENDS ${output}.tplg)
+	add_dependencies(topology2_prod topology2_prod_${output})
 endforeach()


### PR DESCRIPTION
The target name for the production should have been more precise as it ended up:
```
ninja -C tools/build_tools/ help
topology2_dev: phony
...
topology2_dev_sof-tgl-nocodec: phony
topology2_dev_sof-tgl-nocodec-crossover-2way: phony ...
topology2_prod: phony
...
topology2_sof-hda-generic: phony
topology2_sof-hda-generic-2ch: phony
...
```
Change it to be consistent:
```
topology2_dev: phony
...
topology2_dev_sof-tgl-nocodec: phony
topology2_dev_sof-tgl-nocodec-crossover-2way: phony ...
topology2_prod: phony
...
topology2_prod_sof-hda-generic: phony
topology2_prod_sof-hda-generic-2ch: phony
...
```
No functional change.

Suggested-by: Marc Herbert <marc.herbert@intel.com>