### PR TITLE
regions_mm: New memory mapping functions

### DIFF
--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -6,11 +6,10 @@
  */
 
 #include <zephyr/init.h>
-
 #include <sof/lib/regions_mm.h>
 
 /* list of vmh_heap objects created */
-static struct list_item vmh_list;
+static struct list_item vmh_list = LIST_INIT(vmh_list);
 
 /**
  * @brief Initialize new heap
@@ -676,23 +675,6 @@ void vmh_get_default_heap_config(const struct sys_mm_drv_region *region,
 		cfg->block_bundles_table[i].number_of_blocks = block_count;
 	}
 }
-
-/**
- * @brief Initialization of static objects in virtual heaps API
- *
- * This will initialize lists of allocations and physical mappings.
- *
- * @param unused Variable is unused - needed by arch to clear warning.
- *
- * @retval Returns 0 on success
- */
-static int virtual_heaps_init(void)
-{
-	list_init(&vmh_list);
-	return 0;
-}
-
-SYS_INIT(virtual_heaps_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 
 /**
  * @brief Gets pointer to already created heap identified by


### PR DESCRIPTION
The previous memory mapping function did not work properly if the buffer size exceeded the memory page size. In this case the size of the region to be checked passed to the `sys_bitarray_is_region_cleared` function was zero, causing the function to always return false. As a result, the allocator stated that a page was already mapped for a given address and did not map it. This led to a cpu exception when trying to access the allocated buffer. 

The function responsible for unmapping memory had a similar problem. Additionally, the size of the freed area was incorrectly determined and an incorrect offset was passed to the `sys_bitarray_is_region_cleared` function.

New functions have been created to map and unmap memory pages for allocated buffers. It don't need allocation of temporary array and manipulation of memblocks bitarray.

Used static initialization of the vmh_list list head using macro.