### PR TITLE
idc: zephyr: add a timeout to blocking IDC send

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -151,7 +151,7 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 
 	switch (mode) {
 	case IDC_BLOCKING:
-		ret = k_p4wq_wait(work, K_FOREVER);
+		ret = k_p4wq_wait(work, K_USEC(IDC_TIMEOUT));
 		if (!ret)
 			/* message was sent and executed successfully, get status code */
 			ret = idc_msg_status_get(msg->core);


### PR DESCRIPTION
Replace infinite wait with a time-limited wait. In case a blocking IDC message is not handled within IDC_TIMEOUT, return an error instead of waiting. This allows to debug stuck core-to-core communication easier.