### PR TITLE
Audio: basefw: Implemented ipc4 libraries info get

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -637,6 +637,31 @@ enum ipc4_alh_version {
 	IPC4_ALH_CAVS_1_8 = 0x10000,
 };
 
+struct ipc4_library_props {
+	/* Library run-time identifier, depends on order of loading. */
+    /* Base FW is always reported with id 0. */
+	uint32_t id;
+	/* Name of the library. */
+	uint8_t name[8];
+	/* Major version of the library. */
+	uint16_t major_version;
+	/* Minor version of the library. */
+	uint16_t minor_version;
+	/* Hotfix version of the library. */
+	uint16_t hotfix_version;
+	/* Build version of the library. */
+	uint16_t build_version;
+	/* Number of modules packed into the library. */
+	uint32_t num_module_entries;
+} __packed __aligned(4);
+
+struct ipc4_libraries_info {
+	/* Specifies number of items in libraries array. */
+	uint32_t library_count;
+	/* Array of libraries properties. */
+	struct ipc4_library_props libraries[0];
+} __packed __aligned(4);
+
 struct ipc4_log_state_info {
 	/*
 	 * Specifies how frequently FW sends Log Buffer Status

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -22,4 +22,11 @@
  */
 int platform_basefw_hw_config(uint32_t *data_offset, char *data);
 
-#endif
+/**
+ * \brief Platform specific routine which return the pointer to
+ * the boot base manifest.
+ * \return pointer to struct if successful, null otherwise.
+ */
+struct sof_man_fw_desc *platform_base_fw_get_manifest(void);
+
+#endif /* __SOF_IPC4_BASE_FW_PLATFORM_H__ */

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -118,6 +118,9 @@ static inline struct lib_manager_mod_ctx *lib_manager_get_mod_ctx(int module_id)
 	uint32_t lib_id = LIB_MANAGER_GET_LIB_ID(module_id);
 	struct ext_library *_ext_lib = ext_lib_get();
 
+	if (!_ext_lib)
+		return NULL;
+
 	return _ext_lib->desc[lib_id];
 }
 

--- a/src/platform/intel/ace/lib/base_fw_platform.c
+++ b/src/platform/intel/ace/lib/base_fw_platform.c
@@ -30,3 +30,12 @@ int platform_basefw_hw_config(uint32_t *data_offset, char *data)
 
 	return 0;
 }
+
+struct sof_man_fw_desc *platform_base_fw_get_manifest(void)
+{
+	struct sof_man_fw_desc *desc;
+
+	desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
+
+	return desc;
+}

--- a/src/platform/posix/base_fw_platform.c
+++ b/src/platform/posix/base_fw_platform.c
@@ -5,6 +5,7 @@
 // Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
 
 #include <stdint.h>
+#include <stddef.h>
 #include <ipc4/base_fw_platform.h>
 
 int platform_basefw_hw_config(uint32_t *data_offset, char *data)
@@ -12,4 +13,11 @@ int platform_basefw_hw_config(uint32_t *data_offset, char *data)
 	*data_offset = 0;
 
 	return 0;
+}
+
+struct sof_man_fw_desc *platform_base_fw_get_manifest(void)
+{
+	struct sof_man_fw_desc *desc = NULL;
+
+	return desc;
 }


### PR DESCRIPTION
Added support for ipc4 query no 16.
This makes it possible to get information about the current basefw library.