### PR TITLE
Tools: Topology2: Intel: Add 16 bit DMIC DAI copier format option

### DIFF
--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -211,12 +211,40 @@ IncludeByKey.PASSTHROUGH {
 					type		dai_out
 					stream_name	$DMIC0_NAME
 					node_type $DMIC_LINK_INPUT_CLASS
-					num_input_audio_formats	2
+					num_input_audio_formats	6
 					Object.Base.input_audio_format [
+						{
+							in_rate			$DMIC0_RATE
+							in_bit_depth		16
+							in_valid_bit_depth	16
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_bit_depth		32
+							in_valid_bit_depth	24
+							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+						}
 						{
 							in_rate			$DMIC0_RATE
 							in_bit_depth		32
 							in_valid_bit_depth	32
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_channels		4
+							in_bit_depth		16
+							in_valid_bit_depth	16
+							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map		$CHANNEL_MAP_3_POINT_1
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_channels		4
+							in_bit_depth		32
+							in_valid_bit_depth	24
+							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map		$CHANNEL_MAP_3_POINT_1
 						}
 						{
 							in_rate			$DMIC0_RATE
@@ -391,12 +419,40 @@ IncludeByKey.PASSTHROUGH {
 					type		dai_out
 					stream_name	$DMIC0_NAME
 					node_type $DMIC_LINK_INPUT_CLASS
-					num_input_audio_formats	2
+					num_input_audio_formats	6
 					Object.Base.input_audio_format [
+						{
+							in_rate			$DMIC0_RATE
+							in_bit_depth		16
+							in_valid_bit_depth	16
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_bit_depth		32
+							in_valid_bit_depth	24
+							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+						}
 						{
 							in_rate			$DMIC0_RATE
 							in_bit_depth		32
 							in_valid_bit_depth	32
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_channels		4
+							in_bit_depth		16
+							in_valid_bit_depth	16
+							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map		$CHANNEL_MAP_3_POINT_1
+						}
+						{
+							in_rate			$DMIC0_RATE
+							in_channels		4
+							in_bit_depth		32
+							in_valid_bit_depth	24
+							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+							in_ch_map		$CHANNEL_MAP_3_POINT_1
 						}
 						{
 							in_rate			$DMIC0_RATE

--- a/tools/topology/topology2/platform/intel/dmic1-passthrough.conf
+++ b/tools/topology/topology2/platform/intel/dmic1-passthrough.conf
@@ -54,12 +54,40 @@ Object.Pipeline.io-gateway-capture [
                         type		dai_out
                         stream_name	$DMIC1_NAME
                         node_type $DMIC_LINK_INPUT_CLASS
-                        num_input_audio_formats	2
+                        num_input_audio_formats	6
                         Object.Base.input_audio_format [
+                                {
+                                        in_rate			$DMIC1_RATE
+                                        in_bit_depth		16
+                                        in_valid_bit_depth	16
+                                }
+                                {
+                                        in_rate			$DMIC1_RATE
+                                        in_bit_depth		32
+                                        in_valid_bit_depth	24
+					in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+                                }
                                 {
                                         in_rate			$DMIC1_RATE
                                         in_bit_depth		32
                                         in_valid_bit_depth	32
+                                }
+                                {
+                                        in_rate			$DMIC1_RATE
+                                        in_channels		4
+                                        in_bit_depth		16
+                                        in_valid_bit_depth	16
+                                        in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+                                        in_ch_map		$CHANNEL_MAP_3_POINT_1
+                                }
+                                {
+                                        in_rate			$DMIC1_RATE
+                                        in_channels		4
+                                        in_bit_depth		32
+                                        in_valid_bit_depth	24
+					in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+                                        in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+                                        in_ch_map		$CHANNEL_MAP_3_POINT_1
                                 }
                                 {
                                         in_rate			$DMIC1_RATE


### PR DESCRIPTION
This patch allows the kernel to choose 16 bit format if the DMIC NHLT is missing the recommended 32 bit mode blob.

The DAI copier is converting the output format for internal pipelines into S32_LE format, so the other operation is not impacted. For systems with 32 bit DMIC NHLT there is no impact.