### PR TITLE
[DNM] dai: zephyr: add support for parsing new SAI/ESAI handshake encoding

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -565,6 +565,37 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 	return 0;
 }
 
+static int dai_get_dma_slot(struct dai_data *dd, struct comp_dev *dev, uint32_t *slot)
+{
+	struct dai_config cfg;
+	int ret;
+	int hs;
+
+	ret = dai_config_get(dd->dai->dev, &cfg, dev->direction);
+	if (ret < 0) {
+		comp_err(dev, "failed to fetch DAI configuration");
+		return ret;
+	}
+
+	hs = dai_get_handshake(dd->dai, dev->direction, dd->stream_id);
+	if (ret < 0) {
+		comp_err(dev, "failed to fetch DAI handshake");
+		return ret;
+	}
+
+	switch (cfg.type) {
+	case DAI_IMX_SAI:
+	case DAI_IMX_ESAI:
+		*slot = (hs & GENMASK(15, 8)) >> 8;
+		break;
+	default:
+		*slot = hs;
+		return 0;
+	}
+
+	return 0;
+}
+
 static int dai_set_sg_config(struct dai_data *dd, struct comp_dev *dev, uint32_t period_bytes,
 			     uint32_t period_count)
 {
@@ -578,11 +609,15 @@ static int dai_set_sg_config(struct dai_data *dd, struct comp_dev *dev, uint32_t
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
 		config->direction = DMA_DIR_MEM_TO_DEV;
-		config->dest_dev = dai_get_handshake(dd->dai, dev->direction, dd->stream_id);
+		err = dai_get_dma_slot(dd, dev, &config->dest_dev);
+		if (err < 0)
+			return err;
 	} else {
 		dd->process = pcm_get_conversion_function(dma_fmt, local_fmt);
 		config->direction = DMA_DIR_DEV_TO_MEM;
-		config->src_dev = dai_get_handshake(dd->dai, dev->direction, dd->stream_id);
+		err = dai_get_dma_slot(dd, dev, &config->src_dev);
+		if (err < 0)
+			return err;
 	}
 
 	if (!dd->process) {

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -63,7 +63,12 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	case SOF_DAI_IMX_ESAI:
 		handshake = dai_get_handshake(dd->dai, dai->direction,
 					      dd->stream_id);
+/* TODO: remove this when transition to native drivers is complete on all NXP platforms */
+#ifndef CONFIG_ZEPHYR_NATIVE_DRIVERS
 		channel = EDMA_HS_GET_CHAN(handshake);
+#else
+		channel = handshake & GENMASK(7, 0);
+#endif /* CONFIG_ZEPHYR_NATIVE_DRIVERS */
 		break;
 	case SOF_DAI_IMX_MICFIL:
 		channel = dai_get_handshake(dd->dai, dai->direction,


### PR DESCRIPTION
For native SAI and ESAI, the channel and DMA slot are encoded differently in the handshake. As such, we need to add support for parsing this new encoding.

@kv2019i perhaps it may be worth adding a new function in the Zephyr DAI subsystem that will move all of this complexity to Zephyr. Something like:

```
enum dai_hs_attribute {
    DAI_HS_ATTRIBUTE_CHANNEL,
    DAI_HS_ATTRIBUTE_DMA_SLOT,
};

int dai_get_handshake_attribute(const struct device *dev, enum dai_dir dir, enum dai_hs_attribute hs_attr)
{
      /* do decoding here */
}
```
This ought to remove the need to use functions such as `dai_dma_get_slot` or `dai_config_dma_channel`. Of course, this all depends on how Intel does the encoding as well.
