### PR TITLE
Audio: TDFB: Fix firmware crash caused by TDFB sink format set

### DIFF
--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -537,7 +537,11 @@ static int tdfb_prepare(struct processing_module *mod,
 
 	comp_info(dev, "tdfb_prepare()");
 
-	tdfb_params(mod);
+	ret = tdfb_params(mod);
+	if (ret) {
+		comp_err(dev, "Failed tdfb_params()");
+		return ret;
+	}
 
 	/* Find source and sink buffers */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);

--- a/src/audio/tdfb/tdfb.h
+++ b/src/audio/tdfb/tdfb.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+#define SOF_TDFB_NUM_INPUT_PINS 1	/* One source */
+#define SOF_TDFB_NUM_OUTPUT_PINS 1	/* One sink */
 #define SOF_TDFB_MAX_SIZE 4096		/* Max size for coef data in bytes */
 #define SOF_TDFB_FIR_MAX_LENGTH 256	/* Max length for individual filter */
 #define SOF_TDFB_FIR_MAX_COUNT 16	/* A blob can define max 16 FIR EQs */

--- a/src/audio/tdfb/tdfb.toml
+++ b/src/audio/tdfb/tdfb.toml
@@ -6,6 +6,7 @@
 	instance_count = "40"
 	domain_types = "0"
 	load_type = "0"
+        init_config = "1"
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]

--- a/src/audio/tdfb/tdfb_comp.h
+++ b/src/audio/tdfb/tdfb_comp.h
@@ -168,7 +168,7 @@ int tdfb_set_ipc_config(struct processing_module *mod, uint32_t param_id,
 			enum module_cfg_fragment_position pos, uint32_t data_offset_size,
 			const uint8_t *fragment, size_t fragment_size, uint8_t *response,
 			size_t response_size);
-void tdfb_params(struct processing_module *mod);
+int tdfb_params(struct processing_module *mod);
 
 #ifdef UNIT_TEST
 void sys_comp_module_tdfb_interface_init(void);

--- a/src/audio/tdfb/tdfb_ipc3.c
+++ b/src/audio/tdfb/tdfb_ipc3.c
@@ -223,7 +223,8 @@ int tdfb_set_ipc_config(struct processing_module *mod, uint32_t param_id,
 	return ret;
 }
 
-void tdfb_params(struct processing_module *mod)
+int tdfb_params(struct processing_module *mod)
 {
+	return 0;
 }
 

--- a/tools/rimage/config/tgl-h.toml
+++ b/tools/rimage/config/tgl-h.toml
@@ -489,6 +489,7 @@ count = 24
 	instance_count = "40"
 	domain_types = "0"
 	load_type = "0"
+	init_config = "1"
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]

--- a/tools/rimage/config/tgl.toml
+++ b/tools/rimage/config/tgl.toml
@@ -489,6 +489,7 @@ count = 24
 	instance_count = "40"
 	domain_types = "0"
 	load_type = "0"
+	init_config = "1"
 	module_type = "9"
 	auto_start = "0"
 	sched_caps = [1, 0x00008000]


### PR DESCRIPTION
The code in tdfb_params() was incorrect for a component that can have different number of channels in source and sink. The update of sink format can it worst case crash the successive component in pipeline if the source channels count has changed from the value the component has been initialized for.

The channels count need to be retrieved from input and output pins information in extended IPC4 base config. To get the extension the rimage toml files need to add for TDFB component the line init_config = "1".