### PR TITLE
Tools: Testbench: Fix load of MFCC component

### DIFF
--- a/tools/testbench/common_test.c
+++ b/tools/testbench/common_test.c
@@ -55,6 +55,7 @@ int tb_setup(struct sof *sof, struct testbench_prm *tp)
 	sys_comp_module_eq_iir_interface_init();
 	sys_comp_module_google_rtc_audio_processing_interface_init();
 	sys_comp_module_igo_nr_interface_init();
+	sys_comp_module_mfcc_interface_init();
 	sys_comp_module_multiband_drc_interface_init();
 	sys_comp_module_mux_interface_init();
 	sys_comp_module_rtnr_interface_init();


### PR DESCRIPTION
The load of MFCC fails with testbench due to missing call of sys_comp_module_mfcc_interface_init() in common_test.c testbench initialize.