### PR TITLE
west.yml: update Zephyr to e97d33d0c896 

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: d3c9a986ec30e4c1fde5092e73d76f7020ea20ee
+      revision: e97d33d0c896767a676b20e9bdc928ff46f25905
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fast-forward Zephyr by around 350 patches, including following affecting SOF build targets:

soc/intel_adsp: ipc: initialize semaphore in driver init
drivers: dai: ssp: fix MN_MDIVCTRL_M_DIV_ENABLE for ACE+ platform
drivers: dai: intel: ssp: Only setup mclk/bclk when it is needed by role