### PR TITLE
Tools: Topology2: Use for LNL own platform configuration lnl.conf

### DIFF
--- a/tools/topology/topology2/cavs-es83x6.conf
+++ b/tools/topology/topology2/cavs-es83x6.conf
@@ -67,6 +67,7 @@ Define {
 # override defaults with platform-specific config
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 # include HDMI config if needed.

--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -62,6 +62,7 @@ IncludeByKey.PLATFORM {
 	"tgl"	"platform/intel/tgl.conf"
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -101,7 +101,7 @@ IncludeByKey.PLATFORM {
 	"tgl"	"platform/intel/tgl.conf"
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
-	"lnl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -126,6 +126,7 @@ Define {
 # override defaults with platform-specific config
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -84,7 +84,7 @@ Define {
 # override defaults with platform-specific config
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
-	"lnl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 IncludeByKey.ADD_BT {

--- a/tools/topology/topology2/development/cavs-nocodec-crossover.conf
+++ b/tools/topology/topology2/development/cavs-nocodec-crossover.conf
@@ -52,7 +52,7 @@ IncludeByKey.PLATFORM {
 	"tgl"	"platform/intel/tgl.conf"
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
-	"lnl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 #

--- a/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
+++ b/tools/topology/topology2/development/cavs-nocodec-rtcaec.conf
@@ -50,7 +50,7 @@ IncludeByKey.PLATFORM {
 	"tgl"	"platform/intel/tgl.conf"
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
-	"lnl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 #

--- a/tools/topology/topology2/platform/intel/lnl.conf
+++ b/tools/topology/topology2/platform/intel/lnl.conf
@@ -1,0 +1,6 @@
+# LNL-specific variable definitions
+Define {
+	DMIC_DRIVER_VERSION		4
+	SSP_BLOB_VERSION		0x105
+	NUM_HDMIS			3
+}

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -57,7 +57,7 @@ Define {
 # override defaults with platform-specific config
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
-	"lnl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/lnl.conf"
 }
 
 # include HDA config if needed.


### PR DESCRIPTION
The new lnl.conf is copy of mtl.conf but DMIC_DRIVER_VERSION needs to be increased by one for a small registers change.