### PR TITLE
[stable-v2.2] topology1: Add topology for 4ch DMIC+ SSP codec+HDMI-in capture..

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -316,6 +316,7 @@ set(TPLGS
 
 	#sof-adl-es8336-ssp1-hdmi-ssp02 supports es8336 codec along with 2xHDMI_over_SSP Capture's.
 	"sof-glk-es8336\;sof-adl-es8336-ssp1-hdmi-ssp02\;-DPLATFORM=adl\;-DSSP_NUM=1\;-DCHANNELS=0\;-DHDMI_1_SSP_NUM=0\;-DHDMI_2_SSP_NUM=2"
+	"sof-glk-es8336\;sof-adl-es8336-ssp1-hdmi-ssp02-4ch\;-DPLATFORM=adl\;-DSSP_NUM=1\;-DCHANNELS=4\;-DHDMI_1_SSP_NUM=0\;-DHDMI_2_SSP_NUM=2"
 
 	#To support HDMI-in capture with RT1308 ssp-amplifier products.
 	"sof-tgl-rt1308-hdmi-ssp\;sof-tgl-rt1308-ssp2-hdmi-ssp15\;-DAMP_SSP_NUM=2\;-DHDMI_1_SSP_NUM=1\;-DHDMI_2_SSP_NUM=5\;-DPLATFORM=tgl"


### PR DESCRIPTION
Add support to generate the topology which can be used to support 
4channel DMIC,SSP based codec and HDMI-in capture via I2S combo.