### PR TITLE
Preparatory patches for NXP platforms transition to Zephyr native drivers

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -718,6 +718,13 @@ static int dai_set_dma_config(struct dai_data *dd, struct comp_dev *dev)
 		dma_block_cfg->block_size = config->elem_array.elems[i].size;
 		dma_block_cfg->source_address = config->elem_array.elems[i].src;
 		dma_block_cfg->dest_address = config->elem_array.elems[i].dest;
+		if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
+			dma_block_cfg->source_addr_adj = DMA_ADDR_ADJ_DECREMENT;
+			dma_block_cfg->dest_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+		} else {
+			dma_block_cfg->source_addr_adj = DMA_ADDR_ADJ_INCREMENT;
+			dma_block_cfg->dest_addr_adj = DMA_ADDR_ADJ_DECREMENT;
+		}
 		prev = dma_block_cfg;
 		prev->next_block = ++dma_block_cfg;
 	}

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1053,6 +1053,11 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 
 	comp_dbg(dev, "dai_comp_trigger_internal(), command = %u", cmd);
 
+#ifdef CONFIG_IPC_MAJOR_3
+	if (dev->state == comp_get_requested_state(cmd))
+		return PPL_STATUS_PATH_STOP;
+#endif /* CONFIG_IPC_MAJOR_3 */
+
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		comp_dbg(dev, "dai_comp_trigger_internal(), START");
@@ -1150,6 +1155,17 @@ static int dai_comp_trigger_internal(struct dai_data *dd, struct comp_dev *dev, 
 			dai_trigger_op(dd->dai, cmd, dev->direction);
 		break;
 	}
+
+#ifdef CONFIG_IPC_MAJOR_3
+	/* TODO: investigate why making this IPC version-agnostic
+	 * breaks some Intel tests and check if doing so would be
+	 * possible (or even make sense) on Intel platforms.
+	 *
+	 * See issue #8920 for details.
+	 */
+	if (!ret)
+		return comp_set_state(dev, cmd);
+#endif /* CONFIG_IPC_MAJOR_3 */
 
 	return ret;
 }

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -161,6 +161,10 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 		cfg.type = is_blob ? DAI_INTEL_HDA_NHLT : DAI_INTEL_HDA;
 		cfg_params = is_blob ? spec_config : &sof_cfg->hda;
 		break;
+	case SOF_DAI_IMX_SAI:
+		cfg.type = DAI_IMX_SAI;
+		cfg_params = &sof_cfg->sai;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -203,6 +203,7 @@ static uint32_t host_get_copy_bytes_one_shot(struct host_data *hd)
 static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_callback_t cb)
 {
 	uint32_t copy_bytes;
+	struct dma_sg_elem *local_elem = hd->config.elem_array.elems;
 	int ret = 0;
 
 	comp_dbg(dev, "host_copy_one_shot()");
@@ -212,6 +213,13 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 		comp_info(dev, "host_copy_one_shot(): no bytes to copy");
 		return ret;
 	}
+
+	/* SRC/DEST addresses have changed so the DMAC needs
+	 * to be re-configured.
+	 */
+	hd->z_config.head_block->source_address = local_elem->src;
+	hd->z_config.head_block->dest_address = local_elem->dest;
+	hd->z_config.head_block->block_size = local_elem->size;
 
 	/* reconfigure transfer */
 	ret = dma_config(hd->chan->dma->z_dev, hd->chan->index, &hd->z_config);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -935,10 +935,12 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	case DMA_DIR_LMEM_TO_HMEM:
 		dma_cfg->channel_direction = MEMORY_TO_HOST;
 		dma_block_cfg->source_address = buffer_addr;
+		dma_block_cfg->dest_address = hd->config.elem_array.elems[0].dest;
 		break;
 	case DMA_DIR_HMEM_TO_LMEM:
 		dma_cfg->channel_direction = HOST_TO_MEMORY;
 		dma_block_cfg->dest_address = buffer_addr;
+		dma_block_cfg->source_address = hd->config.elem_array.elems[0].src;
 		break;
 	}
 

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -63,7 +63,12 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 	case SOF_DAI_IMX_ESAI:
 		handshake = dai_get_handshake(dd->dai, dai->direction,
 					      dd->stream_id);
+/* TODO: remove this when transition to native drivers is complete on all NXP platforms */
+#ifndef CONFIG_ZEPHYR_NATIVE_DRIVERS
 		channel = EDMA_HS_GET_CHAN(handshake);
+#else
+		channel = handshake & GENMASK(7, 0);
+#endif /* CONFIG_ZEPHYR_NATIVE_DRIVERS */
 		break;
 	case SOF_DAI_IMX_MICFIL:
 		channel = dai_get_handshake(dd->dai, dai->direction,

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -145,6 +145,9 @@ const struct device *zephyr_dev[] = {
 #if CONFIG_DAI_INTEL_HDA
 	DT_FOREACH_STATUS_OKAY(intel_hda_dai, GET_DEVICE_LIST)
 #endif
+#if CONFIG_DAI_NXP_SAI
+	DT_FOREACH_STATUS_OKAY(nxp_dai_sai, GET_DEVICE_LIST)
+#endif
 };
 
 static const struct device *dai_get_zephyr_device(uint32_t type, uint32_t index)

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -107,6 +107,29 @@ SHARED_DATA struct dma dma[] = {
 	.z_dev		= DEVICE_DT_GET(DT_NODELABEL(hda_link_out)),
 },
 #endif
+#ifdef CONFIG_SOC_SERIES_MIMX9_A55
+{
+	.plat_data = {
+		.dir = DMA_DIR_MEM_TO_DEV | DMA_DIR_DEV_TO_MEM,
+		.devs = DMA_DEV_SAI,
+		/* TODO: might be worth using `dma-channels` here
+		 * (needs to become a mandatory property)
+		 */
+		.channels = 64,
+		.period_count = 2,
+	},
+	.z_dev = DEVICE_DT_GET(DT_NODELABEL(edma4)),
+},
+{
+	.plat_data = {
+		.dir = DMA_DIR_HMEM_TO_LMEM | DMA_DIR_LMEM_TO_HMEM,
+		.devs = DMA_DEV_HOST,
+		.channels = DT_PROP(DT_NODELABEL(host_dma), dma_channels),
+		.period_count = 2,
+	},
+	.z_dev = DEVICE_DT_GET(DT_NODELABEL(host_dma)),
+},
+#endif /* CONFIG_SOC_SERIES_MIMX9_A55 */
 };
 
 const struct dma_info lib_dma = {


### PR DESCRIPTION
This PR is a combination of patches cherry-picked from https://github.com/thesofproject/sof/pull/8520 and https://github.com/thesofproject/sof/pull/8844. These patches don't require a Zephyr hash bump and are needed for the transition of NXP platforms to native Zephyr drivers.