### PR TITLE
zephyr: shell: add initial SOF custom commands

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -905,6 +905,10 @@ zephyr_library_sources_ifdef(CONFIG_SOF_BOOT_TEST
        boot_test.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_SHELL
+       sof_shell.c
+)
+
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)
 

--- a/zephyr/sof_shell.c
+++ b/zephyr/sof_shell.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2024 Intel Corporation.
+ *
+ * Author: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+ */
+
+#include <rtos/sof.h> /* sof_get() */
+#include <sof/schedule/ll_schedule_domain.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/shell/shell.h>
+
+#define SOF_TEST_INJECT_SCHED_GAP_USEC 1500
+
+static int cmd_sof_test_inject_sched_gap(const struct shell *sh,
+		       size_t argc, char *argv[])
+{
+	uint32_t block_time = SOF_TEST_INJECT_SCHED_GAP_USEC;
+	char *endptr = NULL;
+
+#ifndef CONFIG_CROSS_CORE_STREAM
+	shell_fprintf(sh, SHELL_NORMAL, "Domain blocking not supported, not reliable on SMP\n");
+#endif
+
+	domain_block(sof_get()->platform_timer_domain);
+
+	if (argc > 1) {
+		block_time = strtol(argv[1], &endptr, 0);
+		if (endptr == argv[1])
+			return -EINVAL;
+	}
+
+	k_busy_wait(block_time);
+
+	domain_unblock(sof_get()->platform_timer_domain);
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sof_commands,
+	SHELL_CMD(test_inject_sched_gap, NULL,
+		  "Inject a gap to audio scheduling\n",
+		  cmd_sof_test_inject_sched_gap),
+
+	SHELL_SUBCMD_SET_END
+);
+
+SHELL_CMD_REGISTER(sof, &sof_commands,
+		   "SOF application commands", NULL);


### PR DESCRIPTION
Builds on (and contains all commits of) PRs https://github.com/thesofproject/sof/pull/9133 

#9133 adds the basic shell support and this PR adds SOF custom commands to the shell. Both are draft until the Zephyr side PRs are merged.