### PR TITLE
Tools: Topology2: Add include of mtl.conf for LNL HDA generic

### DIFF
--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -57,6 +57,7 @@ Define {
 # override defaults with platform-specific config
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
+	"lnl"	"platform/intel/mtl.conf"
 }
 
 # include HDA config if needed.


### PR DESCRIPTION
This quick fix avoids build of NHLT blob for the default (TGL) for LNL HDA generic platform.

The DMIC part of NHLT from TGL is not suitable for LNL, while a blob for MTL can be used. A proper lnl.conf will be added later.