### PR TITLE
lib_manager: modules: Fix missing call to modules_free

### DIFF
--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -10,12 +10,8 @@
 #include <utilities/array.h>
 #include <iadk_module_adapter.h>
 #include <system_agent.h>
-#include <native_system_agent.h>
-#include <api_version.h>
 #include <sof/lib_manager.h>
 #include <sof/audio/module_adapter/module/module_interface.h>
-#include <module/module/api_ver.h>
-#include <zephyr/llext/llext.h>
 
 /* Intel module adapter is an extension to SOF module adapter component that allows to integrate
  * modules developed under IADK (Intel Audio Development Kit) Framework. IADK modules uses uniform
@@ -51,63 +47,6 @@ DECLARE_SOF_RT_UUID("modules", intel_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
 		    0x90, 0xab, 0x42, 0x24, 0xe0, 0x0c, 0x3e, 0x84);
 DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(intel_uuid), LOG_LEVEL_INFO);
 
-static int modules_new(struct processing_module *mod, const void *buildinfo,
-		       uintptr_t module_entry_point)
-{
-	struct module_data *md = &mod->priv;
-	struct comp_dev *dev = mod->dev;
-	struct comp_driver *drv = (struct comp_driver *)dev->drv;
-	uint32_t module_id = IPC4_MOD_ID(dev->ipc_config.id);
-	uint32_t instance_id = IPC4_INST_ID(dev->ipc_config.id);
-	uint32_t log_handle = (uint32_t) dev->drv->tctx;
-	/* Connect loadable module interfaces with module adapter entity. */
-	/* Check if native Zephyr lib is loaded */
-	void *system_agent;
-
-	const struct sof_module_api_build_info *mod_buildinfo;
-
-	if (buildinfo) {
-		mod_buildinfo = buildinfo;
-	} else {
-		const struct sof_man_module *const module_entry =
-			lib_manager_get_module_manifest(module_id);
-
-		if (!module_entry) {
-			comp_err(dev, "modules_new(): Failed to load manifest");
-			return -ENODATA;
-		}
-
-		mod_buildinfo =
-			(struct sof_module_api_build_info *)
-			(module_entry->segment[SOF_MAN_SEGMENT_TEXT].v_base_addr);
-	}
-
-	byte_array_t mod_cfg = {
-		.data = (uint8_t *)md->cfg.init_data,
-		/* Intel modules expects DW size here */
-		.size = md->cfg.size >> 2,
-	};
-
-	/* Check if module is FDK */
-	if (mod_buildinfo->format == IADK_MODULE_API_BUILD_INFO_FORMAT &&
-	    mod_buildinfo->api_version_number.full == IADK_MODULE_API_CURRENT_VERSION) {
-		system_agent = system_agent_start(module_entry_point, module_id, instance_id, 0,
-						  log_handle, &mod_cfg);
-
-		module_set_private_data(mod, system_agent);
-	} else if (mod_buildinfo->format == SOF_MODULE_API_BUILD_INFO_FORMAT &&
-		   mod_buildinfo->api_version_number.full == SOF_MODULE_API_CURRENT_VERSION) {
-		/* The module is native: start agent for sof loadable */
-		mod->is_native_sof = true;
-		drv->adapter_ops = native_system_agent_start(module_entry_point, module_id,
-							     instance_id, 0, log_handle, &mod_cfg);
-	} else {
-		return -ENOEXEC;
-	}
-
-	return 0;
-}
-
 /**
  * \brief modules_init.
  * \param[in] mod - processing module pointer.
@@ -121,51 +60,39 @@ static int modules_init(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 	const struct comp_driver *const drv = dev->drv;
 	const struct ipc4_base_module_cfg *src_cfg = &md->cfg.base_cfg;
-	struct comp_ipc_config *config = &(dev->ipc_config);
-	/* At this point module resources are allocated and it is moved to L2 memory. */
-	const void *buildinfo = NULL;
-	int ret;
-	uintptr_t module_entry_point = lib_manager_allocate_module(mod, config, src_cfg,
-								   &buildinfo);
+	const struct comp_ipc_config *config = &dev->ipc_config;
+	void *system_agent;
+
+	uintptr_t module_entry_point = lib_manager_allocate_module(mod, config, src_cfg);
 
 	if (module_entry_point == 0) {
 		comp_err(dev, "modules_init(), lib_manager_allocate_module() failed!");
 		return -EINVAL;
 	}
+
+	/* At this point module resources are allocated and it is moved to L2 memory. */
 	comp_info(dev, "modules_init() start");
 
-	if (!module_get_private_data(mod) &&
-	    drv->adapter_ops == &processing_module_adapter_interface) {
-		/* First load */
-		ret = modules_new(mod, buildinfo, module_entry_point);
-		if (ret < 0)
-			return ret;
-	}
+	const uint32_t module_id = IPC4_MOD_ID(config->id);
+	const uint32_t instance_id = IPC4_INST_ID(config->id);
+	const uint32_t log_handle = (uint32_t)drv->tctx;
+
+	byte_array_t mod_cfg = {
+		.data = (uint8_t *)md->cfg.init_data,
+		/* Intel modules expects DW size here */
+		.size = md->cfg.size >> 2,
+	};
+
+	system_agent = system_agent_start(module_entry_point, module_id, instance_id, 0, log_handle,
+					  &mod_cfg);
+
+	module_set_private_data(mod, system_agent);
 
 	md->mpd.in_buff_size = src_cfg->ibs;
 	md->mpd.out_buff_size = src_cfg->obs;
 
-	/* Call module specific init function if exists. */
-	if (mod->is_native_sof) {
-		const struct module_interface *mod_in = drv->adapter_ops;
-
-		/* The order of preference */
-		if (mod_in->process)
-			mod->proc_type = MODULE_PROCESS_TYPE_SOURCE_SINK;
-		else if (mod_in->process_audio_stream)
-			mod->proc_type = MODULE_PROCESS_TYPE_STREAM;
-		else if (mod_in->process_raw_data)
-			mod->proc_type = MODULE_PROCESS_TYPE_RAW;
-		else
-			return -EINVAL;
-
-		ret = mod_in->init(mod);
-	} else {
-		mod->proc_type = MODULE_PROCESS_TYPE_SOURCE_SINK;
-		ret = iadk_wrapper_init(module_get_private_data(mod));
-	}
-
-	return ret;
+	mod->proc_type = MODULE_PROCESS_TYPE_SOURCE_SINK;
+	return iadk_wrapper_init(system_agent);
 }
 
 /**
@@ -208,7 +135,6 @@ static int modules_process(struct processing_module *mod,
 static int modules_free(struct processing_module *mod)
 {
 	struct comp_dev *dev = mod->dev;
-	struct module_data *md = &mod->priv;
 	int ret;
 
 	comp_info(dev, "modules_free()");
@@ -216,13 +142,10 @@ static int modules_free(struct processing_module *mod)
 	if (ret)
 		comp_err(dev, "modules_free(): iadk_wrapper_free failed with error: %d", ret);
 
-
-	if (!md->llext || !llext_unload(&md->llext)) {
-		/* Free module resources allocated in L2 memory. */
-		ret = lib_manager_free_module(dev->ipc_config.id);
-		if (ret < 0)
-			comp_err(dev, "modules_free(), lib_manager_free_module() failed!");
-	}
+	/* Free module resources allocated in L2 memory. */
+	ret = lib_manager_free_module(dev->ipc_config.id);
+	if (ret < 0)
+		comp_err(dev, "modules_free(), lib_manager_free_module() failed!");
 
 	return ret;
 }

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -33,6 +33,7 @@ LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
  * \brief Create a module adapter component.
  * \param[in] drv - component driver pointer.
  * \param[in] config - component ipc descriptor pointer.
+ * \param[in] spec - passdowned data from driver.
  *
  * \return: a pointer to newly created module adapter component on success. NULL on error.
  */

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -179,9 +179,6 @@ struct processing_module {
 	 */
 	bool stream_copy_single_to_single;
 
-	/* flag to insure that module is loadable */
-	bool is_native_sof;
-
 	/* total processed data after stream started */
 	uint64_t total_data_consumed;
 	uint64_t total_data_produced;

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -81,8 +81,11 @@ struct ipc_lib_msg {
 	struct list_item list;
 };
 
+struct sof_man_module_manifest;
+
 struct lib_manager_mod_ctx {
 	void *base_addr;
+	const struct sof_man_module_manifest *mod_manifest;
 	size_t segment_size[3];
 };
 
@@ -166,7 +169,7 @@ struct processing_module;
  */
 uintptr_t lib_manager_allocate_module(struct processing_module *proc,
 				      const struct comp_ipc_config *ipc_config,
-				      const void *ipc_specific_config, const void **buildinfo);
+				      const void *ipc_specific_config);
 
 /*
  * \brief Free module

--- a/src/include/sof/llext_manager.h
+++ b/src/include/sof/llext_manager.h
@@ -13,7 +13,7 @@ struct comp_ipc_config;
 
 uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 					const struct comp_ipc_config *ipc_config,
-					const void *ipc_specific_config, const void **buildinfo);
+					const void *ipc_specific_config);
 
 int llext_manager_free_module(const uint32_t component_id);
 

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -30,6 +30,7 @@
 #include <zephyr/llext/llext.h>
 
 #include <rimage/sof/user/manifest.h>
+#include <module/module/api_ver.h>
 
 #include <errno.h>
 #include <stdbool.h>
@@ -179,7 +180,7 @@ static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_modul
 	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
 	int ret = llext_load(&ebl.loader, mod->name, &md->llext, &ldr_parm);
 
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	mod->segment[SOF_MAN_SEGMENT_TEXT].v_base_addr = ebl.loader.sects[LLEXT_MEM_TEXT].sh_addr;
@@ -229,7 +230,7 @@ static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_modul
 
 uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 					const struct comp_ipc_config *ipc_config,
-					const void *ipc_specific_config, const void **buildinfo)
+					const void *ipc_specific_config)
 {
 	struct sof_man_fw_desc *desc;
 	struct sof_man_module *mod;
@@ -237,7 +238,7 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 	uint32_t module_id = IPC4_MOD_ID(ipc_config->id);
 	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
 	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
-	const struct sof_man_module_manifest *mod_manifest;
+	const struct sof_module_api_build_info *buildinfo;
 
 	tr_dbg(&lib_manager_tr, "llext_manager_allocate_module(): mod_id: %#x",
 	       ipc_config->id);
@@ -251,23 +252,35 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 
 	mod = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(entry_index));
 
-	ret = llext_manager_link(desc, mod, module_id, &proc->priv, buildinfo, &mod_manifest);
+	ret = llext_manager_link(desc, mod, module_id, &proc->priv, (const void **)&buildinfo,
+				 &ctx->mod_manifest);
 	if (ret < 0)
 		return 0;
 
-	/* Map .text and the rest as .data */
-	ret = llext_manager_load_module(module_id, mod);
-	if (ret < 0)
-		return 0;
+	if (!ret) {
+		/* First instance: check that the module is native */
+		if (buildinfo->format != SOF_MODULE_API_BUILD_INFO_FORMAT ||
+		    buildinfo->api_version_number.full != SOF_MODULE_API_CURRENT_VERSION) {
+			tr_err(&lib_manager_tr,
+			       "llext_manager_allocate_module(): Unsupported module API version");
+			return -ENOEXEC;
+		}
 
-	ret = llext_manager_allocate_module_bss(module_id, mod);
-	if (ret < 0) {
-		tr_err(&lib_manager_tr,
-		       "llext_manager_allocate_module(): module allocation failed: %d", ret);
-		return 0;
+		/* Map .text and the rest as .data */
+		ret = llext_manager_load_module(module_id, mod);
+		if (ret < 0)
+			return 0;
+
+		ret = llext_manager_allocate_module_bss(module_id, mod);
+		if (ret < 0) {
+			tr_err(&lib_manager_tr,
+			       "llext_manager_allocate_module(): module allocation failed: %d",
+			       ret);
+			return 0;
+		}
 	}
 
-	return mod_manifest->module.entry_point;
+	return ctx->mod_manifest->module.entry_point;
 }
 
 int llext_manager_free_module(const uint32_t component_id)


### PR DESCRIPTION
This PR addresses an issue with non-iadk loadable modules for which the `modules_free` function is not called.

For some of following commits I already prepared PRs - pending review.

- [x] https://github.com/thesofproject/sof/pull/8897:
<del>d37d68961 modules: Remove unused module_entry_point from module_data
87f5e3e69 module_adapter: modules: Remove unused sys_service pointer
c951d57d6 module/base: modules: Remove module_adapter from module_data
c85d87216 modules: Remove unused buffers
2b49f997e modules: Remove unnecessary functions from Processing Module Adapter</del>

Actual PR content:
e27ea44f5 lib_manager: modules: move native lib support to lib_manager

- [x] https://github.com/thesofproject/sof/pull/8974:
<del>94b9976df lib_manager: Rename lib_manager_get_library_module_desc function
ca42dff5a lib_manager: Add lib_manager_get_module_manifest function
11d8a423b ipc4/helper: ipc4_get_comp_drv: Change parameter type to uint32_t</del>

- [x] https://github.com/thesofproject/sof/pull/8898:
<del>efd957d51 llext_manager: Remove unused desc parameter
7407ecdda lib_manager: llext_manager: Add const to module allocate functions
66f35c92a FIX lib_manager: llext_manager: Add const modifier to module manifest pointers
61e877f15 lib_manager: llext_manager: Add const modifier to module manifest pointers
30fd9df1d lib_manager: llext_manager: Simplifying parameter list for free module
5c6c7c8c2 lib_manager: Simplifying parameter list for lib_manager_register_module
0e05cefe4 lib_manager: Verify preload_page_count from module manifest
da99651a8 lib_manager: Add const to library manifest variable</del>

- [x] https://github.com/thesofproject/sof/pull/8905:
<del>3d34605ab modules: lib_manager: Move declare_dynamic_module_adapter to lib_manager
6e80e8bff component: module_adapter: Move module_interface pointer to comp_driver</del>
