### PR TITLE
scripts: Add support for MediaTek mt8188 platform

### DIFF
--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -10,15 +10,12 @@ set -e
 DEFAULT_PLATFORMS=(
     imx8m
     rn rmb vangogh
-    mt8186 mt8195
+    mt8186 mt8195 mt8188
 )
 
 # Work in progress can be added to this "staging area" without breaking
 # the -a option for everyone.
 SUPPORTED_PLATFORMS=( "${DEFAULT_PLATFORMS[@]}" )
-
-# Waiting for container work in progress
-SUPPORTED_PLATFORMS+=( mt8188 )
 
 # Container work is in progress
 SUPPORTED_PLATFORMS+=( acp_6_3 )


### PR DESCRIPTION
The Kconfig for mt8188 has already been included in #6796, and I have added the toolchains support for mt8188 in #9137.
So I moved mt8188 from the SUPPORTED_PLATFORMS list to the DEFAULT_PLATFORMS list in xtensa-build-all.sh.