### PR TITLE
zephyr: pm_runtime: Remove outdated TODO comment

### DIFF
--- a/zephyr/lib/pm_runtime.c
+++ b/zephyr/lib/pm_runtime.c
@@ -56,9 +56,6 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 
 		if (ticks == K_TICKS_FOREVER ||
 		    (ticks >= (min_residency + exit_latency))) {
-			/* TODO: PM_STATE_RUNTIME_IDLE requires substates to be defined
-			 * to handle case with enabled PG andf disabled CG.
-			 */
 			tr_dbg(&power_tr, "transition to state %x (min_residency = %u, exit_latency = %u)",
 			       state->state, min_residency, exit_latency);
 			return state;


### PR DESCRIPTION
Clean up an incorrect TODO comment in the power management runtime policy.

The removed comment suggested the need for substates to handle cases where power gating (PG) is enabled and clock gating (CG) is disabled. However, this is not accurate because:
- Enabling PG when CG is not allowed is not feasible; entering PG could inadvertently gate the clock even if CG prevent is active.
- Substates are no longer required as clock gating is now always enabled.

This change clarifies the power management behavior and removes confusion around the handling of power and clock gating.