### PR TITLE
audio: base_fw: add platform layer to hw_config data

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -6,6 +6,7 @@
 #include <sof/ut.h>
 #include <sof/tlv.h>
 #include <ipc4/base_fw.h>
+#include <ipc4/base_fw_platform.h>
 #include <ipc4/pipeline.h>
 #include <ipc4/logging.h>
 #include <sof_versions.h>
@@ -129,6 +130,7 @@ static int basefw_config(uint32_t *data_offset, char *data)
 static int basefw_hw_config(uint32_t *data_offset, char *data)
 {
 	struct sof_tlv *tuple = (struct sof_tlv *)data;
+	uint32_t plat_data_offset = 0;
 	uint32_t value;
 
 	tlv_value_uint32_set(tuple, IPC4_CAVS_VER_HW_CFG, HW_CFG_VERSION);
@@ -147,19 +149,11 @@ static int basefw_hw_config(uint32_t *data_offset, char *data)
 	tlv_value_uint32_set(tuple, IPC4_TOTAL_PHYS_MEM_PAGES_HW_CFG, value);
 
 	tuple = tlv_next(tuple);
-	tlv_value_uint32_set(tuple, IPC4_HP_EBB_COUNT_HW_CFG, PLATFORM_HPSRAM_EBB_COUNT);
 
-	tuple = tlv_next(tuple);
-	/* 2 DMIC dais */
-	value =  DAI_NUM_SSP_BASE + DAI_NUM_HDA_IN + DAI_NUM_HDA_OUT +
-			DAI_NUM_ALH_BI_DIR_LINKS + 2;
-	tlv_value_uint32_set(tuple, IPC4_GATEWAY_COUNT_HW_CFG, value);
+	/* add platform specific tuples */
+	platform_basefw_hw_config(&plat_data_offset, (char *)tuple);
 
-	tuple = tlv_next(tuple);
-	tlv_value_uint32_set(tuple, IPC4_LP_EBB_COUNT_HW_CFG, PLATFORM_LPSRAM_EBB_COUNT);
-
-	tuple = tlv_next(tuple);
-	*data_offset = (int)((char *)tuple - data);
+	*data_offset = (int)((char *)tuple - data) + plat_data_offset;
 
 	return 0;
 }

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2024 Intel Corporation.
+ *
+ * Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+ */
+
+/**
+ * \file include/ipc4/base_fw_platform.h
+ * \brief Platform specific IPC4 base firmware functionality.
+ */
+
+#ifndef __SOF_IPC4_BASE_FW_PLATFORM_H__
+#define __SOF_IPC4_BASE_FW_PLATFORM_H__
+
+/**
+ * \brief Platform specific routine to add data tuples to HW_CONFIG
+ * structure sent to host via IPC.
+ * \param[out] data_offset data offset after tuples added
+ * \parma[in] data pointer where to add new entries
+ * \return 0 if successful, error code otherwise.
+ */
+int platform_basefw_hw_config(uint32_t *data_offset, char *data);
+
+#endif

--- a/src/platform/intel/ace/lib/base_fw_platform.c
+++ b/src/platform/intel/ace/lib/base_fw_platform.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2024 Intel Corporation.
+//
+// Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+
+#include <rtos/string.h>
+#include <sof/tlv.h>
+#include <sof/lib/dai.h>
+#include <ipc4/base_fw.h>
+
+int platform_basefw_hw_config(uint32_t *data_offset, char *data)
+{
+	struct sof_tlv *tuple = (struct sof_tlv *)data;
+	uint32_t value;
+
+	tlv_value_uint32_set(tuple, IPC4_HP_EBB_COUNT_HW_CFG, PLATFORM_HPSRAM_EBB_COUNT);
+
+	tuple = tlv_next(tuple);
+	/* 2 DMIC dais */
+	value =  DAI_NUM_SSP_BASE + DAI_NUM_HDA_IN + DAI_NUM_HDA_OUT +
+			DAI_NUM_ALH_BI_DIR_LINKS + 2;
+	tlv_value_uint32_set(tuple, IPC4_GATEWAY_COUNT_HW_CFG, value);
+
+	tuple = tlv_next(tuple);
+	tlv_value_uint32_set(tuple, IPC4_LP_EBB_COUNT_HW_CFG, PLATFORM_LPSRAM_EBB_COUNT);
+
+	tuple = tlv_next(tuple);
+	*data_offset = (int)((char *)tuple - data);
+
+	return 0;
+}

--- a/src/platform/posix/base_fw_platform.c
+++ b/src/platform/posix/base_fw_platform.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2024 Intel Corporation.
+//
+// Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+
+#include <stdint.h>
+#include <ipc4/base_fw_platform.h>
+
+int platform_basefw_hw_config(uint32_t *data_offset, char *data)
+{
+	*data_offset = 0;
+
+	return 0;
+}

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -162,6 +162,7 @@ if (CONFIG_SOC_SERIES_INTEL_CAVS_V25)
 	# Platform sources
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/intel/cavs/platform.c
+		${SOF_PLATFORM_PATH}/intel/ace/lib/base_fw_platform.c
 		${SOF_PLATFORM_PATH}/tigerlake/lib/clk.c
 		lib/pm_runtime.c
 		lib/clk.c
@@ -183,6 +184,7 @@ if (CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	# Platform sources
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/intel/ace/platform.c
+		${SOF_PLATFORM_PATH}/intel/ace/lib/base_fw_platform.c
 		lib/pm_runtime.c
 		lib/clk.c
 		lib/dma.c
@@ -345,6 +347,7 @@ zephyr_library_sources_ifdef(CONFIG_ZEPHYR_POSIX
 	${SOF_PLATFORM_PATH}/posix/dai.c
 	${SOF_PLATFORM_PATH}/posix/ipc.c
 	${SOF_PLATFORM_PATH}/posix/posix.c
+	${SOF_PLATFORM_PATH}/posix/base_fw_platform.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_LIBRARY


### PR DESCRIPTION
First patch to address https://github.com/thesofproject/sof/issues/8391 - more to come later.

Some of the HW_CONFIG fields are platform specific and cannot be filled with generic means in generic code.

Handle this data via a simple platform abstraction to hook platform specific code to HW_CONFIG handling. Move out existing code for Intel cAVS and ACE platforms.