### PR TITLE
audio: base_fw: move platform specific code from base_fw.c

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
+// Copyright(c) 2024 Intel Corporation.
+//
 
 #include <sof/audio/component.h>
 #include <sof/lib/memory.h>

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -59,6 +59,7 @@ static int basefw_config(uint32_t *data_offset, char *data)
 	uint16_t version[4] = {SOF_MAJOR, SOF_MINOR, SOF_MICRO, SOF_BUILD};
 	struct sof_tlv *tuple = (struct sof_tlv *)data;
 	struct ipc4_scheduler_config sche_cfg;
+	uint32_t plat_data_offset = 0;
 	uint32_t log_bytes_size = 0;
 
 	tlv_value_set(tuple, IPC4_FW_VERSION_FW_CFG, sizeof(version), version);
@@ -73,15 +74,6 @@ static int basefw_config(uint32_t *data_offset, char *data)
 	tlv_value_uint32_set(tuple,
 			     IPC4_SLOW_CLOCK_FREQ_HZ_FW_CFG,
 			     clock_get_freq(CPU_LOWEST_FREQ_IDX));
-
-	tuple = tlv_next(tuple);
-	tlv_value_uint32_set(tuple, IPC4_SLOW_CLOCK_FREQ_HZ_FW_CFG, IPC4_ALH_CAVS_1_8);
-
-	tuple = tlv_next(tuple);
-	tlv_value_uint32_set(tuple, IPC4_UAOL_SUPPORT, 0);
-
-	tuple = tlv_next(tuple);
-	tlv_value_uint32_set(tuple, IPC4_ALH_SUPPORT_LEVEL_FW_CFG, IPC4_ALH_CAVS_1_8);
 
 	tuple = tlv_next(tuple);
 	tlv_value_uint32_set(tuple, IPC4_DL_MAILBOX_BYTES_FW_CFG, MAILBOX_HOSTBOX_SIZE);
@@ -137,7 +129,11 @@ static int basefw_config(uint32_t *data_offset, char *data)
 			     IS_ENABLED(CONFIG_ADSP_IMR_CONTEXT_SAVE));
 
 	tuple = tlv_next(tuple);
-	*data_offset = (int)((char *)tuple - data);
+
+	/* add platform specific tuples */
+	platform_basefw_fw_config(&plat_data_offset, (char *)tuple);
+
+	*data_offset = (int)((char *)tuple - data) + plat_data_offset;
 
 	return 0;
 }

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -664,7 +664,8 @@ static int basefw_get_large_config(struct comp_dev *dev,
 		break;
 	}
 
-	return -EINVAL;
+	return platform_basefw_get_large_config(dev, param_id, first_block, last_block,
+						data_offset, data);
 };
 
 static int basefw_set_large_config(struct comp_dev *dev,
@@ -693,7 +694,8 @@ static int basefw_set_large_config(struct comp_dev *dev,
 		break;
 	}
 
-	return IPC4_UNKNOWN_MESSAGE_TYPE;
+	return platform_basefw_set_large_config(dev, param_id, first_block, last_block,
+						data_offset, data);
 };
 
 static const struct comp_driver comp_basefw = {

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -36,11 +36,6 @@
 #endif
 #include <zephyr/logging/log_ctrl.h>
 
-/* TODO: Remove platform-specific code, see https://github.com/thesofproject/sof/issues/7549 */
-#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE) || defined(CONFIG_INTEL_ADSP_CAVS)
-# define INTEL_ADSP 1
-#endif
-
 LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
 
 /* 0e398c32-5ade-ba4b-93b1-c50432280ee4 */
@@ -163,85 +158,6 @@ static int basefw_hw_config(uint32_t *data_offset, char *data)
 
 	*data_offset = (int)((char *)tuple - data) + plat_data_offset;
 
-	return 0;
-}
-
-/* There are two types of sram memory : high power mode sram and
- * low power mode sram. This function retures memory size in page
- * , memory bank power and usage status of each sram to host driver
- */
-static int basefw_mem_state_info(uint32_t *data_offset, char *data)
-{
-	struct sof_tlv *tuple = (struct sof_tlv *)data;
-	struct ipc4_sram_state_info info;
-	uint32_t *tuple_data;
-	uint32_t index;
-	uint32_t size;
-	uint16_t *ptr;
-	int i;
-
-	/* set hpsram */
-	info.free_phys_mem_pages = SRAM_BANK_SIZE * PLATFORM_HPSRAM_EBB_COUNT / HOST_PAGE_SIZE;
-	info.ebb_state_dword_count = SOF_DIV_ROUND_UP(PLATFORM_HPSRAM_EBB_COUNT, 32);
-	info.page_alloc_struct.page_alloc_count = PLATFORM_HPSRAM_EBB_COUNT;
-	size = sizeof(info) + info.ebb_state_dword_count * sizeof(uint32_t) +
-		info.page_alloc_struct.page_alloc_count * sizeof(uint32_t);
-	size = ALIGN(size, 4);
-	/* size is also saved as tuple length */
-	tuple_data = rballoc(0, SOF_MEM_CAPS_RAM, size);
-
-	/* save memory info in data array since info length is variable */
-	index = 0;
-	tuple_data[index++] = info.free_phys_mem_pages;
-	tuple_data[index++] = info.ebb_state_dword_count;
-	for (i = 0; i < info.ebb_state_dword_count; i++) {
-#ifdef INTEL_ADSP
-		tuple_data[index + i] = io_reg_read(SHIM_HSPGCTL(i));
-#else
-		tuple_data[index + i] = 0;
-#endif
-	}
-	index += info.ebb_state_dword_count;
-
-	tuple_data[index++] = info.page_alloc_struct.page_alloc_count;
-	/* TLB is not supported now, so all pages are marked as occupied
-	 * TODO: add page-size allocator and TLB support
-	 */
-	ptr = (uint16_t *)(tuple_data + index);
-	for (i = 0; i < info.page_alloc_struct.page_alloc_count; i++)
-		ptr[i] = 0xfff;
-
-	tlv_value_set(tuple, IPC4_HPSRAM_STATE, size, tuple_data);
-
-	/* set lpsram */
-	info.free_phys_mem_pages = 0;
-	info.ebb_state_dword_count = SOF_DIV_ROUND_UP(PLATFORM_LPSRAM_EBB_COUNT, 32);
-	info.page_alloc_struct.page_alloc_count = PLATFORM_LPSRAM_EBB_COUNT;
-	size = sizeof(info) + info.ebb_state_dword_count * sizeof(uint32_t) +
-		info.page_alloc_struct.page_alloc_count * sizeof(uint32_t);
-	size = ALIGN(size, 4);
-
-	index = 0;
-	tuple_data[index++] = info.free_phys_mem_pages;
-	tuple_data[index++] = info.ebb_state_dword_count;
-#ifdef INTEL_ADSP
-	tuple_data[index++] = io_reg_read(LSPGCTL);
-#else
-	tuple_data[index++] = 0;
-#endif
-	tuple_data[index++] = info.page_alloc_struct.page_alloc_count;
-	ptr = (uint16_t *)(tuple_data + index);
-	for (i = 0; i < info.page_alloc_struct.page_alloc_count; i++)
-		ptr[i] = 0xfff;
-
-	tuple = tlv_next(tuple);
-	tlv_value_set(tuple, IPC4_LPSRAM_STATE, size, tuple_data);
-
-	/* calculate total tuple size */
-	tuple = tlv_next(tuple);
-	*data_offset = (int)((char *)tuple - data);
-
-	rfree(tuple_data);
 	return 0;
 }
 
@@ -589,8 +505,6 @@ static int basefw_get_large_config(struct comp_dev *dev,
 		return basefw_config(data_offset, data);
 	case IPC4_HW_CONFIG_GET:
 		return basefw_hw_config(data_offset, data);
-	case IPC4_MEMORY_STATE_INFO_GET:
-		return basefw_mem_state_info(data_offset, data);
 	case IPC4_SYSTEM_TIME:
 		return basefw_get_system_time(data_offset, data);
 	case IPC4_EXTENDED_SYSTEM_TIME:

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -726,4 +726,6 @@ struct schedulers_info {
 	struct scheduler_props  scheduler_info[];
 } __packed __aligned(4);
 
+struct ipc4_system_time_info *basefw_get_system_time_info(void);
+
 #endif /* __SOF_IPC4_BASE_FW_H__ */

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -13,6 +13,12 @@
 #ifndef __SOF_IPC4_BASE_FW_PLATFORM_H__
 #define __SOF_IPC4_BASE_FW_PLATFORM_H__
 
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct comp_dev;
+
 /**
  * \brief Platform specific routine to add data tuples to FW_CONFIG
  * structure sent to host via IPC.
@@ -37,5 +43,29 @@ int platform_basefw_hw_config(uint32_t *data_offset, char *data);
  * \return pointer to struct if successful, null otherwise.
  */
 struct sof_man_fw_desc *platform_base_fw_get_manifest(void);
+
+/**
+ * \brief Implement platform specific parameter for basefw module.
+ * This function is called for parameters not handled by
+ * generic base_fw code.
+ */
+int platform_basefw_get_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t *data_offset,
+				     char *data);
+
+/**
+ * \brief Implement platform specific parameter for basefw module.
+ * This function is called for parameters not handled by
+ * generic base_fw code.
+ */
+int platform_basefw_set_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t data_offset,
+				     const char *data);
 
 #endif /* __SOF_IPC4_BASE_FW_PLATFORM_H__ */

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -14,6 +14,15 @@
 #define __SOF_IPC4_BASE_FW_PLATFORM_H__
 
 /**
+ * \brief Platform specific routine to add data tuples to FW_CONFIG
+ * structure sent to host via IPC.
+ * \param[out] data_offset data offset after tuples added
+ * \param[in] data pointer where to add new entries
+ * \return 0 if successful, error code otherwise.
+ */
+int platform_basefw_fw_config(uint32_t *data_offset, char *data);
+
+/**
  * \brief Platform specific routine to add data tuples to HW_CONFIG
  * structure sent to host via IPC.
  * \param[out] data_offset data offset after tuples added

--- a/src/include/ipc4/base_fw_platform.h
+++ b/src/include/ipc4/base_fw_platform.h
@@ -17,7 +17,7 @@
  * \brief Platform specific routine to add data tuples to HW_CONFIG
  * structure sent to host via IPC.
  * \param[out] data_offset data offset after tuples added
- * \parma[in] data pointer where to add new entries
+ * \param[in] data pointer where to add new entries
  * \return 0 if successful, error code otherwise.
  */
 int platform_basefw_hw_config(uint32_t *data_offset, char *data);

--- a/src/platform/intel/ace/lib/base_fw_platform.c
+++ b/src/platform/intel/ace/lib/base_fw_platform.c
@@ -9,6 +9,24 @@
 #include <sof/lib/dai.h>
 #include <ipc4/base_fw.h>
 
+int platform_basefw_fw_config(uint32_t *data_offset, char *data)
+{
+	struct sof_tlv *tuple = (struct sof_tlv *)data;
+
+	tlv_value_uint32_set(tuple, IPC4_SLOW_CLOCK_FREQ_HZ_FW_CFG, IPC4_ALH_CAVS_1_8);
+
+	tuple = tlv_next(tuple);
+	tlv_value_uint32_set(tuple, IPC4_UAOL_SUPPORT, 0);
+
+	tuple = tlv_next(tuple);
+	tlv_value_uint32_set(tuple, IPC4_ALH_SUPPORT_LEVEL_FW_CFG, IPC4_ALH_CAVS_1_8);
+
+	tuple = tlv_next(tuple);
+	*data_offset = (int)((char *)tuple - data);
+
+	return 0;
+}
+
 int platform_basefw_hw_config(uint32_t *data_offset, char *data)
 {
 	struct sof_tlv *tuple = (struct sof_tlv *)data;

--- a/src/platform/intel/ace/lib/base_fw_platform.c
+++ b/src/platform/intel/ace/lib/base_fw_platform.c
@@ -57,3 +57,23 @@ struct sof_man_fw_desc *platform_base_fw_get_manifest(void)
 
 	return desc;
 }
+
+int platform_basefw_get_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t *data_offset,
+				     char *data)
+{
+	return -EINVAL;
+}
+
+int platform_basefw_set_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t data_offset,
+				     const char *data)
+{
+	return IPC4_UNKNOWN_MESSAGE_TYPE;
+}

--- a/src/platform/intel/ace/lib/base_fw_platform.c
+++ b/src/platform/intel/ace/lib/base_fw_platform.c
@@ -4,10 +4,19 @@
 //
 // Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
 
+#include <zephyr/logging/log_ctrl.h>
+
 #include <rtos/string.h>
 #include <sof/tlv.h>
 #include <sof/lib/dai.h>
+
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
+#include <intel_adsp_hda.h>
+#endif
+
 #include <ipc4/base_fw.h>
+
+LOG_MODULE_REGISTER(basefw_platform, CONFIG_SOF_LOG_LEVEL);
 
 int platform_basefw_fw_config(uint32_t *data_offset, char *data)
 {
@@ -68,6 +77,42 @@ int platform_basefw_get_large_config(struct comp_dev *dev,
 	return -EINVAL;
 }
 
+static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
+{
+#if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
+	const uint32_t force = tlv->value[0];
+
+	if (force) {
+		tr_info(&basefw_comp_tr, "FW config set force dmi l0 state");
+		intel_adsp_force_dmi_l0_state();
+	} else {
+		tr_info(&basefw_comp_tr, "FW config set allow dmi l1 state");
+		intel_adsp_allow_dmi_l1_state();
+	}
+
+	return 0;
+#else
+	return IPC4_UNAVAILABLE;
+#endif
+}
+
+static int basefw_set_fw_config(bool first_block,
+				bool last_block,
+				uint32_t data_offset,
+				const char *data)
+{
+	const struct sof_tlv *tlv = (const struct sof_tlv *)data;
+
+	switch (tlv->type) {
+	case IPC4_DMI_FORCE_L1_EXIT:
+		return fw_config_set_force_l1_exit(tlv);
+	default:
+		break;
+	}
+	tr_warn(&basefw_comp_tr, "returning success for Set FW_CONFIG without handling it");
+	return 0;
+}
+
 int platform_basefw_set_large_config(struct comp_dev *dev,
 				     uint32_t param_id,
 				     bool first_block,
@@ -75,5 +120,12 @@ int platform_basefw_set_large_config(struct comp_dev *dev,
 				     uint32_t data_offset,
 				     const char *data)
 {
+	switch (param_id) {
+	case IPC4_FW_CONFIG:
+		return basefw_set_fw_config(first_block, last_block, data_offset, data);
+	default:
+		break;
+	}
+
 	return IPC4_UNKNOWN_MESSAGE_TYPE;
 }

--- a/src/platform/posix/base_fw_platform.c
+++ b/src/platform/posix/base_fw_platform.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <ipc4/error_status.h>
 #include <ipc4/base_fw_platform.h>
 
 int platform_basefw_fw_config(uint32_t *data_offset, char *data)
@@ -27,4 +28,24 @@ struct sof_man_fw_desc *platform_base_fw_get_manifest(void)
 	struct sof_man_fw_desc *desc = NULL;
 
 	return desc;
+}
+
+int platform_basefw_get_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t *data_offset,
+				     char *data)
+{
+	return -EINVAL;
+}
+
+int platform_basefw_set_large_config(struct comp_dev *dev,
+				     uint32_t param_id,
+				     bool first_block,
+				     bool last_block,
+				     uint32_t data_offset,
+				     const char *data)
+{
+	return IPC4_UNKNOWN_MESSAGE_TYPE;
 }

--- a/src/platform/posix/base_fw_platform.c
+++ b/src/platform/posix/base_fw_platform.c
@@ -8,6 +8,13 @@
 #include <stddef.h>
 #include <ipc4/base_fw_platform.h>
 
+int platform_basefw_fw_config(uint32_t *data_offset, char *data)
+{
+	*data_offset = 0;
+
+	return 0;
+}
+
 int platform_basefw_hw_config(uint32_t *data_offset, char *data)
 {
 	*data_offset = 0;


### PR DESCRIPTION
Continue from https://github.com/thesofproject/sof/pull/9059 (first 2 patches here are from #9059) and move more implementation out from the generic file.
UPDATE: 9059 closed, let's review the whole set in one go.

Addressing https://github.com/thesofproject/sof/issues/8391 and https://github.com/thesofproject/sof/issues/7549