### PR TITLE
topology2: common_definitions: improve SAMPLE_TYPE documentation

### DIFF
--- a/tools/topology/topology2/include/common/common_definitions.conf
+++ b/tools/topology/topology2/include/common/common_definitions.conf
@@ -27,8 +27,10 @@ Define {
 	CHANNEL_MAP_INVALID			0xFFFFFFFF
 
 	# Sample types
-	SAMPLE_TYPE_MSB_INTEGER			0 # integer with Most Significant Byte first
-	SAMPLE_TYPE_LSB_INTEGER			1 # integer with Most Significant Byte first
+	SAMPLE_TYPE_MSB_INTEGER 		0 # integer with valid samples in most significant
+						  # bits, aka left aligned (not endianness!)
+	SAMPLE_TYPE_LSB_INTEGER 		1 # integer with valid samples in least significant
+						  # bits, aka right aligned (not endianness!)
 	SAMPLE_TYPE_SIGNED_INTEGER		2 # Signed Integer
 	SAMPLE_TYPE_UNSIGNED_INTEGER		3 # Unsigned Integer
 	SAMPLE_TYPE_FLOAT			4 # Float


### PR DESCRIPTION
Clarify documentation of SAMPLE_TYPE_MSB_INTEGER sample type value and fix documentation of SAMPLE_TYPE_LSB_INTEGER. These definitions are often confused with integer endianness, which is not related. Clarify this better.