### PR TITLE
dp: delayed start should apply to the first DP cycle only 

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1046,8 +1046,10 @@ static int module_adapter_copy_dp_queues(struct comp_dev *dev)
 				       source_get_data_available(data_src));
 
 		err = source_to_sink_copy(data_src, data_sink, true, to_copy);
-		if (err)
+		if (err) {
+			comp_err(dev, "LL to DP copy error status: %d", err);
 			return err;
+		}
 
 		dp_queue = dp_queue_get_next_item(dp_queue);
 	}
@@ -1080,8 +1082,10 @@ static int module_adapter_copy_dp_queues(struct comp_dev *dev)
 				       source_get_data_available(data_src));
 
 		err = source_to_sink_copy(data_src, data_sink, true, to_copy);
-		if (err)
+		if (err) {
+			comp_err(dev, "DP to LL copy error status: %d", err);
 			return err;
+		}
 
 		dp_queue = dp_queue_get_next_item(dp_queue);
 	}


### PR DESCRIPTION
When DP start, copy from DP to LL should be delayed till first
DP deadline time.

In current implementation the cycle counter is set at every
DP scheduler trigger. If DP is - for any reason - scheduled
again before its deadline passes, the counter will be set again
and copying delay time will be too long. In extreme situation
(i.e. if OBS is set to long value when IBS is short - in this case
DP will proceed a short data chunks with a long deadline), it may
lead to permanent stuck in processing.