### PR TITLE
tools: topology1: imx8ulp: correct BCLK rate and change BCLK polarity and protocol

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -59,10 +59,10 @@ set(TPLGS
 	## end i.MX8MP topologies
 
 	## i.MX8ULP topologies
-	"sof-imx8ulp-btsco\;sof-imx8ulp-btsco\;-DRATE=8000"
-	"sof-imx8ulp-btsco\;sof-imx8ulp-btsco-16k\;-DRATE=16000"
-	"sof-imx8ulp-9x9-btsco\;sof-imx8ulp-9x9-btsco\;-DRATE=8000"
-	"sof-imx8ulp-9x9-btsco\;sof-imx8ulp-9x9-btsco-16k\;-DRATE=16000"
+	"sof-imx8ulp-btsco\;sof-imx8ulp-btsco\;-DFSYNC_RATE=8000"
+	"sof-imx8ulp-btsco\;sof-imx8ulp-btsco-16k\;-DFSYNC_RATE=16000"
+	"sof-imx8ulp-9x9-btsco\;sof-imx8ulp-9x9-btsco\;-DFSYNC_RATE=8000"
+	"sof-imx8ulp-9x9-btsco\;sof-imx8ulp-9x9-btsco-16k\;-DFSYNC_RATE=16000"
 	## end i.MX8ULP topologies
 
 	## i.MX93 topologies

--- a/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
@@ -39,14 +39,14 @@ dnl     time_domain, sched_comp)
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 1, s16le,
 	1000, 0, 0,
-	`RATE', `RATE', `RATE')
+	`FSYNC_RATE', `FSYNC_RATE', `FSYNC_RATE')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 1 channels of s16le.
 # Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 1, s16le,
 	1000, 0, 0,
-	`RATE', `RATE', `RATE')
+	`FSYNC_RATE', `FSYNC_RATE', `FSYNC_RATE')
 #
 # DAIs configuration
 #
@@ -79,6 +79,6 @@ dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 6, 0, sai6-bt-sco-pcm-wb,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
 		SAI_CLOCK(bclk, 256000, codec_consumer),
-		SAI_CLOCK(fsync, `RATE', codec_consumer),
+		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 6, 0)))

--- a/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
@@ -75,10 +75,21 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 
+# BCLK frequency is computed using the following formula:
+#	Freq(BCLK) = Freq(FSYNC) * TDM_SLOTS * TDM_SLOT_WIDTH
+#
+# For 8ULP this yields the following frequencies
+# (based on supported BT HFP configurations):
+#
+#	1) NBS (Freq(FSYNC) = 8k)
+#		Freq(BCLK) = 8k * 16 * 1 = 128000
+#
+#	2) WBS (Freq(FSYNC) = 16k)
+#		Freq(BCLK) = 16k * 16 * 1 = 256000
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 6, 0, sai6-bt-sco-pcm-wb,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
-		SAI_CLOCK(bclk, 256000, codec_consumer),
+		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer),
 		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 6, 0)))

--- a/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-9x9-btsco.m4
@@ -88,8 +88,8 @@ PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 #		Freq(BCLK) = 16k * 16 * 1 = 256000
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 6, 0, sai6-bt-sco-pcm-wb,
-	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
-		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer),
+	SAI_CONFIG(DSP_A, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
+		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer, inverted),
 		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 6, 0)))

--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -39,14 +39,14 @@ dnl     time_domain, sched_comp)
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 1, s16le,
 	1000, 0, 0,
-	`RATE', `RATE', `RATE')
+	`FSYNC_RATE', `FSYNC_RATE', `FSYNC_RATE')
 
 # Low Latency capture pipeline 2 on PCM 0 using max 1 channels of s16le.
 # Set 1000us deadline with priority 0 on core 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
 	2, 0, 1, s16le,
 	1000, 0, 0,
-	`RATE', `RATE', `RATE')
+	`FSYNC_RATE', `FSYNC_RATE', `FSYNC_RATE')
 
 #
 # DAIs configuration
@@ -80,6 +80,6 @@ dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 5, 0, sai5-bt-sco-pcm-wb,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
 		SAI_CLOCK(bclk, 256000, codec_consumer),
-		SAI_CLOCK(fsync, `RATE', codec_consumer),
+		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 5, 0)))

--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -89,8 +89,8 @@ PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 #		Freq(BCLK) = 16k * 16 * 1 = 256000
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 5, 0, sai5-bt-sco-pcm-wb,
-	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
-		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer),
+	SAI_CONFIG(DSP_A, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
+		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer, inverted),
 		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 5, 0)))

--- a/tools/topology/topology1/sof-imx8ulp-btsco.m4
+++ b/tools/topology/topology1/sof-imx8ulp-btsco.m4
@@ -76,10 +76,21 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
 PCM_DUPLEX_ADD(Port0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 
+# BCLK frequency is computed using the following formula:
+#	Freq(BCLK) = Freq(SYNC) * TDM_SLOTS * TDM_SLOT_WIDTH
+#
+# For 8ULP this yields the following frequencies (based on
+# supported BT HFP configurations):
+#
+#	1) NBS (Freq(FSYNC) = 8k)
+#		Freq(BCLK) = 8k * 16 * 1 = 128000
+#
+#	2) WBS (Freq(FSYNC) = 16k)
+#		Freq(BCLK) = 16k * 16 * 1 = 256000
 dnl DAI_CONFIG(type, idx, link_id, name, sai_config)
 DAI_CONFIG(SAI, 5, 0, sai5-bt-sco-pcm-wb,
 	SAI_CONFIG(I2S, SAI_CLOCK(mclk, 12288000, codec_mclk_out),
-		SAI_CLOCK(bclk, 256000, codec_consumer),
+		SAI_CLOCK(bclk, `eval(FSYNC_RATE * 16)', codec_consumer),
 		SAI_CLOCK(fsync, `FSYNC_RATE', codec_consumer),
 		SAI_TDM(1, 16, 1, 1),
 		SAI_CONFIG_DATA(SAI, 5, 0)))


### PR DESCRIPTION
These patches are needed for the native transition. Trying to upstream them before the transition itself to make the PR doing the transition easier to review.