### PR TITLE
Audio: IGO_NR: Fix build fail variable size data structure

### DIFF
--- a/src/include/sof/audio/igo_nr/igo_nr_comp.h
+++ b/src/include/sof/audio/igo_nr/igo_nr_comp.h
@@ -26,7 +26,6 @@ struct comp_data {
 	struct IgoStreamData igo_stream_data_ref;
 	struct IgoStreamData igo_stream_data_out;
 	struct comp_data_blob_handler *model_handler;
-	struct sof_igo_nr_config config;	    /**< blob data buffer */
 	int16_t in[IGO_NR_IN_BUF_LENGTH];	    /**< input samples buffer */
 	int16_t out[IGO_NR_IN_BUF_LENGTH];    /**< output samples mix buffer */
 	bool process_enable[SOF_IPC_MAX_CHANNELS];	/**< set if channel process is enabled */
@@ -39,6 +38,7 @@ struct comp_data {
 			   struct sof_source *source,
 			   struct sof_sink *sink,
 			   int32_t frames);
+	struct sof_igo_nr_config config;	    /**< blob data buffer */
 };
 
 #endif /* __SOF_AUDIO_IGO_NR_CONFIG_H__ */


### PR DESCRIPTION
This change avoids error, seen with testbench build for MTL platform with "scripts/rebuild-testbench.sh -p mtl":

sof/src/include/sof/audio/igo_nr/igo_nr_comp.h:29:27: error: field 'config' with variable sized type
'struct sof_igo_nr_config' not at the end of a struct or class is a GNU extension [-Werror,-Wgnu-variable-sized-type-not-at-end]