### PR TITLE
tools: plugin: ipc4: switch to C++17 to build ns module

### DIFF
--- a/tools/plugin/modules/ov_noise_suppression/CMakeLists.txt
+++ b/tools/plugin/modules/ov_noise_suppression/CMakeLists.txt
@@ -4,6 +4,8 @@
 find_package(OpenVINO COMPONENTS Runtime)
 
 if(OpenVINO_FOUND)
+set(CMAKE_CXX_STANDARD 17)
+
 add_library(sof_ns_interface STATIC noise_suppression_interface.cpp)
 target_link_libraries(sof_ns_interface PRIVATE -Wl,--export-dynamic)
 target_link_libraries(sof_ns_interface PRIVATE openvino::runtime)


### PR DESCRIPTION
Compile in C++17 mode to fix:

noise_suppression_interface.cpp:175:14: error: 'clamp' is not a member of 'std'
  175 |     v = std::clamp(v, -1.0f, +1.0f);
      |              ^~~~~
ninja: build stopped: subcommand failed