### PR TITLE
west.ytml: update to Zephyr 53ddff639562 (May 31st)

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -1029,8 +1029,8 @@ def install_platform(platform, sof_output_dir, platf_build_environ, platform_wco
 	installed_files = [
 		# Fail if one of these is missing
 		InstFile(".config", "config", txt=True),
-		InstFile("include/generated/autoconf.h", "generated_autoconf.h", txt=True),
-		InstFile("include/generated/version.h", "zephyr_version.h",
+		InstFile("include/generated/zephyr/autoconf.h", "generated_autoconf.h", txt=True),
+		InstFile("include/generated/zephyr/version.h", "zephyr_version.h",
 			 gzip=False, txt=True),
 		InstFile("include/generated/sof_versions.h", "sof_versions.h",
 			 gzip=False, txt=True),

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 69d790b293316ae3651f244f2452705ee65c1f4b
+      revision: 53ddff639562ef68dc0a6f62b82f7505c75ebdce
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -76,7 +76,7 @@ function(sof_llext_build module)
 		PRE_BUILD
 		COMMAND ${CMAKE_C_COMPILER} -E ${CMAKE_CURRENT_LIST_DIR}/llext.toml.h -P -DREM=
 			-I${SOF_BASE} -I${SOF_BASE}src
-			-imacros ../include/generated/autoconf.h
+			-imacros ../include/generated/zephyr/autoconf.h
 			-o rimage_config.toml
 	)
 


### PR DESCRIPTION
Update Zephyr baseline to 53ddff639562 . The location of generated headers has changed, so modify the SOF build scripts to use the new location.

Change affecting SOF build targets:

6509b8199b02 shell: add shell backend for audio DSP using shared memory window
5a7600bec60b soc: intel_adsp: tools: add shell support to cavstool.py
db00b813f043 soc: intel_adsp: tools: align code style in maps_regs()
44dd5a4da9c0 soc: intel_adsp: tools: fix ace20 fw load flow
fa798ce2d5be soc: intel_adsp: only implement FW_STATUS boot protocol for cavs
8fc76f1b6d16 soc: intel_adsp: tools: improve FW boot handling on ace1.x
024bd41efb65 llext: xtensa: add support for the xt-clang toolchain