### PR TITLE
west.yml: update zephyr Apr17

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 2ccf775396c225f4398db1014886397a91f6d42f
+      revision: 3614d4cb88f4714c47af66d7053304092659fb43
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to new baseline containing following patches affecting SOF targets:

8a63a0a56339 intel_adsp: ipc: Fix policy state lock usage
e85226fd1a03 soc/intel_adsp: ipc: Remove fragile device state check
741bbaca6dd7 soc/intel_adsp: ipc: Remove unnecessary device state lock
a200dd88d878 dts: xtensa: intel_adsp: Set soft-off state as disabled
d5897a48aaab ipc: intel_adsp: Ensure IPC completion before runtime idle