### PR TITLE
topology2: Add new token 'playback_pause_supported' and set it true f…

### DIFF
--- a/tools/topology/topology2/include/common/pcm.conf
+++ b/tools/topology/topology2/include/common/pcm.conf
@@ -44,6 +44,16 @@ Class.PCM."pcm" {
 		token_ref	"stream.bool"
 	}
 
+	DefineAttribute."playback_pause_supported" {
+		# Token reference and type
+		token_ref	"stream.bool"
+	}
+
+	DefineAttribute."capture_pause_supported" {
+		# Token reference and type
+		token_ref	"stream.bool"
+	}
+
 	attributes {
 		!constructor [
 			"name"
@@ -60,4 +70,6 @@ Class.PCM."pcm" {
 
 	# Default values for PCM attributes
 	compress	"false"
+	playback_pause_supported	"false"
+	capture_pause_supported	"false"
 }

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -129,8 +129,10 @@ Object.Base.VendorToken {
 
 	"13" {
 		name "stream"
-		playback_compatible_d0i3         "1200"
-		capture_compatible_d0i3          "1201"
+		playback_compatible_d0i3	1200
+		capture_compatible_d0i3         1201
+		playback_pause_supported	1202
+		capture_pause_supported		1203
 	}
 
         "14" {


### PR DESCRIPTION
We need to face with reality that the pause/resume is a feature that is not
well tested (end users are using audio via audio servers and they don't
use pause/resume) causing constant issues with no real life benefit:
With IPC4 multiple pause/resume will make the delay reporting to be
exponentially shoot out, making the reported delay to be unusable.

Looks like suspend/resume with paused stream has been broken for a long
time and just got noticed (since it was not tested).

Add a new token to allow selected PCMs to advertise pause support and
keep it false by default.

The kernel side will allow ignoring the flag to keep the pause advertised
for continued testing while protecting accidental use of it by users.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>
Link: https://github.com/thesofproject/linux/issues/5035
