### PR TITLE
topology2: add rt1318 and rt714 support on LNL

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -17,4 +17,7 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+# No SDW Jack. SDW DMIC+SPK
+"cavs-sdw\;sof-lnl-rt1318-l12-rt714-l0\;PLATFORM=lnl,SDW_JACK=false,SDW_DMIC=1,\
+NUM_SDW_AMP_LINKS=2,SDW_DMIC_STREAM=SDW0-Capture"
 )


### PR DESCRIPTION
This patch adds following hardware configuration on LNL product:

SDW link0: RT714 DMIC
SDW link1: RT1318 Left Speaker
SDW link2: RT1318 Right Speaker