### PR TITLE
app: add winconsole_overlay.conf

### DIFF
--- a/app/winconsole_overlay.conf
+++ b/app/winconsole_overlay.conf
@@ -1,0 +1,13 @@
+# Overlay to enable logging via winstream backend. This is
+# alternative memory window based logging backend that typically
+# uses memory window 3 as transport. The backend is directly
+# using Zephyr winstream protocol, and has no dependency to SOF
+# IPC definitions.
+#
+# One client is available in Zephyr upstream at:
+# zephyr/soc/intel/intel_adsp/tools/cavstool.py
+#
+# Note: winstream backend is not supported by Linux SOF driver
+#
+CONFIG_LOG_BACKEND_ADSP=y
+CONFIG_WINSTREAM_CONSOLE=y


### PR DESCRIPTION
Add a new overlay to enable logging via winstream backend. This is alternative memory window based logging backend that typically uses memory window 3 as transport. The backend is directly using Zephyr winstream protocol, and has no dependency to SOF IPC definitions.

One client is available in Zephyr upstream at:
zephyr/soc/intel/intel_adsp/tools/cavstool.py

Note: winstream backend is not supported by Linux SOF driver.