### PR TITLE
CHAIN_DMA: fix memory leaks

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -24,7 +24,7 @@
 #include <sof/ut.h>
 #include <zephyr/pm/policy.h>
 #include <rtos/init.h>
-#if CONFIG_IPC4_XRUN_NOTIFICATIONS_ENABLE
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 #include <ipc4/notification.h>
 #include <sof/ipc/msg.h>
 #include <ipc/header.h>
@@ -52,7 +52,7 @@ struct chain_dma_data {
 	enum sof_ipc_stream_direction stream_direction;
 	/* container size in bytes */
 	uint8_t cs;
-#if CONFIG_IPC4_XRUN_NOTIFICATIONS_ENABLE
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 	bool xrun_notification_sent;
 	struct ipc_msg *msg_xrun;
 #endif
@@ -140,7 +140,7 @@ static size_t chain_get_transferred_data_size(const uint32_t out_read_pos, const
 	return buff_size - in_read_pos + out_read_pos;
 }
 
-#if CONFIG_IPC4_XRUN_NOTIFICATIONS_ENABLE
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 static void handle_xrun(struct chain_dma_data *cd)
 {
 	int ret;
@@ -187,7 +187,7 @@ static enum task_state chain_task_run(void *data)
 	case -EPIPE:
 		tr_warn(&chain_dma_tr, "chain_task_run(): dma_get_status() link xrun occurred,"
 			" ret = %u", ret);
-#if CONFIG_IPC4_XRUN_NOTIFICATIONS_ENABLE
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 		handle_xrun(cd);
 #endif
 		break;
@@ -660,7 +660,7 @@ static struct comp_dev *chain_task_create(const struct comp_driver *drv,
 	if (ret)
 		goto error_cd;
 
-#if CONFIG_IPC4_XRUN_NOTIFICATIONS_ENABLE
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 	cd->msg_xrun = ipc_msg_init(header.dat,
 				    sizeof(struct ipc4_resource_event_data_notification));
 	if (!cd->msg_xrun)

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -681,6 +681,10 @@ static void chain_task_free(struct comp_dev *dev)
 {
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
 
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
+	ipc_msg_free(cd->msg_xrun);
+#endif
+
 	chain_release(dev);
 	rfree(cd);
 	rfree(dev);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -749,6 +749,9 @@ int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma)
 {
 	const bool allocate = cdma->primary.r.allocate;
 	const bool enable = cdma->primary.r.enable;
+	struct ipc *ipc = ipc_get();
+	struct ipc_comp_dev *icd;
+	struct list_item *clist, *_tmp;
 	int ret;
 
 	if (!dev)
@@ -767,6 +770,15 @@ int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma)
 		ret = comp_trigger(dev, COMP_TRIGGER_PAUSE);
 		if (ret < 0)
 			return ret;
+
+		list_for_item_safe(clist, _tmp, &ipc->comp_list) {
+			icd = container_of(clist, struct ipc_comp_dev, list);
+			if (icd->cd != dev)
+				continue;
+			list_item_del(&icd->list);
+			rfree(icd);
+			break;
+		}
 		comp_free(dev);
 	}
 	return ret;


### PR DESCRIPTION
The SoundWire BPT/BRA loop tests exposes a DMA buffer allocation issue, which was root-caused after 4 days of my life that I am not getting back to a 20-byte memory leak. After a while this causes the DMA buffer to fail, likely because of alignment/fragmentation.

This PR also suggests fixes for the XRUN_NOTIFICATIONS_ENABLE option, but since this Kconfig is not used it's anyone's guess if the code actually works. Our firmware overlords might decide to completely remove this bad case of bitrot.