### PR TITLE
module_adapter: passthrough: register module logs in Zephyr

### DIFF
--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -9,6 +9,8 @@
 #include <sof/audio/module_adapter/module/generic.h>
 #include <rtos/init.h>
 
+LOG_MODULE_REGISTER(passthrough, CONFIG_SOF_LOG_LEVEL);
+
 /* 376b5e44-9c82-4ec2-bc83-10ea101afa8f */
 DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
 		    0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);


### PR DESCRIPTION
Use LOG_MODULE_REGISTER() to register cadence in the Zephyr logger framework.