### PR TITLE
modules: Remove unused code and variables

### DIFF
--- a/src/audio/module_adapter/library/native_system_agent.c
+++ b/src/audio/module_adapter/library/native_system_agent.c
@@ -19,10 +19,8 @@ typedef void* (*native_create_instance_f)(void *mod_cfg, void *parent_ppl,
 
 struct native_system_agent native_sys_agent;
 
-void *native_system_agent_start(uint32_t *sys_service,
-				uint32_t entry_point, uint32_t module_id,
-				uint32_t instance_id, uint32_t core_id, uint32_t log_handle,
-				void *mod_cfg)
+void *native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+				uint32_t core_id, uint32_t log_handle, void *mod_cfg)
 {
 	native_sys_agent.module_id = module_id;
 	native_sys_agent.instance_id = instance_id;

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -100,9 +100,8 @@ static int modules_new(struct processing_module *mod, const void *buildinfo,
 		   mod_buildinfo->api_version_number.full == SOF_MODULE_API_CURRENT_VERSION) {
 		/* The module is native: start agent for sof loadable */
 		mod->is_native_sof = true;
-		drv->adapter_ops = native_system_agent_start(mod->sys_service, module_entry_point,
-							     module_id, instance_id,
-							     0, log_handle, &mod_cfg);
+		drv->adapter_ops = native_system_agent_start(module_entry_point, module_id,
+							     instance_id, 0, log_handle, &mod_cfg);
 	} else {
 		return -ENOEXEC;
 	}

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -144,20 +144,7 @@ static int modules_init(struct processing_module *mod)
 			return ret;
 	}
 
-	/* Allocate module buffers */
-	md->mpd.in_buff = rballoc(0, SOF_MEM_CAPS_RAM, src_cfg->ibs);
-	if (!md->mpd.in_buff) {
-		comp_err(dev, "modules_init(): Failed to alloc in_buff");
-		return -ENOMEM;
-	}
 	md->mpd.in_buff_size = src_cfg->ibs;
-
-	md->mpd.out_buff = rballoc(0, SOF_MEM_CAPS_RAM, src_cfg->obs);
-	if (!md->mpd.out_buff) {
-		comp_err(dev, "modules_init(): Failed to alloc out_buff");
-		rfree(md->mpd.in_buff);
-		return -ENOMEM;
-	}
 	md->mpd.out_buff_size = src_cfg->obs;
 
 	/* Call module specific init function if exists. */
@@ -285,8 +272,6 @@ static int modules_free(struct processing_module *mod)
 		ret = iadk_wrapper_free(mod->priv.module_adapter);
 	}
 
-	rfree(md->mpd.in_buff);
-	rfree(md->mpd.out_buff);
 
 	if (!md->llext || !llext_unload(&md->llext)) {
 		/* Free module resources allocated in L2 memory. */

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -106,8 +106,6 @@ static int modules_new(struct processing_module *mod, const void *buildinfo,
 		return -ENOEXEC;
 	}
 
-	md->module_entry_point = module_entry_point;
-
 	return 0;
 }
 

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -60,7 +60,6 @@ struct module_data {
 	void *runtime_params;
 	struct module_memory memory; /**< memory allocated by module */
 	struct module_processing_data mpd; /**< shared data comp <-> module */
-	void *module_adapter; /**<loadable module interface handle */
 	uintptr_t module_entry_point; /**<loadable module entry point address */
 	struct llext *llext; /**< Zephyr loadable extension context */
 #endif /* SOF_MODULE_PRIVATE */

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -183,9 +183,6 @@ struct processing_module {
 	/* flag to insure that module is loadable */
 	bool is_native_sof;
 
-	/* pointer to system services for loadable modules */
-	uint32_t *sys_service;
-
 	/* total processed data after stream started */
 	uint64_t total_data_consumed;
 	uint64_t total_data_produced;

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -60,7 +60,6 @@ struct module_data {
 	void *runtime_params;
 	struct module_memory memory; /**< memory allocated by module */
 	struct module_processing_data mpd; /**< shared data comp <-> module */
-	uintptr_t module_entry_point; /**<loadable module entry point address */
 	struct llext *llext; /**< Zephyr loadable extension context */
 #endif /* SOF_MODULE_PRIVATE */
 };

--- a/src/include/sof/audio/module_adapter/library/native_system_agent.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_agent.h
@@ -20,8 +20,7 @@ struct native_system_agent {
 	uint32_t module_size;
 };
 
-void *native_system_agent_start(uint32_t *sys_service,
-				uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+void *native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
 				uint32_t core_id, uint32_t log_handle, void *mod_cfg);
 
 #endif /* __NATIVE_SYSTEM_AGENT_H__ */


### PR DESCRIPTION
Removed unnecessary functions from Processing Module Adapter. To ensure proper operation of native loadable modules it is necessary to bypass Processing Module Adapter used by FDK modules. This is currently done by overriding the pointer to module_interface used by the Module Adapter. Thanks to this, the Module Adapter directly calls functions provided by native module. As in this case the Processing Module Adapter functions are omitted, support for native libraries are removed from it as
it is no longer needed. This leads to remove is_native_sof variable and modules_process_raw, modules_process_audio_stream functions.

The code allocating/freeing in_buff and out_buff buffers, which were not used, was removed from the processing module adapter.

The value stored by the Processing Module Adapter in the module_adapter field of module_data structure has been moved to an unused private field. This change allowed the module_adapter field to be removed.

The unused sys_service field has been removed from the processing_module structure. It was never initialized anywhere, and its value was passed as a parameter to the native_system_agent_start function which did not use it.

The value assigned to the module_entry_point field in the module_data structure wasn't used anywhere. This field has been removed.