### PR TITLE
zephyr: buffer: host: dai: Introduction of functions that allocate a buffer from a range

### DIFF
--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -60,6 +60,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 	CORE_CHECK_STRUCT_INIT(buffer, is_shared);
 
 	buffer->is_shared = is_shared;
+	buffer->caps = caps;
 	stream_addr = rballoc_align(0, caps, size, align);
 	if (!stream_addr) {
 		rfree(buffer);
@@ -70,7 +71,7 @@ struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, u
 
 	/* From here no more uncached access to the buffer object, except its list headers */
 	audio_stream_set_addr(&buffer->stream, stream_addr);
-	buffer_init(buffer, size, caps);
+	buffer_init_stream(buffer, size);
 
 	audio_stream_set_underrun(&buffer->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
 	audio_stream_set_overrun(&buffer->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
@@ -193,7 +194,7 @@ int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignmen
 	if (new_ptr)
 		buffer->stream.addr = new_ptr;
 
-	buffer_init(buffer, size, buffer->caps);
+	buffer_init_stream(buffer, size);
 
 	return 0;
 }

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -797,6 +797,7 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 	uint32_t period_count;
 	uint32_t period_bytes;
 	uint32_t buffer_size;
+	uint32_t buffer_size_preferred;
 	uint32_t addr_align;
 	uint32_t align;
 	int err;
@@ -873,21 +874,23 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 		comp_err(dev, "dai_set_dma_buffer(): no valid dma buffer period count");
 		return -EINVAL;
 	}
-
 	buffer_size = ALIGN_UP(period_count * period_bytes, align);
-	*pc = period_count;
+	period_count = MAX(period_count,
+			   SOF_DIV_ROUND_UP(dd->ipc_config.dma_buffer_size, period_bytes));
+	buffer_size_preferred = ALIGN_UP(period_count * period_bytes, align);
 
 	/* alloc DMA buffer or change its size if exists */
 	if (dd->dma_buffer) {
-		err = buffer_set_size(dd->dma_buffer, buffer_size, addr_align);
+		err = buffer_set_size_range(dd->dma_buffer, buffer_size_preferred, buffer_size,
+					    addr_align);
 
 		if (err < 0) {
 			comp_err(dev, "dai_set_dma_buffer(): buffer_size = %u failed", buffer_size);
 			return err;
 		}
 	} else {
-		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_CAPS_DMA, 0,
-					      addr_align, false);
+		dd->dma_buffer = buffer_alloc_range(buffer_size_preferred, buffer_size,
+						    SOF_MEM_CAPS_DMA, 0, addr_align, false);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "dai_set_dma_buffer(): failed to alloc dma buffer");
 			return -ENOMEM;
@@ -904,6 +907,7 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 		dd->sampling = get_sample_bytes(hw_params.frame_fmt);
 	}
 
+	*pc = audio_stream_get_size(&dd->dma_buffer->stream) / period_bytes;
 	dd->fast_mode = dd->ipc_config.feature_mask & BIT(IPC4_COPIER_FAST_MODE);
 	return 0;
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -286,11 +286,8 @@ static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)
 }
 
 /* Run-time buffer re-configuration calls this too, so it must use cached access */
-static inline void buffer_init(struct comp_buffer *buffer,
-			       uint32_t size, uint32_t caps)
+static inline void buffer_init_stream(struct comp_buffer *buffer, size_t size)
 {
-	buffer->caps = caps;
-
 	/* addr should be set in alloc function */
 	audio_stream_init(&buffer->stream, buffer->stream.addr, size);
 }

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -190,6 +190,8 @@ struct buffer_cb_free {
 /* pipeline buffer creation and destruction */
 struct comp_buffer *buffer_alloc(size_t size, uint32_t caps, uint32_t flags, uint32_t align,
 				 bool is_shared);
+struct comp_buffer *buffer_alloc_range(size_t preferred_size, size_t minimum_size, uint32_t caps,
+				       uint32_t flags, uint32_t align, bool is_shared);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared);
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 /*
@@ -226,6 +228,8 @@ int buffer_create_shadow_dp_queue(struct comp_buffer *buffer, bool at_input);
 int buffer_sync_shadow_dp_queue(struct comp_buffer *buffer, size_t limit);
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment);
+int buffer_set_size_range(struct comp_buffer *buffer, size_t preferred_size, size_t minimum_size,
+			  uint32_t alignment);
 void buffer_free(struct comp_buffer *buffer);
 void buffer_zero(struct comp_buffer *buffer);
 

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -188,7 +188,7 @@ struct buffer_cb_free {
 	} while (0)
 
 /* pipeline buffer creation and destruction */
-struct comp_buffer *buffer_alloc(uint32_t size, uint32_t caps, uint32_t flags, uint32_t align,
+struct comp_buffer *buffer_alloc(size_t size, uint32_t caps, uint32_t flags, uint32_t align,
 				 bool is_shared);
 struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared);
 #if CONFIG_ZEPHYR_DP_SCHEDULER


### PR DESCRIPTION
For the needs of deep buffering, a new functions `buffer_alloc_range` and `buffer_set_size_range` have been added that allocate a buffer with a size given as a range. The suggested buffer size coming from ipc doesn't have to be met if there is not enough memory. It is then reduced step by step until it reaches its minimum size. These functions were used in dai and host.