### PR TITLE
Audio: basefw: Implement ipc4 pipeline info get

### DIFF
--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -62,6 +62,8 @@ int ipc4_pipeline_prepare(struct ipc_comp_dev *ppl_icd, uint32_t cmd);
 int ipc4_pipeline_trigger(struct ipc_comp_dev *ppl_icd, uint32_t cmd, bool *delayed);
 int ipc4_find_dma_config_multiple(struct ipc_config_dai *dai, uint8_t *data_buffer,
 				  uint32_t size, uint32_t device_id, int dma_cfg_idx);
+const struct ipc4_pipeline_set_state_data *ipc4_get_pipeline_data_wrapper(void);
+
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -549,6 +549,15 @@ static int ipc_wait_for_compound_msg(void)
 	return IPC4_SUCCESS;
 }
 
+const struct ipc4_pipeline_set_state_data *ipc4_get_pipeline_data_wrapper(void)
+{
+	const struct ipc4_pipeline_set_state_data *ppl_data;
+
+	ppl_data = ipc4_get_pipeline_data();
+
+	return ppl_data;
+}
+
 static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 {
 	const struct ipc4_pipeline_set_state_data *ppl_data;


### PR DESCRIPTION
Added support for ipc4 query no 255 (10).
This make it possible to get information about
the current loaded pipelines.