### PR TITLE
Audio: Optimize division by speed of sound using fixed-point reciprocal

### DIFF
--- a/src/audio/tdfb/tdfb_direction.c
+++ b/src/audio/tdfb/tdfb_direction.c
@@ -87,9 +87,6 @@ void tdfb_direction_copy_emphasis(struct tdfb_comp_data *cd, int ch_count, int *
 {
 	int32_t y;
 
-	if (!cd->direction_updates)
-		return;
-
 	y = iir_df1(&cd->direction.emphasis[*ch], x);
 	*cd->direction.wp = sat_int16(Q_SHIFT_RND(y, 31, 18)); /* 18 dB boost after high-pass */
 	cd->direction.wp++;
@@ -406,8 +403,11 @@ static void theoretical_time_differences(struct tdfb_comp_data *cd, int16_t az)
 
 	for (i = 0; i < n_mic - 1; i++) {
 		delta_d = d[i + 1] - d[0]; /* Meters Q4.12 */
+		/*  Multiply delta_d (Q4.12) by RECIPROCAL_SPEED_OF_SOUND_Q31 (Q1.31) and
+		 * right-shift the result by 12 bits to preserve the Q1.31 format.
+		 */
 		cd->direction.timediff_iter[i] =
-			(int32_t)((((int64_t)delta_d) << 19) / SPEED_OF_SOUND);
+			Q_MULTS_32X32((int64_t)delta_d, RECIPROCAL_SPEED_OF_SOUND_Q31, 12, 31, 31);
 	}
 }
 

--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -117,5 +117,6 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes);
 
 /* Speed of sound (m/s) in 20 C temperature at standard atmospheric pressure */
 #define SPEED_OF_SOUND		343
+#define RECIPROCAL_SPEED_OF_SOUND_Q31 6260885 /* Q1.31 */
 
 #endif /* __SOF_MATH_NUMBERS_H__ */


### PR DESCRIPTION
This commit optimizes the division by the speed of sound in the `theoretical_time_differences` function. By precomputing the fixed-point reciprocal of the speed of sound, we eliminate the need for a costly division operation in each iteration.