### PR TITLE
init: zephyr: Fix memory leak during secondary core init

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -89,7 +89,7 @@ static inline void lp_sram_unpack(void)
 
 #ifndef __ZEPHYR__
 
-static int check_restore(void)
+static bool check_restore(void)
 {
 	struct idc *idc = *idc_get();
 	struct task *task = *task_main_get();
@@ -100,10 +100,7 @@ static int check_restore(void)
 	 * are available in memory, it means that this is not cold boot and memory
 	 * has not been powered off.
 	 */
-	if (!idc || !task || !notifier || !schedulers)
-		return 0;
-
-	return 1;
+	return !!idc && !!task && !!notifier && !!schedulers;
 }
 
 static int secondary_core_restore(void)


### PR DESCRIPTION
This patch refines the initialization process for secondary cores in a multicore environment when using Zephyr as the RTOS. The patch introduces a `check_restore` function specifically for Zephyr, which checks if basic core structures (IDC, notifier, schedulers) have been previously allocated and are still present in memory, indicating that the system is not undergoing a cold boot.

By adding this check, the system avoids unnecessary re-allocation of these structures during the power-up sequence of secondary cores, effectively preventing the memory leak observed during repeated power cycle tests.

fix #9005