### PR TITLE
cmake: update configs for NXP ADSP

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 66b475a3aa4d73f4ddd5be5a7a1e0f3c7028e539
+      revision: 1f55be8b42dfd54308038d1e422d8d4e0e7f39ab
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -232,7 +232,7 @@ if (CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 endif()
 
 # NXP IMX8 platforms
-if (CONFIG_SOC_MIMX8QM_ADSP OR CONFIG_SOC_MIMX8QXP_ADSP)
+if (CONFIG_SOC_MIMX8QM6_ADSP OR CONFIG_SOC_MIMX8QX6_ADSP)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
 		${SOF_DRIVERS_PATH}/imx/edma.c
@@ -261,7 +261,7 @@ if (CONFIG_SOC_MIMX8QM_ADSP OR CONFIG_SOC_MIMX8QXP_ADSP)
 	set(PLATFORM "imx8")
 endif()
 
-if (CONFIG_SOC_MIMX8MP_ADSP)
+if (CONFIG_SOC_MIMX8ML8_ADSP)
 	zephyr_library_sources(
 		${SOF_DRIVERS_PATH}/generic/dummy-dma.c
 		${SOF_DRIVERS_PATH}/imx/sdma.c


### PR DESCRIPTION
CONFIG_SOC_<name> has changed in zephyr in order to match soc name.
Therefore, update configs with new values.

Update zephy version used in SOF.