### PR TITLE
schedule: zephyr_domain: include domain block in ll time tracking

### DIFF
--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -72,6 +72,8 @@ static void zephyr_domain_thread_fn(void *p1, void *p2, void *p3)
 		/* immediately go to sleep, waiting to be woken up by the timer */
 		k_sem_take(&dt->sem, K_FOREVER);
 
+		cycles0 = k_cycle_get_32();
+
 #if CONFIG_CROSS_CORE_STREAM
 		/*
 		 * If zephyr_domain->block is set -- block LL scheduler from starting its
@@ -92,7 +94,6 @@ static void zephyr_domain_thread_fn(void *p1, void *p2, void *p3)
 		}
 #endif
 
-		cycles0 = k_cycle_get_32();
 		dt->handler(dt->arg);
 		cycles1 = k_cycle_get_32();
 


### PR DESCRIPTION
Include the possible domain block time into measurement of the low-latency scheduler thread execution time. The ll timer metrics are typically used for initial system debug and it is very misleading when domain block events are not counted in reported average/max numbers.

Change the timing code to start measurement immediately after domain thread semaphore is taken.