### PR TITLE
dp: make dp_queue using externally provided params set

### DIFF
--- a/src/audio/dp_queue.c
+++ b/src/audio/dp_queue.c
@@ -201,10 +201,10 @@ static int dp_queue_set_ipc_params(struct dp_queue *dp_queue,
 	if (dp_queue->_hw_params_configured && !force_update)
 		return 0;
 
-	dp_queue->audio_stream_params.frame_fmt = params->frame_fmt;
-	dp_queue->audio_stream_params.rate = params->rate;
-	dp_queue->audio_stream_params.channels = params->channels;
-	dp_queue->audio_stream_params.buffer_fmt = params->buffer_fmt;
+	dp_queue->audio_stream_params->frame_fmt = params->frame_fmt;
+	dp_queue->audio_stream_params->rate = params->rate;
+	dp_queue->audio_stream_params->channels = params->channels;
+	dp_queue->audio_stream_params->buffer_fmt = params->buffer_fmt;
 
 	dp_queue->_hw_params_configured = true;
 
@@ -246,7 +246,7 @@ static const struct sink_ops dp_queue_sink_ops = {
 };
 
 struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, uint32_t flags,
-				 uint32_t id)
+				 uint32_t id, struct sof_audio_stream_params *audio_stream_params)
 {
 	struct dp_queue *dp_queue;
 
@@ -260,14 +260,15 @@ struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, ui
 		return NULL;
 
 	dp_queue->_flags = flags;
+	dp_queue->audio_stream_params = audio_stream_params;
 
 	CORE_CHECK_STRUCT_INIT(dp_queue, flags & DP_QUEUE_MODE_SHARED);
 
 	/* initiate structures */
 	source_init(dp_queue_get_source(dp_queue), &dp_queue_source_ops,
-		    &dp_queue->audio_stream_params);
+		    dp_queue->audio_stream_params);
 	sink_init(dp_queue_get_sink(dp_queue), &dp_queue_sink_ops,
-		  &dp_queue->audio_stream_params);
+		  dp_queue->audio_stream_params);
 
 	list_init(&dp_queue->list);
 
@@ -287,7 +288,7 @@ struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, ui
 	if (!dp_queue->_data_buffer)
 		goto err;
 
-	dp_queue->audio_stream_params.id = id;
+	dp_queue->audio_stream_params->id = id;
 	tr_info(&dp_queue_tr, "DpQueue created, id: %u shared: %u min_available: %u min_free_space %u, size %u",
 		id, dp_queue_is_shared(dp_queue), min_available, min_free_space,
 		dp_queue->data_buffer_size);

--- a/src/include/sof/audio/dp_queue.h
+++ b/src/include/sof/audio/dp_queue.h
@@ -177,18 +177,6 @@ struct sof_source *dp_queue_get_source(struct dp_queue *dp_queue)
 }
 
 /**
- * @brief this is a backdoor to get complete audio params structure from dp_queue
- *	  it is needed till pipeline 2.0 is ready
- *
- */
-static inline
-struct sof_audio_stream_params *dp_queue_get_audio_params(struct dp_queue *dp_queue)
-{
-	CORE_CHECK_STRUCT(dp_queue);
-	return &dp_queue->audio_stream_params;
-}
-
-/**
  * @brief return true if the queue is shared between 2 cores
  */
 static inline

--- a/src/include/sof/audio/dp_queue.h
+++ b/src/include/sof/audio/dp_queue.h
@@ -111,7 +111,15 @@ struct dp_queue {
 	struct list_item list;	/**< fields for connection queues in a list */
 
 	/* public: read only */
-	struct sof_audio_stream_params audio_stream_params;
+
+	/* note!
+	 * as dpQueue is currently used as a shadow for comp_buffer only for DP components,
+	 * the audio_stream_params vector must be shared between comp_buffer and dp_queue
+	 * the audio_stream_params pointer should point to the proper comp_buffer structure
+	 *
+	 * to be changed to the structure itself when pipeline2.0 is introduced
+	 */
+	struct sof_audio_stream_params *audio_stream_params;
 	size_t data_buffer_size;
 
 	/* private: */
@@ -138,9 +146,12 @@ struct dp_queue {
  *
  * @param id a stream ID, accessible later by sink_get_id/source_get_id
  *
+ * @param audio_stream_params pointer to audio params vector, shared between dp_queue and
+ *			      comp_buffer for dp modules
+ *
  */
 struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, uint32_t flags,
-				 uint32_t id);
+				 uint32_t id, struct sof_audio_stream_params *audio_stream_params);
 
 /**
  * @brief remove the queue from the list, free dp queue memory


### PR DESCRIPTION
Dp_queue is currently used only as a comp_buffer "shadow"  for DP modules.
Shadow buffers must have the very same param set as main buffers.
Problem: till now the complete vector of params was copied from comp_buffer to dp_queue inm prepare method.
 If anything will change any of params afterwards, the change won't propagate.
This commit introduces sharing the param vector between comp_buffer and its shadow