### PR TITLE
library_manager: add missing "depends on CONFIG_LLEXT"

### DIFF
--- a/src/library_manager/Kconfig
+++ b/src/library_manager/Kconfig
@@ -7,6 +7,7 @@ menu "Library Manager"
 config LIBRARY_MANAGER
 	bool "Library Manager Support"
 	default n
+	depends on CONFIG_LLEXT
 	depends on IPC_MAJOR_4
 	help
 	  This is support for dynamic modules loading.


### PR DESCRIPTION
Block the possibility of compiling library_manager without CONFIG_LLEXT, which obviously fails with dozens of linker errors.

PS: I have no idea why library_manager depends on IPC_MAJOR_4.  Kconfig is designed to express actual code dependencies, not "supported" configurations.