### PR TITLE
copier: dai: fix sndw init flow

### DIFF
--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -272,7 +272,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		break;
 	case ipc4_alh_link_output_class:
 	case ipc4_alh_link_input_class:
-#if defined(CONFIG_ACE_VERSION_2_0)
+#if ACE_VERSION > ACE_VERSION_1_5
 		dai.type = SOF_DAI_INTEL_HDA;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_link;
@@ -280,7 +280,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.type = SOF_DAI_INTEL_ALH;
 		dai.is_config_blob = true;
 		type = ipc4_gtw_alh;
-#endif /* defined(CONFIG_ACE_VERSION_2_0) */
+#endif /* ACE_VERSION > ACE_VERSION_1_5 */
 		ret = copier_alh_assign_dai_index(dev, cd->gtw_cfg, node_id,
 						  &dai, dai_index, &dai_count);
 		if (ret)


### PR DESCRIPTION
Enable support for HDA DMA on SoundWire interface for ACE_VERSION > ACE_VERSION_1_5