### PR TITLE
volume: fix fadeout curve shape

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -241,6 +241,13 @@ static inline int32_t volume_windows_fade_ramp(struct vol_data *cd, int32_t ramp
 		return cd->tvolume[channel];
 
 	time_ratio = (((int64_t)ramp_time) << 30) / (cd->initial_ramp << 3);
+	if (volume_delta < 0) {
+		time_ratio = (1 << 30) - time_ratio;
+		pow_value = volume_pow_175(time_ratio);
+		return cd->tvolume[channel] - Q_MULTSR_32X32((int64_t)volume_delta,
+							     pow_value, 16, 30, 16);
+	}
+
 	pow_value = volume_pow_175(time_ratio);
 	return cd->rvolume[channel] + Q_MULTSR_32X32((int64_t)volume_delta, pow_value, 16, 30, 16);
 }


### PR DESCRIPTION
Fadeout curve had inaccurate shape due to incorrect computation of ramp function for fadeout case. This patch fixes the problem.