### PR TITLE
Add new CONFIG_DCBLOCK_HIFI and move generic XCHAL_HAVE logic to common.h

### DIFF
--- a/src/audio/dcblock/Kconfig
+++ b/src/audio/dcblock/Kconfig
@@ -6,3 +6,22 @@ config COMP_DCBLOCK
 	help
 	  Select for DC Blocking Filter component. This component filters out
 	  the DC offset which often originates from a microphone's output.
+
+choice
+	prompt "DC Blocking Filter HIFI level"
+	depends on COMP_DCBLOCK
+	default DCBLOCK_HIFI_MAX
+
+config DCBLOCK_HIFI_MAX
+	bool "Max level available in the toolchain"
+
+config DCBLOCK_HIFI_4
+	bool "HIFI4 DCBLOCK"
+
+config DCBLOCK_HIFI_3
+	bool "HIFI3 DCBLOCK"
+
+config DCBLOCK_HIFI_NONE
+	bool "Generic DCBLOCK, no HIFI"
+
+endchoice

--- a/src/audio/dcblock/dcblock.h
+++ b/src/audio/dcblock/dcblock.h
@@ -15,20 +15,6 @@
 #include <module/module/base.h>
 #include <module/module/interface.h>
 
-/* __XCC__ is both for xt_xcc and xt_clang */
-#if defined(__XCC__)
-# include <xtensa/config/core-isa.h>
-# if XCHAL_HAVE_HIFI4
-#  define DCBLOCK_HIFI4
-# elif XCHAL_HAVE_HIFI3
-#  define DCBLOCK_HIFI3
-# else
-#  define DCBLOCK_GENERIC
-# endif
-#else
-# define DCBLOCK_GENERIC
-#endif
-
 struct audio_stream;
 struct comp_dev;
 

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_GENERIC
+#if SOF_USE_HIFI(NONE, DCBLOCK)
 
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI3
+#if SOF_USE_HIFI(3, DCBLOCK)
 
 #include <xtensa/tie/xt_hifi3.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#ifdef DCBLOCK_HIFI4
+#if SOF_USE_HIFI(4, DCBLOCK)
 
 #include <xtensa/tie/xt_hifi4.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -177,6 +177,33 @@
 #define IS_ENABLED_STEP_3(ignore, value, ...) (!!(value))
 #endif
 
+#define SOF_CONFIG_HIFI(level, component) (CONFIG_ ## component ## _HIFI_ ## level)
+
+/* True if:
+ *  (1) EITHER this particular level was manually forced in Kconfig,
+ *  (2) OR:  - this component defaulted to "MAX"
+ *           - AND this level is the max available in the XC HAL.
+ */
+#define SOF_USE_HIFI(level, component) (SOF_CONFIG_HIFI(level, component) || \
+	(SOF_CONFIG_HIFI(MAX, component) && level == SOF_MAX_XCHAL_HIFI))
+
+#ifndef __XCC__ // Cadence toolchains: either xt-xcc or xt-clang.
+#  define SOF_MAX_XCHAL_HIFI NONE
+#else
+#  include <xtensa/config/core-isa.h>
+// Maybe we could make this fully generic (and less readable!) using
+// IS_ENABLED() above.
+#  if XCHAL_HAVE_HIFI5
+#    define SOF_MAX_XCHAL_HIFI 5
+#  elif XCHAL_HAVE_HIFI4
+#    define SOF_MAX_XCHAL_HIFI 4
+#  elif XCHAL_HAVE_HIFI3
+#    define SOF_MAX_XCHAL_HIFI 3
+#  else
+#    define SOF_MAX_XCHAL_HIFI NONE
+#  endif
+#endif
+
 #ifndef __GLIBC_USE
 #define __GLIBC_USE(x) 0
 #endif


### PR DESCRIPTION
1. The `if XCHAL_HAVE_HIFI4` macro logic is duplicated across many source files. Starting with dcblock.h, make it generic and move it to common.h

2. Add the ability to override the max available HIFI level using Kconfig