### PR TITLE
topology2: production: cav2.5: Remove NHLT from SDW topologies and add sof-adl-rt711-l0-rt1308-l12-rt715-l3

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -3,8 +3,7 @@
 # Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 list(APPEND TPLGS
 # IPC4 topology for TGL rt711 Headset + rt1316 Amplifier + rt714 DMIC
-"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1316-rt714.bin"
+"cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
 "cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
@@ -13,8 +12,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1316-rt714.bin"
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\
-SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt715-rt711-rt1308-mono.bin"
+SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false"
 
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + PCH DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMP_LINKS=1,NUM_DMICS=4,DMIC0_ID=3,\

--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -2,17 +2,19 @@
 
 # Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 list(APPEND TPLGS
-# IPC4 topology for TGL rt711 Headset + rt1316 Amplifier + rt714 DMIC
+# IPC4 topology for TGL/ADL rt711 Headset + rt1316 Amplifier + rt714 DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1316-rt714\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
 "cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
+# IPC4 topology for TGL/ADL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1308-rt715\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,SDW_AMP_FEEDBACK=false"
 
-# IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt715-rt711-rt1308-mono\;NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_JACK_OUT_STREAM=SDW1-Playback,SDW_JACK_IN_STREAM=SDW1-Capture,\
 SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false"
+
+"cavs-sdw\;sof-adl-rt711-l0-rt1308-l12-rt715-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,SDW_AMP_FEEDBACK=false"
 
 # IPC4 topology for TGL rt711 Headset + rt1308 Amplifier + PCH DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1308-4ch\;NUM_SDW_AMP_LINKS=1,NUM_DMICS=4,DMIC0_ID=3,\

--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -7,6 +7,9 @@ list(APPEND TPLGS
 
 "cavs-sdw\;sof-adl-rt711-l0-rt1316-l12-rt714-l3\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
+"cavs-sdw\;sof-adl-rt711-l0-rt1316-l13-rt714-l2\;NUM_SDW_AMP_LINKS=2,\
+SDW_DMIC=1,SDW_DMIC_STREAM=SDW2-Capture"
+
 # IPC4 topology for TGL/ADL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1308-rt715\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,SDW_AMP_FEEDBACK=false"
 


### PR DESCRIPTION
Hi,

NHLT blob is not needed when the DMIC is via SDW.
The sof-adl-rt711-l0-rt1308-l12-rt715-l3 is identical configuration as sof-tgl-rt711-rt1308-rt715.
