### PR TITLE
west.yml: update Zephyr to fd1a129a3e63

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 1f55be8b42dfd54308038d1e422d8d4e0e7f39ab
+      revision: fd1a129a3e6330bdf44324e47ac7638dd6cdf5a5
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Contains the following patches affecting SOF:

bba8641354bf dts: xtensa: nxp_imx8: add ESAI0 node
bd9b3c67b240 drivers: dai: add driver for NXP's ESAI
f4c73105e55a drivers: dai: sai: add pinctrl support

Cherry-picked from https://github.com/thesofproject/sof/pull/8863