### PR TITLE
Tools: Topology2: Define only same channels counts for DMIC0 dai-copier

### DIFF
--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -211,66 +211,78 @@ IncludeByKey.PASSTHROUGH {
 					type		dai_out
 					stream_name	$DMIC0_NAME
 					node_type $DMIC_LINK_INPUT_CLASS
-					num_input_audio_formats	6
-					Object.Base.input_audio_format [
-						{
-							in_rate			$DMIC0_RATE
-							in_bit_depth		16
-							in_valid_bit_depth	16
-						}
-						{
-							in_rate			$DMIC0_RATE
-							in_bit_depth		32
-							in_valid_bit_depth	24
-							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-						}
-						{
-							in_rate			$DMIC0_RATE
-							in_bit_depth		32
-							in_valid_bit_depth	32
-						}
-						{
-							in_rate			$DMIC0_RATE
-							in_channels		4
-							in_bit_depth		16
-							in_valid_bit_depth	16
-							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
-							in_ch_map		$CHANNEL_MAP_3_POINT_1
-						}
-						{
-							in_rate			$DMIC0_RATE
-							in_channels		4
-							in_bit_depth		32
-							in_valid_bit_depth	24
-							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-							in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
-							in_ch_map		$CHANNEL_MAP_3_POINT_1
-						}
-						{
-							in_rate			$DMIC0_RATE
-							in_channels		4
-							in_bit_depth		32
-							in_valid_bit_depth	32
-							in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-							in_ch_map	$CHANNEL_MAP_3_POINT_1
-						}
-					]
-					num_output_audio_formats	2
-					Object.Base.output_audio_format [
-						{
-							out_rate		$DMIC0_RATE
-							out_bit_depth		32
-							out_valid_bit_depth	32
-						}
-						{
-							out_rate		$DMIC0_RATE
-							out_channels		4
-							out_bit_depth		32
-							out_valid_bit_depth	32
-							out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
-							out_ch_map	$CHANNEL_MAP_3_POINT_1
-						}
-					]
+					IncludeByKey.NUM_DMICS {
+					"2" {
+						num_input_audio_formats	3
+						Object.Base.input_audio_format [
+							{
+								in_rate			$DMIC0_RATE
+								in_bit_depth		16
+								in_valid_bit_depth	16
+							}
+							{
+								in_rate			$DMIC0_RATE
+								in_bit_depth		32
+								in_valid_bit_depth	24
+								in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							}
+							{
+								in_rate			$DMIC0_RATE
+								in_bit_depth		32
+								in_valid_bit_depth	32
+							}
+						]
+						num_output_audio_formats	1
+						Object.Base.output_audio_format [
+							{
+								out_rate		$DMIC0_RATE
+								out_bit_depth		32
+								out_valid_bit_depth	32
+							}
+						]
+					}
+					"4" {
+						num_input_audio_formats	3
+						Object.Base.input_audio_format [
+							{
+								in_rate			$DMIC0_RATE
+								in_channels		4
+								in_bit_depth		16
+								in_valid_bit_depth	16
+								in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map		$CHANNEL_MAP_3_POINT_1
+							}
+							{
+								in_rate			$DMIC0_RATE
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	24
+								in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+								in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map		$CHANNEL_MAP_3_POINT_1
+							}
+							{
+								in_rate			$DMIC0_RATE
+								in_channels		4
+								in_bit_depth		32
+								in_valid_bit_depth	32
+								in_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+								in_ch_map		$CHANNEL_MAP_3_POINT_1
+							}
+						]
+						num_output_audio_formats	1
+						Object.Base.output_audio_format [
+							{
+								out_rate		$DMIC0_RATE
+								out_channels		4
+								out_bit_depth		32
+								out_valid_bit_depth	32
+								out_ch_cfg		$CHANNEL_CONFIG_3_POINT_1
+								out_ch_map		$CHANNEL_MAP_3_POINT_1
+							}
+						]
+					}
+					}
 				}
 
 				Object.Widget.module-copier."2" {


### PR DESCRIPTION
This patch defines e.g. for sof-hda-generic-2ch.tplg DMIC0 only stereo formats as s16/24/32. Similarly for e.g. sof-hda-generic-4ch.tplg only four channels formats are defined.

The reduction of input formats options avoids the issue with kernel that it possibly selects invalid channels count for DMIC0 DAI when the channels count in connected pipelines varies due to processing components.

In such error the capture fails to no suitable DMIC NHLT blob found from BIOS or from topology depending platform.