### PR TITLE
component: module_adapter: Move module_interface pointer to comp_driver

### DIFF
--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -28,9 +28,9 @@ int asrc_dai_configure_timestamp(struct comp_data *cd)
 		return -ENODEV;
 
 	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
-	struct module_data *md = &mod->priv;
+	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
-	return md->ops->endpoint_ops->dai_ts_config(cd->dai_dev);
+	return ops->endpoint_ops->dai_ts_config(cd->dai_dev);
 }
 
 int asrc_dai_start_timestamp(struct comp_data *cd)
@@ -39,9 +39,9 @@ int asrc_dai_start_timestamp(struct comp_data *cd)
 		return -ENODEV;
 
 	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
-	struct module_data *md = &mod->priv;
+	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
-	return md->ops->endpoint_ops->dai_ts_start(cd->dai_dev);
+	return ops->endpoint_ops->dai_ts_start(cd->dai_dev);
 }
 
 int asrc_dai_stop_timestamp(struct comp_data *cd)
@@ -50,9 +50,9 @@ int asrc_dai_stop_timestamp(struct comp_data *cd)
 		return -ENODEV;
 
 	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
-	struct module_data *md = &mod->priv;
+	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
-	return md->ops->endpoint_ops->dai_ts_stop(cd->dai_dev);
+	return ops->endpoint_ops->dai_ts_stop(cd->dai_dev);
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
@@ -65,9 +65,9 @@ int asrc_dai_get_timestamp(struct comp_data *cd, struct timestamp_data *tsd)
 		return -ENODEV;
 
 	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
-	struct module_data *md = &mod->priv;
+	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
-	return md->ops->endpoint_ops->dai_ts_get(cd->dai_dev, tsd);
+	return ops->endpoint_ops->dai_ts_get(cd->dai_dev, tsd);
 }
 
 void asrc_update_buffer_format(struct comp_buffer *buf_c, struct comp_data *cd)

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -8,6 +8,7 @@
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/module_adapter/module/modules.h>
 #include <utilities/array.h>
+#include <iadk_module_adapter.h>
 #include <system_agent.h>
 #include <native_system_agent.h>
 #include <api_version.h>

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -100,6 +100,7 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			    bool last_block, uint32_t data_offset_size, const char *data)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
+	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	struct module_data *md = &mod->priv;
 	enum module_cfg_fragment_position pos;
 	size_t fragment_size;
@@ -126,10 +127,10 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 		return -EINVAL;
 	}
 
-	if (md->ops->set_configuration)
-		return md->ops->set_configuration(mod, param_id, pos, data_offset_size,
-						  (const uint8_t *)data,
-						  fragment_size, NULL, 0);
+	if (interface->set_configuration)
+		return interface->set_configuration(mod, param_id, pos, data_offset_size,
+						    (const uint8_t *)data, fragment_size,
+						    NULL, 0);
 	return 0;
 }
 EXPORT_SYMBOL(module_set_large_config);
@@ -138,6 +139,7 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			    bool last_block, uint32_t *data_offset_size, char *data)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
+	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	struct module_data *md = &mod->priv;
 	size_t fragment_size;
 
@@ -154,9 +156,9 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			fragment_size = md->cfg.size - *data_offset_size;
 	}
 
-	if (md->ops->get_configuration)
-		return md->ops->get_configuration(mod, param_id, data_offset_size,
-						  (uint8_t *)data, fragment_size);
+	if (interface->get_configuration)
+		return interface->get_configuration(mod, param_id, data_offset_size,
+						    (uint8_t *)data, fragment_size);
 	return 0;
 }
 EXPORT_SYMBOL(module_get_large_config);
@@ -251,10 +253,10 @@ uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input)
 {
 	struct processing_module *mod = comp_get_drvdata(dev);
-	struct module_data *md = &mod->priv;
+	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 
-	if (md->ops->endpoint_ops && md->ops->endpoint_ops->get_total_data_processed)
-		return md->ops->endpoint_ops->get_total_data_processed(dev, stream_no, input);
+	if (interface->endpoint_ops && interface->endpoint_ops->get_total_data_processed)
+		return interface->endpoint_ops->get_total_data_processed(dev, stream_no, input);
 
 	if (input)
 		return mod->total_data_produced;

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -58,7 +58,6 @@ struct module_data {
 	enum module_state state;
 	size_t new_cfg_size; /**< size of new module config data */
 	void *runtime_params;
-	const struct module_interface *ops; /**< module specific operations */
 	struct module_memory memory; /**< memory allocated by module */
 	struct module_processing_data mpd; /**< shared data comp <-> module */
 	void *module_adapter; /**<loadable module interface handle */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -517,10 +517,14 @@ struct comp_ops {
  * - used by all other component types.
  */
 struct comp_driver {
-	uint32_t type;			/**< SOF_COMP_ for driver */
-	const struct sof_uuid *uid;	/**< Address to UUID value */
-	struct tr_ctx *tctx;		/**< Pointer to trace context */
-	struct comp_ops ops;		/**< component operations */
+	uint32_t type;					/**< SOF_COMP_ for driver */
+	const struct sof_uuid *uid;			/**< Address to UUID value */
+	struct tr_ctx *tctx;				/**< Pointer to trace context */
+	struct comp_ops ops;				/**< component operations */
+	const struct module_interface *adapter_ops;	/**< module specific operations.
+							  * Intended to replace the ops field.
+							  * Currently used by module_adapter.
+							  */
 };
 
 /** \brief Holds constant pointer to component driver */

--- a/src/include/sof/audio/module_adapter/module/modules.h
+++ b/src/include/sof/audio/module_adapter/module/modules.h
@@ -40,10 +40,8 @@
  * with version read from elf file.
  */
 
-
-struct comp_dev *modules_shim_new(const struct comp_driver *drv,
-				  const struct comp_ipc_config *config,
-				  const void *spec);
+/* Processing Module Adapter API */
+extern const struct module_interface processing_module_adapter_interface;
 
 static inline void declare_dynamic_module_adapter(struct comp_driver *drv,
 						  enum sof_comp_type mtype,
@@ -53,7 +51,7 @@ static inline void declare_dynamic_module_adapter(struct comp_driver *drv,
 	drv->type = mtype;
 	drv->uid = uuid;
 	drv->tctx = tr;
-	drv->ops.create = modules_shim_new;
+	drv->ops.create = module_adapter_new;
 	drv->ops.prepare = module_adapter_prepare;
 	drv->ops.params = module_adapter_params;
 	drv->ops.copy = module_adapter_copy;
@@ -75,6 +73,7 @@ static inline void declare_dynamic_module_adapter(struct comp_driver *drv,
 	drv->ops.dai_ts_start = module_adapter_ts_start_op;
 	drv->ops.dai_ts_stop = module_adapter_ts_stop_op;
 	drv->ops.dai_ts_get = module_adapter_ts_get_op;
+	drv->adapter_ops = &processing_module_adapter_interface;
 }
 
 #endif /* __SOF_AUDIO_MODULES__ */

--- a/src/include/sof/audio/module_adapter/module/modules.h
+++ b/src/include/sof/audio/module_adapter/module/modules.h
@@ -9,7 +9,6 @@
 #define __SOF_AUDIO_MODULES__
 
 #include <sof/audio/module_adapter/module/generic.h>
-#include <iadk_module_adapter.h>
 
 /* Intel module adapter is an extension to SOF module adapter component that allows to integrate
  * modules developed under IADK (Intel Audio Development Kit)
@@ -42,38 +41,5 @@
 
 /* Processing Module Adapter API */
 extern const struct module_interface processing_module_adapter_interface;
-
-static inline void declare_dynamic_module_adapter(struct comp_driver *drv,
-						  enum sof_comp_type mtype,
-						  const struct sof_uuid *uuid,
-						  struct tr_ctx *tr)
-{
-	drv->type = mtype;
-	drv->uid = uuid;
-	drv->tctx = tr;
-	drv->ops.create = module_adapter_new;
-	drv->ops.prepare = module_adapter_prepare;
-	drv->ops.params = module_adapter_params;
-	drv->ops.copy = module_adapter_copy;
-#if CONFIG_IPC_MAJOR_3
-	drv->ops.cmd = module_adapter_cmd;
-#endif
-	drv->ops.trigger = module_adapter_trigger;
-	drv->ops.reset = module_adapter_reset;
-	drv->ops.free = module_adapter_free;
-	drv->ops.set_large_config = module_set_large_config;
-	drv->ops.get_large_config = module_get_large_config;
-	drv->ops.get_attribute = module_adapter_get_attribute;
-	drv->ops.bind = module_adapter_bind;
-	drv->ops.unbind = module_adapter_unbind;
-	drv->ops.get_total_data_processed = module_adapter_get_total_data_processed;
-	drv->ops.dai_get_hw_params = module_adapter_get_hw_params;
-	drv->ops.position = module_adapter_position;
-	drv->ops.dai_ts_config = module_adapter_ts_config_op;
-	drv->ops.dai_ts_start = module_adapter_ts_start_op;
-	drv->ops.dai_ts_stop = module_adapter_ts_stop_op;
-	drv->ops.dai_ts_get = module_adapter_ts_get_op;
-	drv->adapter_ops = &processing_module_adapter_interface;
-}
 
 #endif /* __SOF_AUDIO_MODULES__ */

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -485,6 +485,36 @@ static void lib_manager_update_sof_ctx(void *base_addr, uint32_t lib_id)
 }
 
 #if CONFIG_INTEL_MODULES
+static void lib_manager_prepare_module_adapter(struct comp_driver *drv, const struct sof_uuid *uuid)
+{
+	drv->type = SOF_COMP_MODULE_ADAPTER;
+	drv->uid = uuid;
+	drv->tctx = &lib_manager_tr;
+	drv->ops.create = module_adapter_new;
+	drv->ops.prepare = module_adapter_prepare;
+	drv->ops.params = module_adapter_params;
+	drv->ops.copy = module_adapter_copy;
+#if CONFIG_IPC_MAJOR_3
+	drv->ops.cmd = module_adapter_cmd;
+#endif
+	drv->ops.trigger = module_adapter_trigger;
+	drv->ops.reset = module_adapter_reset;
+	drv->ops.free = module_adapter_free;
+	drv->ops.set_large_config = module_set_large_config;
+	drv->ops.get_large_config = module_get_large_config;
+	drv->ops.get_attribute = module_adapter_get_attribute;
+	drv->ops.bind = module_adapter_bind;
+	drv->ops.unbind = module_adapter_unbind;
+	drv->ops.get_total_data_processed = module_adapter_get_total_data_processed;
+	drv->ops.dai_get_hw_params = module_adapter_get_hw_params;
+	drv->ops.position = module_adapter_position;
+	drv->ops.dai_ts_config = module_adapter_ts_config_op;
+	drv->ops.dai_ts_start = module_adapter_ts_start_op;
+	drv->ops.dai_ts_stop = module_adapter_ts_stop_op;
+	drv->ops.dai_ts_get = module_adapter_ts_get_op;
+	drv->adapter_ops = &processing_module_adapter_interface;
+}
+
 int lib_manager_register_module(const uint32_t component_id)
 {
 	const struct lib_manager_mod_ctx *const ctx = lib_manager_get_mod_ctx(component_id);
@@ -533,7 +563,7 @@ int lib_manager_register_module(const uint32_t component_id)
 	mod = (struct sof_man_module *)((uint8_t *)desc + SOF_MAN_MODULE_OFFSET(entry_index));
 	const struct sof_uuid *uid = (struct sof_uuid *)&mod->uuid[0];
 
-	declare_dynamic_module_adapter(drv, SOF_COMP_MODULE_ADAPTER, uid, &lib_manager_tr);
+	lib_manager_prepare_module_adapter(drv, uid);
 
 	new_drv_info->drv = drv;
 


### PR DESCRIPTION
Moved pointer to module_interface from struct module_data to comp_driver structure. The change is aimed at clearing the module_data structure of fields intended for exclusive use by sof. All modules are eventually use module interface so this pointer will be in comp_driver anyway.