### PR TITLE
[stable-v2.9] west.yml: update Zephyr with backported fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,8 +43,9 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9852e8e15bc8536aa1a49cc2697c1e8f802e331f
-      remote: zephyrproject
+      # commit in https://github.com/thesofproject/zephyr/tree/sof/stable-v2.9
+      revision: 337b518c3311f826ad494ad9ec0393b718768b2c
+      remote: thesofproject
 
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Update Zephyr with backported fixed from Zephyr upstream including the following patches:

337b518c3311 dai: intel: dmic: demote spurious LOG_ERR in dai_nhlt_get_clock_div()
802baf38426b soc: xtensa: intel_adsp: restore bootctl with per-core state
576924d5f201 drivers: dma: intel-adsp-hda: modify stop dma logic
369241d7bf7d drivers: dma: intel-adsp-hda: add delay to stop host dma