### PR TITLE
[DNM] llext_manager: Fix for multipipeline issue with llext

### DIFF
--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -311,12 +311,10 @@ static int modules_free(struct processing_module *mod)
 	rfree(md->mpd.in_buff);
 	rfree(md->mpd.out_buff);
 
-	if (!md->llext || !llext_unload(&md->llext)) {
-		/* Free module resources allocated in L2 memory. */
-		ret = lib_manager_free_module(dev->ipc_config.id);
-		if (ret < 0)
-			comp_err(dev, "modules_free(), lib_manager_free_module() failed!");
-	}
+	/* Free module resources allocated in L2 memory. */
+	ret = lib_manager_free_module(dev->ipc_config.id);
+	if (ret < 0)
+		comp_err(dev, "modules_free(), lib_manager_free_module() failed!");
 
 	return ret;
 }

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -37,8 +37,6 @@ struct module_config {
 #endif
 };
 
-struct llext;
-
 /*
  * A structure containing a module's private data, intended for its exclusive use.
  *
@@ -63,7 +61,6 @@ struct module_data {
 	struct module_processing_data mpd; /**< shared data comp <-> module */
 	void *module_adapter; /**<loadable module interface handle */
 	uintptr_t module_entry_point; /**<loadable module entry point address */
-	struct llext *llext; /**< Zephyr loadable extension context */
 #endif /* SOF_MODULE_PRIVATE */
 };
 

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -84,6 +84,7 @@ struct ipc_lib_msg {
 struct lib_manager_mod_ctx {
 	void *base_addr;
 	size_t segment_size[3];
+	struct llext *llext;
 };
 
 struct ext_library {

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -167,7 +167,7 @@ static int llext_manager_free_module_bss(uint32_t module_id,
 }
 
 static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_module *mod,
-			      uint32_t module_id, struct module_data *md, const void **buildinfo,
+			      uint32_t module_id, struct llext **llext, const void **buildinfo,
 			      const struct sof_man_module_manifest **mod_manifest)
 {
 	size_t mod_size = desc->header.preload_page_count * PAGE_SZ;
@@ -177,14 +177,14 @@ static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_modul
 						       mod_size);
 	struct llext_load_param ldr_parm = {false};
 	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
-	int ret = llext_load(&ebl.loader, mod->name, &md->llext, &ldr_parm);
+	int ret = llext_load(&ebl.loader, mod->name, llext, &ldr_parm);
 
 	if (ret < 0)
 		return ret;
 
 	mod->segment[SOF_MAN_SEGMENT_TEXT].v_base_addr = ebl.loader.sects[LLEXT_MEM_TEXT].sh_addr;
 	mod->segment[SOF_MAN_SEGMENT_TEXT].file_offset =
-		(uintptr_t)md->llext->mem[LLEXT_MEM_TEXT] -
+		(uintptr_t)(*llext)->mem[LLEXT_MEM_TEXT] -
 		(uintptr_t)desc + SOF_MAN_ELF_TEXT_OFFSET;
 	ctx->segment_size[SOF_MAN_SEGMENT_TEXT] = ebl.loader.sects[LLEXT_MEM_TEXT].sh_size;
 
@@ -197,7 +197,7 @@ static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_modul
 	mod->segment[SOF_MAN_SEGMENT_RODATA].v_base_addr =
 		ebl.loader.sects[LLEXT_MEM_RODATA].sh_addr;
 	mod->segment[SOF_MAN_SEGMENT_RODATA].file_offset =
-		(uintptr_t)md->llext->mem[LLEXT_MEM_RODATA] -
+		(uintptr_t)(*llext)->mem[LLEXT_MEM_RODATA] -
 		(uintptr_t)desc + SOF_MAN_ELF_TEXT_OFFSET;
 	ctx->segment_size[SOF_MAN_SEGMENT_RODATA] = mod_size -
 		ebl.loader.sects[LLEXT_MEM_TEXT].sh_size;
@@ -251,7 +251,7 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 
 	mod = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(entry_index));
 
-	ret = llext_manager_link(desc, mod, module_id, &proc->priv, buildinfo, &mod_manifest);
+	ret = llext_manager_link(desc, mod, module_id, &proc->priv.llext, buildinfo, &mod_manifest);
 	if (ret < 0)
 		return 0;
 

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -251,7 +251,7 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 
 	mod = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(entry_index));
 
-	ret = llext_manager_link(desc, mod, module_id, &proc->priv.llext, buildinfo, &mod_manifest);
+	ret = llext_manager_link(desc, mod, module_id, &ctx->llext, buildinfo, &mod_manifest);
 	if (ret < 0)
 		return 0;
 
@@ -276,6 +276,7 @@ int llext_manager_free_module(const uint32_t component_id)
 	const struct sof_man_module *mod;
 	const uint32_t module_id = IPC4_MOD_ID(component_id);
 	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
+	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
 	int ret;
 
 	tr_dbg(&lib_manager_tr, "llext_manager_free_module(): mod_id: %#x", component_id);
@@ -293,5 +294,12 @@ int llext_manager_free_module(const uint32_t component_id)
 		       "llext_manager_free_module(): free module bss failed: %d", ret);
 		return ret;
 	}
+
+	/*
+	 * FIXME: I'm not sure where to place it. Call to the lib_manager_free_module for llext
+	 * modules was skipped by the modules_free function. I belive it was a bug.
+	 */
+	llext_unload(&ctx->llext);
+
 	return 0;
 }


### PR DESCRIPTION
The `module_data` structure is unique for each module instance. We will not be able to tell whether this is the first loading of the module based on the value of any of its fields. I moved the `llext` structure to the module context and added an instance counter to protect against loading the module code into memory for subsequent instances. When releasing a module, we check whether it was the last instance of it.