### PR TITLE
topology: imx: Add a variable for schedule domain

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -41,21 +41,21 @@ set(TPLGS
 	## end i.MX8 (i.MX8QM and i.MX8QXP) topologies
 
 	## i.MX8MP topologies
-	"sof-imx8-compr-wm8960-mixer\;sof-imx8mp-compr-wm8960-mixer\;-DCODEC=wm8960\;-DSAI_INDEX=3"
-	"sof-imx8-compr-wm8960-mixer\;sof-imx8mp-compr-wm8962-mixer\;-DCODEC=wm8962\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960-mixer\;sof-imx8mp-wm8960-mixer\;-DCODEC=wm8960\;-DRATE=48000\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960-mixer\;sof-imx8mp-wm8962-mixer\;-DCODEC=wm8962\;-DRATE=48000\;-DSAI_INDEX=3"
+	"sof-imx8-compr-wm8960-mixer\;sof-imx8mp-compr-wm8960-mixer\;-DCODEC=wm8960\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-compr-wm8960-mixer\;sof-imx8mp-compr-wm8962-mixer\;-DCODEC=wm8962\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960-mixer\;sof-imx8mp-wm8960-mixer\;-DCODEC=wm8960\;-DRATE=48000\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960-mixer\;sof-imx8mp-wm8962-mixer\;-DCODEC=wm8962\;-DRATE=48000\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
 	"sof-imx8mp-wm8960-kwd\;sof-imx8mp-wm8960-kwd"
 	"sof-imx8mp-micfil\;sof-imx8mp-micfil"
 	"sof-imx8mp-btsco-dual-8ch\;sof-imx8mp-btsco-dual-8ch"
-	"sof-imx8-wm8960\;sof-imx8mp-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-wm8904\;-DCODEC=wm8904\;-DRATE=44100\;-DPPROC=volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-eq-iir-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eq-iir-volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-eq-iir-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=eq-iir-volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-eq-fir-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eq-fir-volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-eq-fir-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=eq-fir-volume\;-DSAI_INDEX=3"
-	"sof-imx8-wm8960\;sof-imx8mp-drc-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=drc\;-DSAI_INDEX=3"
+	"sof-imx8-wm8960\;sof-imx8mp-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-wm8904\;-DCODEC=wm8904\;-DRATE=44100\;-DPPROC=volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-eq-iir-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eq-iir-volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-eq-iir-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=eq-iir-volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-eq-fir-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eq-fir-volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-eq-fir-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=eq-fir-volume\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-wm8960\;sof-imx8mp-drc-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=drc\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
 	## end i.MX8MP topologies
 
 	## i.MX8ULP topologies

--- a/tools/topology/topology1/development/CMakeLists.txt
+++ b/tools/topology/topology1/development/CMakeLists.txt
@@ -12,8 +12,8 @@ set(TPLGS
 	## end i.MX8 (i.MX8QM and i.MX8QXP) topologies
 
 	## i.MX8MP topologies
-	"sof-imx8-src-wm8960\;sof-imx8mp-src-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=src\;-DSAI_INDEX=3"
-	"sof-imx8-src-wm8960\;sof-imx8mp-src-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=src\;-DSAI_INDEX=3"
+	"sof-imx8-src-wm8960\;sof-imx8mp-src-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=src\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
+	"sof-imx8-src-wm8960\;sof-imx8mp-src-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=src\;-DSAI_INDEX=3\;-DDMA_DOMAIN"
 	"sof-imx8mp-compr-pcm-wm8960\;sof-imx8mp-compr-pcm-wm8960"
 	"sof-imx8mp-compr-pcm-cap-wm8960\;sof-imx8mp-compr-pcm-cap-wm8960"
 	"sof-imx8mp-compr-wm8960\;sof-imx8mp-compr-wm8960\;-DCODEC=wm8960\;-DRATE=48000"

--- a/tools/topology/topology1/development/sof-imx8-src-wm8960.m4
+++ b/tools/topology/topology1/development/sof-imx8-src-wm8960.m4
@@ -27,6 +27,8 @@ include(`platform/imx/imx8.m4')
 # PCM0 <----> SRC <----> volume <-----> `SAI_INDEX' (`CODEC')
 #
 
+ifdef(`DMA_DOMAIN', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_DMA)', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_TIMER)')
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
@@ -69,14 +71,14 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 # capture DAI is SAI_SAI_INDEX using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SINK_2, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 
 # PCM Low Latency, id 0

--- a/tools/topology/topology1/sof-imx8-compr-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-compr-wm8960-mixer.m4
@@ -56,6 +56,8 @@ PIPELINE_PCM_ADD(sof/pipe-low-latency-capture.m4,
 	1000, 0, 0,
 	48000, 48000, 48000)
 
+ifdef(`DMA_DOMAIN', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_DMA)', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_TIMER)')
+
 #
 # DAI configuration
 #
@@ -78,7 +80,7 @@ define(`DAI_BE_NAME', concat(concat(`sai', SAI_INDEX), STREAM_NAME))
 DAI_ADD(sof/pipe-mixer-volume-dai-playback.m4,
 	1, SAI, SAI_INDEX, DAI_BE_NAME,
 	NOT_USED_IGNORED, 2, s32le,
-	1000, 1, 0, SCHEDULE_TIME_DOMAIN_TIMER,
+	1000, 1, 0, SCHEDULE_DOMAIN,
 	2, 48000)
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
@@ -88,7 +90,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
 	1000, 0, 0,
 	48000, 48000, 48000,
-	SCHEDULE_TIME_DOMAIN_TIMER,
+	SCHEDULE_DOMAIN,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # Compress Playback pipeline 4 on Compr 1 using max 2 channels of s32le.
@@ -98,7 +100,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-codec-adapter-playback.m4,
 	4, 1, 2, s32le,
 	5000, 0, 0,
 	48000, 48000, 48000,
-	SCHEDULE_TIME_DOMAIN_TIMER,
+	SCHEDULE_DOMAIN,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # Connect pipelines together
@@ -120,7 +122,7 @@ SectionGraph."PIPE_NAME" {
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SINK_2, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 
 # PCM definitions

--- a/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960-mixer.m4
@@ -50,6 +50,8 @@ define(`STREAM_NAME',
 # define DAI BE dai_link name
 define(`DAI_BE_NAME', concat(concat(`sai', SAI_INDEX), STREAM_NAME))
 
+ifdef(`DMA_DOMAIN', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_DMA)', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_TIMER)')
+
 # playback DAI is SAI_SAI_INDEX using 2 periods
 # Buffers use s32le format, 1000us deadline on core 0 with priority 1
 # this defines pipeline 1. The 'NOT_USED_IGNORED' is due to dependencies
@@ -57,7 +59,7 @@ define(`DAI_BE_NAME', concat(concat(`sai', SAI_INDEX), STREAM_NAME))
 DAI_ADD(sof/pipe-mixer-volume-dai-playback.m4,
 	1, SAI, SAI_INDEX, DAI_BE_NAME,
 	NOT_USED_IGNORED, 2, s32le,
-	1000, 1, 0, SCHEDULE_TIME_DOMAIN_TIMER,
+	1000, 1, 0, SCHEDULE_DOMAIN,
 	2, `RATE')
 
 # PCM Playback pipeline 3 on PCM 0 using max 2 channels of s32le.
@@ -67,7 +69,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	3, 0, 2, s32le,
 	1000, 0, 0,
 	`RATE', `RATE', `RATE',
-	SCHEDULE_TIME_DOMAIN_TIMER,
+	SCHEDULE_DOMAIN,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # PCM Playback pipeline 4 on PCM 1 using max 2 channels of s32le.
@@ -77,7 +79,7 @@ PIPELINE_PCM_ADD(sof/pipe-host-volume-playback.m4,
 	4, 1, 2, s32le,
 	5000, 0, 0,
 	`RATE', `RATE', `RATE',
-	SCHEDULE_TIME_DOMAIN_TIMER,
+	SCHEDULE_DOMAIN,
 	PIPELINE_PLAYBACK_SCHED_COMP_1)
 
 # Connect pipelines together
@@ -99,7 +101,7 @@ SectionGraph."PIPE_NAME" {
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SINK_2, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 
 # PCM definitions

--- a/tools/topology/topology1/sof-imx8-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8-wm8960.m4
@@ -27,6 +27,8 @@ include(`platform/imx/imx8.m4')
 # PCM0 <----> `PPROC' <-----> `SAI_INDEX' (`CODEC')
 #
 
+ifdef(`DMA_DOMAIN', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_DMA)', `define(`SCHEDULE_DOMAIN', SCHEDULE_TIME_DOMAIN_TIMER)')
+
 dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     period, priority, core,
@@ -70,14 +72,14 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 # capture DAI is SAI_SAI_INDEX using 2 periods
 # Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, SAI, SAI_INDEX, DAI_BE_NAME,
 	PIPELINE_SINK_2, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
+	1000, 0, 0, SCHEDULE_DOMAIN)
 
 
 # PCM Low Latency, id 0


### PR DESCRIPTION
Add DMA_DOMAIN variable and based on this we set
SCHEDULE_DOMAIN to SCHEDULE_TIME_DOMAIN_DMA, otherwise is SCHEDULE_TIME_DOMAIN_TIMER.

Now, only i.MX8MP is using SCHEDULE_TIME_DOMAIN_DMA. Therefore the DMA_DOMAIN is added only for 8MP topologies.