### PR TITLE
[stable-2.10] audio: volume: disable HIFI4 optimizations

### DIFF
--- a/src/audio/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/volume/volume_hifi3_with_peakvol.c
@@ -21,7 +21,9 @@ LOG_MODULE_DECLARE(volume_hifi3, CONFIG_SOF_LOG_LEVEL);
 
 #include "volume.h"
 
-#if SOF_USE_HIFI(3, VOLUME)
+// Hifi4 is disabled, see bug https://github.com/thesofproject/sof/issues/9213
+// Hifi5 is not there yet.
+#if SOF_USE_HIFI(3, VOLUME) || SOF_USE_HIFI(4, VOLUME) || SOF_USE_HIFI(5, VOLUME)
 
 #if CONFIG_COMP_PEAK_VOL
 

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -21,7 +21,8 @@ LOG_MODULE_DECLARE(volume_hifi4, CONFIG_SOF_LOG_LEVEL);
 
 #include "volume.h"
 
-#if SOF_USE_HIFI(4, VOLUME) || SOF_USE_HIFI(5, VOLUME)
+// disabled and replaced by HIFI3, see issue https://github.com/thesofproject/sof/issues/9213
+#if 0 // SOF_USE_HIFI(4, VOLUME) || SOF_USE_HIFI(5, VOLUME)
 
 #if CONFIG_COMP_PEAK_VOL
 #include <xtensa/tie/xt_hifi4.h>


### PR DESCRIPTION
HIFI4 has been disabled. HIFI3 is being used for
the volume component with peakVol.

There was a problem with test
test_01_09_peakvol_quality[44100Hz_16in16bit_1ch-0]. The main problem was with frequencies: 11025,
22050, 44100, 88200, 176400 Hz.
Because frame is different for these frequencies. For f=44100Hz frame is equal 44 or 45. Some of the samples were simply not processed.

Changes to HIFI4 are not-trivial and failed to fix the problem. However, HIFI3 is fully compatible and works properly. Performance is worse by 1-2,5% in CPU cycle usage
but no glitches appear and all samples are processed correctly.


(cherry picked from commit 87571f337c10ddd87663f3c75dc0cfaf6b932f0e)