### PR TITLE
app: boards: mimx93_evk_a55: change SRAM0's address to 0xd000000

### DIFF
--- a/app/boards/mimx93_evk_a55.overlay
+++ b/app/boards/mimx93_evk_a55.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-	/delete-node/ memory@c0000000;
+	/delete-node/ memory@d0000000;
 	/* Inmate memory, reserved through "mem=1248MB" boot argument,
 	 * starts at 0xce000000.
 	 */


### PR DESCRIPTION
Zephyr commit b985442829dd ("dts: mimx93_evk_a55: avoid conflict with Ethos-U NPU reserved memory") changes SRAM0's address to 0xd0000000. This breaks the i.MX93 SOF build because the SRAM0 node is no longer deleted so west build complains about having 2 SRAM0 nodes with different addresses.

To fix this, update the deleted node's base address.