### PR TITLE
Fix building of native loadable modules

### DIFF
--- a/src/module/audio/sink_api.c
+++ b/src/module/audio/sink_api.c
@@ -5,7 +5,6 @@
 
 #include <module/audio/sink_api.h>
 #include <module/audio/audio_stream.h>
-#include <rtos/symbol.h>
 
 /* This file contains public sink API functions that were too large to mark is as inline. */
 
@@ -24,7 +23,6 @@ int sink_get_buffer(struct sof_sink *sink, size_t req_size,
 		sink->requested_write_frag_size = req_size;
 	return ret;
 }
-EXPORT_SYMBOL(sink_get_buffer);
 
 int sink_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
@@ -46,7 +44,6 @@ int sink_commit_buffer(struct sof_sink *sink, size_t commit_size)
 	sink->num_of_bytes_processed += commit_size;
 	return ret;
 }
-EXPORT_SYMBOL(sink_commit_buffer);
 
 int sink_set_frm_fmt(struct sof_sink *sink, enum sof_ipc_frame frame_fmt)
 {

--- a/src/module/audio/source_api.c
+++ b/src/module/audio/source_api.c
@@ -6,7 +6,6 @@
 
 #include <module/audio/source_api.h>
 #include <module/audio/audio_stream.h>
-#include <rtos/symbol.h>
 
 /* This file contains public source API functions that were too large to mark is as inline. */
 
@@ -24,7 +23,6 @@ int source_get_data(struct sof_source *source, size_t req_size,
 		source->requested_read_frag_size = req_size;
 	return ret;
 }
-EXPORT_SYMBOL(source_get_data);
 
 int source_release_data(struct sof_source *source, size_t free_size)
 {
@@ -46,7 +44,6 @@ int source_release_data(struct sof_source *source, size_t free_size)
 	source->num_of_bytes_processed += free_size;
 	return ret;
 }
-EXPORT_SYMBOL(source_release_data);
 
 size_t source_get_frame_bytes(struct sof_source *source)
 {


### PR DESCRIPTION
This PR reverts changes in:
    src/module/audio/sink_api.c
    src/module/audio/source_api.c
made by commit 12d958a2eb8e3fa2d7a534f1ab1b59bab2a1fb64. These changes made it impossible to build native loadable modules.