### PR TITLE
src: base_fw: adjust ssp copier init flow for ptl (with Zephyr update)

### DIFF
--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -63,6 +63,11 @@ int basefw_vendor_hw_config(uint32_t *data_offset, char *data)
 	tuple = tlv_next(tuple);
 	tlv_value_uint32_set(tuple, IPC4_LP_EBB_COUNT_HW_CFG, PLATFORM_LPSRAM_EBB_COUNT);
 
+#ifdef CONFIG_SOC_INTEL_ACE30_PTL
+	tuple = tlv_next(tuple);
+	tlv_value_uint32_set(tuple, IPC4_I2S_CAPS_HW_CFG, I2S_VER_30_PTL);
+#endif
+
 	tuple = tlv_next(tuple);
 	*data_offset = (int)((char *)tuple - data);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -154,6 +154,8 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 		cfg_params = is_blob ? spec_config : &sof_cfg->ssp;
 		dai_set_link_hda_config(&cfg.link_config,
 					common_config, cfg_params);
+		/* Store tdm slot group index*/
+		cfg.tdm_slot_group = common_config->dai_index & 0xF;
 		break;
 	case SOF_DAI_INTEL_ALH:
 		cfg.type = is_blob ? DAI_INTEL_ALH_NHLT : DAI_INTEL_ALH;

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -728,4 +728,7 @@ struct schedulers_info {
 
 struct ipc4_system_time_info *basefw_get_system_time_info(void);
 
+/* Specifies I2S IPC4 version for PTL platform */
+static const uint32_t I2S_VER_30_PTL       = 0x40000;
+
 #endif /* __SOF_IPC4_BASE_FW_H__ */

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 0a3f2f0397a86425cc7d12fa3a0c0ab8020d80e1
+      revision: a2386efbce1866613f7c714b958a159364dc5f37
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Regarding to https://github.com/zephyrproject-rtos/zephyr/pull/74030 there is necessary to pass properly v_index value.

In addition, PTL has a new version of the IPC4 blob, which will be configured in the TLV information

Necessary zephyr changes:
- [x] https://github.com/zephyrproject-rtos/zephyr/pull/74030

This PR also changes the **West version** to be consistent with the changes from PR 74030