### PR TITLE
lib_manager: Add lib_manager_get_module_manifest function

### DIFF
--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -62,21 +62,20 @@ static int modules_new(struct processing_module *mod, const void *buildinfo,
 	uint32_t log_handle = (uint32_t) dev->drv->tctx;
 	/* Connect loadable module interfaces with module adapter entity. */
 	/* Check if native Zephyr lib is loaded */
-	struct sof_man_fw_desc *desc = lib_manager_get_library_module_desc(module_id);
 	void *system_agent;
-
-	if (!desc) {
-		comp_err(dev, "modules_init(): Failed to load manifest");
-		return -ENOMEM;
-	}
 
 	const struct sof_module_api_build_info *mod_buildinfo;
 
 	if (buildinfo) {
 		mod_buildinfo = buildinfo;
 	} else {
-		struct sof_man_module *module_entry =
-			(struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(0));
+		const struct sof_man_module *const module_entry =
+			lib_manager_get_module_manifest(module_id);
+
+		if (!module_entry) {
+			comp_err(dev, "modules_new(): Failed to load manifest");
+			return -ENODATA;
+		}
 
 		mod_buildinfo =
 			(struct sof_module_api_build_info *)

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -47,7 +47,7 @@ typedef uint32_t ipc_comp;
 #define ipc_from_pipe_connect(x) ((struct ipc4_module_bind_unbind *)x)
 
 struct ipc_comp_dev;
-const struct comp_driver *ipc4_get_comp_drv(int module_id);
+const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id);
 struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id);
 int ipc4_add_comp_dev(struct comp_dev *dev);
 const struct comp_driver *ipc4_get_drv(const uint8_t *uuid);

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -151,7 +151,7 @@ int lib_manager_register_module(const uint32_t component_id);
  *
  * Gets firmware manifest descriptor using module_id to locate it
  */
-struct sof_man_fw_desc *lib_manager_get_library_module_desc(int module_id);
+const struct sof_man_fw_desc *lib_manager_get_library_manifest(int module_id);
 
 struct processing_module;
 /*

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -117,6 +117,15 @@ static inline struct lib_manager_mod_ctx *lib_manager_get_mod_ctx(int module_id)
 
 	return _ext_lib->desc[lib_id];
 }
+
+/*
+ * \brief Get module manifest for given module id
+ *
+ * param[in] module_id - used to get library manifest
+ *
+ * Gets library manifest descriptor using module_id to locate it
+ */
+const struct sof_man_module *lib_manager_get_module_manifest(const uint32_t module_id);
 #endif
 
 /*

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -945,12 +945,12 @@ static const struct comp_driver *ipc4_library_get_drv(int module_id)
 }
 #endif
 
-const struct comp_driver *ipc4_get_comp_drv(int module_id)
+const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id)
 {
 	struct sof_man_fw_desc *desc = NULL;
 	const struct comp_driver *drv;
 	struct sof_man_module *mod;
-	int entry_index;
+	uint32_t entry_index;
 
 #if CONFIG_LIBRARY
 	return ipc4_library_get_drv(module_id);

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -214,7 +214,7 @@ static int lib_manager_unload_module(const struct sof_man_module *const mod)
  */
 static int lib_manager_load_libcode_modules(const uint32_t module_id)
 {
-	const struct sof_man_fw_desc *const desc = lib_manager_get_library_module_desc(module_id);
+	const struct sof_man_fw_desc *const desc = lib_manager_get_library_manifest(module_id);
 	struct ext_library *const ext_lib = ext_lib_get();
 	const struct sof_man_module *module_entry = (struct sof_man_module *)
 		((char *)desc + SOF_MAN_MODULE_OFFSET(0));
@@ -252,7 +252,7 @@ err:
  */
 static int lib_manager_unload_libcode_modules(const uint32_t module_id)
 {
-	const struct sof_man_fw_desc *const desc = lib_manager_get_library_module_desc(module_id);
+	const struct sof_man_fw_desc *const desc = lib_manager_get_library_manifest(module_id);
 	const struct sof_man_module *module_entry = (struct sof_man_module *)
 		((char *)desc + SOF_MAN_MODULE_OFFSET(0));
 	struct ext_library *const ext_lib = ext_lib_get();
@@ -450,7 +450,7 @@ void lib_manager_init(void)
 		sof->ext_library = &loader_ext_lib;
 }
 
-struct sof_man_fw_desc *lib_manager_get_library_module_desc(int module_id)
+const struct sof_man_fw_desc *lib_manager_get_library_manifest(int module_id)
 {
 	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
 	uint8_t *buffptr = ctx ? ctx->base_addr : NULL;

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -242,7 +242,7 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 	tr_dbg(&lib_manager_tr, "llext_manager_allocate_module(): mod_id: %#x",
 	       ipc_config->id);
 
-	desc = lib_manager_get_library_module_desc(module_id);
+	desc = (struct sof_man_fw_desc *)lib_manager_get_library_manifest(module_id);
 	if (!ctx || !desc) {
 		tr_err(&lib_manager_tr,
 		       "llext_manager_allocate_module(): failed to get module descriptor");

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -272,16 +272,13 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 
 int llext_manager_free_module(const uint32_t component_id)
 {
-	struct sof_man_fw_desc *desc;
 	const struct sof_man_module *mod;
 	const uint32_t module_id = IPC4_MOD_ID(component_id);
-	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
 	int ret;
 
 	tr_dbg(&lib_manager_tr, "llext_manager_free_module(): mod_id: %#x", component_id);
 
-	desc = lib_manager_get_library_module_desc(module_id);
-	mod = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(entry_index));
+	mod = lib_manager_get_module_manifest(module_id);
 
 	ret = llext_manager_unload_module(module_id, mod);
 	if (ret < 0)


### PR DESCRIPTION
Added the lib_manager_get_module_manifest function that returns manifest of selected module based on its id. It was performed in many places and moving it into function simplified the code and increased its readability.
The lib_manager_get_library_module_desc function was renamed to lib_manager_get_library_manifest, which better describes what it do.
All calls to the ipc4_get_comp_drv function pass the uint32_t value as a parameter, so the type of functions parameter was changed to uint32_t.