### PR TITLE
modules: restore behaviour for non-LLEXT modules

### DIFF
--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -136,7 +136,7 @@ static int modules_init(struct processing_module *mod)
 	}
 	comp_info(dev, "modules_init() start");
 
-	if (!md->module_adapter && md->ops == &interface) {
+	if (!md->llext || md->ops == &interface) {
 		/* First load */
 		ret = modules_new(mod, buildinfo, module_entry_point);
 		if (ret < 0)


### PR DESCRIPTION
An earlier commit inadvertantly potentially changed behaviour of non-llext modules by imposing too strict a condition for calling modules_new(). Restore the original behaviour for those modules.

Fixes: 6b9b4c24d28f ("modules: don't re-load on each restart")