### PR TITLE
topology2: intel: hdmi-generic: Update rates and format support in pc…

### DIFF
--- a/tools/topology/topology2/platform/intel/hdmi-generic.conf
+++ b/tools/topology/topology2/platform/intel/hdmi-generic.conf
@@ -160,8 +160,9 @@ Object.PCM.pcm [
 		}
 		Object.PCM.pcm_caps.1 {
 			name $HDMI1_PCM_CAPS
-			formats 'S32_LE,S16_LE'
+			formats 'S32_LE,S16_LE,IEC958_SUBFRAME_LE'
 			channels_max 8
+			rates '32000,44100,48000,88200,96000,176400,192000'
 		}
 		direction playback
 	}
@@ -173,8 +174,9 @@ Object.PCM.pcm [
 		}
 		Object.PCM.pcm_caps.1 {
 			name $HDMI2_PCM_CAPS
-			formats 'S32_LE,S16_LE'
+			formats 'S32_LE,S16_LE,IEC958_SUBFRAME_LE'
 			channels_max 8
+			rates '32000,44100,48000,88200,96000,176400,192000'
 		}
 		direction playback
 	}
@@ -186,8 +188,9 @@ Object.PCM.pcm [
 		}
 		Object.PCM.pcm_caps.1 {
 			name $HDMI3_PCM_CAPS
-			formats 'S32_LE,S16_LE'
+			formats 'S32_LE,S16_LE,IEC958_SUBFRAME_LE'
 			channels_max 8
+			rates '32000,44100,48000,88200,96000,176400,192000'
 		}
 		direction playback
 	}
@@ -275,8 +278,9 @@ IncludeByKey.NUM_HDMIS {
 				}
 				Object.PCM.pcm_caps.1 {
 					name $HDMI4_PCM_CAPS
-					formats 'S32_LE,S16_LE'
+					formats 'S32_LE,S16_LE,IEC958_SUBFRAME_LE'
 					channels_max 8
+					rates '32000,44100,48000,88200,96000,176400,192000'
 				}
 				direction playback
 			}


### PR DESCRIPTION
…m.caps

With ChainDMA the HDMI PCM can support IEC958_SUBFRAME_LE and the rate is not limited to 48K only.

To be able to use bytestream passthrough (DD/DTS/etc).