### PR TITLE
topology2: pcm_caps: Remove defaults for rate_min/rate_max

### DIFF
--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -82,8 +82,7 @@ Class.PCM."pcm_caps" {
 
 	# Default attribute values for PCM capabilities
 	formats		"S32_LE,S24_LE,S16_LE"
-	rate_min		48000
-	rate_max		48000
+	rates			"48000"
 	periods_min		2
 	periods_max		16
 	channels_min		2


### PR DESCRIPTION
Use 'rates' instead to specify that 48K is the default supported rate.