### PR TITLE
[DNM] west.ytml: update to Zephyr 243783243cbd (June 25th)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 97a97c744a294ba14278a1f436d46eaa2d488354
+      revision: 243783243cbde53b5353d645c2099eaf48cf8083
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Change affecting SOF build targets:

e9c23274afa2 Revert "soc: intel_adsp: only implement FW_STATUS boot protocol for cavs"
31c96cf3957b xtensa: check stack boundaries during backtrace
5b84bb4f4a55 xtensa: check stack frame pointer before dumping registers
cb9f8b1019f1 xtensa: separate FATAL EXCEPTION printout into two
1198c7ec295b Drivers: DAI: Intel: Move ACE DMIC start reset clear to earlier
78920e839e71 Drivers: DAI: Intel: Reduce traces dai_dmic_start()
9db580357bc6 Drivers: DAI: Intel: Remove trace from dai_dmic_update_bits()

Link: https://github.com/thesofproject/sof/issues/9243
Link: https://github.com/thesofproject/sof/issues/9205