### PR TITLE
west.yml: update Zephyr to 69d790b29331 (May 27th)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9d8059b6e5541f7f6b4eb1697dccd475f2c1b39b
+      revision: 69d790b293316ae3651f244f2452705ee65c1f4b
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fast-forward Zephyr by 450+ commits including following patches affecting SOF build targets:

 5ca3bc92c8e0 intel_adsp: power: SoC restores the clock
 4c5ee9b2dbc5 pm: system: Restore clock after sleep
 1860dd9153c7 pm: system: Resume devices in pm_system_resume
 f7437ac3b1a3 pm: Move z_pm_save_idle_exit to pm subsys
 f54232e9124d intel_adsp/ace: power: Do not re-implement cache func
 693b65583c88 power_domain: intel_adsp: Use register definitions
 b496d0e52d3c intel_adsp/ace: pm: Remove unnecessary cache flush
 c335cb542c24 intel_adsp/ace: pm: Keep irq locked until restore context
 e728adffd276 intel_adsp/ace: pm: Remove unnecessary cache flush
 301055dec086 intel-adsp/ace: pm: Only core 0 can d0i3
 991b3623b014 soc: intel_adsp: ipc: don't call k_sem_init() multiple times
 369a3a167584 soc: intel: adsp: tgl: ace: Set correct virtual memory size