### PR TITLE
zephyr/cmake: fix llext.uuid growing from the last build

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -1102,10 +1102,10 @@ def install_platform(platform, sof_output_dir, platf_build_environ, platform_wco
 BIN_NAME = 'zephyr'
 
 CHECKSUM_WANTED = [
-	# Some .ri files have a deterministic signature, others use
-	# a cryptographic salt. Even for the latter a checksum is still
-	# useful to match an artefact with a specific build log.
-	'*.ri',
+	# Rimage now uses a cryptographic salt and produces a non-deterministic
+	# signature; but the ability to match some release with the corresponding
+	# build log is still useful.
+	'*.ri', '*.llext',
 	'dsp_basefw.bin',
 
 	'*version*.h',

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -584,10 +584,13 @@ def clean_staging(platform):
 
 	# remove IPC4 deployable build directories
 	if platform_configs[platform].ipc4:
-		sof_platform_output_dir = sof_output_dir / platform_configs[platform].vendor / "sof-ipc4"
-		rmtree_if_exists(sof_platform_output_dir / platform)
+		# e.g.: "build-sof-staging/sof/intel/sof-ipc4/mtl/"
+		sof_vendor_dir = sof_output_dir / platform_configs[platform].vendor
+		rmtree_if_exists(sof_vendor_dir / "sof-ipc4" / platform)
+		rmtree_if_exists(sof_vendor_dir / "sof-ipc4-lib" / platform)
 		for p_alias in platform_configs[platform].aliases:
-			rmtree_if_exists(sof_platform_output_dir / p_alias)
+			rmtree_if_exists(sof_vendor_dir / "sof-ipc4" / p_alias)
+			rmtree_if_exists(sof_vendor_dir / "sof-ipc4-lib" / p_alias)
 
 RIMAGE_BUILD_DIR  = west_top / "build-rimage"
 RIMAGE_SOURCE_DIR = west_top / "sof" / "tools" / "rimage"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -39,10 +39,12 @@ endfunction()
 function(sof_llext_write_uuids module)
 	file(STRINGS ${CMAKE_CURRENT_LIST_DIR}/../${module}.toml uuids REGEX "^[ \t]*uuid *=")
 
+	set(UUIDS_LIST_FILE ${ZEPHYR_BINARY_DIR}/${module}_llext/llext.uuid)
+	file(REMOVE ${UUIDS_LIST_FILE})
 	foreach(line IN LISTS uuids)
 		# extract UUID value - drop the 'uuid = ' part of the assignment line
 		string(REGEX REPLACE "^[ \t]*uuid *= \"([0-9A-F\-]*)\"" "\\1" uuid ${line})
-		file(APPEND ${ZEPHYR_BINARY_DIR}/${module}_llext/llext.uuid "${uuid}\n")
+		file(APPEND ${UUIDS_LIST_FILE} "${uuid}\n")
 	endforeach()
 endfunction()
 


### PR DESCRIPTION
3 small LLEXT fixes. Main one:

Reset the llext.uuid file so it does not start with content from the
previous build.

Fixes incremental builds.