### PR TITLE
Deprecate XTOS on imx8/imx8x platforms

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:  # just a vector in this case
         make_env: [
-          IPC_VERSION= UNSIGNED_list='imx8' SIGNED_list=,  # default version
+          IPC_VERSION= UNSIGNED_list='imx8m' SIGNED_list=,  # default version
         ]
 
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -167,7 +167,7 @@ jobs:
         # The main reason for these groups is to avoid the matrix
         # swarming the Github web interface and burying other checks.
         # See longer example above.
-        platform: [imx8 imx8x imx8m,
+        platform: [imx8m,
         ]
 
     steps:

--- a/installer/tests/staging_sof_ref.txt
+++ b/installer/tests/staging_sof_ref.txt
@@ -1,5 +1,5 @@
 .
-├── sof-imx8.ldc
-└── sof-imx8.ri
+├── sof-imx8m.ldc
+└── sof-imx8m.ri
 
 0 directories, 2 files

--- a/scripts/test-repro-build.sh
+++ b/scripts/test-repro-build.sh
@@ -39,7 +39,7 @@ SOF2="$SOF_PARENT"/sof-bind-mount-DO-NOT-DELETE
 # considerably, replace "sof" with something of the same length:
 # SOF2="$SOF_PARENT"/sog
 
-PLATFS=(imx8)
+PLATFS=(rmb)
 
 # diffoscope is great but it has hundreds of dependencies, too long to
 # install for CI so we don't use it here. This is just an alias

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -8,7 +8,7 @@ set -e
 # Platforms built and tested by default in CI using the `-a` option.
 # They must have a toolchain available in the latest Docker image.
 DEFAULT_PLATFORMS=(
-    imx8 imx8x imx8m imx8ulp
+    imx8m imx8ulp
     rn rmb vangogh
     mt8186 mt8195
 )


### PR DESCRIPTION
To prepare for XTOS deprecation and switch to Zephyr native drivers on i.MX8QM/i.MX8QXP, remove the ability to build SOF with XTOS on said platforms. Also, remove all XTOS builds/tests for these platforms from CI.