### PR TITLE
multiband_drc: instantaneous enabled state switch on processing

### DIFF
--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -10,10 +10,10 @@
 #include <sof/audio/multiband_drc/multiband_drc.h>
 #include <sof/math/iir_df2t.h>
 
-static void multiband_drc_default_pass(const struct comp_dev *dev,
-				       const struct audio_stream *source,
-				       struct audio_stream *sink,
-				       uint32_t frames)
+void multiband_drc_default_pass(const struct comp_dev *dev,
+				const struct audio_stream *source,
+				struct audio_stream *sink,
+				uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, source->channels * frames);
 }

--- a/src/include/sof/audio/multiband_drc/multiband_drc.h
+++ b/src/include/sof/audio/multiband_drc/multiband_drc.h
@@ -52,6 +52,11 @@ extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap[];
 extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap_pass[];
 extern const size_t multiband_drc_proc_fncount;
 
+void multiband_drc_default_pass(const struct comp_dev *dev,
+				const struct audio_stream *source,
+				struct audio_stream *sink,
+				uint32_t frames);
+
 /**
  * \brief Returns Multiband DRC processing function.
  */


### PR DESCRIPTION
In present multiband_drc design, the enabled state is determined by the switch control while multiband_drc starts to process. If the switch control toggles while processing, it will take effects on the next time multiband_drc starts to process.

This commit makes change to let the enabled state update instantaneously by the switch control toggle when multiband_drc is processing.