### PR TITLE
[SKIP SOF-TEST] upgrade deprecated Github Actions (node.js v16)

### DIFF
--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -87,7 +87,7 @@ jobs:
           sof/scripts/fuzz.sh -o fuzz-stdout.txt -t "$duration" -j"$(nproc)" -- "$cmake_arg"
 
       - name: Upload stdout
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.IPC }} logs

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -240,14 +240,14 @@ jobs:
       # or delete cache manually in Github Actions tab
       - name: Cache unzip
         id: cache-unzip
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: unzip-5.51-1-bin.zip
           key: ${{ runner.os }}-cache-unzip-5-51-1
 
       - name: Cache wget
         id: cache-wget
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: wget-1.11.4-1-bin.zip
           key: ${{ runner.os }}-cache-wget-1-11-4-1
@@ -256,7 +256,7 @@ jobs:
       # sof/zephyr/docker-run.sh
       - name: Cache Zephyr SDK 0.16.4
         id: cache-zephyr-sdk
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: zephyr-sdk-0.16.4_windows-x86_64.7z
           key: ${{ runner.os }}-cache-zephyr-sdk-0-16-4

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -198,10 +198,11 @@ jobs:
              ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.zephyr_revision == 'mnfst' }}
         with:
           name: linux-build ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
+          if-no-files-found: error
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
@@ -363,9 +364,10 @@ jobs:
           ${{ matrix.build_opts }} ${{ matrix.platforms }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-build ${{ matrix.build_opts }} ${{ matrix.platforms }}
+          if-no-files-found: error
           path: |
             ${{ github.workspace }}/workspace/build-sof-staging
             ${{ github.workspace }}/workspace/**/compile_commands.json
@@ -391,7 +393,7 @@ jobs:
           filter: 'tree:0'
 
       - name: Download Windows and Linux builds
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: apt-get dos2unix
         run: sudo apt-get update; sudo apt-get -y install dos2unix


### PR DESCRIPTION
2 similar commits

Fixes a lot of these warnings:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Example in daily tests:
https://github.com/thesofproject/sof/actions/runs/8165043709
