### PR TITLE
xtensa-build-zephyr.py: make --deployable-build the default

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -272,7 +272,7 @@ This should be used with programmatic script invocations (eg. Continuous Integra
 
 	deploy_args = parser.add_mutually_exclusive_group()
 	# argparse.BooleanOptionalAction requires Python 3.9
-	parser.set_defaults(deployable_build=False)
+	parser.set_defaults(deployable_build=True)
 	deploy_args.add_argument("--no-deployable-build", dest='deployable_build', action='store_false')
 	deploy_args.add_argument("--deployable-build", dest='deployable_build', action='store_true',
 			    help="""Create a directory structure for the firmware files which can be deployed on target as it is.


### PR DESCRIPTION
_[OLD commit message]_

Everyone should use deployable builds by default.

------

_[NEW commit message]_

Every Linux developer should use deployable builds by default.

Until Peter Ujfalusi's very recent work in this script, we had a
complete `/lib/firmware/` structure disconnect between the IPC4 output
of this script and the IPC4 expectations of the Linux kernel. To
workaround this disconnect, every CI and Linux developer used to
implement duplicate and inconsistent firmware deployment hacks.

People crafting sof-bin releases also had to organize IPC4 releases
manually, which was extremely error-prone and with limited test
coverage (Thanks Kai and Mengdong!)

Now that Peter gracefully fixed the layout, documented it in sof-docs
and implemented it in this script, the time for all Linux developers to
drop their inconsistent deployment hacks is overdue. All these hacks
must be replaced with a simple, one-line recursive copy which makes sure
the layout committed in version control is constantly tested by
everyone.

So, make deployable builds the new default.

The new default will also help with sof-bin releases, making sure they
use a well tested /lib/firmware/ layout.

The --no-deployable-build was recently introduced to help minimize
disruption and migration effort for people and automation who do NOT use
Linux. The `/lib/firmware/` directory structure is irrelevant outside
Linux (but everyone is of course free to choose it)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>