### PR TITLE
Audio: SRC: Use valid_bit_depth to select processing function

### DIFF
--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -149,7 +149,7 @@ int src_prepare_general(struct processing_module *mod,
 	/* set align requirements */
 	src_set_alignment(source, sink);
 
-	switch (cd->ipc_config.base.audio_fmt.depth) {
+	switch (cd->ipc_config.base.audio_fmt.valid_bit_depth) {
 #if CONFIG_FORMAT_S16LE
 	case IPC4_DEPTH_16BIT:
 		cd->data_shift = 0;


### PR DESCRIPTION
The check of cd->ipc_config.base.audio_fmt.depth results to select S32_LE format processing function for SRC when the format is S24_LE. The check need to be done for valid_bit_depth instead.

The S32_LE function appears to work but any sample that exceeds the range -2^23 .. +2^23-1 is overflow for S24_le. Also the use of S24_LE processing core will improve the signal-to-noise ratio.

Reported-by: Tomasz Leman <tomasz.m.leman@intel.com>