### PR TITLE
logger: convert: fix variable type for negative value

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -532,7 +532,7 @@ static void print_entry_params(const struct log_entry_header *dma_log,
 				entry->header.line_idx);
 	} else {
 		if (time_precision >= 0) {
-			const unsigned int ts_width = timestamp_width(time_precision);
+			const uint8_t ts_width = timestamp_width(time_precision);
 
 			fprintf(out_fd, "%s[%*.*f] (%*.*f)%s ",
 				use_colors ? KGRN : "",

--- a/tools/logger/convert.h
+++ b/tools/logger/convert.h
@@ -41,7 +41,7 @@ struct convert_config {
 	int dump_ldc;
 	int hide_location;
 	int relative_timestamps;
-	uint8_t time_precision;
+	int8_t time_precision;
 	struct snd_sof_uids_header *uids_dict;
 	struct snd_sof_logs_header *logs_header;
 };


### PR DESCRIPTION
This will fix scan tool reported issue:

time_precision variable can be used as -1

```
case 'f':
        config.time_precision = atoi(optarg);
   	if (config.time_precision < 0) {

case 'g':
   	config.time_precision = -1;
```

Fixes commit ff9343aa4a59