### PR TITLE
[SKIP SOF-TEST] .github/zephyr: upgrade obsolete actions/setup-python@v4 to v5

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -297,7 +297,7 @@ jobs:
         run: zephyr-sdk-0.16.4_windows-x86_64/zephyr-sdk-0.16.4/setup.cmd /t all /h /c
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -320,7 +320,7 @@ jobs:
 
       # Call Setup Python again to save the PIP packages in cache
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: cache-python
         with:
           python-version: '3.8'


### PR DESCRIPTION
Fixes the following warning:
https://github.com/thesofproject/sof/actions/runs/8289483047

```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/setup-python@v4. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```