### PR TITLE
Dp shadow as a part of comp_buffer / audio_stream

### DIFF
--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -8,7 +8,7 @@
 
 static size_t audio_stream_get_free_size(struct sof_sink *sink)
 {
-	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, _sink_api);
 
 	return audio_stream_get_free_bytes(audio_stream);
 }
@@ -16,7 +16,7 @@ static size_t audio_stream_get_free_size(struct sof_sink *sink)
 static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 				   void **data_ptr, void **buffer_start, size_t *buffer_size)
 {
-	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, _sink_api);
 
 	if (req_size > audio_stream_get_free_size(sink))
 		return -ENODATA;
@@ -30,7 +30,7 @@ static int audio_stream_get_buffer(struct sof_sink *sink, size_t req_size,
 
 static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 {
-	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, _sink_api);
 	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (commit_size) {
@@ -43,7 +43,7 @@ static int audio_stream_commit_buffer(struct sof_sink *sink, size_t commit_size)
 
 static size_t audio_stream_get_data_available(struct sof_source *source)
 {
-	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, _source_api);
 
 	return audio_stream_get_avail_bytes(audio_stream);
 }
@@ -52,7 +52,7 @@ static int audio_stream_get_data(struct sof_source *source, size_t req_size,
 				 void const **data_ptr, void const **buffer_start,
 				 size_t *buffer_size)
 {
-	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, _source_api);
 	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	if (req_size > audio_stream_get_data_available(source))
@@ -105,7 +105,7 @@ void audio_stream_set_align(const uint32_t byte_align,
 
 static int audio_stream_release_data(struct sof_source *source, size_t free_size)
 {
-	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, _source_api);
 
 	if (free_size)
 		audio_stream_consume(audio_stream, free_size);
@@ -117,7 +117,7 @@ static int audio_stream_set_ipc_params_source(struct sof_source *source,
 					      struct sof_ipc_stream_params *params,
 					      bool force_update)
 {
-	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, _source_api);
 	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
@@ -127,7 +127,7 @@ static int audio_stream_set_ipc_params_sink(struct sof_sink *sink,
 					    struct sof_ipc_stream_params *params,
 					    bool force_update)
 {
-	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, _sink_api);
 	struct comp_buffer *buffer = container_of(audio_stream, struct comp_buffer, stream);
 
 	return buffer_set_params(buffer, params, force_update);
@@ -137,7 +137,7 @@ static int audio_stream_source_set_alignment_constants(struct sof_source *source
 						       const uint32_t byte_align,
 						       const uint32_t frame_align_req)
 {
-	struct audio_stream *audio_stream = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *audio_stream = container_of(source, struct audio_stream, _source_api);
 
 	audio_stream_set_align(byte_align, frame_align_req, audio_stream);
 
@@ -148,7 +148,7 @@ static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 						     const uint32_t byte_align,
 						     const uint32_t frame_align_req)
 {
-	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *audio_stream = container_of(sink, struct audio_stream, _sink_api);
 
 	audio_stream_set_align(byte_align, frame_align_req, audio_stream);
 
@@ -157,7 +157,7 @@ static int audio_stream_sink_set_alignment_constants(struct sof_sink *sink,
 
 static int source_format_set(struct sof_source *source)
 {
-	struct audio_stream *s = container_of(source, struct audio_stream, source_api);
+	struct audio_stream *s = container_of(source, struct audio_stream, _source_api);
 
 	audio_stream_recalc_align(s);
 	return 0;
@@ -165,7 +165,7 @@ static int source_format_set(struct sof_source *source)
 
 static int sink_format_set(struct sof_sink *sink)
 {
-	struct audio_stream *s = container_of(sink, struct audio_stream, sink_api);
+	struct audio_stream *s = container_of(sink, struct audio_stream, _sink_api);
 
 	audio_stream_recalc_align(s);
 	return 0;

--- a/src/audio/audio_stream.c
+++ b/src/audio/audio_stream.c
@@ -5,6 +5,7 @@
 
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/buffer.h>
+#include <sof/audio/dp_queue.h>
 
 static size_t audio_stream_get_free_size(struct sof_sink *sink)
 {
@@ -202,3 +203,32 @@ void audio_stream_init(struct audio_stream *audio_stream, void *buff_addr, uint3
 		  &audio_stream->runtime_stream_params);
 	audio_stream_reset(audio_stream);
 }
+
+/* get a handler to source API */
+#if CONFIG_ZEPHYR_DP_SCHEDULER
+struct sof_source *audio_stream_get_source(struct audio_stream *audio_stream)
+{
+	return audio_stream->dp_queue_source ?
+			dp_queue_get_source(audio_stream->dp_queue_source) :
+			&audio_stream->_source_api;
+}
+
+struct sof_sink *audio_stream_get_sink(struct audio_stream *audio_stream)
+{
+	return audio_stream->dp_queue_sink ?
+			dp_queue_get_sink(audio_stream->dp_queue_sink) :
+			&audio_stream->_sink_api;
+}
+
+#else /* CONFIG_ZEPHYR_DP_SCHEDULER */
+
+struct sof_source *audio_stream_get_source(struct audio_stream *audio_stream)
+{
+	return &audio_stream->_source_api;
+}
+
+struct sof_sink *audio_stream_get_sink(struct audio_stream *audio_stream)
+{
+	return &audio_stream->_sink_api;
+}
+#endif /* CONFIG_ZEPHYR_DP_SCHEDULER */

--- a/src/audio/dp_queue.c
+++ b/src/audio/dp_queue.c
@@ -270,8 +270,6 @@ struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, ui
 	sink_init(dp_queue_get_sink(dp_queue), &dp_queue_sink_ops,
 		  dp_queue->audio_stream_params);
 
-	list_init(&dp_queue->list);
-
 	/* set obs/ibs in sink/source interfaces */
 	sink_set_min_free_space(&dp_queue->_sink_api, min_free_space);
 	source_set_min_available(&dp_queue->_source_api, min_available);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -304,7 +304,7 @@ static int mixin_process(struct processing_module *mod,
 		 * TODO: find out a solution to reach mixout without knowledge of mixin
 		 * sof_sink implementation.
 		 */
-		stream = container_of(sinks[i], struct audio_stream, sink_api);
+		stream = container_of(sinks[i], struct audio_stream, _sink_api);
 		/* unused buffer between mixin and mixout */
 		unused_in_between_buf = container_of(stream, struct comp_buffer, stream);
 		mixout = unused_in_between_buf->sink;
@@ -492,7 +492,7 @@ static int mixout_process(struct processing_module *mod,
 		 * TODO: find out a solution to reach mixin without knowledge of mixout
 		 * sof_source implementation.
 		 */
-		source_stream = container_of(sources[i], struct audio_stream, source_api);
+		source_stream = container_of(sources[i], struct audio_stream, _source_api);
 		unused_in_between_buf = container_of(source_stream, struct comp_buffer,
 						     stream);
 		mixin = unused_in_between_buf->source;
@@ -511,7 +511,7 @@ static int mixout_process(struct processing_module *mod,
 			struct comp_buffer *unused_in_between_buf;
 			struct comp_dev *mixin;
 
-			source_stream = container_of(sources[i], struct audio_stream, source_api);
+			source_stream = container_of(sources[i], struct audio_stream, _source_api);
 			unused_in_between_buf = container_of(source_stream,
 							     struct comp_buffer, stream);
 			mixin = unused_in_between_buf->source;
@@ -588,7 +588,7 @@ static int mixout_reset(struct processing_module *mod)
 			 * sof_source implementation.
 			 */
 			source_stream = container_of(mod->sources[i],
-						     struct audio_stream, source_api);
+						     struct audio_stream, _source_api);
 			source_buf = container_of(source_stream, struct comp_buffer,
 						  stream);
 

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -104,24 +104,13 @@ struct processing_module {
 	struct sof_sink *sinks[MODULE_MAX_SOURCES];
 	struct sof_source *sources[MODULE_MAX_SOURCES];
 
-	union {
-		struct {
-			/* this is used in case of raw data or audio_stream mode
-			 * number of buffers described by fields:
-			 * input_buffers  - num_of_sources
-			 * output_buffers - num_of_sinks
-			 */
-			struct input_stream_buffer *input_buffers;
-			struct output_stream_buffer *output_buffers;
-		};
-		struct {
-			/* this is used in case of DP processing
-			 * dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP
-			 */
-			struct list_item dp_queue_ll_to_dp_list;
-			struct list_item dp_queue_dp_to_ll_list;
-		};
-	};
+	/* this is used in case of raw data or audio_stream mode
+	 * number of buffers described by fields:
+	 * input_buffers  - num_of_sources
+	 * output_buffers - num_of_sinks
+	 */
+	struct input_stream_buffer *input_buffers;
+	struct output_stream_buffer *output_buffers;
 	struct comp_buffer *source_comp_buffer; /**< single source component buffer */
 	struct comp_buffer *sink_comp_buffer; /**< single sink compoonent buffer */
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -63,6 +63,10 @@ struct audio_stream {
 	void *end_addr;	/**< Buffer end address */
 	uint8_t byte_align_req;
 	uint8_t frame_align_req;
+#if CONFIG_ZEPHYR_DP_SCHEDULER
+	struct dp_queue *dp_queue_sink; /**< sink API shadow, an additional dp_queue at data in */
+	struct dp_queue *dp_queue_source; /**< source API shadow, an additional dp_queue at out */
+#endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
 	/* runtime stream params */
 	struct sof_audio_stream_params runtime_stream_params;
@@ -1018,17 +1022,11 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 
 /** get a handler to source API
  */
-static inline struct sof_source *
-audio_stream_get_source(struct audio_stream *audio_stream)
-{
-	return &audio_stream->_source_api;
-}
+struct sof_source *
+audio_stream_get_source(struct audio_stream *audio_stream);
 
-static inline struct sof_sink *
-audio_stream_get_sink(struct audio_stream *audio_stream)
-{
-	return &audio_stream->_sink_api;
-}
+struct sof_sink *
+audio_stream_get_sink(struct audio_stream *audio_stream);
 
 /** @}*/
 

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -50,8 +50,8 @@
  * Audio stream implements pipeline2.0 sink and source API
  */
 struct audio_stream {
-	struct sof_source source_api;	/**< source API, don't modify, use helper functions only */
-	struct sof_sink sink_api;	/**< sink API, don't modify, use helper functions only  */
+	struct sof_source _source_api;	/**< source API, don't modify, use helper functions only */
+	struct sof_sink _sink_api;	/**< sink API, don't modify, use helper functions only  */
 
 	/* runtime data */
 	uint32_t size;	/**< Runtime buffer size in bytes (period multiple) */
@@ -1021,13 +1021,13 @@ static inline void audio_stream_fmt_conversion(enum ipc4_bit_depth depth,
 static inline struct sof_source *
 audio_stream_get_source(struct audio_stream *audio_stream)
 {
-	return &audio_stream->source_api;
+	return &audio_stream->_source_api;
 }
 
 static inline struct sof_sink *
 audio_stream_get_sink(struct audio_stream *audio_stream)
 {
-	return &audio_stream->sink_api;
+	return &audio_stream->_sink_api;
 }
 
 /** @}*/

--- a/src/include/sof/audio/dp_queue.h
+++ b/src/include/sof/audio/dp_queue.h
@@ -159,6 +159,8 @@ struct dp_queue *dp_queue_create(size_t min_available, size_t min_free_space, ui
 static inline
 void dp_queue_free(struct dp_queue *dp_queue)
 {
+	if (!dp_queue)
+		return;
 	CORE_CHECK_STRUCT(dp_queue);
 	list_item_del(&dp_queue->list);
 	rfree((__sparse_force void *)dp_queue->_data_buffer);

--- a/src/include/sof/audio/dp_queue.h
+++ b/src/include/sof/audio/dp_queue.h
@@ -107,9 +107,6 @@ struct sof_audio_stream_params;
 struct dp_queue {
 	CORE_CHECK_STRUCT_FIELD;
 
-	/* public */
-	struct list_item list;	/**< fields for connection queues in a list */
-
 	/* public: read only */
 
 	/* note!
@@ -162,7 +159,6 @@ void dp_queue_free(struct dp_queue *dp_queue)
 	if (!dp_queue)
 		return;
 	CORE_CHECK_STRUCT(dp_queue);
-	list_item_del(&dp_queue->list);
 	rfree((__sparse_force void *)dp_queue->_data_buffer);
 	rfree(dp_queue);
 }
@@ -197,30 +193,6 @@ bool dp_queue_is_shared(struct dp_queue *dp_queue)
 {
 	CORE_CHECK_STRUCT(dp_queue);
 	return !!(dp_queue->_flags & DP_QUEUE_MODE_SHARED);
-}
-
-/**
- * @brief append a dp_queue to the list
- */
-static inline void dp_queue_append_to_list(struct dp_queue *item, struct list_item *list)
-{
-	list_item_append(&item->list, list);
-}
-
-/**
- * @brief return a pointer to the first dp_queue on the list
- */
-static inline struct dp_queue *dp_queue_get_first_item(struct list_item *list)
-{
-	return list_first_item(list, struct dp_queue, list);
-}
-
-/**
- * @brief return a pointer to the next dp_queue on the list
- */
-static inline struct dp_queue *dp_queue_get_next_item(struct dp_queue *item)
-{
-	return list_next_item(item, list);
 }
 
 #endif /* __SOF_DP_QUEUE_H__ */


### PR DESCRIPTION
This is a follow up to https://github.com/thesofproject/sof/pull/9063 and a bugfix

The PR is connecting shadow dp_queue tightly with comp_buffer/audio_stream. 
1) it is more natural way, after changes comp_buffer is exposing either its own sink/src API or one provided by dp_queue 
2) race prevention. In internal tests there was a race condition found during frequent binding/unbinding DP to a running pipeline
3) less code in heavy module_adapter
