### PR TITLE
west.yml: update Zephyr to ca19e6bb (June 04)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 53ddff639562ef68dc0a6f62b82f7505c75ebdce
+      revision: ca19e6bbaa541d606dbbb8a6d267f448d231c00e
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fast-forward Zephyr by 200+ commits including following affecting SOF build targets:

adabe57f4dd7 soc: intel_adsp/ace: Fix SOC_TOOLCHAIN_NAME symbol
07fb31c31eb7 drivers: dai/ssp: Support dynamic SSP management
74b53df0649f drivers: mm/intel_adsp: Add MMU support to MM driver
d35a2b89f3ee intel_adsp: dmic: enable support for ptl use new headers
b0abe57bc5f6 drivers: dai/dmic: Add support for ace30 (PTL)
9637b8b0bc9a intel_adsp: ace30: Bring up ACE 3.0 (PTL)
1541fe9e2f78 intel_adsp/ace: power: fix address space annotation for powerdown