### PR TITLE
pull-request.yml: add mt8188 to gcc-build-only

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -131,7 +131,7 @@ jobs:
         # to COMMAS. Don't use a single big group so a single failure
         # does not block all other builds.
         platform: [rn rmb,
-                   mt8186 mt8195,
+                   mt8186 mt8195 mt8188,
         ]
 
     steps:


### PR DESCRIPTION
mt8188 toolchain is added to SOF docker image.