### PR TITLE
copier: Use correct multiplier for latency to bytes calculation

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -390,7 +390,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
 		pipe_reg.stream_start_offset = posn.dai_posn +
-			latency * audio_stream_get_size(&buffer->stream);
+			latency * audio_stream_period_bytes(&buffer->stream, dev->frames);
 		pipe_reg.stream_end_offset = 0;
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg, sizeof(pipe_reg));
 	} else if (cmd == COMP_TRIGGER_PAUSE) {
@@ -413,7 +413,8 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 		}
 
 		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
-		pipe_reg.stream_start_offset += latency * audio_stream_get_size(&buffer->stream);
+		pipe_reg.stream_start_offset += latency *
+			audio_stream_period_bytes(&buffer->stream, dev->frames);
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg.stream_start_offset,
 				      sizeof(pipe_reg.stream_start_offset));
 	}


### PR DESCRIPTION
The latency value is in number of periods (1ms) while the buffer allocated for the DAI copier is at least 2 periods.
This can shoot up the calculated  stream_start_offset resulting invalid delay reporting.
Use the period size of the DAI copier to correct this error.

The kernel reported delay currently (on normal non DeepBuffer PCM): at start: ~302 frames
after 20x pause/resume: ~6530 frames

With this patch:
at start: ~254 frames
after 20x pause/resume: ~3600 frames

The drift rate is about the same with DeepBuffer.