### PR TITLE
base_fw: update mem_state_info TLV

### DIFF
--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -128,10 +128,8 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	index = 0;
 	tuple_data[index++] = info.free_phys_mem_pages;
 	tuple_data[index++] = info.ebb_state_dword_count;
-	for (i = 0; i < info.ebb_state_dword_count; i++) {
-		tuple_data[index + i] = io_reg_read(SHIM_HSPGCTL(i));
-	}
-	index += info.ebb_state_dword_count;
+	for (i = 0; i < info.ebb_state_dword_count; i++)
+		tuple_data[index++] = HPSRAM_REGS(i)->HSxPGCTL;
 
 	tuple_data[index++] = info.page_alloc_struct.page_alloc_count;
 	/* TLB is not supported now, so all pages are marked as occupied
@@ -154,7 +152,9 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	index = 0;
 	tuple_data[index++] = info.free_phys_mem_pages;
 	tuple_data[index++] = info.ebb_state_dword_count;
-	tuple_data[index++] = io_reg_read(LSPGCTL);
+	for (i = 0; i < info.ebb_state_dword_count; i++)
+		tuple_data[index++] = LPSRAM_REGS(i)->USxPGCTL;
+
 	tuple_data[index++] = info.page_alloc_struct.page_alloc_count;
 	ptr = (uint16_t *)(tuple_data + index);
 	for (i = 0; i < info.page_alloc_struct.page_alloc_count; i++)

--- a/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/pm_memory.h
@@ -22,6 +22,7 @@
 #include <sof/lib/shim.h>
 #include <rtos/wait.h>
 #include <sof/math/numbers.h>
+#include <adsp_memory.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -72,14 +73,14 @@ static inline void cavs_pm_memory_hp_sram_mask_set(uint32_t mask, int segment,
 	uint32_t delay = 0;
 	uint32_t i;
 
-	io_reg_update_bits(SHIM_HSPGCTL(segment), mask, enabled ? 0 : mask);
-	io_reg_update_bits(SHIM_HSRMCTL(segment), mask, enabled ? 0 : mask);
+	io_reg_update_bits(&HPSRAM_REGS(segment)->HSxPGCTL, mask, enabled ? 0 : mask);
+	io_reg_update_bits(&HPSRAM_REGS(segment)->HSxRMCTL, mask, enabled ? 0 : mask);
 
 	/* Double check of PG status needed to confirm EBB readiness */
 	for (i = 0; i < 2; i++) {
 		idelay(MEMORY_POWER_CHANGE_DELAY);
 
-		while ((io_reg_read(SHIM_HSPGISTS(segment)) & mask) != expected) {
+		while ((io_reg_read(&HPSRAM_REGS(segment)->HSxPGISTS) & mask) != expected) {
 			idelay(MEMORY_POWER_CHANGE_DELAY);
 			delay += MEMORY_POWER_CHANGE_DELAY;
 			if (delay >= MEMORY_POWER_CHANGE_TIMEOUT)

--- a/src/platform/lunarlake/include/platform/lib/shim.h
+++ b/src/platform/lunarlake/include/platform/lib/shim.h
@@ -44,11 +44,6 @@
 /** \brief LP RING Oscillator Clock Status */
 #define SHIM_CLKSTS_LROSCCS		BIT(29)
 
-#define L2HSBPM(x)			(0x17A800 + 0x0008 * (x))
-#define SHIM_HSPGCTL(x)			(L2HSBPM(x) + 0x0000)
-
-#define LSPGCTL				0x71D80
-
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 
 #else

--- a/src/platform/meteorlake/include/platform/lib/shim.h
+++ b/src/platform/meteorlake/include/platform/lib/shim.h
@@ -44,11 +44,6 @@
 /** \brief LP RING Oscillator Clock Status */
 #define SHIM_CLKSTS_LROSCCS		BIT(29)
 
-#define L2HSBPM(x)			(0x17A800 + 0x0008 * (x))
-#define SHIM_HSPGCTL(x)			(L2HSBPM(x) + 0x0000)
-
-#define LSPGCTL				0x71D80
-
 #endif /* __PLATFORM_LIB_SHIM_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/lib/shim.h
+++ b/src/platform/tigerlake/include/platform/lib/shim.h
@@ -224,25 +224,6 @@
 #define I2SLCTL_SPA(x)		BIT(0 + x)
 #define I2SLCTL_CPA(x)		BIT(8 + x)
 
-#define L2LMCAP			0x71D00
-#define L2MPAT			0x71D04
-
-#define HSPGCTL0		0x71D10
-#define HSRMCTL0		0x71D14
-#define HSPGISTS0		0x71D18
-
-#define SHIM_HSPGCTL(x)		(HSPGCTL0 + 0x10 * (x))
-#define SHIM_HSRMCTL(x)		(HSRMCTL0 + 0x10 * (x))
-#define SHIM_HSPGISTS(x)	(HSPGISTS0 + 0x10 * (x))
-
-#define HSPGCTL1		0x71D20
-#define HSRMCTL1		0x71D24
-#define HSPGISTS1		0x71D28
-
-#define LSPGCTL			0x71D50
-#define LSRMCTL			0x71D54
-#define LSPGISTS		0x71D58
-
 #define SHIM_L2_MECS		(SHIM_BASE + 0xd0)
 
 /** \brief LDO Control */


### PR DESCRIPTION
This change improves the TLV assembly algorithm in accordance with how the part for hpsram is assembled. In the case when ebb_state_dword_count is equal to 0, we skip adding the LSPGCTL register value for lpsram.

The following PR must be merged into the Zephyr repository before we can merge this PR:
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/70221