### PR TITLE
[STABLE-v2.2] logger: convert: Fix `%*s` compile time error with newer toolchain

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -318,7 +318,7 @@ static double to_usecs(uint64_t time)
 }
 
 /** Justified timestamp width for printf format string */
-static unsigned int timestamp_width(unsigned int precision)
+static uint8_t timestamp_width(uint8_t precision)
 {
 	/* 64bits yields less than 20 digits precision. As reported by
 	 * gcc 9.3, this avoids a very long precision causing snprintf()
@@ -352,7 +352,7 @@ static inline void print_table_header(void)
 	}
 
 	if (global_config->time_precision >= 0) {
-		const unsigned int ts_width = timestamp_width(global_config->time_precision);
+		const uint8_t ts_width = timestamp_width(global_config->time_precision);
 
 		fprintf(out_fd, "%*s(us)%*s  ", -ts_width, " TIMESTAMP", ts_width, "DELTA");
 	}

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -41,7 +41,7 @@ struct convert_config {
 	int dump_ldc;
 	int hide_location;
 	int relative_timestamps;
-	int time_precision;
+	uint8_t time_precision;
 	struct snd_sof_uids_header *uids_dict;
 	struct snd_sof_logs_header *logs_header;
 };


### PR DESCRIPTION
Using Compiler version: aarch64-poky-linux-gcc (GCC) 13.2.0 we get the following error:
```
tools/logger/convert.c: In function 'convert':
tools/logger/convert.c:357:34: error: '%*s' directive output between 4294967264 and 4294967284 bytes exceeds 'INT_MAX' [-Werror=format-overflow=]
|   357 |                 fprintf(out_fd, "%*s(us)%*s  ", -ts_width, " TIMESTAMP", ts_width, "DELTA");
|       |                                  ^~~                       ~~~~~~~~~~~~
| In file included from /opt/builds/OBNand/build/tmp/work/armv8a-poky-linux/sof-tools/2.8.0/recipe-sysroot/usr/include/stdio.h:964,
|                  from /opt/builds/OBNand/build/tmp/work/armv8a-poky-linux/sof-tools/2.8.0/git/tools/logger/convert.h:13,
|                  from /opt/builds/OBNand/build/tmp/work/armv8a-poky-linux/sof-tools/2.8.0/git/tools/logger/convert.c:21:
| In function 'fprintf',
```
Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>
Signed-off-by: Marc Herbert <marc.herbert@intel.com>
(cherry picked from commit ff9343aa4a59d714f40714aa16950ee37b911df2)