### PR TITLE
basefw: Add handling of IPC4_DMA_CONTROL messages

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -525,6 +525,50 @@ static int basefw_get_large_config(struct comp_dev *dev,
 						data_offset, data);
 };
 
+/**
+ * Handles the DMA Control IPC message to initialize or modify DMA gateway configuration.
+ *
+ * @param first_block Indicates if this is the first data block in the message.
+ * @param last_block Indicates if this is the last data block in the message.
+ * @param data_offset The offset of the data in the message.
+ * @param data Pointer to the data buffer containing the DMA Control message.
+ * @return 0 on success, error code on failure.
+ */
+static int basefw_dma_control(bool first_block,
+			      bool last_block,
+			      uint32_t data_offset,
+			      const char *data)
+{
+	struct ipc4_dma_control *dma_control;
+	size_t data_size;
+	int ret;
+
+	/* Ensure that the message is atomic and contains all necessary information */
+	if (!first_block || !last_block) {
+		tr_err(&ipc_tr, "Non-atomic DMA Control message received");
+		return IPC4_ERROR_INVALID_PARAM;
+	}
+
+	dma_control = (struct ipc4_dma_control *)data;
+	data_size = data_offset - (sizeof(struct ipc4_dma_control) - sizeof(uint32_t));
+
+	if (data_size < (dma_control->config_length * sizeof(uint32_t))) {
+		tr_err(&ipc_tr, "DMA Control data too short: got %u, expected %u",
+		       data_size, dma_control->config_length);
+		return IPC4_ERROR_INVALID_PARAM;
+	}
+
+	ret = basefw_vendor_dma_control(dma_control->node_id,
+					(const char *)dma_control->config_data,
+					data_size);
+	if (ret > 0) {
+		tr_err(&ipc_tr, "DMA gateway configuration failed, error: %d", ret);
+		return ret;
+	}
+
+	return IPC4_SUCCESS;
+}
+
 static int basefw_set_large_config(struct comp_dev *dev,
 				   uint32_t param_id,
 				   bool first_block,
@@ -533,6 +577,8 @@ static int basefw_set_large_config(struct comp_dev *dev,
 				   const char *data)
 {
 	switch (param_id) {
+	case IPC4_DMA_CONTROL:
+		return basefw_dma_control(first_block, last_block, data_offset, data);
 	case IPC4_PERF_MEASUREMENTS_STATE:
 		return set_perf_meas_state(data);
 	case IPC4_SYSTEM_TIME:

--- a/src/include/ipc4/base_fw_vendor.h
+++ b/src/include/ipc4/base_fw_vendor.h
@@ -83,6 +83,18 @@ int basefw_vendor_set_large_config(struct comp_dev *dev,
 				   uint32_t data_offset,
 				   const char *data);
 
+/**
+ * @brief Vendor specific routine to configure DMA gateway.
+ *
+ * @param node_id The node ID of the DMA gateway to configure.
+ * @param config_data pointer to the configuration data.
+ * @param data_size Size of the configuration data.
+ * @return 0 if successful, error code otherwise.
+ */
+int basefw_vendor_dma_control(uint32_t node_id,
+			      const char *config_data,
+			      size_t data_size);
+
 #else /* !CONFIG_IPC4_BASE_FW_INTEL */
 
 static inline int basefw_vendor_fw_config(uint32_t *data_offset, char *data)
@@ -129,6 +141,13 @@ static inline int basefw_vendor_set_large_config(struct comp_dev *dev,
 						 bool last_block,
 						 uint32_t data_offset,
 						 const char *data)
+{
+	return IPC4_UNKNOWN_MESSAGE_TYPE;
+}
+
+static inline int basefw_vendor_dma_control(uint32_t node_id,
+					    const char *config_data,
+					    size_t data_size)
 {
 	return IPC4_UNKNOWN_MESSAGE_TYPE;
 }

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -290,6 +290,11 @@ void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev);
  * \brief release llp slot
  */
 void dai_release_llp_slot(struct dai_data *dd);
+
+/**
+ * \brief Retrieve a pointer to the Zephyr device structure for a DAI of a given type and index.
+ */
+const struct device *dai_get_device(uint32_t type, uint32_t index);
 /** @}*/
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -151,7 +151,7 @@ const struct device *zephyr_dev[] = {
 #endif
 };
 
-static const struct device *dai_get_zephyr_device(uint32_t type, uint32_t index)
+const struct device *dai_get_device(uint32_t type, uint32_t index)
 {
 	struct dai_config cfg;
 	int dir;
@@ -211,7 +211,7 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 	const struct device *dev;
 	struct dai *d;
 
-	dev = dai_get_zephyr_device(type, index);
+	dev = dai_get_device(type, index);
 	if (!dev) {
 		tr_err(&dai_tr, "dai_get: failed to get dai with index %d type %d",
 		       index, type);


### PR DESCRIPTION
This pull request introduces a handling of IPC4_DMA_CONTROL messages for the SSP DAI driver. 

Below is a summary of the commits included in this pull request:
- 64ce0b9b31b91b17f63cd435cc11d93fd3be28be Exposes the function to retrieve Zephyr DAI device structures, allowing other parts of the SOF codebase to access Zephyr native DAI drivers.
- 3801123335de58e0f5f2782f66beeffded1323c6: Implements handling for the IPC4_DMA_CONTROL message within the base firmware.

TODO before merge:

- [x] https://github.com/zephyrproject-rtos/zephyr/pull/73158
- [x] https://github.com/thesofproject/sof/pull/9338