### PR TITLE
component/module refactoring pass

### DIFF
--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -27,7 +27,7 @@ int asrc_dai_configure_timestamp(struct comp_data *cd)
 	if (!cd->dai_dev)
 		return -ENODEV;
 
-	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
+	struct processing_module *mod = comp_mod(cd->dai_dev);
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	return ops->endpoint_ops->dai_ts_config(cd->dai_dev);
@@ -38,7 +38,7 @@ int asrc_dai_start_timestamp(struct comp_data *cd)
 	if (!cd->dai_dev)
 		return -ENODEV;
 
-	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
+	struct processing_module *mod = comp_mod(cd->dai_dev);
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	return ops->endpoint_ops->dai_ts_start(cd->dai_dev);
@@ -49,7 +49,7 @@ int asrc_dai_stop_timestamp(struct comp_data *cd)
 	if (!cd->dai_dev)
 		return -ENODEV;
 
-	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
+	struct processing_module *mod = comp_mod(cd->dai_dev);
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	return ops->endpoint_ops->dai_ts_stop(cd->dai_dev);
@@ -64,7 +64,7 @@ int asrc_dai_get_timestamp(struct comp_data *cd, struct timestamp_data *tsd)
 	if (!cd->dai_dev)
 		return -ENODEV;
 
-	struct processing_module *mod = comp_get_drvdata(cd->dai_dev);
+	struct processing_module *mod = comp_mod(cd->dai_dev);
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	return ops->endpoint_ops->dai_ts_get(cd->dai_dev, tsd);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -293,7 +293,7 @@ static int copier_reset(struct processing_module *mod)
 
 static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct sof_ipc_stream_posn posn;
 	struct comp_dev *dai_copier;
@@ -660,7 +660,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 			       int max_data_size)
 {
 	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct list_item *sink_list;
 	struct comp_buffer *sink;
@@ -711,7 +711,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 
 static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const char *data)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	uint32_t attenuation;
 	enum sof_ipc_frame valid_fmt, frame_fmt;
@@ -860,7 +860,7 @@ static int copier_get_configuration(struct processing_module *mod,
 
 static uint64_t copier_get_processed_data(struct comp_dev *dev, uint32_t stream_no, bool input)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	uint64_t ret = 0;
 	bool source;
@@ -905,7 +905,7 @@ static uint64_t copier_get_processed_data(struct comp_dev *dev, uint32_t stream_
 
 static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *posn)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	int ret = 0;
 
@@ -933,7 +933,7 @@ static int copier_position(struct comp_dev *dev, struct sof_ipc_stream_posn *pos
 
 static int copier_dai_ts_config_op(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd = cd->dd[0];
 
@@ -942,7 +942,7 @@ static int copier_dai_ts_config_op(struct comp_dev *dev)
 
 static int copier_dai_ts_start_op(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd = cd->dd[0];
 
@@ -957,7 +957,7 @@ static int copier_dai_ts_get_op(struct comp_dev *dev, struct dai_ts_data *tsd)
 static int copier_dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
 #endif
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd = cd->dd[0];
 
@@ -968,7 +968,7 @@ static int copier_dai_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd
 
 static int copier_dai_ts_stop_op(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd = cd->dd[0];
 
@@ -980,7 +980,7 @@ static int copier_dai_ts_stop_op(struct comp_dev *dev)
 static int copier_get_hw_params(struct comp_dev *dev, struct sof_ipc_stream_params *params,
 				int dir)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd = cd->dd[0];
 

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -35,7 +35,7 @@ static int copier_set_alh_multi_gtw_channel_map(struct comp_dev *dev,
 						const struct ipc4_copier_module_cfg *copier_cfg,
 						int index)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	const struct sof_alh_configuration_blob *alh_blob;
 	uint8_t chan_bitmask;
@@ -71,7 +71,7 @@ static int copier_alh_assign_dai_index(struct comp_dev *dev,
 				       int *dai_index,
 				       int *dai_count)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	const struct sof_alh_configuration_blob *alh_blob = gtw_cfg_data;
 	uint8_t *dma_config;
@@ -162,7 +162,7 @@ static int copier_dai_init(struct comp_dev *dev,
 			   enum ipc4_gateway_type type,
 			   int index, int dai_count)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct dai_data *dd;
 	int ret;
@@ -230,7 +230,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		      const struct ipc4_copier_module_cfg *copier,
 		      struct pipeline *pipeline)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct comp_ipc_config *config = &dev->ipc_config;
 	int dai_index[IPC4_ALH_MAX_NUMBER_OF_GTW];
 	union ipc4_connector_node_id node_id;

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -94,7 +94,7 @@ void delete_from_fpi_sync_group(struct host_data *hd)
 /* Playback only */
 static int init_pipeline_reg(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	struct ipc4_pipeline_registers pipe_reg;
 	uint32_t gateway_id;
@@ -126,7 +126,7 @@ int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
 		       const struct ipc4_copier_module_cfg *copier_cfg,
 		       struct pipeline *pipeline)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct comp_ipc_config *config = &dev->ipc_config;
 	struct ipc_config_host ipc_host;
 	struct host_data *hd;
@@ -244,7 +244,7 @@ void copier_host_free(struct copier_data *cd)
  */
 void copier_host_dma_cb(struct comp_dev *dev, size_t bytes)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	int ret, frames;
 

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -111,7 +111,7 @@ static int crossover_assign_sinks(struct processing_module *mod,
 		unsigned int sink_id, state;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		sink_id = crossover_get_sink_id(cd, sink->pipeline_id, j);
+		sink_id = crossover_get_sink_id(cd, buffer_pipeline_id(sink), j);
 		state = sink->sink->state;
 		if (state != dev->state) {
 			j++;

--- a/src/audio/crossover/crossover_ipc3.c
+++ b/src/audio/crossover/crossover_ipc3.c
@@ -46,7 +46,7 @@ int crossover_check_sink_assign(struct processing_module *mod,
 		unsigned int pipeline_id;
 
 		sink = container_of(sink_list, struct comp_buffer, source_list);
-		pipeline_id = sink->pipeline_id;
+		pipeline_id = buffer_pipeline_id(sink);
 
 		i = crossover_get_stream_index(mod, config, pipeline_id);
 		if (i < 0) {

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -96,7 +96,7 @@ static int eq_fir_init_coef(struct comp_dev *dev, struct sof_eq_fir_config *conf
 		/* Called from validate(), we shall find nch and assign it accordingly,
 		 * as the parameter is not valid
 		 */
-		struct processing_module *mod = comp_get_drvdata(dev);
+		struct processing_module *mod = comp_mod(dev);
 		struct comp_data *cd = module_get_private_data(mod);
 
 		nch = cd->nch;

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -318,7 +318,7 @@ static int mixin_process(struct processing_module *mod,
 			continue;
 		}
 
-		mixout_mod = comp_get_drvdata(mixout);
+		mixout_mod = comp_mod(mixout);
 		active_mixouts[i] = mixout_mod;
 		mixout_sink = mixout_mod->sinks[0];
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -26,7 +26,7 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 {
 	int ret;
 	struct module_config *dst;
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct module_data *md = &mod->priv;
 
 	comp_dbg(dev, "module_load_config() start");

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -26,6 +26,7 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 {
 	int ret;
 	struct module_config *dst;
+	/* loadable module must use module adapter */
 	struct processing_module *mod = comp_mod(dev);
 	struct module_data *md = &mod->priv;
 

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -245,23 +245,3 @@ const struct module_interface processing_module_adapter_interface = {
 	.reset = modules_reset,
 	.free = modules_free,
 };
-
-/**
- * \brief Create a module adapter component.
- * \param[in] drv - component driver pointer.
- * \param[in] config - component ipc descriptor pointer.
- * \param[in] spec - pointer to module configuration data
- *
- * \return: a pointer to newly created module adapter component on success. NULL on error.
- *
- * \note: For dynamically loaded module the spec size is not known by base FW, since this is
- *        loaded module specific information. Therefore configuration size is required here.
- *        New module details are discovered during its loading, therefore comp_driver initialisation
- *        happens at this point.
- */
-struct comp_dev *modules_shim_new(const struct comp_driver *drv,
-				  const struct comp_ipc_config *config,
-				  const void *spec)
-{
-	return module_adapter_new(drv, config, spec);
-}

--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -168,7 +168,7 @@ int module_adapter_set_state(struct processing_module *mod, struct comp_dev *dev
 static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ctrl_data *cdata,
 					 bool set)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	enum module_cfg_fragment_position pos;
 	uint32_t data_offset_size;
@@ -222,7 +222,7 @@ static int module_adapter_ctrl_get_set_data(struct comp_dev *dev, struct sof_ipc
 					    bool set)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 
 	comp_dbg(dev, "module_adapter_ctrl_set_data() start, state %d, cmd %d",
 		 mod->priv.state, cdata->cmd);
@@ -254,7 +254,7 @@ static int module_adapter_ctrl_get_set_data(struct comp_dev *dev, struct sof_ipc
 int module_adapter_cmd(struct comp_dev *dev, int cmd, void *data, int max_data_size)
 {
 	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	int ret = 0;
 
@@ -306,7 +306,7 @@ int module_adapter_cmd(struct comp_dev *dev, int cmd, void *data, int max_data_s
 
 int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct list_item *blist;
 	int ret;
 	int i;

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -99,7 +99,7 @@ int module_adapter_set_state(struct processing_module *mod, struct comp_dev *dev
 int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t data_offset_size, const char *data)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	struct module_data *md = &mod->priv;
 	enum module_cfg_fragment_position pos;
@@ -138,7 +138,7 @@ EXPORT_SYMBOL(module_set_large_config);
 int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t *data_offset_size, char *data)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 	struct module_data *md = &mod->priv;
 	size_t fragment_size;
@@ -169,7 +169,7 @@ EXPORT_SYMBOL(module_get_large_config);
 
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 
 	switch (type) {
 	case COMP_ATTR_BASE_CONFIG:
@@ -186,7 +186,7 @@ EXPORT_SYMBOL(module_adapter_get_attribute);
 
 static bool module_adapter_multi_sink_source_prepare(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct list_item *blist;
 	int i;
 
@@ -225,7 +225,7 @@ static bool module_adapter_multi_sink_source_prepare(struct comp_dev *dev)
 
 int module_adapter_bind(struct comp_dev *dev, void *data)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	int ret;
 
 	ret = module_bind(mod, data);
@@ -240,7 +240,7 @@ EXPORT_SYMBOL(module_adapter_bind);
 
 int module_adapter_unbind(struct comp_dev *dev, void *data)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	int ret;
 
 	ret = module_unbind(mod, data);
@@ -256,7 +256,7 @@ EXPORT_SYMBOL(module_adapter_unbind);
 uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 
 	if (interface->endpoint_ops && interface->endpoint_ops->get_total_data_processed)
@@ -271,7 +271,7 @@ EXPORT_SYMBOL(module_adapter_get_total_data_processed);
 
 int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 
 	/* Prepare module */
 	return module_prepare(mod, mod->sources, mod->num_of_sources,

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -248,13 +248,13 @@ static int demux_process(struct processing_module *mod,
 	list_for_item(clist, &dev->bsink_list) {
 		sink = container_of(clist, struct comp_buffer, source_list);
 		if (sink->sink->state == dev->state) {
-			i = get_stream_index(dev, cd, sink->pipeline_id);
+			i = get_stream_index(dev, cd, buffer_pipeline_id(sink));
 			/* return if index wrong */
 			if (i < 0) {
 				return i;
 			}
 
-			look_ups[i] = get_lookup_table(dev, cd, sink->pipeline_id);
+			look_ups[i] = get_lookup_table(dev, cd, buffer_pipeline_id(sink));
 			sinks_stream[i] = &sink->stream;
 		}
 	}
@@ -310,7 +310,7 @@ static int mux_process(struct processing_module *mod,
 			else
 				frames = input_buffers[j].size;
 
-			i = get_stream_index(dev, cd, source->pipeline_id);
+			i = get_stream_index(dev, cd, buffer_pipeline_id(source));
 			/* return if index wrong */
 			if (i < 0) {
 				return i;

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -114,7 +114,7 @@ static void set_mux_params(struct processing_module *mod)
 		{
 			source = container_of(source_list, struct comp_buffer, sink_list);
 			j = buf_get_id(source);
-			cd->config.streams[j].pipeline_id = source->pipeline_id;
+			cd->config.streams[j].pipeline_id = buffer_pipeline_id(source);
 			if (j == BASE_CFG_QUEUED_ID)
 				audio_fmt = &cd->md.base_cfg.audio_fmt;
 			else

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -390,7 +390,7 @@ static enum task_state dp_task_run(void *data)
 int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	int ret;
-	struct processing_module *mod = comp_get_drvdata(comp);
+	struct processing_module *mod = comp_mod(comp);
 	struct task_ops ops  = {
 		.run		= dp_task_run,
 		.get_deadline	= NULL,

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -390,6 +390,7 @@ static enum task_state dp_task_run(void *data)
 int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	int ret;
+	/* DP tasks are guaranteed to have a module_adapter */
 	struct processing_module *mod = comp_mod(comp);
 	struct task_ops ops  = {
 		.run		= dp_task_run,

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -336,7 +336,7 @@ static int pipeline_calc_cps_consumption(struct comp_dev *current,
 	if (current->drv->type != SOF_COMP_MODULE_ADAPTER) {
 		cd = comp_get_drvdata(current);
 	} else {
-		struct processing_module *mod = comp_get_drvdata(current);
+		struct processing_module *mod = comp_mod(current);
 		struct module_data *md = &mod->priv;
 
 		cd = &md->cfg.base_cfg;
@@ -472,7 +472,7 @@ static int pipeline_comp_trigger(struct comp_dev *current,
 #if CONFIG_IPC_MAJOR_3
 			dd = comp_get_drvdata(current);
 #elif CONFIG_IPC_MAJOR_4
-			struct processing_module *mod = comp_get_drvdata(current);
+			struct processing_module *mod = comp_mod(current);
 			struct copier_data *cd = module_get_private_data(mod);
 
 			dd = cd->dd[0];

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -87,7 +87,7 @@ int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 void src_get_source_sink_params(struct comp_dev *dev, struct sof_source *source,
 				struct sof_sink *sink)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct comp_data *cd = module_get_private_data(mod);
 
 	/* Set source/sink_rate/frames */

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -122,7 +122,7 @@ int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 void src_get_source_sink_params(struct comp_dev *dev, struct sof_source *source,
 				struct sof_sink *sink)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct comp_data *cd = module_get_private_data(mod);
 	enum sof_ipc_frame frame_fmt, valid_fmt;
 

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -221,7 +221,7 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 							 struct vol_data *cd)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 
 	if (cd->is_passthrough) {
 		switch (mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth) {

--- a/src/include/module/audio/audio_stream.h
+++ b/src/include/module/audio/audio_stream.h
@@ -20,6 +20,7 @@
  */
 struct sof_audio_stream_params {
 	uint32_t id;
+	uint32_t pipeline_id;
 	enum sof_ipc_frame frame_fmt;	/**< Sample data format */
 	enum sof_ipc_frame valid_sample_fmt;
 

--- a/src/include/module/audio/sink_api.h
+++ b/src/include/module/audio/sink_api.h
@@ -248,4 +248,9 @@ static inline uint32_t sink_get_id(struct sof_sink *sink)
 	return sink->audio_stream_params->id;
 }
 
+static inline uint32_t sink_get_pipeline_id(struct sof_sink *sink)
+{
+	return sink->audio_stream_params->pipeline_id;
+}
+
 #endif /* __MODULE_AUDIO_SINK_API_H__ */

--- a/src/include/module/audio/source_api.h
+++ b/src/include/module/audio/source_api.h
@@ -226,4 +226,9 @@ static inline uint32_t source_get_id(struct sof_source *source)
 	return source->audio_stream_params->id;
 }
 
+static inline uint32_t source_get_pipeline_id(struct sof_source *source)
+{
+	return source->audio_stream_params->pipeline_id;
+}
+
 #endif /* __MODULE_AUDIO_SOURCE_API_H__ */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -43,9 +43,6 @@ extern struct tr_ctx buffer_tr;
 /** \brief Retrieves trace context from the buffer */
 #define trace_buf_get_tr_ctx(buf_ptr) (&(buf_ptr)->tctx)
 
-/** \brief Retrieves id (pipe id) from the buffer */
-#define trace_buf_get_id(buf_ptr) ((buf_ptr)->pipeline_id)
-
 /** \brief Retrieves subid (comp id) from the buffer */
 #define buf_get_id(buf_ptr) ((buf_ptr)->stream.runtime_stream_params.id)
 
@@ -57,36 +54,36 @@ extern struct tr_ctx buffer_tr;
 #define __BUF_FMT "buf:%u.%u "
 #endif
 
-#define buf_err(buf_ptr, __e, ...) LOG_ERR(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+#define buf_err(buf_ptr, __e, ...) LOG_ERR(__BUF_FMT __e, buffer_pipeline_id(buf_ptr), \
 					   buf_get_id(buf_ptr), ##__VA_ARGS__)
 
-#define buf_warn(buf_ptr, __e, ...) LOG_WRN(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+#define buf_warn(buf_ptr, __e, ...) LOG_WRN(__BUF_FMT __e, buffer_pipeline_id(buf_ptr), \
 					    buf_get_id(buf_ptr), ##__VA_ARGS__)
 
-#define buf_info(buf_ptr, __e, ...) LOG_INF(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+#define buf_info(buf_ptr, __e, ...) LOG_INF(__BUF_FMT __e, buffer_pipeline_id(buf_ptr), \
 					    buf_get_id(buf_ptr), ##__VA_ARGS__)
 
-#define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__BUF_FMT __e, trace_buf_get_id(buf_ptr), \
+#define buf_dbg(buf_ptr, __e, ...) LOG_DBG(__BUF_FMT __e, buffer_pipeline_id(buf_ptr), \
 					   buf_get_id(buf_ptr), ##__VA_ARGS__)
 
 #else
 /** \brief Trace error message from buffer */
 #define buf_err(buf_ptr, __e, ...)						\
-	trace_dev_err(trace_buf_get_tr_ctx, trace_buf_get_id,			\
+	trace_dev_err(trace_buf_get_tr_ctx, buffer_pipeline_id,			\
 		      buf_get_id,					\
 		      (__sparse_force const struct comp_buffer *)buf_ptr,	\
 		      __e, ##__VA_ARGS__)
 
 /** \brief Trace warning message from buffer */
 #define buf_warn(buf_ptr, __e, ...)						\
-	trace_dev_warn(trace_buf_get_tr_ctx, trace_buf_get_id,			\
+	trace_dev_warn(trace_buf_get_tr_ctx, buffer_pipeline_id,			\
 		       buf_get_id,					\
 		       (__sparse_force const struct comp_buffer *)buf_ptr,	\
 		        __e, ##__VA_ARGS__)
 
 /** \brief Trace info message from buffer */
 #define buf_info(buf_ptr, __e, ...)						\
-	trace_dev_info(trace_buf_get_tr_ctx, trace_buf_get_id,			\
+	trace_dev_info(trace_buf_get_tr_ctx, buffer_pipeline_id,			\
 		       buf_get_id,					\
 		       (__sparse_force const struct comp_buffer *)buf_ptr,	\
 		       __e, ##__VA_ARGS__)
@@ -96,7 +93,7 @@ extern struct tr_ctx buffer_tr;
 #define buf_dbg(buf_ptr, __e, ...)
 #else
 #define buf_dbg(buf_ptr, __e, ...)						\
-	trace_dev_dbg(trace_buf_get_tr_ctx, trace_buf_get_id,			\
+	trace_dev_dbg(trace_buf_get_tr_ctx, buffer_pipeline_id,			\
 		      buf_get_id,					\
 		      (__sparse_force const struct comp_buffer *)buf_ptr,	\
 		      __e, ##__VA_ARGS__)
@@ -139,7 +136,6 @@ struct comp_buffer {
 	struct audio_stream stream;
 
 	/* configuration */
-	uint32_t pipeline_id;
 	uint32_t caps;
 	uint32_t core;
 	struct tr_ctx tctx;			/* trace settings */
@@ -274,6 +270,11 @@ static inline struct comp_dev *buffer_get_comp(struct comp_buffer *buffer, int d
 {
 	struct comp_dev *comp = dir == PPL_DIR_DOWNSTREAM ? buffer->sink : buffer->source;
 	return comp;
+}
+
+static inline uint32_t buffer_pipeline_id(const struct comp_buffer *buffer)
+{
+	return buffer->stream.runtime_stream_params.pipeline_id;
 }
 
 static inline void buffer_reset_pos(struct comp_buffer *buffer, void *data)

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -590,7 +590,9 @@ struct comp_dev {
 
 	const struct comp_driver *drv;	/**< driver */
 
-	struct processing_module *mod; /**< self->mod->dev == self, always */
+	struct processing_module *mod; /**< self->mod->dev == self, NULL if component is not using
+					 *  module adapter
+					 */
 
 	/* lists */
 	struct list_item bsource_list;	/**< list of source buffers */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -590,6 +590,8 @@ struct comp_dev {
 
 	const struct comp_driver *drv;	/**< driver */
 
+	struct processing_module *mod; /**< self->mod->dev == self, always */
+
 	/* lists */
 	struct list_item bsource_list;	/**< list of source buffers */
 	struct list_item bsink_list;	/**< list of sink buffers */
@@ -676,6 +678,15 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 		 trace_comp_drv_get_tr_ctx(dev->drv), sizeof(struct tr_ctx));
 
 	return dev;
+}
+
+/**
+ * \brief Module adapter associated with a component
+ * @param dev Component device
+ */
+static inline struct processing_module *comp_mod(const struct comp_dev *dev)
+{
+	return dev->mod;
 }
 
 /**

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -64,7 +64,7 @@ struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is_shared
 			      is_shared);
 	if (buffer) {
 		buffer->stream.runtime_stream_params.id = desc->comp.id;
-		buffer->pipeline_id = desc->comp.pipeline_id;
+		buffer->stream.runtime_stream_params.pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
 
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
@@ -80,7 +80,7 @@ int32_t ipc_comp_pipe_id(const struct ipc_comp_dev *icd)
 	case COMP_TYPE_COMPONENT:
 		return dev_comp_pipe_id(icd->cd);
 	case COMP_TYPE_BUFFER:
-		return icd->cb->pipeline_id;
+		return buffer_pipeline_id(icd->cb);
 	case COMP_TYPE_PIPELINE:
 		return icd->pipeline->pipeline_id;
 	default:

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -87,7 +87,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 #if defined(CONFIG_ACE_VERSION_2_0)
 		if (copier_cfg->gtw_cfg.node_id.f.dma_type == ipc4_alh_link_output_class ||
 		    copier_cfg->gtw_cfg.node_id.f.dma_type == ipc4_alh_link_input_class) {
-			struct processing_module *mod = comp_get_drvdata(dev);
+			struct processing_module *mod = comp_mod(dev);
 			struct copier_data *cd = module_get_private_data(mod);
 
 			if (!cd->gtw_cfg) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -468,8 +468,8 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	if (!cpu_is_me(source->ipc_config.core) && !cross_core_bind)
 		return ipc4_process_on_core(source->ipc_config.core, false);
 
-	struct processing_module *srcmod = comp_get_drvdata(source);
-	struct processing_module *dstmod = comp_get_drvdata(sink);
+	struct processing_module *srcmod = comp_mod(source);
+	struct processing_module *dstmod = comp_mod(sink);
 	struct module_config *dstcfg = &dstmod->priv.cfg;
 	struct module_config *srccfg = &srcmod->priv.cfg;
 

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -556,7 +556,7 @@ static struct comp_dev *lib_manager_module_create(const struct comp_driver *drv,
 
 	dev = module_adapter_new(drv, config, spec);
 	if (dev) {
-		struct processing_module *mod = comp_get_drvdata(dev);
+		struct processing_module *mod = comp_mod(dev);
 
 		mod->priv.llext = tmp_proc.priv.llext;
 	} else {
@@ -567,7 +567,7 @@ static struct comp_dev *lib_manager_module_create(const struct comp_driver *drv,
 
 static void lib_manager_module_free(struct comp_dev *dev)
 {
-	struct processing_module *mod = comp_get_drvdata(dev);
+	struct processing_module *mod = comp_mod(dev);
 	struct llext *llext = mod->priv.llext;
 	const struct comp_ipc_config *const config = &mod->dev->ipc_config;
 	const uint32_t module_id = config->id;

--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -157,7 +157,7 @@ static int setup(void **state)
 
 	td->dev = dev;
 	dev->frames = params->frames;
-	mod = comp_get_drvdata(dev);
+	mod = comp_mod(dev);
 
 	prepare_sink(td, mod);
 	prepare_source(td, mod);
@@ -184,7 +184,7 @@ static int setup(void **state)
 static int teardown(void **state)
 {
 	struct test_data *td = *state;
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 
 	test_free(mod->input_buffers);
 	test_free(mod->output_buffers);
@@ -200,7 +200,7 @@ static int teardown(void **state)
 #if CONFIG_FORMAT_S16LE
 static void fill_source_s16(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -235,7 +235,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 
 static void verify_sink_s16(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -266,7 +266,7 @@ static void verify_sink_s16(struct test_data *td)
 #if CONFIG_FORMAT_S24LE
 static void fill_source_s24(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -301,7 +301,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 
 static void verify_sink_s24(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -332,7 +332,7 @@ static void verify_sink_s24(struct test_data *td)
 #if CONFIG_FORMAT_S32LE
 static void fill_source_s32(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -367,7 +367,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 
 static void verify_sink_s32(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -410,7 +410,7 @@ static int frames_jitter(int frames)
 static void test_audio_eq_fir(void **state)
 {
 	struct test_data *td = *state;
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 
 	struct comp_buffer *source = td->source;
 	struct comp_buffer *sink = td->sink;

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -156,7 +156,7 @@ static int setup(void **state)
 
 	td->dev = dev;
 	dev->frames = params->frames;
-	mod = comp_get_drvdata(dev);
+	mod = comp_mod(dev);
 
 	prepare_sink(td, mod);
 	prepare_source(td, mod);
@@ -183,7 +183,7 @@ static int setup(void **state)
 static int teardown(void **state)
 {
 	struct test_data *td = *state;
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 
 	test_free(mod->input_buffers);
 	test_free(mod->output_buffers);
@@ -199,7 +199,7 @@ static int teardown(void **state)
 #if CONFIG_FORMAT_S16LE
 static void fill_source_s16(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -234,7 +234,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 
 static void verify_sink_s16(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -262,7 +262,7 @@ static void verify_sink_s16(struct test_data *td)
 #if CONFIG_FORMAT_S24LE
 static void fill_source_s24(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -297,7 +297,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 
 static void verify_sink_s24(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -325,7 +325,7 @@ static void verify_sink_s24(struct test_data *td)
 #if CONFIG_FORMAT_S32LE
 static void fill_source_s32(struct test_data *td, int frames_max)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -360,7 +360,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 
 static void verify_sink_s32(struct test_data *td)
 {
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 	struct comp_dev *dev = td->dev;
 	struct comp_buffer *sb;
 	struct audio_stream *ss;
@@ -400,7 +400,7 @@ static int frames_jitter(int frames)
 static void test_audio_eq_iir(void **state)
 {
 	struct test_data *td = *state;
-	struct processing_module *mod = comp_get_drvdata(td->dev);
+	struct processing_module *mod = comp_mod(td->dev);
 
 	struct comp_buffer *source = td->source;
 	struct comp_buffer *sink = td->sink;

--- a/test/cmocka/src/audio/module_adapter_test.c
+++ b/test/cmocka/src/audio/module_adapter_test.c
@@ -28,7 +28,7 @@ int module_adapter_test_setup(struct processing_module_test_data *test_data)
 	dev = test_malloc(sizeof(struct comp_dev));
 	dev->frames = parameters->frames;
 	mod->dev = dev;
-	comp_set_drvdata(dev, mod);
+	dev->mod = mod;
 
 	test_data->sinks = test_calloc(test_data->num_sinks, sizeof(struct comp_buffer *));
 	test_data->sources = test_calloc(test_data->num_sources, sizeof(struct comp_buffer *));

--- a/test/cmocka/src/audio/mux/demux_copy.c
+++ b/test/cmocka/src/audio/mux/demux_copy.c
@@ -167,7 +167,7 @@ static int setup_test_case(void **state)
 	if (!dev)
 		return -EINVAL;
 
-	mod = comp_get_drvdata(dev);
+	mod = comp_mod(dev);
 	td->dev = dev;
 	td->mod = mod;
 	td->cd = module_get_private_data(mod);

--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -189,7 +189,7 @@ static int setup_test_case(void **state)
 	if (!dev)
 		return -EINVAL;
 
-	mod = comp_get_drvdata(dev);
+	mod = comp_mod(dev);
 	td->dev = dev;
 	td->mod = mod;
 	td->cd = module_get_private_data(mod);

--- a/test/cmocka/src/audio/mux/mux_get_processing_function.c
+++ b/test/cmocka/src/audio/mux/mux_get_processing_function.c
@@ -83,7 +83,7 @@ static int setup_test_case(void **state)
 	if (!dev)
 		return -EINVAL;
 
-	mod = comp_get_drvdata(dev);
+	mod = comp_mod(dev);
 	td->dev = dev;
 	td->mod = mod;
 	td->cd = module_get_private_data(mod);

--- a/tools/testbench/testbench.c
+++ b/tools/testbench/testbench.c
@@ -163,7 +163,7 @@ static void test_pipeline_free_comps(int pipeline_id)
 					icd->id);
 			break;
 		case COMP_TYPE_BUFFER:
-			if (icd->cb->pipeline_id != pipeline_id)
+			if (buffer_pipeline_id(icd->cb) != pipeline_id)
 				break;
 			err = ipc_buffer_free(sof_get()->ipc, icd->id);
 			if (err)


### PR DESCRIPTION
Some API refactoring, no behavioral changes. 

* The comp_buffer change is required to expose the pipeline ID to source/sinker users (see #8919). 
* The processing_module backpointer fix is just a dangerous pattern I stumbled on during that work.  Typesafety is good.  Overloading untyped "private" data when you aren't the defined owner is bad.  This would have certainly blown up on someone at some point even if it hasn't yet.