### PR TITLE
[STABLE-v2.2] drivers: Intel: hda-dma: lower log level of "underrun detected"

### DIFF
--- a/src/drivers/intel/hda/hda-dma.c
+++ b/src/drivers/intel/hda/hda-dma.c
@@ -945,7 +945,7 @@ static int hda_dma_link_check_xrun(struct dma_chan_data *chan)
 	uint32_t dgcs = dma_chan_reg_read(chan, DGCS);
 
 	if (chan->direction == DMA_DIR_MEM_TO_DEV && dgcs & DGCS_BUR) {
-		tr_err(&hdma_tr, "hda_dma_link_check_xrun(): underrun detected");
+		tr_warn(&hdma_tr, "hda_dma_link_check_xrun(): underrun detected");
 		dma_chan_reg_update_bits(chan, DGCS, DGCS_BUR, DGCS_BUR);
 	} else if (chan->direction == DMA_DIR_DEV_TO_MEM && dgcs & DGCS_BOR) {
 		tr_err(&hdma_tr, "hda_dma_link_check_xrun(): overrun detected");


### PR DESCRIPTION
Lower the log level of `tr_err(&hdma_tr, "hda_dma_link_check_xrun(): underrun detected");` to `tr_warn()`.

Underruns are expected when testing pause/start and these errors can hide other, "real", not expected errors; more details in https://github.com/thesofproject/sof-test/pull/1188

This "fixes" 2019 commit 293dfe2469cb ("hda-dma: refactor xrun handling")

Note this driver is not in the main branch anymore, removed by commit 59028ad3d136 ("drivers: Intel: remove Intel XTOS drivers")