### PR TITLE
[DNM] ipc4: set_dx: Change active pipeline check from error to warning

### DIFF
--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -1375,8 +1375,7 @@ static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 		}
 
 		if (is_any_ppl_active()) {
-			ipc_cmd_err(&ipc_tr, "some pipelines are still active");
-			return IPC4_BUSY;
+			tr_warn(&ipc_tr, "some pipelines are still active");
 		}
 
 #if defined(CONFIG_PM)


### PR DESCRIPTION
During the power state transition process for DSP cores, the system previously checked for any active pipelines and prevented the transition if any were found, returning an IPC4_BUSY error. This behavior could potentially block power transitions even in cases where active pipelines do not critically affect the transition process.

This patch changes the behavior to issue a warning instead of an error when active pipelines are detected during a power state transition (DX transition). The intention is to allow the power transition to proceed while still logging the presence of active pipelines for diagnostic purposes.