### PR TITLE
module_adapter: return error if get_conf is not implemented

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -193,21 +193,29 @@ static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ct
 			pos = MODULE_CFG_FRAGMENT_LAST;
 	}
 
-	/*
-	 * The type member in struct sof_abi_hdr is used for component's specific blob type
-	 * for IPC3, just like it is used for component's specific blob param_id for IPC4.
-	 */
-	if (set && interface->set_configuration)
-		return interface->set_configuration(mod, cdata->data[0].type, pos,
-						    data_offset_size, (const uint8_t *)cdata,
-						    cdata->num_elems, NULL, 0);
-	else if (!set && interface->get_configuration)
+	if (set) {
+		/*
+		 * The type member in struct sof_abi_hdr is used for component's specific blob type
+		 * for IPC3, just like it is used for component's specific blob param_id for IPC4.
+		 */
+		if (interface->set_configuration)
+			return interface->set_configuration(mod, cdata->data[0].type, pos,
+							    data_offset_size,
+							    (const uint8_t *)cdata,
+							    cdata->num_elems, NULL, 0);
+
+		comp_warn(dev, "module_adapter_get_set_params(): no configuration op set for %d",
+			  dev_comp_id(dev));
+		return 0;
+	}
+
+	if (interface->get_configuration)
 		return interface->get_configuration(mod, pos, &data_offset_size,
 						    (uint8_t *)cdata, cdata->num_elems);
 
-	comp_warn(dev, "module_adapter_get_set_params(): no configuration op set for %d",
-		  dev_comp_id(dev));
-	return 0;
+	comp_err(dev, "module_adapter_get_set_params(): no configuration op get for %d",
+		 dev_comp_id(dev));
+	return -EIO; /* non-implemented error */
 }
 
 static int module_adapter_ctrl_get_set_data(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata,
@@ -272,6 +280,12 @@ int module_adapter_cmd(struct comp_dev *dev, int cmd, void *data, int max_data_s
 							   0);
 		break;
 	case COMP_CMD_GET_VALUE:
+		/*
+		 * Return error if getter is not implemented. Otherwise, the host will suppose
+		 * the GET_VALUE command is successful, but the received cdata is not filled.
+		 */
+		ret = -EIO;
+
 		/*
 		 * IPC3 does not use config_id, so pass 0 for config ID as it will be ignored
 		 * anyway. Also, pass the 0 as the fragment size and data offset as they are not

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -159,7 +159,11 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 	if (interface->get_configuration)
 		return interface->get_configuration(mod, param_id, data_offset_size,
 						    (uint8_t *)data, fragment_size);
-	return 0;
+	/*
+	 * Return error if getter is not implemented. Otherwise, the host will suppose
+	 * the GET_VALUE command is successful, but the received cdata is not filled.
+	 */
+	return -EIO;
 }
 EXPORT_SYMBOL(module_get_large_config);
 


### PR DESCRIPTION
At present, if get_configuration is not implemented by internal module, module_adapter will return 0 directly on config read commands. Under the circumstances, the host will suppose the reading is succeeded, but in fact the ata in IPC buffer is unwanted.

This commit changes the return code to non-zero for such cases, which prevents the host getting the unwanted config data.