### PR TITLE
Tools: Topology2: Add benchmark topologies for TDFB component

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -3,6 +3,7 @@
 <include/components/igo_nr.conf>
 <include/components/src_lite.conf>
 <include/components/asrc.conf>
+<include/components/tdfb.conf>
 
 Define {
 	ANALOG_PLAYBACK_PCM		'Analog Playback'
@@ -374,5 +375,21 @@ IncludeByKey.BENCH_CONFIG {
 
 	"src_lite32" {
 		<include/bench/src_lite_s32.conf>
+	}
+
+	#
+	# tdfb component
+	#
+
+	"tdfb16" {
+		<include/bench/tdfb_s16.conf>
+	}
+
+	"tdfb24" {
+		<include/bench/tdfb_s24.conf>
+	}
+
+	"tdfb32" {
+		<include/bench/tdfb_s32.conf>
 	}
 }

--- a/tools/topology/topology2/development/tplg-targets-bench.cmake
+++ b/tools/topology/topology2/development/tplg-targets-bench.cmake
@@ -19,6 +19,7 @@ set(components
 	"rtnr"
 	"src"
 	"src_lite"
+	"tdfb"
 )
 
 set(component_parameters
@@ -33,6 +34,7 @@ set(component_parameters
 	"BENCH_RTNR_PARAMS=default"
 	"BENCH_SRC_PARAMS=default"
 	"BENCH_SRC_LITE_PARAMS=default"
+	"BENCH_TDFB_PARAMS=default"
 )
 
 set(components_s32

--- a/tools/topology/topology2/include/bench/tdfb_controls_capture.conf
+++ b/tools/topology/topology2/include/bench/tdfb_controls_capture.conf
@@ -1,0 +1,23 @@
+			# Created initially with script "./bench_comp_generate.sh tdfb"
+			# may need edits to modify controls
+			Object.Control {
+				bytes."1" {
+					name '$ANALOG_CAPTURE_PCM TDFB bytes'
+                                        max 4096
+					IncludeByKey.BENCH_TDFB_PARAMS {
+						"default" "include/components/tdfb/line2_50mm_pm0_30_90deg_48khz.conf"
+					}
+				}
+				mixer."1" {
+					name '$ANALOG_CAPTURE_PCM TDFB beam'
+				}
+				mixer."2" {
+					name '$ANALOG_CAPTURE_PCM TDFB track'
+				}
+				enum."1" {
+					name '$ANALOG_CAPTURE_PCM TDFB angle set'
+				}
+				enum."2" {
+					name '$ANALOG_CAPTURE_PCM TDFB angle estimate'
+				}
+			}

--- a/tools/topology/topology2/include/bench/tdfb_controls_playback.conf
+++ b/tools/topology/topology2/include/bench/tdfb_controls_playback.conf
@@ -1,0 +1,23 @@
+			# Created initially with script "./bench_comp_generate.sh tdfb"
+			# may need edits to modify controls
+			Object.Control {
+				bytes."1" {
+					name '$ANALOG_PLAYBACK_PCM TDFB bytes'
+                                        max 4096
+					IncludeByKey.BENCH_TDFB_PARAMS {
+						"default" "include/components/tdfb/line2_50mm_pm0_30_90deg_48khz.conf"
+					}
+				}
+				mixer."1" {
+					name '$ANALOG_PLAYBACK_PCM TDFB beam'
+				}
+				mixer."2" {
+					name '$ANALOG_PLAYBACK_PCM TDFB track'
+				}
+				enum."1" {
+					name '$ANALOG_PLAYBACK_PCM TDFB angle set'
+				}
+				enum."2" {
+					name '$ANALOG_PLAYBACK_PCM TDFB angle estimate'
+				}
+			}

--- a/tools/topology/topology2/include/bench/tdfb_hda_route.conf
+++ b/tools/topology/topology2/include/bench/tdfb_hda_route.conf
@@ -1,0 +1,19 @@
+		# Created with script "./bench_comp_generate.sh tdfb"
+		Object.Base.route [
+			{
+				sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+				source 'tdfb.1.1'
+			}
+			{
+				sink 'tdfb.1.1'
+				source 'host-copier.0.playback'
+			}
+			{
+				source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+				sink 'tdfb.3.2'
+			}
+			{
+				source 'tdfb.3.2'
+				sink 'host-copier.0.capture'
+			}
+		]

--- a/tools/topology/topology2/include/bench/tdfb_s16.conf
+++ b/tools/topology/topology2/include/bench/tdfb_s16.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh tdfb"
+		Object.Widget.tdfb.1 {
+			index 1
+			<include/bench/one_input_output_format_s16.conf>
+			<include/bench/tdfb_controls_playback.conf>
+		}
+		Object.Widget.tdfb.2 {
+			index 3
+			<include/bench/one_input_output_format_s16.conf>
+			<include/bench/tdfb_controls_capture.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_s16.conf>
+		<include/bench/tdfb_hda_route.conf>

--- a/tools/topology/topology2/include/bench/tdfb_s24.conf
+++ b/tools/topology/topology2/include/bench/tdfb_s24.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh tdfb"
+		Object.Widget.tdfb.1 {
+			index 1
+			<include/bench/one_input_output_format_s24.conf>
+			<include/bench/tdfb_controls_playback.conf>
+		}
+		Object.Widget.tdfb.2 {
+			index 3
+			<include/bench/one_input_output_format_s24.conf>
+			<include/bench/tdfb_controls_capture.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_s24.conf>
+		<include/bench/tdfb_hda_route.conf>

--- a/tools/topology/topology2/include/bench/tdfb_s32.conf
+++ b/tools/topology/topology2/include/bench/tdfb_s32.conf
@@ -1,0 +1,13 @@
+		# Created with script "./bench_comp_generate.sh tdfb"
+		Object.Widget.tdfb.1 {
+			index 1
+			<include/bench/one_input_output_format_s32.conf>
+			<include/bench/tdfb_controls_playback.conf>
+		}
+		Object.Widget.tdfb.2 {
+			index 3
+			<include/bench/one_input_output_format_s32.conf>
+			<include/bench/tdfb_controls_capture.conf>
+		}
+		<include/bench/host_io_gateway_pipelines_s32.conf>
+		<include/bench/tdfb_hda_route.conf>


### PR DESCRIPTION
This patch adds s16/s24/s32 format test topologies for the time domain fixed beamformercomponent.