### PR TITLE
[SKIP SOF-TEST] .github: fallback on rebuild-testbench -j 1 when failing

### DIFF
--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -49,7 +49,8 @@ jobs:
              ./scripts/build-tools.sh -t
 
       - name: build testbench
-        run: ./scripts/rebuild-testbench.sh
+        run: ./scripts/rebuild-testbench.sh ||
+             ./scripts/rebuild-testbench.sh -j 1
 
       - name: run testbench
         run: ./scripts/host-testbench.sh


### PR DESCRIPTION
Parallel builds are fast but they bury errors, for instance good luck finding the cause of this failure:
 https://github.com/thesofproject/sof/actions/runs/7667629748/job/20897861756?pr=8019

Use the well known technique of falling back on a single thread when failing.