### PR TITLE
[stable-v2.10] west.yml: update Zephyr to sof/stable-v2.10 0f7a01d360e

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,7 +44,7 @@ manifest:
     - name: zephyr
       repo-path: zephyr
       # commit in https://github.com/thesofproject/zephyr/tree/sof/stable-v2.10
-      revision: 0f7a01d360ed5b0801f5a3033996ef7d0f4dd9d3
+      revision: 64ee60cf3a6a532861e722c9446864b95d28b1ba
       remote: thesofproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fast-forward the Zephyr version with following backported fixes:

64ee60cf3a6a Drivers: DAI: Intel: Move ACE DMIC start reset clear to earlier
1b78308a6c7c Drivers: DAI: Intel: Reduce traces dai_dmic_start()
995e182b87ab Drivers: DAI: Intel: Remove trace from dai_dmic_update_bits()

Link: https://github.com/thesofproject/sof/issues/9205