### PR TITLE
multicore: don't enable timer interrupts on secondary cores

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -45,7 +45,6 @@ static FUNC_NORETURN void secondary_init(void *arg)
 
 	atomic_set(&ready_flag, 1);
 	z_smp_thread_init(arg, &dummy_thread);
-	smp_timer_init();
 
 	secondary_core_init(sof_get());
 


### PR DESCRIPTION
Keep timer interrupt handling on the primary core, this avoids secondary cores failing to handle timer interrupts immediately after power on.

This fixes the IPC timeout when starting a secondary core, most frequently happening on mtl-008