### PR TITLE
Tools: Topology2: No need for HDA platform variants for benchmark tplg

### DIFF
--- a/tools/topology/topology2/development/tplg-targets-bench.cmake
+++ b/tools/topology/topology2/development/tplg-targets-bench.cmake
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 #
-# Append test topologies for multiple platforms and multiple formats
+# Append test topologies for multiple formats
 # to TPLGS array.
 #
 
-set(platforms "TGL" "MTL")
 set(sampleformats "16" "24" "32")
 
 set(components
@@ -44,23 +43,19 @@ set(component_parameters_s32
 	"BENCH_ARIA_PARAMS=default"
 )
 
-foreach(p ${platforms})
-	string(TOLOWER ${p} pl)
-
-	# Add components with all sample formats
-	foreach(sf ${sampleformats})
-		foreach(comp bench_param IN ZIP_LISTS components component_parameters)
-			    set(item "sof-hda-generic\;sof-hda-benchmark-${comp}${sf}-${pl}\;PLATFORM=${p},HDA_CONFIG=benchmark,BENCH_CONFIG=${comp}${sf},${bench_param}")
-			    #message(STATUS "Item=" ${item})
-			    list(APPEND TPLGS "${item}")
-		endforeach()
-	endforeach()
-
-	# Add components with single format
-	set (sf "32")
-	foreach(comp bench_param IN ZIP_LISTS components_s32 component_parameters_s32)
-		set(item "sof-hda-generic\;sof-hda-benchmark-${comp}${sf}-${pl}\;PLATFORM=${p},HDA_CONFIG=benchmark,BENCH_CONFIG=${comp}${sf},${bench_param}")
+# Add components with all sample formats
+foreach(sf ${sampleformats})
+	foreach(comp bench_param IN ZIP_LISTS components component_parameters)
+		set(item "sof-hda-generic\;sof-hda-benchmark-${comp}${sf}\;HDA_CONFIG=benchmark,BENCH_CONFIG=${comp}${sf},${bench_param}")
 		#message(STATUS "Item=" ${item})
 		list(APPEND TPLGS "${item}")
 	endforeach()
+endforeach()
+
+# Add components with single format
+set (sf "32")
+foreach(comp bench_param IN ZIP_LISTS components_s32 component_parameters_s32)
+	set(item "sof-hda-generic\;sof-hda-benchmark-${comp}${sf}\;HDA_CONFIG=benchmark,BENCH_CONFIG=${comp}${sf},${bench_param}")
+	#message(STATUS "Item=" ${item})
+	list(APPEND TPLGS "${item}")
 endforeach()

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -100,12 +100,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-mtl-lbm.bin"
 
 # CAVS HDA topology for benchmarking performance
 # Copier - peak volume - mixin - mixout - aria - peak volume - mixin - mixout - copier
-"sof-hda-generic\;sof-hda-benchmark-generic-tgl\;PLATFORM=TGL,HDA_CONFIG=benchmark,\
-BENCH_CONFIG=benchmark"
-"sof-hda-generic\;sof-hda-benchmark-generic-mtl\;PLATFORM=MTL,HDA_CONFIG=benchmark,\
-BENCH_CONFIG=benchmark"
-"sof-hda-generic\;sof-hda-benchmark-generic-lnl\;PLATFORM=LNL,HDA_CONFIG=benchmark,\
-BENCH_CONFIG=benchmark"
+"sof-hda-generic\;sof-hda-benchmark-generic\;HDA_CONFIG=benchmark,BENCH_CONFIG=benchmark"
 
 # Topology to test IPC4 Crossover
 "development/cavs-nocodec-crossover\;sof-tgl-nocodec-crossover-2way\;PLATFORM=tgl,\


### PR DESCRIPTION
Since there is no NHLT blob included to these topologies, the same topology works for all HDA platforms, e.g. TGL, MTL, LNL.