### PR TITLE
[STABLE-2.2] dma-trace.c: lower log level of dropped logs and stop the recursion

### DIFF
--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -645,15 +645,9 @@ static void dtrace_add_event(const char *e, uint32_t length)
 			uint32_t tmp_dropped_entries =
 				trace_data->dropped_entries;
 			trace_data->dropped_entries = 0;
-			/*
-			 * this trace_error invocation causes recursion,
-			 * so after it we have to recalculate margin and
-			 * overflow
-			 */
-			tr_err(&dt_tr, "dtrace_add_event(): number of dropped logs = %u",
-			       tmp_dropped_entries);
-			margin = dtrace_calc_buf_margin(buffer);
-			overflow = dtrace_calc_buf_overflow(buffer, length);
+			mtrace_printf(LOG_LEVEL_WARNING,
+				      "dtrace_add_event(): number of dropped logs = %u",
+				      tmp_dropped_entries);
 		}
 	}
 


### PR DESCRIPTION
Dropping logs is bad but it should not be fatal in itself.

This ERROR is one of the last remaining errors in stable-v2.2, see
https://github.com/thesofproject/sof-test/pull/1075#issuecomment-2049051006

Also switch to the "etrace": drop the dubious recursion and stop using
the DMA trace when it's already saturated.

Disclaimer: this was (successfully) tested only on stable-v2.2, see https://github.com/thesofproject/sof/pull/9036

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
(cherry picked from commit https://github.com/marc-hb/sof/commit/bb31696aa6c9b6785e07237f8c6d4b29f59a7946)