### PR TITLE
Tools: Topology2: Use rates instead of rate_min/max in benchmark

### DIFF
--- a/tools/topology/topology2/cavs-benchmark-hda.conf
+++ b/tools/topology/topology2/cavs-benchmark-hda.conf
@@ -35,15 +35,13 @@ Object.PCM.pcm [
 			direction	"playback"
 			name $ANALOG_PLAYBACK_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
-			rate_min 8000
-			rate_max 192000
+			rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
 		}
 		Object.PCM.pcm_caps.2 {
 			direction	"capture"
 			name $ANALOG_CAPTURE_PCM
 			formats 'S32_LE,S24_LE,S16_LE'
-			rate_min 8000
-			rate_max 192000
+			rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
 		}
 		direction duplex
 	}


### PR DESCRIPTION
The rate_min/rate_max is obsolete, should use rates with list of rates to support. Without this change the playback of non-48 kHz content happens with 48 kHz rate with pitch shift effect. Aplay shows only a warning.