### PR TITLE
audio: copier: use v_index for DAI index in I2S link creation

### DIFF
--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -259,7 +259,6 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		break;
 	case ipc4_i2s_link_output_class:
 	case ipc4_i2s_link_input_class:
-		dai_index[dai_count - 1] = (dai_index[dai_count - 1] >> 4) & 0xF;
 		dai.type = SOF_DAI_INTEL_SSP;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_ssp;

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 799a456c25868521024e5104b5fc927faea7b41c
+      revision: 24554363379d69469e35b254c42c999a2a98a9c1
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
This commit updates the copier DAI creation logic for I2S links to use the `v_index` field from the `node_id` structure as the DAI index. This change ensures that the correct DAI index is used when creating I2S links, aligning with the new SSP link management mechanism.

The following PR must be merged into the Zephyr repository before we can merge this PR:
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/70660