### PR TITLE
ipc-helper.c: reject invalid SOF_MEM_CAPS_* bits

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -86,6 +86,8 @@ struct sof_ipc_comp {
 #define SOF_MEM_CAPS_CACHE		BIT(6) /**< cacheable */
 #define SOF_MEM_CAPS_EXEC		BIT(7) /**< executable */
 #define SOF_MEM_CAPS_L3			BIT(8) /**< L3 memory */
+/* Don't forget to update when adding a new bit to the ABI. */
+#define SOF_MEM_CAPS_LOWEST_INVALID	BIT(9) /**< Used for input validation */
 
 /*
  * overrun will cause ring buffer overwrite, instead of XRUN.

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -36,6 +36,15 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
+static bool valid_ipc_buffer_desc(const struct sof_ipc_buffer *desc)
+{
+	if (desc->caps >= SOF_MEM_CAPS_LOWEST_INVALID)
+		return false;
+
+	/* TODO: check desc->size and maybe other things */
+	return true;
+}
+
 /* create a new component in the pipeline */
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared)
 {
@@ -43,6 +52,12 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared
 
 	tr_info(&buffer_tr, "buffer new size 0x%x id %d.%d flags 0x%x",
 		desc->size, desc->comp.pipeline_id, desc->comp.id, desc->flags);
+
+	if (!valid_ipc_buffer_desc(desc)) {
+		tr_err(&buffer_tr, "Invalid buffer desc! New size 0x%x id %d.%d caps 0x%x",
+		       desc->size, desc->comp.pipeline_id, desc->comp.id, desc->caps);
+		return NULL;
+	}
 
 	/* allocate buffer */
 	buffer = buffer_alloc(desc->size, desc->caps, desc->flags, PLATFORM_DCACHE_ALIGN,

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -76,6 +76,9 @@ LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 #define iGS(x) ((x) & SOF_GLB_TYPE_MASK)
 #define iCS(x) ((x) & SOF_CMD_TYPE_MASK)
 
+/* FIXME: assert() is most likely turned off in production builds
+ * https://open-std.org/jtc1/sc22/wg14/www/docs/n1967.htm
+ */
 #define _IPC_COPY_CMD(rx, tx, rx_size)					\
 	do {								\
 		int ___ret;						\


### PR DESCRIPTION
Fixes lack of SOF_MEM_CAPS_* input validation found in #8832