### PR TITLE
topology2: intel: bt-generic.conf: fix rate constraints

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -235,8 +235,7 @@ Object.PCM.pcm [
 			direction   "playback"
 			name $BT_PB_PCM_CAPS
 			formats	'S16_LE'
-			rate_min 8000
-			rate_max 48000
+			rates '8000,16000,48000'
 			channels_min 1
 			channels_max 2
 		}
@@ -245,8 +244,7 @@ Object.PCM.pcm [
 			direction   "capture"
 			name	$BT_CP_PCM_CAPS
 			formats 'S16_LE'
-			rate_min 8000
-			rate_max 48000
+			rates '8000,16000,48000'
 			channels_min 1
 			channels_max 2
 		}


### PR DESCRIPTION
Commit c77a4feb2f1f1 ("topology2: pcm_caps: Remove defaults for rate_min/rate_max") changed how rate constraints are described in topology. After this change, the rate_min/max was ignored by SOF Linux driver and the rate was incorrectly limited to 48000Hz for these topologies.

Fix this issue by enumerating the supported sampling rates with "rates".

Link: https://github.com/thesofproject/sof/issues/9067