### PR TITLE
Tools: Topology2: Remove unnecessary NHLT binary from EFX topologies

### DIFF
--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -60,13 +60,12 @@ NHLT_BIN=nhlt-sof-lnl-nocodec-fpga-4ch.bin,PASSTHROUGH=true,DMIC_IO_CLK=19200000
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,EFX_DRC_PARAMS=passthrough"
 
 "sof-hda-generic\;sof-hda-efx-generic-2ch\;\
-HDA_CONFIG=efx,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-fir-generic-2ch.bin,\
+HDA_CONFIG=efx,NUM_DMICS=2,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,\
 EFX_DRC_PARAMS=passthrough"
 
 "sof-hda-generic\;sof-hda-efx-generic-4ch\;\
 HDA_CONFIG=efx,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-efx-generic-4ch.bin,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,\
 EFX_DRC_PARAMS=passthrough"
 
@@ -75,13 +74,12 @@ EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,\
 EFX_DRC_COMPONENT=multiband,EFX_MBDRC_PARAMS=passthrough"
 
 "sof-hda-generic\;sof-hda-efx-mbdrc-generic-2ch\;\
-HDA_CONFIG=efx,NUM_DMICS=2,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-fir-generic-2ch.bin,\
+HDA_CONFIG=efx,NUM_DMICS=2,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,\
 EFX_DRC_COMPONENT=multiband,EFX_MBDRC_PARAMS=passthrough"
 
 "sof-hda-generic\;sof-hda-efx-mbdrc-generic-4ch\;\
 HDA_CONFIG=efx,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-efx-generic-4ch.bin,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,\
 EFX_DRC_COMPONENT=multiband,EFX_MBDRC_PARAMS=passthrough"
 


### PR DESCRIPTION
The NHLT binary is not needed in these audio processing development and test topologies. With the current build options the NHLT would work only with cAVS2.5 platforms (TGL). Without NHLT add these are safe to use in all platforms where the NHLT blob is retrieved from BIOS.