### PR TITLE
[DNM] dai: add support for Intel UAOL DAI

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -139,6 +139,8 @@ static int copier_init(struct processing_module *mod)
 		case ipc4_i2s_link_input_class:
 		case ipc4_alh_link_output_class:
 		case ipc4_alh_link_input_class:
+		case ipc4_alh_uaol_stream_link_output_class:
+		case ipc4_alh_uaol_stream_link_input_class:
 			ret = copier_dai_create(dev, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create dai");

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -311,6 +311,19 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		if (ret)
 			return ret;
 		break;
+	case ipc4_alh_uaol_stream_link_output_class:
+	case ipc4_alh_uaol_stream_link_input_class:
+		dai.type = SOF_DAI_INTEL_UAOL;
+		dai.is_config_blob = true;
+		cd->gtw_type = ipc4_gtw_alh;
+		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
+					   copier->gtw_cfg.config_length * 4);
+		if (ret != IPC4_SUCCESS) {
+			comp_err(dev, "No uaol dma_config found in blob!");
+			return -EINVAL;
+		}
+		dai.out_fmt = &copier->out_fmt;
+		break;
 	case ipc4_dmic_link_input_class:
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -140,6 +140,7 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 {
 	const struct device *dev = dai->dev;
 	const struct sof_ipc_dai_config *sof_cfg = spec_config;
+	const struct ipc4_copier_gateway_cfg *gtw_cfg = spec_config;
 	struct dai_config cfg;
 	const void *cfg_params;
 	bool is_blob;
@@ -153,7 +154,7 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	switch (common_config->type) {
 	case SOF_DAI_INTEL_SSP:
 		cfg.type = is_blob ? DAI_INTEL_SSP_NHLT : DAI_INTEL_SSP;
-		cfg_params = is_blob ? spec_config : &sof_cfg->ssp;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : (void *)&sof_cfg->ssp;
 		dai_set_link_hda_config(&cfg.link_config,
 					common_config, cfg_params);
 		/* Store tdm slot group index*/
@@ -161,17 +162,17 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 		break;
 	case SOF_DAI_INTEL_ALH:
 		cfg.type = is_blob ? DAI_INTEL_ALH_NHLT : DAI_INTEL_ALH;
-		cfg_params = is_blob ? spec_config : &sof_cfg->alh;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : (void *)&sof_cfg->alh;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		cfg.type = is_blob ? DAI_INTEL_DMIC_NHLT : DAI_INTEL_DMIC;
-		cfg_params = is_blob ? spec_config : &sof_cfg->dmic;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : (void *)&sof_cfg->dmic;
 		dai_set_link_hda_config(&cfg.link_config,
 					common_config, cfg_params);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		cfg.type = is_blob ? DAI_INTEL_HDA_NHLT : DAI_INTEL_HDA;
-		cfg_params = is_blob ? spec_config : &sof_cfg->hda;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : (void *)&sof_cfg->hda;
 		break;
 	case SOF_DAI_IMX_SAI:
 		cfg.type = DAI_IMX_SAI;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -150,6 +150,8 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	cfg.format = sof_cfg->format;
 	cfg.options = sof_cfg->flags;
 	cfg.rate = common_config->sampling_frequency;
+	cfg.channels = common_config->out_fmt->channels_count;
+	cfg.word_size = common_config->out_fmt->valid_bit_depth;
 
 	switch (common_config->type) {
 	case SOF_DAI_INTEL_SSP:
@@ -181,6 +183,11 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	case SOF_DAI_IMX_ESAI:
 		cfg.type = DAI_IMX_ESAI;
 		cfg_params = &sof_cfg->esai;
+		break;
+	case SOF_DAI_INTEL_UAOL:
+		cfg.type = DAI_INTEL_UAOL;
+		cfg_params = gtw_cfg;
+		dai_set_link_hda_config(&cfg.link_config, common_config, &gtw_cfg->config_data);
 		break;
 	default:
 		return -EINVAL;

--- a/src/include/ipc/dai.h
+++ b/src/include/ipc/dai.h
@@ -94,7 +94,8 @@ enum sof_ipc_dai_type {
 	SOF_DAI_AMD_SP_VIRTUAL,		/**<Amd SP VIRTUAL */
 	SOF_DAI_AMD_HS_VIRTUAL,		/**<Amd HS VIRTUAL */
 	SOF_DAI_IMX_MICFIL,		/**< i.MX MICFIL */
-	SOF_DAI_AMD_SW_AUDIO		/**<Amd SW AUDIO */
+	SOF_DAI_AMD_SW_AUDIO,		/**<Amd SW AUDIO */
+	SOF_DAI_INTEL_UAOL,		/**< Intel UAOL */
 };
 
 /* general purpose DAI configuration */

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -393,7 +393,7 @@ int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai 
 	if (ret < 0)
 		return ret;
 
-	return dai_set_config(dd->dai, common_config, copier_cfg->gtw_cfg.config_data);
+	return dai_set_config(dd->dai, common_config, &copier_cfg->gtw_cfg);
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1055,6 +1055,18 @@ int ipc4_add_comp_dev(struct comp_dev *dev)
 int ipc4_find_dma_config(struct ipc_config_dai *dai, uint8_t *data_buffer, uint32_t size)
 {
 #if ACE_VERSION > ACE_VERSION_1_5
+	if (dai->type == SOF_DAI_INTEL_UAOL) {
+		void *value_ptr = NULL;
+		uint32_t value_size;
+
+		tlv_value_get(data_buffer, size, GTW_DMA_CONFIG_ID, &value_ptr, &value_size);
+		if (!value_ptr)
+			return IPC4_INVALID_REQUEST;
+
+		dai->host_dma_config[0] = (struct ipc_dma_config *)value_ptr;
+		return IPC4_SUCCESS;
+	}
+
 	uint32_t *dma_config_id = GET_IPC_DMA_CONFIG_ID(data_buffer, size);
 
 	if (*dma_config_id != GTW_DMA_CONFIG_ID)

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -157,7 +157,7 @@ const struct device *dai_get_device(uint32_t type, uint32_t index)
 	int dir;
 	int i;
 
-	dir = (type == SOF_DAI_INTEL_DMIC) ? DAI_DIR_RX : DAI_DIR_BOTH;
+	dir = (type == DAI_INTEL_DMIC) ? DAI_DIR_RX : DAI_DIR_BOTH;
 
 	for (i = 0; i < ARRAY_SIZE(zephyr_dev); i++) {
 		if (dai_config_get(zephyr_dev[i], &cfg, dir))
@@ -210,8 +210,44 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 {
 	const struct device *dev;
 	struct dai *d;
+	uint32_t z_type;
 
-	dev = dai_get_device(type, index);
+	switch (type) {
+	case SOF_DAI_INTEL_SSP:
+		z_type = DAI_INTEL_SSP;
+		break;
+	case SOF_DAI_INTEL_DMIC:
+		z_type = DAI_INTEL_DMIC;
+		break;
+	case SOF_DAI_INTEL_HDA:
+		z_type = DAI_INTEL_HDA;
+		break;
+	case SOF_DAI_INTEL_ALH:
+		z_type = DAI_INTEL_ALH;
+		break;
+	case SOF_DAI_IMX_SAI:
+		z_type = DAI_IMX_SAI;
+		break;
+	case SOF_DAI_IMX_ESAI:
+		z_type = DAI_IMX_ESAI;
+		break;
+	case SOF_DAI_AMD_BT:
+		z_type = DAI_AMD_BT;
+		break;
+	case SOF_DAI_AMD_SP:
+		z_type = DAI_AMD_SP;
+		break;
+	case SOF_DAI_AMD_DMIC:
+		z_type = DAI_AMD_DMIC;
+		break;
+	case SOF_DAI_MEDIATEK_AFE:
+		z_type = DAI_MEDIATEK_AFE;
+		break;
+	default:
+		return NULL;
+	}
+
+	dev = dai_get_device(z_type, index);
 	if (!dev) {
 		tr_err(&dai_tr, "dai_get: failed to get dai with index %d type %d",
 		       index, type);

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -149,6 +149,9 @@ const struct device *zephyr_dev[] = {
 #if CONFIG_DAI_NXP_ESAI
 	DT_FOREACH_STATUS_OKAY(nxp_dai_esai, GET_DEVICE_LIST)
 #endif
+#if CONFIG_DAI_INTEL_UAOL
+	DT_FOREACH_STATUS_OKAY(intel_uaol_dai, GET_DEVICE_LIST)
+#endif
 };
 
 const struct device *dai_get_device(uint32_t type, uint32_t index)
@@ -197,6 +200,7 @@ static void dai_set_device_params(struct dai *d)
 #endif
 		break;
 	case SOF_DAI_INTEL_HDA:
+	case SOF_DAI_INTEL_UAOL:
 		d->dma_dev = SOF_DMA_DEV_HDA;
 		d->dma_caps = SOF_DMA_CAP_HDA;
 		break;
@@ -242,6 +246,9 @@ struct dai *dai_get(uint32_t type, uint32_t index, uint32_t flags)
 		break;
 	case SOF_DAI_MEDIATEK_AFE:
 		z_type = DAI_MEDIATEK_AFE;
+		break;
+	case SOF_DAI_INTEL_UAOL:
+		z_type = DAI_INTEL_UAOL;
 		break;
 	default:
 		return NULL;

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 36517253160663f5cdb0f496cb166236fe4ad4c4
+      revision: pull/69906/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
This adds support for Intel USB Audio Offload Link (UAOL) DAI.

This PR needs another (Zephyr) PR [drivers: dai: add DAI driver for Intel UAOL](https://github.com/zephyrproject-rtos/zephyr/pull/69906) to be merged first.