### PR TITLE
[stable-v2.9] Tools: Topology2: Add IIR, FIR, DRC to HDA analog playback

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -7,6 +7,9 @@ Define {
 	DEEP_BUFFER_PIPELINE_SRC	'mixin.15.1'
 	DEEP_BUFFER_PIPELINE_SINK	'mixout.2.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer HDA Analog'
+	EFX_FIR_PARAMS			'passthrough'
+	EFX_IIR_PARAMS			'passthrough'
+	EFX_DRC_PARAMS			'passthrough'
 }
 
 # include deep buffer config if buffer size is in 1 - 1000 ms.
@@ -28,7 +31,7 @@ Object.Dai.HDA [
 ]
 
 Object.Pipeline {
-	mixout-gain-dai-copier-playback [
+	mixout-gain-efx-dai-copier-playback [
 		{
 			index 2
 
@@ -41,6 +44,26 @@ Object.Pipeline {
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
 					name 'Post Mixer $ANALOG_PLAYBACK_PCM Volume'
+				}
+			}
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes."1" {
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM IIR Eq bytes'
+				}
+			}
+			Object.Widget.eqfir.1 {
+				Object.Control.bytes."1" {
+					name 'Post Mixer $ANALOG_PLAYBACK_PCM FIR Eq bytes'
+				}
+			}
+			Object.Widget.drc.1 {
+				Object.Control {
+					bytes."1" {
+						name 'Post Mixer $ANALOG_PLAYBACK_PCM DRC bytes'
+					}
+					mixer."1" {
+						name 'Post Mixer $ANALOG_PLAYBACK_PCM DRC switch'
+					}
 				}
 			}
 		}
@@ -133,7 +156,7 @@ Object.PCM.pcm [
 Object.Base.route [
 	{
 		sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
-		source 'gain.2.1'
+		source 'drc.2.1'
 	}
 	{
 		source 'mixin.1.1'


### PR DESCRIPTION
This patch replaces pipeline mixout-gain-dai-copier-playback with mixout-gain-efx-dai-copier-playback. The purpose is to allow enhance of audio playback quality with equalizers (IIR and FIR) and dynamic range control (DRC).

The components are programmed by default to passthrough for minimal overhead. They can be activated via sof-ctl or UCM with ALSA controls.

- Post Mixer Analog Playback IIR Eq bytes
- Post Mixer Analog Playback FIR Eq bytes
- Post Mixer Analog Playback DRC bytes
- Post Mixer Analog Playback DRC switch

The recommendation is to keep headphone playback flat and enable processing only when HDA output is in speaker mode.