### PR TITLE
lmdk: module: Extend module error code definitions

### DIFF
--- a/lmdk/libraries/dummy/CMakeLists.txt
+++ b/lmdk/libraries/dummy/CMakeLists.txt
@@ -10,10 +10,4 @@ set(MODULES_LIST dummy)
 # toml file for rimage to generate manifets
 set(TOML "${CMAKE_CURRENT_LIST_DIR}/dummy_mtl.toml")
 
-# TODO: Move it somewhere?! This probably should be defined in some API header file!
-# SOF loadable modules API version
-add_definitions(-DMAJOR_IADSP_API_VERSION=5)
-add_definitions(-DMIDDLE_IADSP_API_VERSION=0)
-add_definitions(-DMINOR_IADSP_API_VERSION=0)
-
 include(../../cmake/build.cmake)

--- a/src/include/module/iadk/adsp_error_code.h
+++ b/src/include/module/iadk/adsp_error_code.h
@@ -36,4 +36,25 @@ typedef uint32_t AdspErrorCode;
 /* Service is not supported on target platform. */
 #define ADSP_SERVICE_UNAVAILABLE 143
 
+/* SystemAgentInterface */
+#define ADSP_MODULE_CREATION_FAILURE	16
+
+/* ProcessingModuleFactoryInterface */
+
+/* Reports that the given value of Input Buffer Size is invalid */
+#define ADSP_INVALID_IBS		17
+/* Reports that the given value of Output Buffer Size is invalid */
+#define ADSP_INVALID_OBS		18
+/* Reports that the given value of Cycles Per Chunk processing is invalid */
+#define ADSP_INVALID_CPC		19
+/* Reports that the settings provided for module creation are invalid */
+#define ADSP_INVALID_SETTINGS		20
+
+/* ProcessingModuleInterface */
+/* Reports that the message content given for configuration is invalid */
+#define ADSP_INVALID_CONFIGURATION	21
+
+/* Reports that the module does not support retrieval of its current configuration information */
+#define ADSP_NO_CONFIGURATION		22
+
 #endif /* __MODULE_IADK_ADSP_ERROR_CODE_H__ */


### PR DESCRIPTION
Ported additional error code definitions from iadk module API.

Removed unused api version definitions. The API version used by the module is now defined in the module api version header file. The definitions in CMakeLists.txt are no longer needed.