### PR TITLE
[stable-v2.10] west.yml: update Zephyr to sof/stable-v2.10 0f7a01d360e

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
     - name: zephyr
       repo-path: zephyr
       # commit in https://github.com/thesofproject/zephyr/tree/sof/stable-v2.10
-      revision: 53ddff639562ef68dc0a6f62b82f7505c75ebdce
+      revision: 0f7a01d360ed5b0801f5a3033996ef7d0f4dd9d3
       remote: thesofproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fast-forward the Zephyr version with two fixes:

0f7a01d360ed drivers: dma: intel_adsp_hda: change L1 exit defaults
8f9384c0fe69 Revert "soc: intel_adsp: only implement FW_STATUS boot protocol for cavs"