### PR TITLE
Tools: Tune: Eq: Fix IIR data files names in example_spk_eq.m

### DIFF
--- a/tools/tune/eq/example_spk_eq.m
+++ b/tools/tune/eq/example_spk_eq.m
@@ -30,9 +30,9 @@ fir.txt = 'eq_fir_spk.txt';
 fir.bin = 'eq_fir_spk.bin';
 fir.tplg1 = 'eq_fir_coef_spk.m4';
 fir.tplg2 = 'example_speaker.conf';
-iir.txt = 'eq_fir_spk.txt';
-iir.bin = 'eq_fir_spk.bin';
-iir.tplg1 = 'eq_fir_coef_spk.m4';
+iir.txt = 'eq_iir_spk.txt';
+iir.bin = 'eq_iir_spk.bin';
+iir.tplg1 = 'eq_iir_coef_spk.m4';
 iir.tplg2 = 'example_speaker.conf';
 
 %% Get defaults for equalizer design


### PR DESCRIPTION
The IIR files export overwrites the FIR files due to mistake in the script.

Fixes commit 5ddbd34ba917 ("Tools: Tune: EQ: Add tplg2 blobs create")