### PR TITLE
[stable-v2.10] Tools: Topology2: Update sof-hda-efx-generic controls names

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-efx-hda.conf
@@ -47,12 +47,12 @@ Object.Pipeline {
                                         }
                                         Object.Widget.eqiir.1 {
                                                 Object.Control.bytes."1" {
-                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM IIR Eq'
+                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM IIR Eq bytes'
                                                 }
                                         }
                                         Object.Widget.eqfir.1 {
                                                 Object.Control.bytes."1" {
-                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM FIR Eq'
+                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM FIR Eq bytes'
                                                 }
                                         }
                                         Object.Widget.drc.1 {
@@ -86,12 +86,12 @@ Object.Pipeline {
                                         }
                                         Object.Widget.eqiir.1 {
                                                 Object.Control.bytes."1" {
-                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM IIR Eq'
+                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM IIR Eq bytes'
                                                 }
                                         }
                                         Object.Widget.eqfir.1 {
                                                 Object.Control.bytes."1" {
-                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM FIR Eq'
+                                                        name 'Post Mixer $ANALOG_PLAYBACK_PCM FIR Eq bytes'
                                                 }
                                         }
                                         Object.Widget.multiband_drc.1 {


### PR DESCRIPTION
The controls names for IIR, FIR need to be same as in sof-hda-generic for UCM to find the controls and set up the components for processing.


(cherry picked from commit 3da8e6474531411bef64819113a29a7edbd51fcf)