### PR TITLE
Topology: Topology2: Add sof-hda-benchmark-asrc32/24/16-<platform>

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -2,6 +2,7 @@
 <include/components/rtnr.conf>
 <include/components/igo_nr.conf>
 <include/components/src_lite.conf>
+<include/components/asrc.conf>
 
 Define {
 	ANALOG_PLAYBACK_PCM		'Analog Playback'
@@ -196,6 +197,25 @@ IncludeByKey.BENCH_CONFIG {
 	}
 
 	#
+	# ASRC component
+	#
+
+	# '^' indicates the start of the string and '$' means the end of string
+	# manually adding '^' and '$' for whole string precise matching
+
+	"^asrc16$" {
+		<include/bench/asrc_s16.conf>
+	}
+
+	"^asrc24$" {
+		<include/bench/asrc_s24.conf>
+	}
+
+	"^asrc32$" {
+		<include/bench/asrc_s32.conf>
+	}
+
+	#
 	# DCblock component
 	#
 
@@ -328,15 +348,15 @@ IncludeByKey.BENCH_CONFIG {
 	# SRC component
 	#
 
-	"src16" {
+	"^src16$" {
 		<include/bench/src_s16.conf>
 	}
 
-	"src24" {
+	"^src24$" {
 		<include/bench/src_s24.conf>
 	}
 
-	"src32" {
+	"^src32$" {
 		<include/bench/src_s32.conf>
 	}
 

--- a/tools/topology/topology2/development/tplg-targets-bench.cmake
+++ b/tools/topology/topology2/development/tplg-targets-bench.cmake
@@ -9,6 +9,7 @@ set(platforms "TGL" "MTL")
 set(sampleformats "16" "24" "32")
 
 set(components
+	"asrc"
 	"dcblock"
 	"drc"
 	"drc_multiband"
@@ -22,6 +23,7 @@ set(components
 )
 
 set(component_parameters
+	"BENCH_ASRC_PARAMS=default"
 	"BENCH_DCBLOCK_PARAMS=default"
 	"BENCH_DRC_PARAMS=enabled"
 	"BENCH_DRC_MULTIBAND_PARAMS=default"

--- a/tools/topology/topology2/include/bench/asrc_hda_route.conf
+++ b/tools/topology/topology2/include/bench/asrc_hda_route.conf
@@ -1,0 +1,19 @@
+		# Created with script "./bench_comp_generate.sh asrc"
+		Object.Base.route [
+			{
+				sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+				source 'asrc.1.1'
+			}
+			{
+				sink 'asrc.1.1'
+				source 'host-copier.0.playback'
+			}
+			{
+				source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+				sink 'asrc.3.2'
+			}
+			{
+				source 'asrc.3.2'
+				sink 'host-copier.0.capture'
+			}
+		]

--- a/tools/topology/topology2/include/bench/asrc_s16.conf
+++ b/tools/topology/topology2/include/bench/asrc_s16.conf
@@ -1,0 +1,17 @@
+		# Created with script "./bench_comp_generate.sh asrc"
+		Object.Widget.asrc.1 {
+			index 1
+			asynchronous_mode	0
+			operation_mode		0
+			rate_out 48000
+			<include/components/src_format_s16_convert_to_48k.conf>
+		}
+		Object.Widget.asrc.2 {
+			index 3
+			rate_in 48000
+			asynchronous_mode	0
+			operation_mode		1
+			<include/components/src_format_s16_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s16.conf>
+		<include/bench/asrc_hda_route.conf>

--- a/tools/topology/topology2/include/bench/asrc_s24.conf
+++ b/tools/topology/topology2/include/bench/asrc_s24.conf
@@ -1,0 +1,17 @@
+		# Created with script "./bench_comp_generate.sh asrc"
+		Object.Widget.asrc.1 {
+			index 1
+			asynchronous_mode	0
+			operation_mode		0
+			rate_out 48000
+			<include/components/src_format_s24_convert_to_48k.conf>
+		}
+		Object.Widget.asrc.2 {
+			index 3
+			asynchronous_mode	0
+			operation_mode		1
+			rate_in 48000
+			<include/components/src_format_s24_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s24.conf>
+		<include/bench/asrc_hda_route.conf>

--- a/tools/topology/topology2/include/bench/asrc_s32.conf
+++ b/tools/topology/topology2/include/bench/asrc_s32.conf
@@ -1,0 +1,17 @@
+		# Created with script "./bench_comp_generate.sh asrc"
+		Object.Widget.asrc.1 {
+			index 1
+			asynchronous_mode	0
+			operation_mode		0
+			rate_out 48000
+			<include/components/src_format_s32_convert_to_48k.conf>
+		}
+		Object.Widget.asrc.2 {
+			index 3
+			asynchronous_mode	0
+			operation_mode		1
+			rate_in 48000
+			<include/components/src_format_s32_convert_from_48k.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_src_s32.conf>
+		<include/bench/asrc_hda_route.conf>

--- a/tools/topology/topology2/include/components/asrc.conf
+++ b/tools/topology/topology2/include/components/asrc.conf
@@ -66,10 +66,12 @@ Class.Widget."asrc" {
 		]
 
 		!mandatory [
-			"format"
-			"rate_out"
 			"asynchronous_mode"
 			"operation_mode"
+			"num_input_audio_formats"
+			"num_output_audio_formats"
+			"num_input_pins"
+			"num_output_pins"
 		]
 
 		#
@@ -96,4 +98,6 @@ Class.Widget."asrc" {
 	type		"asrc"
 	uuid 		"2d:40:b4:66:68:b4:f2:42:81:a7:b3:71:21:86:3d:d4"
 	no_pm		"true"
+	num_input_pins		1
+	num_output_pins		1
 }


### PR DESCRIPTION
This patch adds build of hda-generic development topologies to test ASRC component with s32/24/16 format.