### PR TITLE
Audio: Improvement of multiband_drc memory allocation error handling.

### DIFF
--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -198,17 +198,12 @@ err:
 static int multiband_drc_setup(struct processing_module *mod, int16_t channels, uint32_t rate)
 {
 	struct multiband_drc_comp_data *cd = module_get_private_data(mod);
-	int ret;
 
 	/* Reset any previous state */
 	multiband_drc_reset_state(&cd->state);
 
 	/* Setup Crossover, Emphasis EQ, Deemphasis EQ, and DRC */
-	ret = multiband_drc_init_coef(mod, channels, rate);
-	if (ret < 0)
-		return ret;
-
-	return 0;
+	return multiband_drc_init_coef(mod, channels, rate);
 }
 
 /*


### PR DESCRIPTION
This check-in improves error handling in the `multiband_drc` component by enabling error logging and returning `-ENOMEM` if memory allocation fails. It replaces asserts with conditional checks to detect and log errors during memory copy operations. Finally, it streamlines the return logic in` multiband_drc_setup` and propagates the `init_coef` error code.