### PR TITLE
topology2: Add topology for testing SOF plugin

### DIFF
--- a/tools/plugin/README.md
+++ b/tools/plugin/README.md
@@ -41,16 +41,16 @@ Ex: "~/work/sof/sof/build_plugin/sof_ep/install/lib:~/work/sof/sof/build_plugin/
 And set the environment variable SOF_PLUGIN_TOPOLOGY_PATH to point to the directory containing the topology binary
 ```
 
-Code can then be run by starting sof-pipe with your desired topology
+Code can then be run by starting sof-pipe with your desired topology (Ex: sof-plugin.tplg)
 
 ```
- ./sof-pipe -T sof-tgl-nocodec.tplg
+ ./sof-pipe -T sof-plugin.tplg
 ```
 
 At this point the sof-pipe daemon is waiting for IPC. Audio applications can now invoke sof-pipe processing via
 
 ```
-aplay -Dsof:tgl-nocodec:1:default:default:48k2c16b -f dat some48kHz.wav
+aplay -Dsof:plugin:1:default:default:48k2c16b -f dat some48kHz.wav
 ```
 The command line is parsed as follows:
 - "sof" is the plugin name
@@ -66,9 +66,9 @@ The above example needs to be 48k as example pipe has no SRC/ASRC.
 Likewise
 
 ```
-arecord -Dsof:tgl-nocodec:1:default:default:48k2c16b -f dat file.wav
+arecord -Dsof:plugin:1:default:default:48k2c16b -f dat file.wav
 ```
-Will record audio using the tgl-nocodec topology and PCM ID 1.
+Will record audio using the plugin topology and PCM ID 1.
 
 Mixer settings can be adjusted for bdw-nocodec by (Not functional yet)
 

--- a/tools/topology/topology2/development/sof-plugin.conf
+++ b/tools/topology/topology2/development/sof-plugin.conf
@@ -1,0 +1,170 @@
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<tokens.conf>
+<host-gateway-capture.conf>
+<host-gateway-playback.conf>
+<io-gateway-capture.conf>
+<io-gateway.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<ssp.conf>
+<route.conf>
+<intel/common_definitions.conf>
+<dai-copier.conf>
+<module-copier.conf>
+<pipeline.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+
+Object.Pipeline.io-gateway-capture [
+	{
+		index		10
+		direction	capture
+
+		Object.Widget.dai-copier."1" {
+			dai_index	1
+			dai_type	"SSP"
+			type		dai_out
+			copier_type	"SSP"
+			stream_name	"NoCodec-1"
+			node_type	$I2S_LINK_INPUT_CLASS
+
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.host-gateway-capture [
+	{
+		index 	9
+
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP1 Capture'
+			pcm_id 1
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.Pipeline.io-gateway [
+	{
+		index	4
+		direction	playback
+
+		Object.Widget.dai-copier.1 {
+			dai_index 1
+			dai_type "SSP"
+			copier_type "SSP"
+			stream_name "NoCodec-1"
+			node_type $I2S_LINK_OUTPUT_CLASS
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+Object.Pipeline.host-gateway-playback [
+	{
+		index	3
+		Object.Widget.host-copier.1 {
+			stream_name 'SSP1 Playback'
+			pcm_id 1
+			num_input_audio_formats 1
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		16
+					in_valid_bit_depth	16
+				}
+			]
+			num_output_audio_formats 1
+			Object.Base.output_audio_format [
+				{
+					out_bit_depth		16
+					out_valid_bit_depth	16
+				}
+			]
+		}
+	}
+]
+
+Object.PCM.pcm [
+	{
+		name	"PluginPCM"
+		id 1
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	"PluginPlayback"
+		}
+
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name "SSP1 Playback"
+			formats 'S16_LE'
+		}
+
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name "SSP1 Capture"
+			formats 'S16_LE'
+		}
+	}
+]
+
+
+Object.Base.route [
+	{
+		source	"host-copier.1.playback"
+		sink	"dai-copier.SSP.NoCodec-1.playback"
+	}
+	{
+		source	"dai-copier.SSP.NoCodec-1.capture"
+		sink	"host-copier.1.capture"
+	}
+]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -114,4 +114,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-crossover.bin,EFX_CROSSOVE
 # Topology to test RTC AEC
 "development/cavs-nocodec-rtcaec\;sof-tgl-nocodec-rtcaec\;PLATFORM=tgl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-rtcaec.bin"
+
+# Topology for SOF plugin
+"development/sof-plugin\;sof-plugin"
 )


### PR DESCRIPTION
The topology uses passthrough pipelines for playback/capture and supports only 48k, 2ch, 16bit format for now.