### PR TITLE
src: dai-zephyr: copy data to all available sinks

### DIFF
--- a/posix/include/sof/lib/dma.h
+++ b/posix/include/sof/lib/dma.h
@@ -534,14 +534,14 @@ int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
 		       dma_process_func process, uint32_t sink_bytes, uint32_t chmap);
 
 /*
- * Used when copying DMA buffer bytes into multiple sink buffers, one at a time using the provided
+ * Used when copying stream audio into multiple sink buffers, one at a time using the provided
  * conversion function. DMA buffer consume should be performed after the data has been copied
  * to all sinks.
  */
-int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
-				    struct comp_buffer __sparse_cache *sink,
-				    dma_process_func process,
-				    uint32_t source_bytes, uint32_t chmap);
+int stream_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
+				struct comp_buffer __sparse_cache *sink,
+				dma_process_func process,
+				uint32_t source_bytes, uint32_t chmap);
 
 /* generic DMA DSP <-> Host copier */
 

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -447,9 +447,8 @@ int dma_buffer_copy_to(struct comp_buffer *source,
 	return ret;
 }
 
-int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
-				    struct comp_buffer *sink,
-				    dma_process_func process, uint32_t source_bytes, uint32_t chmap)
+int stream_copy_from_no_consume(struct comp_buffer *source, struct comp_buffer *sink,
+				dma_process_func process, uint32_t source_bytes, uint32_t chmap)
 {
 	int source_channels = audio_stream_get_channels(&source->stream);
 	int sink_channels = audio_stream_get_channels(&sink->stream);

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -534,14 +534,14 @@ int dma_buffer_copy_from(struct comp_buffer *source,
 			 dma_process_func process, uint32_t source_bytes, uint32_t chmap);
 
 /*
- * Used when copying DMA buffer bytes into multiple sink buffers, one at a time using the provided
+ * Used when copying stream audio into multiple sink buffers, one at a time using the provided
  * conversion function. DMA buffer consume should be performed after the data has been copied
  * to all sinks.
  */
-int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
-				    struct comp_buffer *sink,
-				    dma_process_func process,
-				    uint32_t source_bytes, uint32_t chmap);
+int stream_copy_from_no_consume(struct comp_buffer *source,
+				struct comp_buffer *sink,
+				dma_process_func process,
+				uint32_t source_bytes, uint32_t chmap);
 
 /* copies data to DMA buffer using provided processing function */
 int dma_buffer_copy_to(struct comp_buffer *source,


### PR DESCRIPTION
In the case where the copier has more than one output and, additionally, we will be using a pin other than pin 0 (for example, when we want to copy data from pin 1 of a gateway-type copier to the next pipeline), it is necessary to copy data in playback path from the source to the output for all possible sinks.