### PR TITLE
lp64: fix undefined reference compilation breakage

### DIFF
--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -176,5 +176,7 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes)
 	return ~crc;
 }
 
+#if !CONFIG_SOC_MIMX9352_A55
 uint64_t __udivdi3(uint64_t a, uint64_t b);
 EXPORT_SYMBOL(__udivdi3);
+#endif


### PR DESCRIPTION
__udivdi3 isn't defined on LP64, don't export it.

Fixes: a306792a6804 ("llext: add missing symbol exports")