### PR TITLE
topology2: cavs-cs42l43: Add topology for cs42l43/cs35l56 on MTL

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -32,6 +32,11 @@ NUM_HDMIS=0,SDW_SPK_STREAM=Playback-SmartAmp,SDW_SPK_IN_STREAM=Capture-SmartAmp,
 SDW_DMIC_STREAM=Capture-SmartMic,SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
 SDW_JACK_IN_STREAM=Capture-SimpleJack,SDW_AMP_FMT_24=true,SDW_JACK_FMT_24=true"
 
+"cavs-sdw\;sof-mtl-cs42l43-l0-cs35l56-l23\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+SDW_AMP_FMT_24=true,SDW_JACK_FMT_24=true"
+
 # Below topologies are used on Chromebooks
 
 "cavs-rt5682\;sof-mtl-max98357a-rt5682\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\


### PR DESCRIPTION
The layout is configured as:
    - Link0: CS42L43 Jack and mics
    - Link2: 2x CS35L56 Speaker (amps 3 and 4, right)
    - Link3: 2x CS35L56 Speaker (amps 1 and 2, left)