### PR TITLE
topology2: add support for MTL Acer Swift Go 14

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -29,6 +29,27 @@ HDMI1_ID=6,HDMI2_ID=7,HDMI3_ID=8"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+"cavs-sdw\;sof-mtl-rt712-l0\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+HDMI1_ID=3,HDMI2_ID=4,HDMI3_ID=5"
+
+"cavs-sdw\;sof-mtl-rt712-l0-4ch\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt712-l0-4ch.bin,\
+HDMI1_ID=5,HDMI2_ID=6,HDMI3_ID=7"
+
+# sof_sdw creates dmic01 and dmic16k no matter 1 or 2 dmics are present.
+# So, HDMI link ids are the same for -2ch and -4ch topologies.
+"cavs-sdw\;sof-mtl-rt712-l0-2ch\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+NUM_DMICS=2,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-rt712-l0-2ch.bin,\
+HDMI1_ID=5,HDMI2_ID=6,HDMI3_ID=7"
+
 "cavs-sdw\;sof-mtl-rt1318-l12-rt714-l0\;PLATFORM=mtl,SDW_JACK=false,SDW_DMIC=1,\
 NUM_SDW_AMP_LINKS=2,SDW_SPK_STREAM=SDW1-Playback,SDW_SPK_IN_STREAM=SDW1-Capture,\
 SDW_DMIC_STREAM=SDW0-Capture"


### PR DESCRIPTION
This device has RT712 on link0 2 PCH-attached DMICs.

Add 3 configurations with no DMIC, 4 DMIC and 2 DMIC. For now no support for -pdm1.

Link: https://github.com/thesofproject/linux/issues/4923