### PR TITLE
Zephyr manifest update and fix for repro build issue

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -195,6 +195,7 @@ jobs:
              --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
              --cmake-args=--warn-uninitialized
              --cmake-args=-DCONFIG_OUTPUT_DISASSEMBLY=y
+             --cmake-args=-DCONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE=n
              ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
@@ -361,6 +362,7 @@ jobs:
           --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
           --cmake-args=--warn-uninitialized
           --cmake-args=-DCONFIG_OUTPUT_DISASSEMBLY=y
+          --cmake-args=-DCONFIG_OUTPUT_DISASSEMBLY_WITH_SOURCE=n
           ${{ matrix.build_opts }} ${{ matrix.platforms }}
 
       - name: Upload build artifacts

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 3614d4cb88f4714c47af66d7053304092659fb43
+      revision: fb7e9379e137a466b224a0ccd3a6c61020580f83
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Pulls in the following patches relevant to SOF:

94d156c9c84c nxp: imx8ulp: enable serial interface
bc63835ba240 dts: xtensa: intel_adsp_cavs25_tgph: correct SSP definition
aecf19c3c1be dts: xtensa: intel_adsp_ace15: correct SSP definition
45205f865e18 dts: xtensa: intel_adsp_ace20: correct SSP definition
17081222e2e7 drivers: dai: intel: ssp: fix LOG_ERR level / false positive
fb7e9379e137 cmake: add control over inline source code disassembly


and fixes https://github.com/thesofproject/sof/issues/9034