### PR TITLE
LLEXT: clean data and code segmentation

### DIFF
--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -262,9 +262,8 @@ SOF_MODULE_INIT(eq_iir, sys_comp_module_eq_iir_interface_init);
 /* modular: llext dynamic link */
 
 #include <module/module/api_ver.h>
-#include <rimage/sof/user/manifest.h>
-
 #include <module/module/llext.h>
+#include <rimage/sof/user/manifest.h>
 
 #define UUID_EQIIR 0xE6, 0xC0, 0x50, 0x51, 0xF9, 0x27, 0xC8, 0x4E, \
 		0x83, 0x51, 0xC7, 0x05, 0xB6, 0x42, 0xD1, 0x2F

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -969,9 +969,8 @@ SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);
 /* modular: llext dynamic link */
 
 #include <module/module/api_ver.h>
-#include <rimage/sof/user/manifest.h>
-
 #include <module/module/llext.h>
+#include <rimage/sof/user/manifest.h>
 
 #define UUID_MIXIN 0xB2, 0x6E, 0x65, 0x39, 0x71, 0x3B, 0x49, 0x40, \
 		0x8D, 0x3F, 0xF9, 0x2C, 0xD5, 0xC4, 0x3C, 0x09

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -83,10 +83,24 @@ struct ipc_lib_msg {
 
 struct sof_man_module_manifest;
 
+enum {
+	LIB_MANAGER_TEXT,
+	LIB_MANAGER_DATA,
+	LIB_MANAGER_RODATA,
+	LIB_MANAGER_BSS,
+	LIB_MANAGER_N_SEGMENTS,
+};
+
+struct lib_manager_segment_desc {
+	uintptr_t addr;
+	size_t size;
+	size_t file_offset;
+};
+
 struct lib_manager_mod_ctx {
 	void *base_addr;
 	const struct sof_man_module_manifest *mod_manifest;
-	size_t segment_size[3];
+	struct lib_manager_segment_desc segment[LIB_MANAGER_N_SEGMENTS];
 };
 
 struct ext_library {

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -235,12 +235,12 @@ static int llext_manager_link(struct sof_man_fw_desc *desc, struct sof_man_modul
 
 	ssize_t binfo_o = llext_find_section(&ebl.loader, ".mod_buildinfo");
 
-	if (binfo_o)
+	if (binfo_o >= 0)
 		*buildinfo = llext_peek(&ebl.loader, binfo_o);
 
 	ssize_t mod_o = llext_find_section(&ebl.loader, ".module");
 
-	if (mod_o)
+	if (mod_o >= 0)
 		*mod_manifest = llext_peek(&ebl.loader, mod_o);
 
 	return 0;

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -251,7 +251,7 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 					const void *ipc_specific_config)
 {
 	struct sof_man_fw_desc *desc;
-	struct sof_man_module *mod, *mod_array;
+	struct sof_man_module *mod_array;
 	int ret;
 	uint32_t module_id = IPC4_MOD_ID(ipc_config->id);
 	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
@@ -270,7 +270,6 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 	}
 
 	mod_array = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(0));
-	mod = mod_array + entry_index;
 
 	/* LLEXT linking is only needed once for all the modules in the library */
 	ret = llext_manager_link(desc, mod_array, module_id, &proc->priv, (const void **)&buildinfo,
@@ -291,11 +290,11 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 		ctx->mod_manifest = mod_manifest;
 
 		/* Map .text and the rest as .data */
-		ret = llext_manager_load_module(module_id, mod);
+		ret = llext_manager_load_module(module_id, mod_array);
 		if (ret < 0)
 			return 0;
 
-		ret = llext_manager_allocate_module_bss(module_id, mod);
+		ret = llext_manager_allocate_module_bss(module_id, mod_array);
 		if (ret < 0) {
 			tr_err(&lib_manager_tr,
 			       "llext_manager_allocate_module(): module allocation failed: %d",


### PR DESCRIPTION
Cleanly separate LLEXT code and data segments, handle .bss together with .data. Using Zephyr's automatic section grouping, based on feature flags.