### PR TITLE
[SKIP SOF-TEST] .github: upgrade all checkout actions, v3 -> v4 (deprecated Node.js 16). Extend fetch-depth when building firmware

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
+          filter: 'tree:0'
 
       - name: west update
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get -y install
             clang llvm ninja-build device-tree-compiler python3-pyelftools
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
 

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: 'tree:0'
 
       - name: run yamllint
         # Quoting to please all parsers is hard. This indirection helps.

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -33,7 +33,7 @@ jobs:
       # depth 2 so:
       # ^1. we can show the Subject of the current target branch tip
       # ^2. we reconnect/graft to the later fetch pull/1234/head,
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 2}
 
       - name: install codespell
@@ -56,7 +56,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: run yamllint
         # Quoting to please all parsers is hard. This indirection helps.

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -27,7 +27,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # From time to time this will catch a git tag and change SOF_VERSION
         with: {fetch-depth: 50, submodules: recursive}
 

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -28,8 +28,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        # From time to time this will catch a git tag and change SOF_VERSION
-        with: {fetch-depth: 50, submodules: recursive}
+        with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: docker
         run: docker pull thesofproject/sof && docker tag thesofproject/sof sof

--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -60,7 +60,7 @@ jobs:
           sudo apt-get -y install
             clang llvm ninja-build device-tree-compiler python3-pyelftools
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
 

--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
+          filter: 'tree:0'
 
       - name: west update
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: apt get doxygen graphviz
         run: sudo apt-get -y install ninja-build doxygen graphviz
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-20.04  # sof-docs is still stuck to this for now
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: apt-get update
         run: sudo apt-get update
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 5, submodules: recursive}
 
       - name: docker
@@ -133,7 +133,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 0, submodules: recursive}
 
       - name: docker
@@ -168,7 +168,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 0, submodules: recursive}
 
       - name: turn off HAVE_AGENT

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: 'tree:0'
 
       - name: apt get doxygen graphviz
         run: sudo apt-get -y install ninja-build doxygen graphviz
@@ -72,6 +74,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: 'tree:0'
 
       - name: apt-get update
         run: sudo apt-get update
@@ -107,7 +111,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: {fetch-depth: 5, submodules: recursive}
+        with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: docker
         run: docker pull thesofproject/sof && docker tag thesofproject/sof sof
@@ -134,7 +138,7 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-        with: {fetch-depth: 0, submodules: recursive}
+        with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: docker
         run: docker pull thesofproject/sof && docker tag thesofproject/sof sof
@@ -169,7 +173,7 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-        with: {fetch-depth: 0, submodules: recursive}
+        with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: turn off HAVE_AGENT
         run: echo CONFIG_HAVE_AGENT=n >

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: {fetch-depth: 5, submodules: recursive}
+        with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: docker pull
         run: docker pull thesofproject/sof &&  docker tag thesofproject/sof sof

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 5, submodules: recursive}
 
       - name: docker pull

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: {fetch-depth: 5}
+        with: {fetch-depth: 0, filter: 'tree:0'}
 
       - name: apt get
         run: sudo apt-get update &&

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 5}
 
       - name: apt get

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -12,7 +12,7 @@ jobs:
   top-level_default_CMake_target_ALL:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # The ALSA version in Ubuntu 20.04 is buggy
       # (https://github.com/thesofproject/sof/issues/2543) and likely

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: 'tree:0'
 
       # The ALSA version in Ubuntu 20.04 is buggy
       # (https://github.com/thesofproject/sof/issues/2543) and likely

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: {fetch-depth: 2}
+        with: {fetch-depth: 2, filter: 'tree:0'}
 
       - name: build and run all defconfigs
         run: ./test/test-all-defconfigs.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
   cmocka_utests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: {fetch-depth: 2}
 
       - name: build and run all defconfigs

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
+          filter: 'tree:0'
 
       - name: plain west update
         run: |
@@ -70,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
+          filter: 'tree:0'
 
       - name: west clones
         run: pip3 install west && cd workspace/sof/ && west init -l &&
@@ -128,6 +130,7 @@ jobs:
         # This is especially useful for daily builds (but not just).
         with:
           fetch-depth: 0
+          filter: 'tree:0'
           path: ./workspace/sof
 
       - name: west clones
@@ -227,6 +230,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: 'tree:0'
           path: ./workspace/sof
 
       # Cache artifacts so we do not overload external servers with downloads
@@ -381,6 +385,7 @@ jobs:
           # Isolate the clone in a subdirectory to make sure globbing
           # does not catch random SOF files.
           path: ./sof
+          filter: 'tree:0'
 
       - name: Download Windows and Linux builds
         uses: actions/download-artifact@v3

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -19,7 +19,7 @@ jobs:
   manifest-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./workspace/sof
 
@@ -122,7 +122,7 @@ jobs:
             IPC_platforms: mtl
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Download a full clone to fix `git describe`, sof_version.h and
         # build reproducibility. sof.git is still small.
         # This is especially useful for daily builds (but not just).
@@ -224,7 +224,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: ./workspace/sof
@@ -374,7 +374,7 @@ jobs:
     needs: [build-linux, build-windows]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # we need only one script but it's simpler to get the (last
         # revision of the) whole repo and it takes seconds.
         with:


### PR DESCRIPTION
2 commits to review separately.

Main change, fixes the new, mass warnings:

Node.js 16 actions are deprecated. Please update the following
actions to use Node.js 20: actions/checkout@v3. For more information
see:
https://github.blog/changelog/
   2023-09-22-github-actions-transitioning-from-node-16-to-node-20/