### PR TITLE
west.yml: update Zephyr to 251f52cbceb8  (March 13)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: f9f44b6dcdd4b80765df8922e8d12fdb9213e13a
+      revision: 251f52cbceb8a1682233c1792cbe68d28676318c
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to newer baseline. Among other updates, this brings in Zephyr commit "intel_adsp/ace: power: Lock interruption when power gate fails" that fixes a frequent issue seen in SOF CI on Intel MTL platforms.

Link: https://github.com/thesofproject/sof/issues/8908