### PR TITLE
Audio: Mixin_mixout: Add HiFi5 implementation.

### DIFF
--- a/src/audio/mixin_mixout/CMakeLists.txt
+++ b/src/audio/mixin_mixout/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_local_sources(sof mixin_mixout.c mixin_mixout_generic.c mixin_mixout_hifi3.c)
+add_local_sources(sof mixin_mixout.c mixin_mixout_generic.c mixin_mixout_hifi3.c mixin_mixout_hifi5.c)

--- a/src/audio/mixin_mixout/Kconfig
+++ b/src/audio/mixin_mixout/Kconfig
@@ -6,3 +6,40 @@ config COMP_MIXIN_MIXOUT
 	default y
 	help
 	  Select for Mixin_mixout component
+
+choice "MIXIN_MIXOUT_SIMD_LEVEL_SELECT"
+	prompt "choose which SIMD level used for MIXIN_MIXOUT module"
+	depends on COMP_MIXIN_MIXOUT
+	default MIXIN_MIXOUT_HIFI_MAX
+
+	config MIXIN_MIXOUT_HIFI_MAX
+		prompt "Max HiFi level available in the toolchain"
+		bool
+		help
+			When this was selected, optimization level will be determined
+			by toolchain.
+
+	config MIXIN_MIXOUT_HIFI_5
+		prompt "choose HIFI4 intrinsic optimized MIXIN_MIXOUT module"
+		bool
+		help
+			This option used to build HIFI4 optimized MIXIN_MIXOUT code
+
+	config MIXIN_MIXOUT_HIFI_4
+		prompt "choose HIFI4 intrinsic optimized MIXIN_MIXOUT module"
+		bool
+		help
+			This option used to build HIFI4 optimized MIXIN_MIXOUT code
+
+	config MIXIN_MIXOUT_HIFI_3
+		prompt "choose HIFI3 intrinsic optimized MIXIN_MIXOUT module"
+		bool
+		help
+			This option used to build HIFI3 intrinsic optimized MIXIN_MIXOUT code
+
+	config MIXIN_MIXOUT_HIFI_NONE
+		prompt "choose generic C MIXIN_MIXOUT module, no HIFI SIMD involved"
+		bool
+		help
+			This option used to build MIXIN_MIXOUT generic code.
+endchoice

--- a/src/audio/mixin_mixout/mixin_mixout.h
+++ b/src/audio/mixin_mixout/mixin_mixout.h
@@ -31,18 +31,6 @@
 #include <sof/platform.h>
 #include <stddef.h>
 
-#define MIXIN_MIXOUT_GENERIC
-
-#if defined(__XCC__)
-
-#include <xtensa/config/core-isa.h>
-#if XCHAL_HAVE_HIFI3 || XCHAL_HAVE_HIFI4
-#undef MIXIN_MIXOUT_GENERIC
-#define MIXIN_MIXOUT_HIFI3
-#endif
-
-#endif
-
 enum ipc4_mixin_config_param {
 	/* large_config_set param id for ipc4_mixer_mode_config */
 	IPC4_MIXER_MODE = 1

--- a/src/audio/mixin_mixout/mixin_mixout_generic.c
+++ b/src/audio/mixin_mixout/mixin_mixout_generic.c
@@ -9,7 +9,7 @@
 
 #include "mixin_mixout.h"
 
-#ifdef MIXIN_MIXOUT_GENERIC
+#if SOF_USE_HIFI(NONE, MIXIN_MIXOUT)
 
 #if CONFIG_FORMAT_S16LE
 static void mix_s16(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixed_samples,

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -561,6 +561,7 @@ zephyr_library_sources_ifdef(CONFIG_COMP_MIXIN_MIXOUT
 	${SOF_AUDIO_PATH}/mixin_mixout/mixin_mixout.c
 	${SOF_AUDIO_PATH}/mixin_mixout/mixin_mixout_generic.c
 	${SOF_AUDIO_PATH}/mixin_mixout/mixin_mixout_hifi3.c
+	${SOF_AUDIO_PATH}/mixin_mixout/mixin_mixout_hifi5.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_COMP_TONE


### PR DESCRIPTION
Add HiFi5 implementation of mix functions, compared with HiFi3 version, can reduce about 27% cycles.