### PR TITLE
Topology2: add mtl rt713 rt1318 rt1713 support

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -35,6 +35,10 @@ SDW_DMIC_STREAM=SDW0-Capture"
 
 "cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
 
+"cavs-sdw\;sof-mtl-rt713-l0-rt1318-l12-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1"
+
+"cavs-sdw\;sof-mtl-rt713-l0-rt1318-l1-rt1713-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1"
+
 # Jack codec + SmartAmp topology. No SDW_DMIC connection
 "cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,HDMI1_ID=4,HDMI2_ID=5,HDMI3_ID=6"
 


### PR DESCRIPTION
Two configurations for sof-mtl-rt713-l0-rt1318-l12-rt1713-l3 and sof-mtl-rt713-l0-rt1318-l1-rt1713-l3.