### PR TITLE
topology2: Revisit period and buffer size settings

### DIFF
--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -84,7 +84,7 @@ Class.PCM."pcm_caps" {
 	formats		"S32_LE,S24_LE,S16_LE"
 	rates			"48000"
 	periods_min		2
-	periods_max		16
+	periods_max		1024
 	channels_min		2
 	channels_max		2
 	period_size_min		192

--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -87,8 +87,8 @@ Class.PCM."pcm_caps" {
 	periods_max		1024
 	channels_min		2
 	channels_max		2
-	period_size_min		192
-	period_size_max		16384
-	buffer_size_min		65536
-	buffer_size_max		65536
+	period_size_min		192	# "$[((2 * $channels_min) * 48000) / 1000]" (48K, S16_LE, 1ms)
+	period_size_max		2097152	# Large enough to cover user's needs
+	buffer_size_min		384	# "$[$period_size_min * $periods_min]"
+	buffer_size_max		4194304 # "$[2 * $period_size_max]"
 }

--- a/tools/topology/topology2/platform/intel/deep-buffer.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer.conf
@@ -33,9 +33,14 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			name $DEEP_BUFFER_PCM_NAME
 			formats 'S16_LE,S24_LE,S32_LE'
-			# align with $DEEPBUFFER_FW_DMA_MS
-			period_size_max		65535
-			buffer_size_max		262144
+			# To avoid DMA spinning on a buffer we need bigger
+			# buffer than the host buffer size, let's say twice as
+			# big
+			# (S16_LE, Stereo, 48KHz, DEEPBUFFER_FW_DMA_MS) * 2
+			#
+			# Note: The lower limit for the buffer size is rate
+			#	dependent
+			buffer_size_min "$[(((2 * $channels_min) * 48) * $DEEPBUFFER_FW_DMA_MS) * 2]"
 		}
 	}
 ]
@@ -83,9 +88,14 @@ IncludeByKey.DEEP_BUF_SPK {
 				Object.PCM.pcm_caps.1 {
 					name $DEEP_BUFFER_PCM_NAME_2
 					formats 'S16_LE,S24_LE,S32_LE'
-					# align with $DEEPBUFFER_FW_DMA_MS
-					period_size_max		65535
-					buffer_size_max		262144
+					# To avoid DMA spinning on a buffer we need bigger
+					# buffer than the host buffer size, let's say twice as
+					# big
+					# (S16_LE, Stereo, 48KHz, DEEPBUFFER_FW_DMA_MS) * 2
+					#
+					# Note: The lower limit for the buffer size is rate
+					#	dependent
+					buffer_size_min "$[(((2 * $channels_min) * 48) * $DEEPBUFFER_FW_DMA_MS) * 2]"
 				}
 			}
 		]


### PR DESCRIPTION
topology2: Revisit period and buffer size settings

To be pragmatic about the period/buffer size values:
period_size_min = 192 is for Stereo, S16_le, 48Khz, 1ms
period_size_max = 2097152 common value among other sound cards

The buffer size:
buffer_size_min	=	384 # period_size_min * periods_min
buffer_size_max	=	4194304 # period_size_max * 2

The deep buffer PCM only changes the buffer_size_min to (S16_LE, Stereo, 48KHz, DEEPBUFFER_FW_DMA_MS) * 2
