### PR TITLE
fixup! topology2: Use SAMPLE_TYPE_MSB_INTEGER for ALH copier

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -452,6 +452,8 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 									in_valid_bit_depth	32
 									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									in_ch_map	$CHANNEL_MAP_3_POINT_1
+									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+									in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 								}
 							]
 							Object.Base.output_audio_format [
@@ -461,6 +463,8 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 									out_valid_bit_depth	32
 									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									out_ch_map	$CHANNEL_MAP_3_POINT_1
+									out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+									out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 								}
 							]
 						}


### PR DESCRIPTION
Some ALH DAI copier missed SAMPLE_TYPE_MSB_INTEGER setting.