### PR TITLE
Audio: basefw: Implement ipc4 modules info get

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -334,6 +334,11 @@ static int basefw_libraries_info_get(uint32_t *data_offset, char *data)
 	return 0;
 }
 
+static int basefw_modules_info_get(uint32_t *data_offset, char *data)
+{
+	return platform_basefw_modules_info_get(data_offset, data);
+}
+
 int schedulers_info_get(uint32_t *data_off_size,
 			char *data,
 			uint32_t core_id)
@@ -458,15 +463,15 @@ static int basefw_get_large_config(struct comp_dev *dev,
 					 extended_param_id.part.parameter_instance);
 	case IPC4_PIPELINE_LIST_INFO_GET:
 		return basefw_pipeline_list_info_get(data_offset, data);
+	case IPC4_MODULES_INFO_GET:
+		return basefw_modules_info_get(data_offset, data);
+	case IPC4_LIBRARIES_INFO_GET:
+		return basefw_libraries_info_get(data_offset, data);
 	/* TODO: add more support */
 	case IPC4_DSP_RESOURCE_STATE:
 	case IPC4_NOTIFICATION_MASK:
-	case IPC4_MODULES_INFO_GET:
 	case IPC4_PIPELINE_PROPS_GET:
 	case IPC4_GATEWAYS_INFO_GET:
-		break;
-	case IPC4_LIBRARIES_INFO_GET:
-		return basefw_libraries_info_get(data_offset, data);
 	case IPC4_PERF_MEASUREMENTS_STATE:
 	case IPC4_GLOBAL_PERF_DATA:
 		COMPILER_FALLTHROUGH;

--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -329,8 +329,11 @@ struct ipc_cmd_hdr;
 #define SOF_IPC_MESSAGE_ID(x)			((x) & 0xffff)
 
 /** Maximum message size for mailbox Tx/Rx */
+#if CONFIG_IPC_MAJOR_4
+#define SOF_IPC_MSG_MAX_SIZE			0x1000
+#else
 #define SOF_IPC_MSG_MAX_SIZE			384
-
+#endif
 /** @} */
 
 /**

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -45,6 +45,15 @@ int platform_basefw_hw_config(uint32_t *data_offset, char *data);
 struct sof_man_fw_desc *platform_base_fw_get_manifest(void);
 
 /**
+ * \brief Platform specific routine to get information about modules.
+ * Function add information and sent to host via IPC.
+ * \param[out] data_offset data offset after structure added
+ * \param[in] data pointer where to add new entries
+ * \return 0 if successful, error code otherwise.
+ */
+int platform_basefw_modules_info_get(uint32_t *data_offset, char *data);
+
+/**
  * \brief Implement platform specific parameter for basefw module.
  * This function is called for parameters not handled by
  * generic base_fw code.

--- a/src/platform/posix/base_fw_platform.c
+++ b/src/platform/posix/base_fw_platform.c
@@ -30,6 +30,13 @@ struct sof_man_fw_desc *platform_base_fw_get_manifest(void)
 	return desc;
 }
 
+int platform_basefw_modules_info_get(uint32_t *data_offset, char *data)
+{
+	*data_offset = 0;
+
+	return 0;
+}
+
 int platform_basefw_get_large_config(struct comp_dev *dev,
 				     uint32_t param_id,
 				     bool first_block,


### PR DESCRIPTION
Add support to handle IPC4_MODULES_INFO_GET message.
This make it possible to get information about the current loaded modules.

