### PR TITLE
ipc4: Unify component ID logging format across various IPC and pipeline logs

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -252,7 +252,7 @@ static int pipeline_comp_complete(struct comp_dev *current,
 {
 	struct pipeline_data *ppl_data = ctx->comp_data;
 
-	pipe_dbg(ppl_data->p, "pipeline_comp_complete(), current->comp.id = %u, dir = %u",
+	pipe_dbg(ppl_data->p, "pipeline_comp_complete(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	if (!comp_is_single_pipeline(current, ppl_data->start)) {
@@ -327,7 +327,7 @@ static int pipeline_comp_reset(struct comp_dev *current,
 	int is_same_sched = pipeline_is_same_sched_comp(p_current, p);
 	int err;
 
-	pipe_dbg(p_current, "pipeline_comp_reset(), current->comp.id = %u, dir = %u",
+	pipe_dbg(p_current, "pipeline_comp_reset(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	/*
@@ -377,7 +377,7 @@ int pipeline_reset(struct pipeline *p, struct comp_dev *host)
 
 	ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_reset(): ret = %d, host->comp.id = %u",
+		pipe_err(p, "pipeline_reset(): ret = %d, host->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 	} else {
 		 /* pipeline is reset to default state */

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -32,7 +32,7 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 	struct pipeline_data *ppl_data = ctx->comp_data;
 	int err = 0;
 
-	pipe_dbg(current->pipeline, "pipeline_comp_params_neg(), current->comp.id = %u, dir = %u",
+	pipe_dbg(current->pipeline, "pipeline_comp_params_neg(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	/* check if 'current' is already configured */
@@ -82,7 +82,7 @@ static int pipeline_comp_params(struct comp_dev *current,
 	int stream_direction = ppl_data->params->params.direction;
 	int err;
 
-	pipe_dbg(current->pipeline, "pipeline_comp_params(), current->comp.id = %u, dir = %u",
+	pipe_dbg(current->pipeline, "pipeline_comp_params(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	/* Don't propagate to pipelines in the opposite direction */
@@ -132,7 +132,7 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 	struct pipeline_data *ppl_data = ctx->comp_data;
 	int ret;
 
-	pipe_dbg(current->pipeline, "pipeline_comp_hw_params(), current->comp.id = %u, dir = %u",
+	pipe_dbg(current->pipeline, "pipeline_comp_hw_params(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	ret = pipeline_for_each_comp(current, ctx, dir);
@@ -227,14 +227,14 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = hw_param_ctx.comp_func(host, NULL, &hw_param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = %u",
+		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 		return ret;
 	}
 
 	ret = buf_param_ctx.comp_func(host, NULL, &buf_param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = %u",
+		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 		return ret;
 	}
@@ -245,7 +245,7 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = param_ctx.comp_func(host, NULL, &param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, host->comp.id = %u",
+		pipe_err(p, "pipeline_params(): ret = %d, host->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 	}
 
@@ -263,7 +263,7 @@ static int pipeline_comp_prepare(struct comp_dev *current,
 	struct pipeline_data *ppl_data = ctx->comp_data;
 	int err;
 
-	pipe_dbg(current->pipeline, "pipeline_comp_prepare(), current->comp.id = %u, dir = %u",
+	pipe_dbg(current->pipeline, "pipeline_comp_prepare(), current->comp.id = 0x%x, dir = %u",
 		 dev_comp_id(current), dir);
 
 	if (!comp_is_single_pipeline(current, ppl_data->start)) {
@@ -308,7 +308,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 
 	ret = walk_ctx.comp_func(dev, NULL, &walk_ctx, dev->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_prepare(): ret = %d, dev->comp.id = %u",
+		pipe_err(p, "pipeline_prepare(): ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(dev));
 		return ret;
 	}

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -205,7 +205,7 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	/* check whether pipeline exists */
 	ipc_pipe = ipc_get_pipeline_by_id(ipc, comp_id);
 	if (!ipc_pipe) {
-		tr_err(&ipc_tr, "ipc: ipc_pipeline_complete looking for pipe component id %d failed",
+		tr_err(&ipc_tr, "ipc: ipc_pipeline_complete looking for pipe component id 0x%x failed",
 		       comp_id);
 		return -EINVAL;
 	}
@@ -233,14 +233,14 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	/* find the scheduling component */
 	icd = ipc_get_comp_by_id(ipc, p->sched_id);
 	if (!icd) {
-		tr_warn(&ipc_tr, "ipc_pipeline_complete(): no scheduling component specified, use comp %d",
+		tr_warn(&ipc_tr, "ipc_pipeline_complete(): no scheduling component specified, use comp 0x%x",
 			ipc_ppl_sink->id);
 
 		icd = ipc_ppl_sink;
 	}
 
 	if (icd->core != ipc_pipe->core) {
-		tr_err(&ipc_tr, "ipc_pipeline_complete(): icd->core (%d) != ipc_pipe->core (%d) for pipeline scheduling component icd->id %d",
+		tr_err(&ipc_tr, "ipc_pipeline_complete(): icd->core (%d) != ipc_pipe->core (%d) for pipeline scheduling component icd->id 0x%x",
 		       icd->core, ipc_pipe->core, icd->id);
 		return -EINVAL;
 	}
@@ -249,7 +249,7 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 
 	pipeline_id = ipc_pipe->pipeline->pipeline_id;
 
-	tr_dbg(&ipc_tr, "ipc: pipe %d -> complete on comp %d", pipeline_id,
+	tr_dbg(&ipc_tr, "ipc: pipe %d -> complete on comp 0x%x", pipeline_id,
 	       comp_id);
 
 	return pipeline_complete(ipc_pipe->pipeline, ipc_ppl_source->cd,
@@ -265,7 +265,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	/* check whether component exists */
 	icd = ipc_get_comp_by_id(ipc, comp_id);
 	if (!icd) {
-		tr_err(&ipc_tr, "ipc_comp_free(): comp id: %d is not found",
+		tr_err(&ipc_tr, "ipc_comp_free(): comp id: 0x%x is not found",
 		       comp_id);
 		return -ENODEV;
 	}
@@ -276,7 +276,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check state */
 	if (icd->cd->state != COMP_STATE_READY) {
-		tr_err(&ipc_tr, "ipc_comp_free(): comp id: %d state is %d cannot be freed",
+		tr_err(&ipc_tr, "ipc_comp_free(): comp id: 0x%x state is %d cannot be freed",
 		       comp_id, icd->cd->state);
 		return -EINVAL;
 	}
@@ -291,7 +291,7 @@ int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 		 * leak on error.  Bug-free host drivers won't do
 		 * this, this was found via fuzzing.
 		 */
-		tr_err(&ipc_tr, "ipc_comp_free(): uninitialized buffer lists on comp %d\n",
+		tr_err(&ipc_tr, "ipc_comp_free(): uninitialized buffer lists on comp 0x%x\n",
 		       icd->id);
 		return -EINVAL;
 	}

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -107,7 +107,7 @@ struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init)
 		return NULL;
 
 	if (ipc4_get_comp_dev(comp_id)) {
-		tr_err(&ipc_tr, "comp %d exists", comp_id);
+		tr_err(&ipc_tr, "comp 0x%x exists", comp_id);
 		return NULL;
 	}
 
@@ -129,7 +129,7 @@ struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init)
 		ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
 #else /* CONFIG_ZEPHYR_DP_SCHEDULER */
 	if (module_init->extension.r.proc_domain) {
-		tr_err(&ipc_tr, "ipc: DP scheduling is disabled, cannot create comp %d", comp_id);
+		tr_err(&ipc_tr, "ipc: DP scheduling is disabled, cannot create comp 0x%x", comp_id);
 		return NULL;
 	}
 	ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
@@ -1031,7 +1031,7 @@ int ipc4_add_comp_dev(struct comp_dev *dev)
 	icd->core = dev->ipc_config.core;
 	icd->id = dev->ipc_config.id;
 
-	tr_dbg(&ipc_tr, "ipc4_add_comp_dev add comp %x", icd->id);
+	tr_dbg(&ipc_tr, "ipc4_add_comp_dev add comp 0x%x", icd->id);
 	/* add new component to the list */
 	list_item_append(&icd->list, &ipc->comp_list);
 


### PR DESCRIPTION
This pull request includes a series of commits that standardize the logging format for component IDs across different parts of the audio firmware. The changes convert component ID logs from decimal to hexadecimal format, aligning with the common logging practices within the firmware and other debugging tools. This consistency simplifies the process of cross-referencing component IDs during development and debugging.

The commits cover updates to ipc-helper logs, ipc4 helper logs, and pipeline graph logs, ensuring that component IDs are uniformly displayed in hexadecimal format. These changes not only improve readability but also enhance the efficiency of searching and correlating logs when investigating issues.

List of changes:
- ipc4: helper: Use hex format for component IDs in ipc-helper logs
- pipeline: params: Display component IDs in hex format in pipeline logs
- ipc4: helper: Convert component ID logs to hexadecimal format
- pipeline: graph: Use hex format for component IDs in graph logs

Each commit is focused on a specific area of the codebase, making the changes easy to review and verify.