### PR TITLE
Add device posture feature

### DIFF
--- a/posix/include/sof/lib/dma.h
+++ b/posix/include/sof/lib/dma.h
@@ -254,7 +254,7 @@ struct dma_info {
 struct audio_stream;
 typedef int (*dma_process_func)(const struct audio_stream __sparse_cache *source,
 				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
-				uint32_t ooffset, uint32_t frames);
+				uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
 
 /**
  * \brief API to initialize a platform DMA controllers.
@@ -523,19 +523,15 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 	return size;
 }
 
-struct audio_stream;
-typedef void (*dma_process)(const struct audio_stream *,
-			    struct audio_stream *, uint32_t);
-
 /* copies data from DMA buffer using provided processing function */
 int dma_buffer_copy_from(struct comp_buffer __sparse_cache *source,
 			 struct comp_buffer __sparse_cache *sink,
-			 dma_process_func process, uint32_t source_bytes);
+			 dma_process_func process, uint32_t source_bytes, uint32_t chmap);
 
 /* copies data to DMA buffer using provided processing function */
 int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
 		       struct comp_buffer __sparse_cache *sink,
-		       dma_process_func process, uint32_t sink_bytes);
+		       dma_process_func process, uint32_t sink_bytes, uint32_t chmap);
 
 /*
  * Used when copying DMA buffer bytes into multiple sink buffers, one at a time using the provided
@@ -544,7 +540,8 @@ int dma_buffer_copy_to(struct comp_buffer __sparse_cache *source,
  */
 int dma_buffer_copy_from_no_consume(struct comp_buffer __sparse_cache *source,
 				    struct comp_buffer __sparse_cache *sink,
-				    dma_process_func process, uint32_t source_bytes);
+				    dma_process_func process,
+				    uint32_t source_bytes, uint32_t chmap);
 
 /* generic DMA DSP <-> Host copier */
 

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -251,6 +251,13 @@ config PCM_CONVERTER_FORMAT_S32LE
 	help
 	  Support 32 bit processing data format with sign and in little endian format
 
+config PCM_CONVERTER_FORMAT_S16_4LE
+	bool "Support S16_4LE"
+	default y
+	help
+	  Support the format of signed 16-bit little-endian in the 2 lower bytes
+	  of a 32-bit container. This format is used, for example, by the SSP gateway.
+
 config PCM_CONVERTER_FORMAT_FLOAT
 	bool "Support float"
 	default y
@@ -304,6 +311,14 @@ config PCM_CONVERTER_FORMAT_CONVERT_HIFI3
 	default y
 	help
 	  Use HIFI3 extensions for optimized format conversion (experimental).
+
+config PCM_REMAPPING_CONVERTERS
+	bool "Channel remapping conversions"
+	default y
+	depends on IPC_MAJOR_4
+	help
+	  Enable conversion functions that perform both format conversion
+	  and channel remapping simultaneously.
 
 config TRACE_CHANNEL
 	int "TRACE DMA Channel configuration"

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -440,7 +440,8 @@ static int do_conversion_copy(struct comp_dev *dev,
 	buffer_stream_invalidate(src, processed_data->source_bytes);
 
 	cd->converter[i](&src->stream, 0, &sink->stream, 0,
-			 processed_data->frames * audio_stream_get_channels(&sink->stream));
+			 processed_data->frames * audio_stream_get_channels(&src->stream),
+			 DUMMY_CHMAP);
 
 	buffer_stream_writeback(sink, processed_data->sink_bytes);
 	comp_update_buffer_produce(sink, processed_data->sink_bytes);
@@ -509,7 +510,7 @@ static int copier_module_copy(struct processing_module *mod,
 		sink_dev = sink_c->sink;
 		processed_data.sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {
-			uint32_t samples;
+			uint32_t source_samples;
 			int sink_queue_id;
 
 			sink_queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(sink_c));
@@ -518,10 +519,11 @@ static int copier_module_copy(struct processing_module *mod,
 
 			comp_get_copy_limits(src_c, sink_c, &processed_data);
 
-			samples = processed_data.frames *
-					audio_stream_get_channels(output_buffers[i].data);
+			source_samples = processed_data.frames *
+					audio_stream_get_channels(input_buffers[0].data);
 			cd->converter[sink_queue_id](input_buffers[0].data, 0,
-						     output_buffers[i].data, 0, samples);
+						     output_buffers[i].data, 0,
+						     source_samples, DUMMY_CHMAP);
 
 			output_buffers[i].size = processed_data.sink_bytes;
 			cd->output_total_data_processed += processed_data.sink_bytes;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -164,6 +164,8 @@ static int copier_init(struct processing_module *mod)
 
 		dev->direction_set = true;
 	} else {
+		cd->gtw_type = ipc4_gtw_none;
+
 		/* set max sink count for module copier */
 		mod->max_sinks = IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT;
 	}
@@ -244,7 +246,7 @@ static int copier_prepare(struct processing_module *mod,
 		 */
 		cd->converter[0] = get_converter_func(&cd->config.base.audio_fmt,
 							      &cd->config.out_fmt, ipc4_gtw_none,
-							      ipc4_bidirection);
+							      ipc4_bidirection, DUMMY_CHMAP);
 		if (!cd->converter[0]) {
 			comp_err(dev, "can't support for in format %d, out format %d",
 				 cd->config.base.audio_fmt.depth,  cd->config.out_fmt.depth);
@@ -686,7 +688,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	cd->out_fmt[sink_fmt->sink_id] = sink_fmt->sink_fmt;
 	cd->converter[sink_fmt->sink_id] = get_converter_func(&sink_fmt->source_fmt,
 							      &sink_fmt->sink_fmt, ipc4_gtw_none,
-							      ipc4_bidirection);
+							      ipc4_bidirection, DUMMY_CHMAP);
 
 	return 0;
 }

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -661,6 +661,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
 	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
+	uint32_t chmap;
 
 	if (max_data_size < sizeof(*sink_fmt)) {
 		comp_err(dev, "error: max_data_size %d should be bigger than %d", max_data_size,
@@ -686,9 +687,15 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	}
 
 	cd->out_fmt[sink_fmt->sink_id] = sink_fmt->sink_fmt;
+
+	if (cd->endpoint_num > 0 && dev->ipc_config.type == SOF_COMP_DAI)
+		chmap = cd->dd[0]->chmap;
+	else
+		chmap = DUMMY_CHMAP;
+
 	cd->converter[sink_fmt->sink_id] = get_converter_func(&sink_fmt->source_fmt,
 							      &sink_fmt->sink_fmt, ipc4_gtw_none,
-							      ipc4_bidirection, DUMMY_CHMAP);
+							      ipc4_bidirection, chmap);
 
 	return 0;
 }
@@ -728,6 +735,82 @@ static int set_attenuation(struct comp_dev *dev, uint32_t data_offset, const cha
 	return 0;
 }
 
+static int set_chmap(struct comp_dev *dev, const void *data, size_t data_size)
+{
+	const struct ipc4_copier_config_channel_map *chmap_cfg = data;
+	struct processing_module *mod = comp_mod(dev);
+	struct copier_data *cd = module_get_private_data(mod);
+	enum ipc4_direction_type dir;
+	struct ipc4_audio_format in_fmt = cd->config.base.audio_fmt;
+	struct ipc4_audio_format out_fmt = cd->config.out_fmt;
+	pcm_converter_func process;
+	pcm_converter_func converters[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
+	int i;
+	uint32_t irq_flags;
+
+	if (data_size < sizeof(*chmap_cfg)) {
+		comp_err(dev, "Wrong payload size: %d", data_size);
+		return -EINVAL;
+	}
+
+	if (cd->endpoint_num == 0 || dev->ipc_config.type != SOF_COMP_DAI) {
+		comp_err(dev, "Only DAI gateway supports changing chmap");
+		return -EINVAL;
+	}
+
+	comp_info(dev, "New chmap requested: %x", chmap_cfg->channel_map);
+
+	if (!cd->dd[0]->dma_buffer) {
+		/* DMA buffer not yet created. Remember the chmap, it will be used
+		 * later in .params() handler.
+		 *
+		 * The assignment should be atomic as LL thread can preempt this IPC thread.
+		 */
+		cd->dd[0]->chmap = chmap_cfg->channel_map;
+		return 0;
+	}
+
+	copier_dai_adjust_params(cd, &in_fmt, &out_fmt);
+
+	dir = (cd->direction == SOF_IPC_STREAM_PLAYBACK) ?
+		ipc4_playback : ipc4_capture;
+
+	process = get_converter_func(&in_fmt, &out_fmt, cd->gtw_type, dir, chmap_cfg->channel_map);
+
+	if (!process) {
+		comp_err(dev, "No gtw converter func found!");
+		return -EINVAL;
+	}
+
+	/* Channel map is same for all sinks. However, as sinks allowed to have different
+	 * sample formats, get new convert/remap function for each sink.
+	 */
+	for (i = 0; i < IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT; i++) {
+		if (cd->converter[i]) {
+			converters[i] = get_converter_func(&in_fmt, &cd->out_fmt[i],
+							   ipc4_gtw_none, ipc4_bidirection,
+							   chmap_cfg->channel_map);
+			/* Do not report an error if converter not found as sinks could be
+			 * bound/unbound on a fly and out_fmt[i] may contain obsolete data.
+			 */
+		} else {
+			converters[i] = NULL;
+		}
+	}
+
+	/* Atomically update chmap, process and converters */
+	irq_local_disable(irq_flags);
+
+	cd->dd[0]->chmap = chmap_cfg->channel_map;
+	cd->dd[0]->process = process;
+	for (i = 0; i < IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT; i++)
+		cd->converter[i] = converters[i];
+
+	irq_local_enable(irq_flags);
+
+	return 0;
+}
+
 static int copier_set_configuration(struct processing_module *mod,
 				    uint32_t config_id,
 				    enum module_cfg_fragment_position pos,
@@ -745,6 +828,8 @@ static int copier_set_configuration(struct processing_module *mod,
 		return copier_set_sink_fmt(dev, fragment, fragment_size);
 	case IPC4_COPIER_MODULE_CFG_ATTENUATION:
 		return set_attenuation(dev, fragment_size, (const char *)fragment);
+	case IPC4_COPIER_MODULE_CFG_PARAM_CHANNEL_MAP:
+		return set_chmap(dev, fragment, fragment_size);
 	default:
 		return -EINVAL;
 	}

--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -232,6 +232,7 @@ struct copier_data {
 	 */
 	struct ipc4_copier_module_cfg config;
 	void *gtw_cfg;
+	enum ipc4_gateway_type gtw_type;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint32_t endpoint_num;
@@ -267,7 +268,8 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 				      const struct ipc4_audio_format *out_fmt,
 				      enum ipc4_gateway_type type,
-				      enum ipc4_direction_type dir);
+				      enum ipc4_direction_type dir,
+				      uint32_t chmap);
 
 struct comp_ipc_config;
 int create_endpoint_buffer(struct comp_dev *dev,

--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -180,7 +180,12 @@ enum ipc4_copier_module_config_params {
 	 * uint32_t. Config is only allowed when output pin is set up for 32bit and
 	 * source is connected to Gateway
 	 */
-	IPC4_COPIER_MODULE_CFG_ATTENUATION = 6
+	IPC4_COPIER_MODULE_CFG_ATTENUATION = 6,
+	/* Use LARGE_CONFIG_SET to setup new channel map, which allows to map channels
+	 * from gateway buffer to copier with any order.
+	 * Same mapping will be applied for all copier sinks.
+	 */
+	IPC4_COPIER_MODULE_CFG_PARAM_CHANNEL_MAP = 7
 };
 
 struct ipc4_copier_config_timestamp_init_data {
@@ -199,6 +204,13 @@ struct ipc4_copier_config_set_sink_format {
 	struct ipc4_audio_format source_fmt;
 	/* Output format used by the sink */
 	struct ipc4_audio_format sink_fmt;
+} __attribute__((packed, aligned(4)));
+
+struct ipc4_copier_config_channel_map {
+	/* Each half-byte of the channel map is an index of the DMA stream channel that
+	 * should be copied to the position determined by this half-byte index.
+	 */
+	uint32_t channel_map;
 } __attribute__((packed, aligned(4)));
 
 #define IPC4_COPIER_DATA_SEGMENT_DISABLE	(0 << 0)

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -502,10 +502,10 @@ int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 
 	switch (container_size) {
 	case 2:
-		cd->dd[dai_index]->process = copy_single_channel_c16;
+		cd->dd[dai_index]->channel_copy = copy_single_channel_c16;
 		break;
 	case 4:
-		cd->dd[dai_index]->process = copy_single_channel_c32;
+		cd->dd[dai_index]->channel_copy = copy_single_channel_c32;
 		break;
 	default:
 		comp_err(dev, "Unexpected container size: %d", container_size);

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -136,6 +136,7 @@ int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
 	enum sof_ipc_frame in_valid_fmt, out_valid_fmt;
 
 	config->type = SOF_COMP_HOST;
+	cd->gtw_type = ipc4_gtw_host;
 
 	audio_stream_fmt_conversion(copier_cfg->base.audio_fmt.depth,
 				    copier_cfg->base.audio_fmt.valid_bit_depth,
@@ -195,7 +196,7 @@ int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
 		get_converter_func(&copier_cfg->base.audio_fmt,
 				   &copier_cfg->out_fmt,
-				   ipc4_gtw_host, IPC4_DIRECTION(dir));
+				   ipc4_gtw_host, IPC4_DIRECTION(dir), DUMMY_CHMAP);
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter for host, dir %d", dir);
 		ret = -EINVAL;

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -229,6 +229,7 @@ int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	 * IPC gateway should be handled similarly as host gateway.
 	 */
 	config->type = SOF_COMP_HOST;
+	cd->gtw_type = ipc4_gtw_host;
 
 	ret = create_endpoint_buffer(dev, cd, copier, false);
 	if (ret < 0)
@@ -255,7 +256,7 @@ int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
 		get_converter_func(&copier->base.audio_fmt,
 				   &copier->out_fmt,
-				   ipc4_gtw_host, IPC4_DIRECTION(cd->direction));
+				   ipc4_gtw_host, IPC4_DIRECTION(cd->direction), DUMMY_CHMAP);
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter for IPC gateway, dir %d",
 			 cd->direction);

--- a/src/audio/copier/dai_copier.h
+++ b/src/audio/copier/dai_copier.h
@@ -83,6 +83,10 @@ void copier_dai_free(struct copier_data *cd);
 
 int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd);
 
+void copier_dai_adjust_params(const struct copier_data *cd,
+			      struct ipc4_audio_format *in_fmt,
+			      struct ipc4_audio_format *out_fmt);
+
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -122,10 +122,10 @@ static void dai_dma_cb(void *arg, enum notify_id type, void *data)
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
-					 dd->process, bytes);
+					 dd->process, bytes, DUMMY_CHMAP);
 	} else {
 		ret = dma_buffer_copy_from(dd->dma_buffer, dd->local_buffer,
-					   dd->process, bytes);
+					   dd->process, bytes, DUMMY_CHMAP);
 	}
 
 	/* assert dma_buffer_copy succeed */

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -379,16 +379,19 @@ dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t fr
 	if (dev->direction == SOF_IPC_STREAM_CAPTURE)
 		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 
+	assert(dd->channel_copy);
+
 	/* copy all channels one by one */
 	for (i = 0; i < audio_stream_get_channels(&dd->dma_buffer->stream); i++) {
 		uint32_t multi_buf_channel = dd->dma_buffer->chmap[i];
 
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-			dd->process(&multi_endpoint_buffer->stream, multi_buf_channel,
-				    &dd->dma_buffer->stream, i, frames);
+			dd->channel_copy(&multi_endpoint_buffer->stream, multi_buf_channel,
+					 &dd->dma_buffer->stream, i, frames);
 		else
-			dd->process(&dd->dma_buffer->stream, i, &multi_endpoint_buffer->stream,
-				    multi_buf_channel, frames);
+			dd->channel_copy(&dd->dma_buffer->stream, i,
+					 &multi_endpoint_buffer->stream, multi_buf_channel,
+					 frames);
 	}
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -269,7 +269,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
-					 dd->process, bytes);
+					 dd->process, bytes, DUMMY_CHMAP);
 	} else {
 		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 		/*
@@ -277,7 +277,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 		 * so no need to check the return value of dma_buffer_copy_from_no_consume().
 		 */
 		ret = dma_buffer_copy_from_no_consume(dd->dma_buffer, dd->local_buffer,
-						      dd->process, bytes);
+						      dd->process, bytes, DUMMY_CHMAP);
 #if CONFIG_IPC_MAJOR_4
 		struct list_item *sink_list;
 		/* Skip in case of endpoint DAI devices created by the copier */
@@ -318,7 +318,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				    sink->hw_params_configured)
 					ret = dma_buffer_copy_from_no_consume(dd->dma_buffer,
 									      sink, converter[j],
-									      bytes);
+									      bytes, DUMMY_CHMAP);
 			}
 		}
 #endif

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -794,7 +794,8 @@ static int dai_set_dma_config(struct dai_data *dd, struct comp_dev *dev)
 }
 
 static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
-			      struct sof_ipc_stream_params *params, uint32_t *pb, uint32_t *pc)
+			      const struct sof_ipc_stream_params *params,
+			      uint32_t *pb, uint32_t *pc)
 {
 	struct sof_ipc_stream_params hw_params = *params;
 	uint32_t frame_size;
@@ -916,8 +917,10 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 }
 
 int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
-		      struct sof_ipc_stream_params *params)
+		      struct sof_ipc_stream_params *base_cfg_params)
 {
+	struct sof_ipc_stream_params params = *base_cfg_params;
+	struct sof_ipc_stream_params hw_params;
 	struct dma_sg_config *config = &dd->config;
 	uint32_t period_bytes = 0;
 	uint32_t period_count = 0;
@@ -932,13 +935,30 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		return err;
 	}
 
-	err = dai_verify_params(dd, dev, params);
+	/* When the hardware is able to return a valid number of DMA buffer audio channels
+	 * (e.g., extracted from a blob), give the returned number of channels higher precedence
+	 * over the number supplied via the base config params.
+	 */
+	memset(&hw_params, 0, sizeof(hw_params));
+	err = dai_common_get_hw_params(dd, dev, &hw_params, params.direction);
+	if (err < 0) {
+		comp_err(dev, "dai_common_get_hw_params() failed: %d", err);
+		return err;
+	}
+
+	if (hw_params.channels != 0 && hw_params.channels != params.channels) {
+		params.channels = hw_params.channels;
+		comp_info(dev, "Replacing %d base config channels with %d hw params channels.",
+			  base_cfg_params->channels, params.channels);
+	}
+
+	err = dai_verify_params(dd, dev, &params);
 	if (err < 0) {
 		comp_err(dev, "dai_zephyr_params(): pcm params verification failed.");
 		return -EINVAL;
 	}
 
-	err = dai_set_dma_buffer(dd, dev, params, &period_bytes, &period_count);
+	err = dai_set_dma_buffer(dd, dev, &params, &period_bytes, &period_count);
 	if (err < 0) {
 		comp_err(dev, "dai_zephyr_params(): alloc dma buffer failed.");
 		goto out;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -269,7 +269,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
-					 dd->process, bytes, DUMMY_CHMAP);
+					 dd->process, bytes, dd->chmap);
 	} else {
 		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 		/*
@@ -277,7 +277,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 		 * so no need to check the return value of dma_buffer_copy_from_no_consume().
 		 */
 		ret = dma_buffer_copy_from_no_consume(dd->dma_buffer, dd->local_buffer,
-						      dd->process, bytes, DUMMY_CHMAP);
+						      dd->process, bytes, dd->chmap);
 #if CONFIG_IPC_MAJOR_4
 		struct list_item *sink_list;
 		/* Skip in case of endpoint DAI devices created by the copier */
@@ -318,7 +318,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				    sink->hw_params_configured)
 					ret = dma_buffer_copy_from_no_consume(dd->dma_buffer,
 									      sink, converter[j],
-									      bytes, DUMMY_CHMAP);
+									      bytes, dd->chmap);
 			}
 		}
 #endif
@@ -467,6 +467,8 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	ret = dai_common_new(dd, dev, dai_cfg);
 	if (ret < 0)
 		goto error;
+
+	dd->chmap = DUMMY_CHMAP;
 
 	dev->state = COMP_STATE_READY;
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -314,7 +314,8 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 					continue;
 				}
 
-				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE)
+				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
+				    sink->hw_params_configured)
 					ret = dma_buffer_copy_from_no_consume(dd->dma_buffer,
 									      sink, converter[j],
 									      bytes);
@@ -1555,7 +1556,8 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 				sink = container_of(sink_list, struct comp_buffer, source_list);
 				sink_dev = sink->sink;
 
-				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE) {
+				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
+				    sink->hw_params_configured) {
 					sink_samples =
 						audio_stream_get_free_samples(&sink->stream);
 					samples = MIN(samples, sink_samples);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -233,11 +233,11 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		source = hd->dma_buffer;
 		sink = hd->local_buffer;
-		ret = dma_buffer_copy_from(source, sink, hd->process, bytes);
+		ret = dma_buffer_copy_from(source, sink, hd->process, bytes, DUMMY_CHMAP);
 	} else {
 		source = hd->local_buffer;
 		sink = hd->dma_buffer;
-		ret = dma_buffer_copy_to(source, sink, hd->process, bytes);
+		ret = dma_buffer_copy_to(source, sink, hd->process, bytes, DUMMY_CHMAP);
 	}
 
 	/* assert dma_buffer_copy succeed */

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -409,6 +409,14 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 
 	/* dma_copy_bytes should be aligned to minimum possible chunk of
 	 * data to be copied by dma.
+	 *
+	 * FIXME: WARNING: For some frame sizes, this can lead to a split first and/or last frame:
+	 * one part of the frame is processed during one LL cycle, while the remaining portion
+	 * is processed in the subsequent LL cycle. This could be a problem for components
+	 * that assume the first sample in the buffer belongs to the first channel. Even
+	 * if such components consume full frames, they could be bound on a fly as additional
+	 * copier sinks or additional mixin sources or sinks, causing them to start processing
+	 * from the wrong channel.
 	 */
 	return ALIGN_DOWN(dma_copy_bytes, hd->dma_copy_align);
 }

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -247,11 +247,11 @@ void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t byt
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		source = hd->dma_buffer;
 		sink = hd->local_buffer;
-		ret = dma_buffer_copy_from(source, sink, hd->process, bytes);
+		ret = dma_buffer_copy_from(source, sink, hd->process, bytes, DUMMY_CHMAP);
 	} else {
 		source = hd->local_buffer;
 		sink = hd->dma_buffer;
-		ret = dma_buffer_copy_to(source, sink, hd->process, bytes);
+		ret = dma_buffer_copy_to(source, sink, hd->process, bytes, DUMMY_CHMAP);
 	}
 
 	if (ret < 0) {

--- a/src/audio/pcm_converter/CMakeLists.txt
+++ b/src/audio/pcm_converter/CMakeLists.txt
@@ -4,3 +4,7 @@ add_local_sources(sof
 	pcm_converter.c
 	pcm_converter_generic.c
 	pcm_converter_hifi3.c)
+
+if(CONFIG_PCM_REMAPPING_CONVERTERS)
+	add_local_sources(sof pcm_remap.c)
+endif()

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -58,3 +58,9 @@ int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
 
 	return samples;
 }
+
+int just_copy(const struct audio_stream *source, uint32_t ioffset,
+	      struct audio_stream *sink, uint32_t ooffset, uint32_t samples, uint32_t chmap)
+{
+	return audio_stream_copy(source, ioffset, sink, ooffset, samples);
+}

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -36,7 +36,7 @@
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 static int pcm_convert_u8_to_s32(const struct audio_stream *source,
 				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+				 uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -65,7 +65,7 @@ static int pcm_convert_u8_to_s32(const struct audio_stream *source,
 
 static int pcm_convert_s32_to_u8(const struct audio_stream *source,
 				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples)
+				 uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = audio_stream_get_wptr(sink);
@@ -97,7 +97,7 @@ static int pcm_convert_s32_to_u8(const struct audio_stream *source,
 
 static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -126,7 +126,7 @@ static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 
 static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = audio_stream_get_wptr(sink);
@@ -159,7 +159,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 
 static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -188,7 +188,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 
 static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = audio_stream_get_wptr(sink);
@@ -221,7 +221,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 
 static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -250,7 +250,7 @@ static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 
 static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -279,7 +279,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 
 static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
 				     uint32_t ioffset, struct audio_stream *sink,
-				     uint32_t ooffset, uint32_t samples)
+				     uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -444,7 +444,7 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
 
 static int pcm_convert_s16_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s16_to_f_lin);
@@ -452,7 +452,7 @@ static int pcm_convert_s16_to_f(const struct audio_stream *source,
 
 static int pcm_convert_f_to_s16(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s16_lin);
@@ -488,7 +488,7 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
 
 static int pcm_convert_s24_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s24_to_f_lin);
@@ -496,7 +496,7 @@ static int pcm_convert_s24_to_f(const struct audio_stream *source,
 
 static int pcm_convert_f_to_s24(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s24_lin);
@@ -532,7 +532,7 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
 
 static int pcm_convert_s32_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s32_to_f_lin);
@@ -540,7 +540,7 @@ static int pcm_convert_s32_to_f(const struct audio_stream *source,
 
 static int pcm_convert_f_to_s32(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s32_lin);
@@ -549,27 +549,27 @@ static int pcm_convert_f_to_s32(const struct audio_stream *source,
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_U8
-	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, audio_stream_copy },
+	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 */
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_S32_LE, pcm_convert_u8_to_s32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_U8, pcm_convert_s32_to_u8 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
-	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -580,7 +580,7 @@ const struct pcm_func_map pcm_func_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },
@@ -601,7 +601,7 @@ const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -630,7 +630,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 
 static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = audio_stream_get_wptr(sink);
@@ -660,7 +660,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
 static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -689,7 +689,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 
 static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -719,7 +719,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
 static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -748,7 +748,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 
 static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -779,7 +779,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
 static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -809,7 +809,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 
 static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = audio_stream_get_wptr(sink);
@@ -843,7 +843,8 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 /* 2x24bit samples are packed into 3x16bit samples for hda link dma */
 static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *source,
 						   uint32_t ioffset, struct audio_stream *sink,
-						   uint32_t ooffset, uint32_t samples)
+						   uint32_t ooffset, uint32_t samples,
+						   uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	uint16_t *dst = audio_stream_get_wptr(sink);
@@ -904,11 +905,11 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8,
-		audio_stream_copy },
+		just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		audio_stream_copy},
+		just_copy},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		pcm_convert_s24_to_s32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
@@ -930,7 +931,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		audio_stream_copy },
+		just_copy },
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S24LE
@@ -939,14 +940,14 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, audio_stream_copy},
+		SOF_IPC_FRAME_S24_4LE_MSB, just_copy},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S32_LE, audio_stream_copy},
+		SOF_IPC_FRAME_S32_LE, just_copy},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S16LE

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -38,7 +38,7 @@
  */
 static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	ae_int16x4 sample = AE_ZERO16();
 	uint32_t nmax, i, n, m, left, left_samples;
@@ -112,7 +112,7 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  */
 static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
@@ -183,7 +183,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
  */
 static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -239,7 +239,7 @@ static int pcm_convert_s16_to_s32(const struct audio_stream *source,
  */
 static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = audio_stream_get_wptr(sink);
@@ -305,7 +305,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
  */
 static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -370,7 +370,7 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  */
 static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples)
+				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -415,7 +415,7 @@ static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 
 static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
 				     uint32_t ioffset, struct audio_stream *sink,
-				     uint32_t ooffset, uint32_t samples)
+				     uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -543,7 +543,7 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
  */
 static int pcm_convert_s16_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s16_to_f_lin);
@@ -558,7 +558,7 @@ static int pcm_convert_s16_to_f(const struct audio_stream *source,
  */
 static int pcm_convert_f_to_s16(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s16_lin);
@@ -644,7 +644,7 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
  */
 static int pcm_convert_s24_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s24_to_f_lin);
@@ -659,7 +659,7 @@ static int pcm_convert_s24_to_f(const struct audio_stream *source,
  */
 static int pcm_convert_f_to_s24(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s24_lin);
@@ -741,7 +741,7 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
  */
 static int pcm_convert_s32_to_f(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_s32_to_f_lin);
@@ -756,7 +756,7 @@ static int pcm_convert_s32_to_f(const struct audio_stream *source,
  */
 static int pcm_convert_f_to_s32(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples)
+				uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
 				     pcm_convert_f_to_s32_lin);
@@ -766,20 +766,20 @@ static int pcm_convert_f_to_s32(const struct audio_stream *source,
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
-	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, audio_stream_copy },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -791,7 +791,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if XCHAL_HAVE_FP
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, audio_stream_copy },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },
@@ -813,7 +813,7 @@ const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int16_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -863,7 +863,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int16_t *dst = audio_stream_get_wptr(sink);
@@ -922,7 +922,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -965,7 +965,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -1010,7 +1010,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -1065,7 +1065,7 @@ static ae_int32x2 pcm_shift_s24_c32_to_s16(ae_int32x2 sample)
 static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -1112,7 +1112,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	uint8_t *src = audio_stream_get_rptr(source);
 	int32_t *dst = audio_stream_get_wptr(sink);
@@ -1159,7 +1159,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 					  uint32_t ioffset,
 					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples)
+					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
 {
 	int32_t *src = audio_stream_get_rptr(source);
 	uint8_t *dst = audio_stream_get_wptr(sink);
@@ -1227,7 +1227,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		audio_stream_copy},
+		just_copy},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		pcm_convert_s24_to_s32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
@@ -1249,7 +1249,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		audio_stream_copy },
+		just_copy },
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S24LE
@@ -1258,14 +1258,14 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, audio_stream_copy},
+		SOF_IPC_FRAME_S24_4LE_MSB, just_copy},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S32_LE, audio_stream_copy},
+		SOF_IPC_FRAME_S32_LE, just_copy},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S16LE

--- a/src/audio/pcm_converter/pcm_remap.c
+++ b/src/audio/pcm_converter/pcm_remap.c
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * (c) 2024 Intel Corporation. All rights reserved.
+ */
+
+#include <sof/audio/pcm_converter.h>
+#include <sof/audio/audio_stream.h>
+
+static void mute_channel_c16(struct audio_stream *stream, int channel, int frames)
+{
+	int num_channels = audio_stream_get_channels(stream);
+	int16_t *ptr = (int16_t *)audio_stream_get_wptr(stream) + channel;
+
+	while (frames) {
+		int samples_wo_wrap, n, i;
+
+		ptr = audio_stream_wrap(stream, ptr);
+
+		samples_wo_wrap = audio_stream_samples_without_wrap_s16(stream, ptr);
+		n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_channels);
+		n = MIN(n, frames);
+
+		for (i = 0; i < n; i++) {
+			*ptr = 0;
+			ptr += num_channels;
+		}
+
+		frames -= n;
+	}
+}
+
+static void mute_channel_c32(struct audio_stream *stream, int channel, int frames)
+{
+	int num_channels = audio_stream_get_channels(stream);
+	int32_t *ptr = (int32_t *)audio_stream_get_wptr(stream) + channel;
+
+	while (frames) {
+		int samples_wo_wrap, n, i;
+
+		ptr = audio_stream_wrap(stream, ptr);
+
+		samples_wo_wrap = audio_stream_samples_without_wrap_s32(stream, ptr);
+		n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_channels);
+		n = MIN(n, frames);
+
+		for (i = 0; i < n; i++) {
+			*ptr = 0;
+			ptr += num_channels;
+		}
+
+		frames -= n;
+	}
+}
+
+static int remap_c16(const struct audio_stream *source, uint32_t dummy1,
+		     struct audio_stream *sink, uint32_t dummy2,
+		     uint32_t source_samples, uint32_t chmap)
+{
+	int src_channel, sink_channel;
+	int num_src_channels = audio_stream_get_channels(source);
+	int num_sink_channels = audio_stream_get_channels(sink);
+	int frames = source_samples / num_src_channels;
+
+	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
+		int16_t *src, *dst;
+		int frames_left;
+
+		src_channel = chmap & 0xf;
+		chmap >>= 4;
+
+		if (src_channel == 0xf) {
+			mute_channel_c16(sink, sink_channel, frames);
+			continue;
+		}
+
+		assert(src_channel < num_src_channels);
+
+		src = (int16_t *)audio_stream_get_rptr(source) + src_channel;
+		dst = (int16_t *)audio_stream_get_wptr(sink) + sink_channel;
+
+		frames_left = frames;
+
+		while (frames_left) {
+			int src_samples_wo_wrap, dst_samples_wo_wrap;
+			int src_loops, dst_loops, n, i;
+
+			src = audio_stream_wrap(source, src);
+			dst = audio_stream_wrap(sink, dst);
+
+			src_samples_wo_wrap = audio_stream_samples_without_wrap_s16(source, src);
+			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+
+			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s16(sink, dst);
+			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+
+			n = MIN(src_loops, dst_loops);
+			n = MIN(n, frames_left);
+
+			for (i = 0; i < n; i++) {
+				*dst = *src;
+				src += num_src_channels;
+				dst += num_sink_channels;
+			}
+
+			frames_left -= n;
+		}
+	}
+
+	return source_samples;
+}
+
+static inline int remap_c32_left_shift(const struct audio_stream *source,
+				       struct audio_stream *sink,
+				       uint32_t source_samples, uint32_t chmap,
+				       int shift)
+{
+	int src_channel, sink_channel;
+	int num_src_channels = audio_stream_get_channels(source);
+	int num_sink_channels = audio_stream_get_channels(sink);
+	int frames = source_samples / num_src_channels;
+
+	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
+		int32_t *src, *dst;
+		int frames_left;
+
+		src_channel = chmap & 0xf;
+		chmap >>= 4;
+
+		if (src_channel == 0xf) {
+			mute_channel_c32(sink, sink_channel, frames);
+			continue;
+		}
+
+		assert(src_channel < num_src_channels);
+
+		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
+		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+
+		frames_left = frames;
+
+		while (frames_left) {
+			int src_samples_wo_wrap, dst_samples_wo_wrap;
+			int src_loops, dst_loops, n, i;
+
+			src = audio_stream_wrap(source, src);
+			dst = audio_stream_wrap(sink, dst);
+
+			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
+			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+
+			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
+			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+
+			n = MIN(src_loops, dst_loops);
+			n = MIN(n, frames_left);
+
+			for (i = 0; i < n; i++) {
+				*dst = *src << shift;
+				src += num_src_channels;
+				dst += num_sink_channels;
+			}
+
+			frames_left -= n;
+		}
+	}
+
+	return source_samples;
+}
+
+static inline int remap_c32_right_shift(const struct audio_stream *source,
+					struct audio_stream *sink,
+					uint32_t source_samples, uint32_t chmap,
+					int shift)
+{
+	int src_channel, sink_channel;
+	int num_src_channels = audio_stream_get_channels(source);
+	int num_sink_channels = audio_stream_get_channels(sink);
+	int frames = source_samples / num_src_channels;
+
+	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
+		int32_t *src, *dst;
+		int frames_left;
+
+		src_channel = chmap & 0xf;
+		chmap >>= 4;
+
+		if (src_channel == 0xf) {
+			mute_channel_c32(sink, sink_channel, frames);
+			continue;
+		}
+
+		assert(src_channel < num_src_channels);
+
+		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
+		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+
+		frames_left = frames;
+
+		while (frames_left) {
+			int src_samples_wo_wrap, dst_samples_wo_wrap;
+			int src_loops, dst_loops, n, i;
+
+			src = audio_stream_wrap(source, src);
+			dst = audio_stream_wrap(sink, dst);
+
+			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
+			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+
+			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
+			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+
+			n = MIN(src_loops, dst_loops);
+			n = MIN(n, frames_left);
+
+			for (i = 0; i < n; i++) {
+				*dst = *src >> shift;
+				src += num_src_channels;
+				dst += num_sink_channels;
+			}
+
+			frames_left -= n;
+		}
+	}
+
+	return source_samples;
+}
+
+static inline int remap_c16_to_c32(const struct audio_stream *source,
+				   struct audio_stream *sink,
+				   uint32_t source_samples, uint32_t chmap,
+				   int shift)
+{
+	int src_channel, sink_channel;
+	int num_src_channels = audio_stream_get_channels(source);
+	int num_sink_channels = audio_stream_get_channels(sink);
+	int frames = source_samples / num_src_channels;
+
+	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
+		int16_t *src;
+		int32_t *dst;
+		int frames_left;
+
+		src_channel = chmap & 0xf;
+		chmap >>= 4;
+
+		if (src_channel == 0xf) {
+			mute_channel_c32(sink, sink_channel, frames);
+			continue;
+		}
+
+		assert(src_channel < num_src_channels);
+
+		src = (int16_t *)audio_stream_get_rptr(source) + src_channel;
+		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+
+		frames_left = frames;
+
+		while (frames_left) {
+			int src_samples_wo_wrap, dst_samples_wo_wrap;
+			int src_loops, dst_loops, n, i;
+
+			src = audio_stream_wrap(source, src);
+			dst = audio_stream_wrap(sink, dst);
+
+			src_samples_wo_wrap = audio_stream_samples_without_wrap_s16(source, src);
+			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+
+			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
+			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+
+			n = MIN(src_loops, dst_loops);
+			n = MIN(n, frames_left);
+
+			for (i = 0; i < n; i++) {
+				*dst = (int32_t)*src << shift;
+				src += num_src_channels;
+				dst += num_sink_channels;
+			}
+
+			frames_left -= n;
+		}
+	}
+
+	return source_samples;
+}
+
+static inline int remap_c32_to_c16(const struct audio_stream *source,
+				   struct audio_stream *sink,
+				   uint32_t source_samples, uint32_t chmap,
+				   int shift)
+{
+	int src_channel, sink_channel;
+	int num_src_channels = audio_stream_get_channels(source);
+	int num_sink_channels = audio_stream_get_channels(sink);
+	int frames = source_samples / num_src_channels;
+
+	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
+		int32_t *src;
+		int16_t *dst;
+		int frames_left;
+
+		src_channel = chmap & 0xf;
+		chmap >>= 4;
+
+		if (src_channel == 0xf) {
+			mute_channel_c16(sink, sink_channel, frames);
+			continue;
+		}
+
+		assert(src_channel < num_src_channels);
+
+		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
+		dst = (int16_t *)audio_stream_get_wptr(sink) + sink_channel;
+
+		frames_left = frames;
+
+		while (frames_left) {
+			int src_samples_wo_wrap, dst_samples_wo_wrap;
+			int src_loops, dst_loops, n, i;
+
+			src = audio_stream_wrap(source, src);
+			dst = audio_stream_wrap(sink, dst);
+
+			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
+			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+
+			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s16(sink, dst);
+			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+
+			n = MIN(src_loops, dst_loops);
+			n = MIN(n, frames_left);
+
+			for (i = 0; i < n; i++) {
+				*dst = *src >> shift;
+				src += num_src_channels;
+				dst += num_sink_channels;
+			}
+
+			frames_left -= n;
+		}
+	}
+
+	return source_samples;
+}
+
+static int remap_c32(const struct audio_stream *source, uint32_t dummy1,
+		     struct audio_stream *sink, uint32_t dummy2,
+		     uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_left_shift(source, sink, source_samples, chmap, 0);
+}
+
+static int remap_c32_to_c16_right_shift_16(const struct audio_stream *source, uint32_t dummy1,
+					   struct audio_stream *sink, uint32_t dummy2,
+					   uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_to_c16(source, sink, source_samples, chmap, 16);
+}
+
+static int remap_c16_to_c32_left_shift_16(const struct audio_stream *source, uint32_t dummy1,
+					  struct audio_stream *sink, uint32_t dummy2,
+					  uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c16_to_c32(source, sink, source_samples, chmap, 16);
+}
+
+static int remap_c32_to_c16_right_shift_8(const struct audio_stream *source, uint32_t dummy1,
+					  struct audio_stream *sink, uint32_t dummy2,
+					  uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_to_c16(source, sink, source_samples, chmap, 8);
+}
+
+static int remap_c16_to_c32_left_shift_8(const struct audio_stream *source, uint32_t dummy1,
+					 struct audio_stream *sink, uint32_t dummy2,
+					 uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c16_to_c32(source, sink, source_samples, chmap, 8);
+}
+
+static int remap_c32_right_shift_8(const struct audio_stream *source, uint32_t dummy1,
+				   struct audio_stream *sink, uint32_t dummy2,
+				   uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_right_shift(source, sink, source_samples, chmap, 8);
+}
+
+static int remap_c32_left_shift_8(const struct audio_stream *source, uint32_t dummy1,
+				  struct audio_stream *sink, uint32_t dummy2,
+				  uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_left_shift(source, sink, source_samples, chmap, 8);
+}
+
+static int remap_c32_right_shift_16(const struct audio_stream *source, uint32_t dummy1,
+				    struct audio_stream *sink, uint32_t dummy2,
+				    uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_right_shift(source, sink, source_samples, chmap, 16);
+}
+
+static int remap_c32_left_shift_16(const struct audio_stream *source, uint32_t dummy1,
+				   struct audio_stream *sink, uint32_t dummy2,
+				   uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_left_shift(source, sink, source_samples, chmap, 16);
+}
+
+static int remap_c32_to_c16_no_shift(const struct audio_stream *source, uint32_t dummy1,
+				     struct audio_stream *sink, uint32_t dummy2,
+				     uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c32_to_c16(source, sink, source_samples, chmap, 0);
+}
+
+static int remap_c16_to_c32_no_shift(const struct audio_stream *source, uint32_t dummy1,
+				     struct audio_stream *sink, uint32_t dummy2,
+				     uint32_t source_samples, uint32_t chmap)
+{
+	return remap_c16_to_c32(source, sink, source_samples, chmap, 0);
+}
+
+/* Unfortunately, all these nice "if"s were commented out to suppress
+ * CI "defined but not used" warnings.
+ */
+const struct pcm_func_map pcm_remap_func_map[] = {
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE */
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, remap_c16},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE */
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, remap_c16_to_c32_left_shift_8},
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, remap_c32_to_c16_right_shift_8},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB */
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE_MSB, remap_c16_to_c32_left_shift_16},
+	{ SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S16_LE, remap_c32_to_c16_right_shift_16},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, remap_c16_to_c32_left_shift_16},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, remap_c32_to_c16_right_shift_16},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S16_4LE */
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_4LE, remap_c16_to_c32_no_shift},
+	{ SOF_IPC_FRAME_S16_4LE, SOF_IPC_FRAME_S16_LE, remap_c32_to_c16_no_shift},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE */
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, remap_c32},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB */
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE_MSB, remap_c32_left_shift_8},
+	{ SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S24_4LE, remap_c32_right_shift_8},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, remap_c32_left_shift_8},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, remap_c32_right_shift_8},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE && CONFIG_PCM_CONVERTER_FORMAT_S16_4LE */
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_4LE, remap_c32_right_shift_8},
+	{ SOF_IPC_FRAME_S16_4LE, SOF_IPC_FRAME_S24_4LE, remap_c32_left_shift_8},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
+	{ SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE, remap_c32},
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, remap_c32},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S32LE */
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, remap_c32},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S16_4LE */
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_4LE, remap_c32_right_shift_16},
+	{ SOF_IPC_FRAME_S16_4LE, SOF_IPC_FRAME_S32_LE, remap_c32_left_shift_16},
+/* #endif */
+/* #if CONFIG_PCM_CONVERTER_FORMAT_S16_4LE */
+	{ SOF_IPC_FRAME_S16_4LE, SOF_IPC_FRAME_S16_4LE, remap_c32},
+/* #endif */
+};
+
+const size_t pcm_remap_func_count = ARRAY_SIZE(pcm_remap_func_map);

--- a/src/include/module/ipc/stream.h
+++ b/src/include/module/ipc/stream.h
@@ -20,6 +20,7 @@ enum sof_ipc_frame {
 	SOF_IPC_FRAME_S24_3LE,
 	SOF_IPC_FRAME_S24_4LE_MSB,
 	SOF_IPC_FRAME_U8,
+	SOF_IPC_FRAME_S16_4LE		/* 16-bit in 32-bit container */
 };
 
 #endif /* __MODULE_IPC_STREAM_H__ */

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -42,12 +42,16 @@ struct audio_stream;
  * \param ioffset offset to first sample in source stream
  * \param sink output buffer, write pointer is not modified
  * \param ooffset offset to first sample in sink stream
- * \param samples number of samples to convert
- * \return error code or number of processed samples.
+ * \param source_samples number of samples to convert, for remapping -- number of source samples
+ * \param chmap channel map for remapping, ignored by non-remapping conversion func
+ * \return error code or number of processed samples (source samples in case of remapping).
  */
 typedef int (*pcm_converter_func)(const struct audio_stream *source,
 				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples);
+				  uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
+
+/* A channel map that does not perform any remapping. */
+#define DUMMY_CHMAP 0x76543210
 
 /**
  * \brief PCM conversion function interface for data in linear buffer
@@ -159,5 +163,9 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
 			  struct audio_stream *sink, uint32_t ooffset,
 			  uint32_t samples, pcm_converter_lin_func converter);
+
+/* Copy stream without conversion. chmap parameter is ignored. */
+int just_copy(const struct audio_stream *source, uint32_t ioffset,
+	      struct audio_stream *sink, uint32_t ooffset, uint32_t samples, uint32_t chmap);
 
 #endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -75,6 +75,14 @@ extern const struct pcm_func_map pcm_func_map[];
 /** \brief Number of conversion functions. */
 extern const size_t pcm_func_count;
 
+#if CONFIG_PCM_REMAPPING_CONVERTERS
+/** \brief Map of formats with dedicated remap with conversion functions. */
+extern const struct pcm_func_map pcm_remap_func_map[];
+
+/** \brief Number of remap with conversion functions. */
+extern const size_t pcm_remap_func_count;
+#endif
+
 /**
  * \brief Retrieves PCM conversion function.
  * \param[in] in Source frame format.
@@ -97,6 +105,30 @@ pcm_get_conversion_function(enum sof_ipc_frame in,
 
 	return NULL;
 }
+
+#if CONFIG_PCM_REMAPPING_CONVERTERS
+/**
+ * \brief Retrieves PCM remap with conversion function.
+ * \param[in] in Source frame format.
+ * \param[in] out Sink frame format.
+ */
+static inline pcm_converter_func
+pcm_get_remap_function(enum sof_ipc_frame in, enum sof_ipc_frame out)
+{
+	int i;
+
+	for (i = 0; i < pcm_remap_func_count; i++) {
+		if (in != pcm_remap_func_map[i].source)
+			continue;
+		if (out != pcm_remap_func_map[i].sink)
+			continue;
+
+		return pcm_remap_func_map[i].func;
+	}
+
+	return NULL;
+}
+#endif
 
 /** \brief PCM conversion functions mapfor different size of valid bit and container. */
 struct pcm_func_vc_map {

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -106,6 +106,10 @@ struct llp_slot_info {
 	uint32_t reg_offset;
 };
 
+typedef int (*channel_copy_func)(const struct audio_stream *src, unsigned int src_channel,
+				 struct audio_stream *dst, unsigned int dst_channel,
+				 unsigned int frames);
+
 /**
  * \brief DAI runtime data
  */
@@ -125,6 +129,11 @@ struct dai_data {
 	int xrun;				/* true if we are doing xrun recovery */
 
 	pcm_converter_func process;		/* processing function */
+
+	channel_copy_func channel_copy;		/* channel copy func used by multi-endpoint
+						 * gateway to mux/demux stream from/to multiple
+						 * DMA buffers
+						 */
 
 	uint32_t period_bytes;			/* number of bytes per one period */
 	uint64_t total_data_processed;

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -129,6 +129,7 @@ struct dai_data {
 	int xrun;				/* true if we are doing xrun recovery */
 
 	pcm_converter_func process;		/* processing function */
+	uint32_t chmap;
 
 	channel_copy_func channel_copy;		/* channel copy func used by multi-endpoint
 						 * gateway to mux/demux stream from/to multiple

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -135,7 +135,7 @@ struct dai_data {
 						 * DMA buffers
 						 */
 
-	uint32_t period_bytes;			/* number of bytes per one period */
+	uint32_t period_bytes;			/* number of DMA bytes per one period */
 	uint64_t total_data_processed;
 
 	struct ipc_config_dai ipc_config;	/* generic common config */
@@ -154,8 +154,6 @@ struct dai_data {
 
 	/* llp slot info in memory windows */
 	struct llp_slot_info slot_info;
-	/* save current sampling for current dai device */
-	uint32_t sampling;
 	/* fast mode, use one byte memory to save repreated cycles */
 	bool fast_mode;
 };

--- a/test/cmocka/src/audio/pcm_converter/pcm_float.c
+++ b/test/cmocka/src/audio/pcm_converter/pcm_float.c
@@ -99,7 +99,7 @@ static struct comp_buffer *_test_pcm_convert(enum sof_ipc_frame frm_in, enum sof
 	/* run conversion */
 	fun = pcm_get_conversion_function(frm_in, frm_out);
 	assert_non_null(fun);
-	fun(&source->stream, 0, &sink->stream, 0, samples);
+	fun(&source->stream, 0, &sink->stream, 0, samples, DUMMY_CHMAP);
 
 	/* assert last value in sink is untouched */
 	assert_int_equal(((uint8_t *)sink->stream.w_ptr)[outbytes - 1], fillval);

--- a/xtos/include/sof/lib/dma.h
+++ b/xtos/include/sof/lib/dma.h
@@ -259,7 +259,7 @@ struct dma_info {
 struct audio_stream;
 typedef int (*dma_process_func)(const struct audio_stream *source,
 				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t frames);
+				uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
 
 /**
  * \brief API to initialize a platform DMA controllers.
@@ -528,14 +528,10 @@ static inline uint32_t dma_sg_get_size(struct dma_sg_elem_array *ea)
 	return size;
 }
 
-struct audio_stream;
-typedef void (*dma_process)(const struct audio_stream *,
-			    struct audio_stream *, uint32_t);
-
 /* copies data from DMA buffer using provided processing function */
 int dma_buffer_copy_from(struct comp_buffer *source,
 			 struct comp_buffer *sink,
-			 dma_process_func process, uint32_t source_bytes);
+			 dma_process_func process, uint32_t source_bytes, uint32_t chmap);
 
 /*
  * Used when copying DMA buffer bytes into multiple sink buffers, one at a time using the provided
@@ -544,12 +540,13 @@ int dma_buffer_copy_from(struct comp_buffer *source,
  */
 int dma_buffer_copy_from_no_consume(struct comp_buffer *source,
 				    struct comp_buffer *sink,
-				    dma_process_func process, uint32_t source_bytes);
+				    dma_process_func process,
+				    uint32_t source_bytes, uint32_t chmap);
 
 /* copies data to DMA buffer using provided processing function */
 int dma_buffer_copy_to(struct comp_buffer *source,
 		       struct comp_buffer *sink,
-		       dma_process_func process, uint32_t sink_bytes);
+		       dma_process_func process, uint32_t sink_bytes, uint32_t chmap);
 
 /* generic DMA DSP <-> Host copier */
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -412,9 +412,6 @@ zephyr_library_sources(
 
 	# SOF mandatory audio processing
 	${SOF_AUDIO_PATH}/channel_map.c
-	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_hifi3.c
-	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter.c
-	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_generic.c
 	${SOF_AUDIO_PATH}/buffer.c
 	${SOF_AUDIO_PATH}/source_api_helper.c
 	${SOF_AUDIO_PATH}/sink_api_helper.c
@@ -702,6 +699,15 @@ zephyr_library_sources_ifdef(CONFIG_COMP_COPIER
 	${SOF_AUDIO_PATH}/copier/copier.c
 	${SOF_AUDIO_PATH}/copier/copier_host.c
 	${SOF_AUDIO_PATH}/copier/copier_dai.c
+)
+
+zephyr_library_sources(
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_hifi3.c
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter.c
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_converter_generic.c
+)
+zephyr_library_sources_ifdef(CONFIG_PCM_REMAPPING_CONVERTERS
+	${SOF_AUDIO_PATH}/pcm_converter/pcm_remap.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_MAXIM_DSM


### PR DESCRIPTION
Adds a device posture feature. The driver sends IPC4_COPIER_MODULE_CFG_PARAM_CHANNEL_MAP with a channel map to be used for swapping channels according to the device orientation.
IPC4_COPIER_MODULE_CFG_PARAM_CHANNEL_MAP is applied only for the DAI gateway.