### PR TITLE
app: boards: ace20_lnl: set DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT=y

### DIFF
--- a/app/boards/intel_adsp_ace20_lnl.conf
+++ b/app/boards/intel_adsp_ace20_lnl.conf
@@ -77,6 +77,9 @@ CONFIG_PROBE_DMA_MAX=2
 
 CONFIG_MEMORY_WIN_2_SIZE=12288
 
+# must be set for LNL/ACE20
+# (can be removed once platform default changed in Zephyr upstream)
+CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT=y
 
 # Temporary disabled options
 CONFIG_TRACE=n


### PR DESCRIPTION
Set CONFIG_DMA_INTEL_ADSP_HDA_TIMING_L1_EXIT in board overlay as the Zephyr platform default is not correct in the current version of Zephyr.

Link: https://github.com/thesofproject/sof/issues/9191