### PR TITLE
west.yml: update Zephyr to 8858a024c015

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: ceff785434b970a4570d82023dc136ef8a050f3f
+      revision: 8858a024c0151e3b4cd35262bed935248211d6b1
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains following updates affecting SOF targets:

81658e67e7c0 dts: xtensa: intel_adsp: Remove ALH nodes from ACE 2.0 LNL DTS
4ea52bdd1297 soc: xtensa: intel: Update power status bitfields for LNL
a39a61015c59 dts: xtensa: intel: Reorder LNL power domains
64a81ffb23ba dts: xtensa: intel_adsp: ace15: Update power domain for hda link nodes
ff2dd7f25a99 dts: xtensa: intel: Reorder ACE 1.5 power domain nodes
315ee38b95a2 ADSP: don't use timer interrupts on secondary cores
e914c60ae156 boards: intel_adsp: fix dead link
010f39a409e0 soc: intel_adsp_cavs: store PS when power gating secondary core