### PR TITLE
[DNM] dai-zephyr: use frames aligned for multi-endpoint copy

### DIFF
--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -208,6 +208,8 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	audio_stream_set_buffer_fmt(&buffer->stream,
 				    copier_cfg->base.audio_fmt.interleaving_style);
 
+	audio_stream_set_align(1, 1, &buffer->stream);
+
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		buffer->chmap[i] = (chan_map >> i * 4) & 0xf;
 


### PR DESCRIPTION
When aggregating streams using `dai_zephyr_multi_endpoint_copy()` multiple glitches observed in audio streams with odd number of channels. Use `audio_stream_avail_frames_aligned()` for every dai in a loop to correctly calculate processing frames.