### PR TITLE
module_adapter: fix double-free of base_cfg_ext data

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1338,10 +1338,6 @@ int module_adapter_reset(struct comp_dev *dev)
 	rfree(mod->stream_params);
 	mod->stream_params = NULL;
 
-#if CONFIG_IPC_MAJOR_4
-	rfree(mod->priv.cfg.input_pins);
-#endif
-
 	comp_dbg(dev, "module_adapter_reset(): done");
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);
@@ -1370,6 +1366,10 @@ void module_adapter_free(struct comp_dev *dev)
 		irq_local_enable(flags);
 		buffer_free(buffer);
 	}
+
+#if CONFIG_IPC_MAJOR_4
+	rfree(mod->priv.cfg.input_pins);
+#endif
 
 	rfree(mod);
 	rfree(dev);


### PR DESCRIPTION
Fix handling of input_pins free. Module reset can be called multiple times, so move the resource release to module_adapter_free().

Fixes: 70460043844f ("module_adapter_ipc4: Save and pre-parse base_cfg_ext data")