### PR TITLE
tplg: bt: use KNOT for supported rates

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -235,7 +235,7 @@ Object.PCM.pcm [
 			direction   "playback"
 			name $BT_PB_PCM_CAPS
 			formats	'S16_LE'
-			rates '8000,16000,48000'
+			rates 'KNOT'
 			channels_min 1
 			channels_max 2
 		}
@@ -244,7 +244,7 @@ Object.PCM.pcm [
 			direction   "capture"
 			name	$BT_CP_PCM_CAPS
 			formats 'S16_LE'
-			rates '8000,16000,48000'
+			rates 'KNOT'
 			channels_min 1
 			channels_max 2
 		}


### PR DESCRIPTION
BT LE supports 24kHz, non-standard sampling rate defined by ALSA, so switch to SNDRV_PCM_RATE_KNOT to prepare for 24kHz rate support.