### PR TITLE
ipc4: Ensure pipeline component directions are synchronized

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -251,6 +251,28 @@ static struct ipc_comp_dev *pipeline_get_host_dev(struct ipc_comp_dev *ppl_icd)
 	struct ipc *ipc = ipc_get();
 	int host_id;
 
+	/* If the source component's direction is not set but the sink's direction is,
+	 * this block will copy the direction from the sink to the source component and
+	 * mark the source's direction as set.
+	 */
+	if (!ppl_icd->pipeline->source_comp->direction_set &&
+	    ppl_icd->pipeline->sink_comp->direction_set) {
+		ppl_icd->pipeline->source_comp->direction =
+			ppl_icd->pipeline->sink_comp->direction;
+		ppl_icd->pipeline->source_comp->direction_set = true;
+	}
+
+	/* If the sink component's direction is not set but the source's direction is,
+	 * this block will copy the direction from the source to the sink component and
+	 * mark the sink's direction as set.
+	 */
+	if (!ppl_icd->pipeline->sink_comp->direction_set &&
+	    ppl_icd->pipeline->source_comp->direction_set) {
+		ppl_icd->pipeline->sink_comp->direction =
+			ppl_icd->pipeline->source_comp->direction;
+		ppl_icd->pipeline->sink_comp->direction_set = true;
+	}
+
 	if (ppl_icd->pipeline->source_comp->direction == SOF_IPC_STREAM_PLAYBACK)
 		host_id = ppl_icd->pipeline->source_comp->ipc_config.id;
 	else


### PR DESCRIPTION
This patch addresses an issue where audio output could be silent due to the direction property of pipeline components not being set. The added code ensures that if the source component's direction is unset but the sink's direction is set, or vice versa, the direction is copied from the set component to the unset one.

This synchronization of the direction property guarantees that the pipeline's data flow is correctly established, allowing the `pipeline_for_each_comp` function to traverse and process all components as intended, thus resolving the silent audio output problem.