### PR TITLE
topology2: common: pcm_caps: Change the periods_max from 1024 to 256

### DIFF
--- a/tools/topology/topology2/include/common/pcm_caps.conf
+++ b/tools/topology/topology2/include/common/pcm_caps.conf
@@ -84,7 +84,7 @@ Class.PCM."pcm_caps" {
 	formats		"S32_LE,S24_LE,S16_LE"
 	rates			"48000"
 	periods_min		2
-	periods_max		1024
+	periods_max		256
 	channels_min		2
 	channels_max		2
 	period_size_min		192	# "$[((2 * $channels_min) * 48000) / 1000]" (48K, S16_LE, 1ms)


### PR DESCRIPTION
HDA host DMA has limitation on the number of BDL entries which translates to number of periods, this limit is 256.

The Chrome ALSA compliance test is eagerly try to use as many periods as it can which exceeds the BDL limit and the stream cannot be started.

Fixes: b3a6d1c5708e ("topology2: common: pcm_caps: Increase periods_max from 16 to 1024")