### PR TITLE
Use new '-DREM=#' prefix to preserve comments in pre-processed .toml

### DIFF
--- a/src/audio/aria/aria.toml
+++ b/src/audio/aria/aria.toml
@@ -1,4 +1,4 @@
-	// Aria module config
+	REM # Aria module config
 	[[module.entry]]
 	name = "ARIA"
 	uuid = "99F7166D-372C-43EF-81F6-22007AA15F03"
@@ -11,11 +11,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 260, 1063000, 16, 21, 0, 0, 0,
 				1, 0, 0, 0, 260, 1873500, 192, 256, 0, 0, 0,
 				2, 0, 0, 0, 260, 2680000, 32, 42, 0, 0, 0,

--- a/src/audio/codec/dts/dts.toml
+++ b/src/audio/codec/dts/dts.toml
@@ -1,4 +1,4 @@
-	// dts codec module config
+	REM # dts codec module config
 	[[module.entry]]
 	name = "DTS"
 	uuid = "D95FC34F-370F-4AC7-BC86-BFDC5BE241E6"
@@ -10,11 +10,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 296, 5000000, 384, 384, 0, 5000, 0]
 
 	index = __COUNTER__

--- a/src/audio/copier/copier.toml
+++ b/src/audio/copier/copier.toml
@@ -9,14 +9,14 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 280, 4918000, 768, 768, 0, 4918, 0,
 			2, 0, 0, 0, 280, 6526000, 768, 768, 0, 6526, 0,
 			3, 0, 0, 0, 280, 6388000, 384, 384, 0, 6388, 0,

--- a/src/audio/crossover/crossover.toml
+++ b/src/audio/crossover/crossover.toml
@@ -1,6 +1,6 @@
-	// Crossover module config
-	// Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
-	// be appended to the IPC payload. The Extension is needed to know the output pin indices.
+	REM # Crossover module config
+	REM # Note: Crossover has init_config set to 1 to let kernel know that the base_cfg_ext needs to
+	REM # be appended to the IPC payload. The Extension is needed to know the output pin indices.
 	[[module.entry]]
 	name = "XOVER"
 	uuid = "948C9AD1-806A-4131-AD6C-B2BDA9E35A9F"
@@ -12,9 +12,9 @@
 	init_config = "1"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/dcblock/dcblock.toml
+++ b/src/audio/dcblock/dcblock.toml
@@ -1,4 +1,4 @@
-	// DCblock module config
+	REM # DCblock module config
 	[[module.entry]]
 	name = "DCBLOCK"
 	uuid = "B809EFAF-5681-42B1-9ED6-04BB012DD384"
@@ -9,9 +9,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/drc/drc.toml
+++ b/src/audio/drc/drc.toml
@@ -1,4 +1,4 @@
-	// DRC module config
+	REM # DRC module config
 	[[module.entry]]
 	name = "DRC"
 	uuid = "B36EE4DA-006F-47F9-A06D-FECBE2D8B6CE"
@@ -9,9 +9,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/eq_fir/eq_fir.toml
+++ b/src/audio/eq_fir/eq_fir.toml
@@ -1,4 +1,4 @@
-	// eq fir module config
+	REM # eq fir module config
 	[[module.entry]]
 	name = "EQFIR"
 	uuid = "43A90CE7-f3A5-41Df-AC06-BA98651AE6A3"
@@ -10,11 +10,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/eq_iir/eq_iir.toml
+++ b/src/audio/eq_iir/eq_iir.toml
@@ -1,4 +1,4 @@
-	// eq iir module config
+	REM # eq iir module config
 	[[module.entry]]
 	name = "EQIIR"
 	uuid = "5150C0E6-27F9-4EC8-8351-C705B642D12F"
@@ -10,11 +10,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 		1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 1000, 0,
 			0, 0, 0, 0, 4096, 20663000, 768, 768, 0, 20663, 0,
 			0, 0, 0, 0, 4096, 11357000, 384, 384, 0, 11357, 0]

--- a/src/audio/google/google_rtc_audio_processing.toml
+++ b/src/audio/google/google_rtc_audio_processing.toml
@@ -1,7 +1,7 @@
 	[[module.entry]]
 	name = "RTC_AEC"
         uuid = "B780A0A6-269F-466F-B477-23DFA05AF758"
-        // bit #i = 1 means core #i is allowed.
+        REM # bit #i = 1 means core #i is allowed.
         affinity_mask = "0x7"
         instance_count = "1"
         domain_types = "1"
@@ -11,7 +11,7 @@
         auto_start = "0"
         sched_caps = [1, 0x00008000]
 
-        // pin = [dir, type, sample rate, size, container, channel-cfg]
+        REM # pin = [dir, type, sample rate, size, container, channel-cfg]
         pin = [0, 0, 0x8, 0x2, 0x2, 0x1,
                 0, 0, 0x8, 0x2, 0x2, 0x4,
                 1, 0, 0x8, 0x2, 0x2, 0x1]

--- a/src/audio/igo_nr/igo_nr.toml
+++ b/src/audio/igo_nr/igo_nr.toml
@@ -1,5 +1,5 @@
 
-	// IGO_NR module config
+	REM # IGO_NR module config
 	[[module.entry]]
 	name = "IGO_NR"
 	uuid = "696AE2BC-2877-11EB-ADC1-0242AC120002"
@@ -10,9 +10,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/kpb.toml
+++ b/src/audio/kpb.toml
@@ -9,11 +9,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 14400, 1114000, 16, 16, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/mixin_mixout/mixin_mixout.toml
+++ b/src/audio/mixin_mixout/mixin_mixout.toml
@@ -9,13 +9,13 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0,   0,   0xfeef, 0xc,  0x8,   0x45ff,
 		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
 		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
 		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 296, 4996000, 384, 384, 0, 4996, 0,
 			2, 0, 0, 0, 296, 2652000, 384, 384, 0, 2652, 0,
 			3, 0, 0, 0, 296, 2928000, 512, 512, 0, 2928, 0,
@@ -35,7 +35,7 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
 			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
 			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
@@ -46,7 +46,7 @@
 			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
 			1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 520, 2280000, 384, 384, 0, 2280, 0,
 			2, 0, 0, 0, 520, 1988000, 384, 384, 0, 1988, 0,
 			3, 0, 0, 0, 520, 7631000, 512, 512, 0, 7631, 0,

--- a/src/audio/module_adapter/module/cadence.toml
+++ b/src/audio/module_adapter/module/cadence.toml
@@ -1,4 +1,4 @@
-	// Cadence module config
+	REM # Cadence module config
 	[[module.entry]]
 	name = "CADENCE"
 	uuid = "D8218443-5FF3-4A4C-B388-6CFE07B956AA"
@@ -11,12 +11,12 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/multiband_drc/multiband_drc.toml
+++ b/src/audio/multiband_drc/multiband_drc.toml
@@ -1,4 +1,4 @@
-	// Multiband-DRC module config
+	REM # Multiband-DRC module config
 	[[module.entry]]
 	name = "MB_DRC"
 	uuid = "0D9F2256-8E4F-47B3-8448-239A334F1191"
@@ -9,9 +9,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/mux/mux.toml
+++ b/src/audio/mux/mux.toml
@@ -9,12 +9,12 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 280, 460700, 16, 16, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/rtnr/rtnr.toml
+++ b/src/audio/rtnr/rtnr.toml
@@ -1,4 +1,4 @@
-	// RTNR module config
+	REM # RTNR module config
 	[[module.entry]]
 	name = "RTNR"
 	uuid = "5C7CA334-E15D-11EB-BA80-0242AC130004"
@@ -9,9 +9,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/selector/selector.toml
+++ b/src/audio/selector/selector.toml
@@ -10,10 +10,10 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xe, 0xa, 0x45ff, 1, 0, 0xfeef, 0xe, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
 			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
 			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]

--- a/src/audio/src/src.toml
+++ b/src/audio/src/src.toml
@@ -2,18 +2,18 @@
 	name = "SRC"
 	uuid = "E61BB28D-149A-4C1F-B709-46823EF5F5AE"
 	affinity_mask = "0x1"
-	//instance_count = "10"
+	REM #instance_count = "10"
 	domain_types = "0"
 	load_type = "0"
 	module_type = "7"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
 			1, 0, 0xf6c9, 0xc, 0x8, 0x05ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 12832, 15976000, 128, 512, 0, 15976, 0,
 			2, 0, 0, 0, 12832, 15340000, 64, 256, 0, 15340, 0,
 			3, 0, 0, 0, 12832, 21880000, 96, 512, 0, 21880, 0,

--- a/src/audio/src/src_lite.toml
+++ b/src/audio/src/src_lite.toml
@@ -1,20 +1,20 @@
-	// SRC lite module config
+	REM # SRC lite module config
 	[[module.entry]]
 	name = "SRC_LITE"
 	uuid = "33441051-44CD-466A-83A3-178478708AEA"
 	affinity_mask = "0x1"
-	//instance_count = "10"
+	REM #instance_count = "10"
 	domain_types = "0"
 	load_type = "0"
 	module_type = "0x1F"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
 			1, 0, 0xf6c9, 0xc, 0x8, 0x05ff]
 
- 	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+ 	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 12832, 1365500, 0, 0, 0, 1365, 0,
 				1, 0, 0, 0, 12832, 2302300, 0, 0, 0, 2302, 0,
 				2, 0, 0, 0, 12832, 3218200, 0, 0, 0, 3218, 0,

--- a/src/audio/tdfb/tdfb.toml
+++ b/src/audio/tdfb/tdfb.toml
@@ -1,4 +1,4 @@
-	// TDFB module config
+	REM # TDFB module config
 	[[module.entry]]
 	name = "TDFB"
 	uuid = "DD511749-D9FA-455C-B3A7-13585693F1AF"
@@ -9,9 +9,9 @@
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff, 1, 0, 0xfeef, 0xf, 0xf, 0x1ff]
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/audio/up_down_mixer/up_down_mixer.toml
+++ b/src/audio/up_down_mixer/up_down_mixer.toml
@@ -9,11 +9,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
 			1, 0, 0xffff, 0xc, 0x8, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 216, 5044000, 384, 192, 0, 5044, 0,
 			2, 0, 0, 0, 216, 2660000, 384, 384, 0, 2660, 0,
 			3, 0, 0, 0, 216, 3164000, 576, 384, 0, 3164, 0,

--- a/src/audio/volume/gain.toml
+++ b/src/audio/volume/gain.toml
@@ -9,11 +9,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 416, 12100000, 1536, 1536, 0, 12100, 0,
 			2, 0, 0, 0, 416, 10183000, 384, 384, 0, 10183, 0,
 			3, 0, 0, 0, 416, 8192000, 512, 512, 0, 8192, 0,

--- a/src/audio/volume/peakvol.toml
+++ b/src/audio/volume/peakvol.toml
@@ -9,11 +9,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [1, 0, 0, 0, 480, 11667000, 384, 384, 0, 11667, 0,
 			2, 0, 0, 0, 480, 5943000, 192, 192, 0, 5943, 0,
 			3, 0, 0, 0, 480, 12567000, 720, 720, 0, 12567, 0,

--- a/src/probe/probe.toml
+++ b/src/probe/probe.toml
@@ -9,7 +9,7 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
 
 	index = __COUNTER__

--- a/src/samples/audio/detect_test.toml
+++ b/src/samples/audio/detect_test.toml
@@ -9,11 +9,11 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 480, 1114000, 64, 64, 0, 0, 0]
 
 	index = __COUNTER__

--- a/src/samples/audio/smart_amp_test.toml
+++ b/src/samples/audio/smart_amp_test.toml
@@ -1,4 +1,4 @@
-	// smart amp test module config
+	REM # smart amp test module config
 	[[module.entry]]
 	name = "SMATEST"
 	uuid = "167A961E-8AE4-11EA-89F1-000C29CE1635"
@@ -11,12 +11,12 @@
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]
 
-	// pin = [dir, type, sample rate, size, container, channel-cfg]
+	REM # pin = [dir, type, sample rate, size, container, channel-cfg]
 	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
 			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
 
-	// mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
 	mod_cfg = [0, 0, 0, 0, 296, 5000000, 384, 384, 0, 5000, 0]
 
 	index = __COUNTER__


### PR DESCRIPTION
Having to find source files to read comments is not convenient.

This depends on https://github.com/zephyrproject-rtos/zephyr/pull/67019 which was merged a while ago.