### PR TITLE
cpu: multiprocessing: add new broadcast rutine

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 53ddff639562ef68dc0a6f62b82f7505c75ebdce
+      revision: 2efc447c1b41efd23447ea180731d673114f06d8
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -156,7 +156,7 @@ void cpu_disable_core(int id)
 		return;
 
 	/* Broadcasting interrupts to other cores. */
-	arch_sched_ipi();
+	arch_sched_broadcast_ipi();
 
 	uint64_t timeout = k_cycle_get_64() +
 		k_ms_to_cyc_ceil64(CONFIG_SECONDARY_CORE_DISABLING_TIMEOUT);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -332,7 +332,7 @@ int poll_for_register_delay(uint32_t reg, uint32_t mask,
 volatile int *_sof_fatal_null = NULL;
 
 void k_sys_fatal_error_handler(unsigned int reason,
-			       const z_arch_esf_t *esf)
+			       const struct arch_esf *esf)
 {
 	ARG_UNUSED(esf);
 


### PR DESCRIPTION
Platforms that support IPIs allow them to be broadcast via the
new arch_sched_broadcast_ipi() routine (replacing arch_sched_ipi()).
Those that also allow IPIs to be directed to specific CPUs may
use arch_sched_directed_ipi() to do so.
