### PR TITLE
config L3_HEAP: add missing "ACE" dependency

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -381,6 +381,7 @@ config CAVS_USE_LPRO_IN_WAITI
 config L3_HEAP
 	bool "Use L3 memory heap"
 	default n
+	depends on ACE
 	help
 	  Select this if L3 memory is supported on the platform and
 	  it is intended to be used for dynamic allocations.


### PR DESCRIPTION
Current commit message:

In Zephyr, L3_HEAP is available in `intel_ace15_mtpm/adsp_memory.h` and
`intel_ace20_lnl/adsp_memory.h` but not in `intel_tgl_adsp/adsp_memory.h`

Don't allow configuration that can't possible compile.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>