### PR TITLE
Global UUID registry, cleanup, simplification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ set_property(DIRECTORY APPEND
 add_dependencies(sof_public_headers genconfig check_version_h)
 target_include_directories(sof_public_headers INTERFACE ${GENERATED_DIRECTORY}/include)
 
+include(scripts/cmake/uuid-registry.cmake)
+
 if(CONFIG_LIBRARY)
 	if (CONFIG_LIBRARY_STATIC)
 		add_library(sof STATIC "")

--- a/scripts/cmake/uuid-registry.cmake
+++ b/scripts/cmake/uuid-registry.cmake
@@ -1,0 +1,37 @@
+#
+# UUID registry generation
+#
+
+# Simple target.  FOUR (really 4.5, as LIBRARY builds use the same
+# CMakeLists.txt but differ significantly in how it executes)
+# different cmake environments into which it needs to build.
+is_zephyr(zephyr_is)
+if(zephyr_is)
+  set(TOPDIR ${sof_top_dir})
+  set(UUID_REG_H ${PROJECT_BINARY_DIR}/include/generated/uuid-registry.h)
+  set(DEP_TARGET zephyr_interface)
+elseif(${PROJECT_NAME} STREQUAL "SOF_TOOLS")
+  set(TOPDIR "${PROJECT_SOURCE_DIR}/..")
+  set(UUID_REG_H "${CMAKE_CURRENT_BINARY_DIR}/uuid-registry.h")
+  set(DEP_TARGET sof-logger)
+elseif(${PROJECT_NAME} STREQUAL "SOF_TPLG_PARSER")
+  set(TOPDIR "${PROJECT_SOURCE_DIR}/../..")
+  set(UUID_REG_H "${PROJECT_BINARY_DIR}/include/uuid-registry.h")
+  set(DEP_TARGET sof_tplg_parser)
+else()
+  # Legacy SOF, or CONFIG_LIBRARY
+  set(TOPDIR ${PROJECT_SOURCE_DIR})
+  set(UUID_REG_H ${PROJECT_BINARY_DIR}/generated/include/uuid-registry.h)
+  set(DEP_TARGET sof_public_headers)
+endif()
+
+add_custom_command(
+	OUTPUT ${UUID_REG_H}
+	COMMAND
+	${PYTHON_EXECUTABLE} ${TOPDIR}/scripts/gen-uuid-reg.py
+	                     ${TOPDIR}/uuid-registry.txt
+			     ${UUID_REG_H})
+
+add_custom_target(uuid_reg_h DEPENDS ${UUID_REG_H})
+
+add_dependencies(${DEP_TARGET} uuid_reg_h)

--- a/scripts/gen-uuid-reg.py
+++ b/scripts/gen-uuid-reg.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+import re
+import sys
+
+# Very simple UUID registry validator and C header generator.  Parses
+# uuid-registry.txt (passed as the first command line argument) and
+# writes a C header (named in the second argument) containing
+# definitions to be used at build time.  Fails via assertion if the
+# any element in the registry is invalid.
+
+header = """/*
+ * GENERATED CODE.  DO NOT EDIT.
+ *
+ * Generated UUID records (initializers for struct sof_uuid)
+ * See scripts/gen-uuid-reg.py
+ */
+#ifndef _UUID_REGISTRY_H
+#define _UUID_REGISTRY_H
+"""
+
+all_syms = set()
+all_uuids = set()
+out_recs = []
+
+def emit_uuid_rec(uu, sym):
+    recs = uu.split('-')
+    brec = recs[3]
+    wrecs = [ "0x" + r for r in recs[0:3] ]
+    byts = [ "0x" + brec[ 2*i : 2*i+2 ] for i in range(int(len(brec) / 2)) ]
+    uuidinit = "{ " + ", ".join(wrecs) + ", { " + ", ".join(byts) + " } }"
+    out_recs.append(f"#define _UUIDREG_{sym} {uuidinit}")
+
+def main():
+    with open(sys.argv[1]) as f:
+        for line in f.readlines():
+            line = re.sub(r'\s*#.*', '', line) # trim comments
+            line = re.sub(r'^\s*', '', line)   # trim leading ws
+            line = re.sub(r'\s*$', '', line)   # trim trailing ws
+            if line == "":
+                continue
+            m = re.match(r'(.*)\s+(.*)', line)
+            assert m
+            (uu, sym) = (m.group(1).lower(), m.group(2))
+            assert re.match(r'[0-9a-f]{8}(?:-[0-9a-f]{4}){2}-[0-9a-f]{16}', uu)
+            assert re.match(r'[a-zA-Z_][a-zA-Z0-9_]*', sym)
+            assert len(sym) < 32
+            assert uu not in all_uuids
+            assert sym not in all_syms
+            all_uuids.add(uu)
+            all_syms.add(sym)
+            emit_uuid_rec(uu, sym)
+
+    with open(sys.argv[2], "w") as f:
+        f.write(header)
+        for l in out_recs:
+            f.write(l + "\n")
+        f.write("#endif /* _UUID_REGISTRY_H */\n")
+
+if __name__ == "__main__":
+	main()

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -877,16 +877,6 @@ def build_platforms():
 			else: # unknown failure
 				raise cpe
 
-		smex_executable = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "smex_ep",
-			"build", "smex")
-		fw_ldc_file = pathlib.Path(sof_platform_output_dir, f"sof-{platform}.ldc")
-		input_elf_file = pathlib.Path(west_top, platform_build_dir_name, "zephyr", "zephyr.elf")
-		# Extract metadata
-		execute_command([str(smex_executable), "-l", str(fw_ldc_file), str(input_elf_file)])
-
-		for p_alias in platform_configs[platform].aliases:
-			symlink_or_copy(sof_platform_output_dir, f"sof-{platform}.ldc", sof_platform_output_dir, f"sof-{p_alias}.ldc")
-
 		# reproducible-zephyr.ri is less useful now that show_installed_files() shows
 		# checksums too. However: - it's still useful when only the .ri file is
 		# available (no build logs for the other image), - it makes sure sof_ri_info.py
@@ -899,15 +889,6 @@ def build_platforms():
 
 	src_dest_list = []
 	tools_output_dir = pathlib.Path(STAGING_DIR, "tools")
-
-	# Install sof-logger from the last platform built (requires building at least one platform).
-	if platform_build_dir_name:
-		sof_logger_dir = pathlib.Path(west_top, platform_build_dir_name, "zephyr",
-					      "sof-logger_ep", "build", "logger")
-		sof_logger_executable_to_copy = pathlib.Path(shutil.which("sof-logger", path=sof_logger_dir))
-		sof_logger_installed_file = pathlib.Path(tools_output_dir, sof_logger_executable_to_copy.name).resolve()
-
-		src_dest_list += [(sof_logger_executable_to_copy, sof_logger_installed_file)]
 
 	src_dest_list += [(pathlib.Path(SOF_TOP) /
 		"tools" / "mtrace"/ "mtrace-reader.py",

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(aria, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
 /* 99f7166d-372c-43ef-81f6-22007aa15f03 */
-DECLARE_SOF_RT_UUID("aria", aria_comp_uuid, 0x99f7166d, 0x372c, 0x43ef,
+SOF_DEFINE_UUID("aria", aria_comp_uuid, 0x99f7166d, 0x372c, 0x43ef,
 		    0x81, 0xf6, 0x22, 0x00, 0x7a, 0xa1, 0x5f, 0x03);
 
 DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -32,9 +32,7 @@
 LOG_MODULE_REGISTER(aria, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
-/* 99f7166d-372c-43ef-81f6-22007aa15f03 */
-SOF_DEFINE_UUID("aria", aria_uuid, 0x99f7166d, 0x372c, 0x43ef,
-		    0x81, 0xf6, 0x22, 0x00, 0x7a, 0xa1, 0x5f, 0x03);
+SOF_DEFINE_REG_UUID(aria);
 
 DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -33,10 +33,10 @@ LOG_MODULE_REGISTER(aria, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
 /* 99f7166d-372c-43ef-81f6-22007aa15f03 */
-SOF_DEFINE_UUID("aria", aria_comp_uuid, 0x99f7166d, 0x372c, 0x43ef,
+SOF_DEFINE_UUID("aria", aria_uuid, 0x99f7166d, 0x372c, 0x43ef,
 		    0x81, 0xf6, 0x22, 0x00, 0x7a, 0xa1, 0x5f, 0x03);
 
-DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_uuid), LOG_LEVEL_INFO);
 
 static size_t get_required_emory(size_t chan_cnt, size_t smpl_group_cnt)
 {
@@ -292,5 +292,5 @@ static const struct module_interface aria_interface = {
 	.set_configuration = aria_set_config,
 };
 
-DECLARE_MODULE_ADAPTER(aria_interface, aria_comp_uuid, aria_comp_tr);
+DECLARE_MODULE_ADAPTER(aria_interface, aria_uuid, aria_comp_tr);
 SOF_MODULE_INIT(aria, sys_comp_module_aria_interface_init);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -877,5 +877,5 @@ static const struct module_interface asrc_interface = {
 	.free = asrc_free,
 };
 
-DECLARE_MODULE_ADAPTER(asrc_interface, asrc_uuid, asrc_tr);
+DECLARE_MODULE_ADAPTER(asrc_interface, ASRC_UUID, asrc_tr);
 SOF_MODULE_INIT(asrc, sys_comp_module_asrc_interface_init);

--- a/src/audio/asrc/asrc.h
+++ b/src/audio/asrc/asrc.h
@@ -124,7 +124,14 @@ int asrc_dai_start_timestamp(struct comp_data *cd);
 int asrc_dai_stop_timestamp(struct comp_data *cd);
 void asrc_update_buffer_format(struct comp_buffer *buf_c, struct comp_data *cd);
 void asrc_set_stream_params(struct comp_data *cd, struct sof_ipc_stream_params *params);
-extern const struct sof_uuid asrc_uuid;
 extern struct tr_ctx asrc_tr;
+
+/* Different UUID names for different build configurations... */
+#ifdef CONFIG_IPC_MAJOR_4
+#define ASRC_UUID asrc4_uuid
+#else
+#define ASRC_UUID asrc_uuid
+#endif
+extern const struct sof_uuid ASRC_UUID;
 
 #endif

--- a/src/audio/asrc/asrc_ipc3.c
+++ b/src/audio/asrc/asrc_ipc3.c
@@ -16,9 +16,7 @@
 #include <errno.h>
 #include "asrc.h"
 
-/* c8ec72f6-8526-4faf-9d39-a23d0b541de2 */
-SOF_DEFINE_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,
-		    0x9d, 0x39, 0xa2, 0x3d, 0x0b, 0x54, 0x1d, 0xe2);
+SOF_DEFINE_REG_UUID(asrc);
 
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/asrc/asrc_ipc3.c
+++ b/src/audio/asrc/asrc_ipc3.c
@@ -17,7 +17,7 @@
 #include "asrc.h"
 
 /* c8ec72f6-8526-4faf-9d39-a23d0b541de2 */
-DECLARE_SOF_RT_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,
+SOF_DEFINE_UUID("asrc", asrc_uuid, 0xc8ec72f6, 0x8526, 0x4faf,
 		    0x9d, 0x39, 0xa2, 0x3d, 0x0b, 0x54, 0x1d, 0xe2);
 
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -17,7 +17,7 @@
 #include "asrc.h"
 
 /* 66b4402d-b468-42f2-81a7-b37121863dd4 */
-DECLARE_SOF_RT_UUID("asrc", asrc_uuid, 0x66b4402d, 0xb468, 0x42f2,
+SOF_DEFINE_UUID("asrc", asrc_uuid, 0x66b4402d, 0xb468, 0x42f2,
 		    0x81, 0xa7, 0xb3, 0x71, 0x21, 0x86, 0x3d, 0xd4);
 
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -17,10 +17,10 @@
 #include "asrc.h"
 
 /* 66b4402d-b468-42f2-81a7-b37121863dd4 */
-SOF_DEFINE_UUID("asrc", asrc_uuid, 0x66b4402d, 0xb468, 0x42f2,
+SOF_DEFINE_UUID("asrc4", asrc4_uuid, 0x66b4402d, 0xb468, 0x42f2,
 		    0x81, 0xa7, 0xb3, 0x71, 0x21, 0x86, 0x3d, 0xd4);
 
-DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc4_uuid), LOG_LEVEL_INFO);
 
 int asrc_dai_configure_timestamp(struct comp_data *cd)
 {

--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -16,9 +16,7 @@
 #include <errno.h>
 #include "asrc.h"
 
-/* 66b4402d-b468-42f2-81a7-b37121863dd4 */
-SOF_DEFINE_UUID("asrc4", asrc4_uuid, 0x66b4402d, 0xb468, 0x42f2,
-		    0x81, 0xa7, 0xb3, 0x71, 0x21, 0x86, 0x3d, 0xd4);
+SOF_DEFINE_REG_UUID(asrc4);
 
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc4_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -36,9 +36,7 @@
 
 LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
 
-/* 0e398c32-5ade-ba4b-93b1-c50432280ee4 */
-SOF_DEFINE_UUID("basefw", basefw_uuid, 0xe398c32, 0x5ade, 0xba4b,
-		    0x93, 0xb1, 0xc5, 0x04, 0x32, 0x28, 0x0e, 0xe4);
+SOF_DEFINE_REG_UUID(basefw);
 DECLARE_TR_CTX(basefw_comp_tr, SOF_UUID(basefw_uuid), LOG_LEVEL_INFO);
 
 static struct ipc4_system_time_info global_system_time_info;

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -37,9 +37,9 @@
 LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
 
 /* 0e398c32-5ade-ba4b-93b1-c50432280ee4 */
-SOF_DEFINE_UUID("basefw", basefw_comp_uuid, 0xe398c32, 0x5ade, 0xba4b,
+SOF_DEFINE_UUID("basefw", basefw_uuid, 0xe398c32, 0x5ade, 0xba4b,
 		    0x93, 0xb1, 0xc5, 0x04, 0x32, 0x28, 0x0e, 0xe4);
-DECLARE_TR_CTX(basefw_comp_tr, SOF_UUID(basefw_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(basefw_comp_tr, SOF_UUID(basefw_uuid), LOG_LEVEL_INFO);
 
 static struct ipc4_system_time_info global_system_time_info;
 static uint64_t global_cycle_delta;
@@ -512,7 +512,7 @@ static int basefw_set_large_config(struct comp_dev *dev,
 };
 
 static const struct comp_driver comp_basefw = {
-	.uid	= SOF_RT_UUID(basefw_comp_uuid),
+	.uid	= SOF_RT_UUID(basefw_uuid),
 	.tctx	= &basefw_comp_tr,
 	.ops	= {
 		.get_large_config = basefw_get_large_config,

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -37,7 +37,7 @@
 LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
 
 /* 0e398c32-5ade-ba4b-93b1-c50432280ee4 */
-DECLARE_SOF_RT_UUID("basefw", basefw_comp_uuid, 0xe398c32, 0x5ade, 0xba4b,
+SOF_DEFINE_UUID("basefw", basefw_comp_uuid, 0xe398c32, 0x5ade, 0xba4b,
 		    0x93, 0xb1, 0xc5, 0x04, 0x32, 0x28, 0x0e, 0xe4);
 DECLARE_TR_CTX(basefw_comp_tr, SOF_UUID(basefw_comp_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -27,9 +27,7 @@
 
 LOG_MODULE_REGISTER(buffer, CONFIG_SOF_LOG_LEVEL);
 
-/* 42544c92-8e92-4e41-b679-34519f1c1d28 */
-SOF_DEFINE_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
-		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
+SOF_DEFINE_REG_UUID(buffer);
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 
 static struct comp_buffer *buffer_alloc_struct(void *stream_addr, size_t size, uint32_t caps,

--- a/src/audio/buffer.c
+++ b/src/audio/buffer.c
@@ -28,7 +28,7 @@
 LOG_MODULE_REGISTER(buffer, CONFIG_SOF_LOG_LEVEL);
 
 /* 42544c92-8e92-4e41-b679-34519f1c1d28 */
-DECLARE_SOF_RT_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
+SOF_DEFINE_UUID("buffer", buffer_uuid, 0x42544c92, 0x8e92, 0x4e41,
 		 0xb6, 0x79, 0x34, 0x51, 0x9f, 0x1c, 0x1d, 0x28);
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -36,7 +36,7 @@ static const uint32_t max_chain_number = DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN;
 LOG_MODULE_REGISTER(chain_dma, CONFIG_SOF_LOG_LEVEL);
 
 /* 6a0a274f-27cc-4afb-a3e7-3444723f432e */
-DECLARE_SOF_RT_UUID("chain_dma", chain_dma_uuid, 0x6a0a274f, 0x27cc, 0x4afb,
+SOF_DEFINE_UUID("chain_dma", chain_dma_uuid, 0x6a0a274f, 0x27cc, 0x4afb,
 		    0xa3, 0xe7, 0x34, 0x44, 0x72, 0x3f, 0x43, 0x2e);
 DECLARE_TR_CTX(chain_dma_tr, SOF_UUID(chain_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -35,9 +35,7 @@ static const uint32_t max_chain_number = DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN;
 
 LOG_MODULE_REGISTER(chain_dma, CONFIG_SOF_LOG_LEVEL);
 
-/* 6a0a274f-27cc-4afb-a3e7-3444723f432e */
-SOF_DEFINE_UUID("chain_dma", chain_dma_uuid, 0x6a0a274f, 0x27cc, 0x4afb,
-		    0xa3, 0xe7, 0x34, 0x44, 0x72, 0x3f, 0x43, 0x2e);
+SOF_DEFINE_REG_UUID(chain_dma);
 DECLARE_TR_CTX(chain_dma_tr, SOF_UUID(chain_dma_uuid), LOG_LEVEL_INFO);
 
 /* chain dma component private data */

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -17,7 +17,7 @@
 LOG_MODULE_REGISTER(channel_map, CONFIG_SOF_LOG_LEVEL);
 
 /* ec290e95-4a20-47eb-bbff-d9c888431831 */
-DECLARE_SOF_UUID("channel-map", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
+SOF_DEFINE_UUID("channel-map", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
 		 0xbb, 0xff, 0xd9, 0xc8, 0x88, 0x43, 0x18, 0x31);
 
 DECLARE_TR_CTX(chmap_tr, SOF_UUID(chmap_uuid), LOG_LEVEL_INFO);

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -16,9 +16,7 @@
 
 LOG_MODULE_REGISTER(channel_map, CONFIG_SOF_LOG_LEVEL);
 
-/* ec290e95-4a20-47eb-bbff-d9c888431831 */
-SOF_DEFINE_UUID("chmap", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
-		 0xbb, 0xff, 0xd9, 0xc8, 0x88, 0x43, 0x18, 0x31);
+SOF_DEFINE_REG_UUID(chmap);
 
 DECLARE_TR_CTX(chmap_tr, SOF_UUID(chmap_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -17,7 +17,7 @@
 LOG_MODULE_REGISTER(channel_map, CONFIG_SOF_LOG_LEVEL);
 
 /* ec290e95-4a20-47eb-bbff-d9c888431831 */
-SOF_DEFINE_UUID("channel-map", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
+SOF_DEFINE_UUID("chmap", chmap_uuid, 0xec290e95, 0x4a20, 0x47eb,
 		 0xbb, 0xff, 0xd9, 0xc8, 0x88, 0x43, 0x18, 0x31);
 
 DECLARE_TR_CTX(chmap_tr, SOF_UUID(chmap_uuid), LOG_LEVEL_INFO);

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -11,9 +11,7 @@
 
 LOG_MODULE_REGISTER(dts, CONFIG_SOF_LOG_LEVEL);
 
-/* d95fc34f-370f-4ac7-bc86-bfdc5be241e6 */
-SOF_DEFINE_UUID("dts", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7,
-			0xbc, 0x86, 0xbf, 0xdc, 0x5b, 0xe2, 0x41, 0xe6);
+SOF_DEFINE_REG_UUID(dts);
 DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 
 #define MAX_EXPECTED_DTS_CONFIG_DATA_SIZE 8192

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(dts, CONFIG_SOF_LOG_LEVEL);
 
 /* d95fc34f-370f-4ac7-bc86-bfdc5be241e6 */
-DECLARE_SOF_RT_UUID("dts_codec", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7,
+SOF_DEFINE_UUID("dts_codec", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7,
 			0xbc, 0x86, 0xbf, 0xdc, 0x5b, 0xe2, 0x41, 0xe6);
 DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(dts, CONFIG_SOF_LOG_LEVEL);
 
 /* d95fc34f-370f-4ac7-bc86-bfdc5be241e6 */
-SOF_DEFINE_UUID("dts_codec", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7,
+SOF_DEFINE_UUID("dts", dts_uuid, 0xd95fc34f, 0x370f, 0x4ac7,
 			0xbc, 0x86, 0xbf, 0xdc, 0x5b, 0xe2, 0x41, 0xe6);
 DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -36,7 +36,7 @@ LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 static SHARED_DATA struct comp_driver_list cd;
 
 /* 7c42ce8b-0108-43d0-9137-56d660478c5f */
-DECLARE_SOF_UUID("component", comp_uuid, 0x7c42ce8b, 0x0108, 0x43d0,
+SOF_DEFINE_UUID("component", comp_uuid, 0x7c42ce8b, 0x0108, 0x43d0,
 		 0x91, 0x37, 0x56, 0xd6, 0x60, 0x47, 0x8c, 0x5f);
 
 DECLARE_TR_CTX(comp_tr, SOF_UUID(comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -36,10 +36,10 @@ LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 static SHARED_DATA struct comp_driver_list cd;
 
 /* 7c42ce8b-0108-43d0-9137-56d660478c5f */
-SOF_DEFINE_UUID("component", comp_uuid, 0x7c42ce8b, 0x0108, 0x43d0,
+SOF_DEFINE_UUID("component", component_uuid, 0x7c42ce8b, 0x0108, 0x43d0,
 		 0x91, 0x37, 0x56, 0xd6, 0x60, 0x47, 0x8c, 0x5f);
 
-DECLARE_TR_CTX(comp_tr, SOF_UUID(comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(comp_tr, SOF_UUID(component_uuid), LOG_LEVEL_INFO);
 
 int comp_register(struct comp_driver_info *drv)
 {

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -35,9 +35,7 @@ LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 
 static SHARED_DATA struct comp_driver_list cd;
 
-/* 7c42ce8b-0108-43d0-9137-56d660478c5f */
-SOF_DEFINE_UUID("component", component_uuid, 0x7c42ce8b, 0x0108, 0x43d0,
-		 0x91, 0x37, 0x56, 0xd6, 0x60, 0x47, 0x8c, 0x5f);
+SOF_DEFINE_REG_UUID(component);
 
 DECLARE_TR_CTX(comp_tr, SOF_UUID(component_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -49,7 +49,7 @@ LOG_MODULE_REGISTER(copier, CONFIG_SOF_LOG_LEVEL);
 
 /* this id aligns windows driver requirement to support windows driver */
 /* 9ba00c83-ca12-4a83-943c-1fa2e82f9dda */
-DECLARE_SOF_RT_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
+SOF_DEFINE_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
 		    0x94, 0x3c, 0x1f, 0xa2, 0xe8, 0x2f, 0x9d, 0xda);
 
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -49,10 +49,10 @@ LOG_MODULE_REGISTER(copier, CONFIG_SOF_LOG_LEVEL);
 
 /* this id aligns windows driver requirement to support windows driver */
 /* 9ba00c83-ca12-4a83-943c-1fa2e82f9dda */
-SOF_DEFINE_UUID("copier", copier_comp_uuid, 0x9ba00c83, 0xca12, 0x4a83,
+SOF_DEFINE_UUID("copier", copier_uuid, 0x9ba00c83, 0xca12, 0x4a83,
 		    0x94, 0x3c, 0x1f, 0xa2, 0xe8, 0x2f, 0x9d, 0xda);
 
-DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_uuid), LOG_LEVEL_INFO);
 
 static int copier_init(struct processing_module *mod)
 {
@@ -1027,5 +1027,5 @@ static const struct module_interface copier_interface = {
 	.endpoint_ops = &copier_endpoint_ops,
 };
 
-DECLARE_MODULE_ADAPTER(copier_interface, copier_comp_uuid, copier_comp_tr);
+DECLARE_MODULE_ADAPTER(copier_interface, copier_uuid, copier_comp_tr);
 SOF_MODULE_INIT(copier, sys_comp_module_copier_interface_init);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -48,9 +48,7 @@
 LOG_MODULE_REGISTER(copier, CONFIG_SOF_LOG_LEVEL);
 
 /* this id aligns windows driver requirement to support windows driver */
-/* 9ba00c83-ca12-4a83-943c-1fa2e82f9dda */
-SOF_DEFINE_UUID("copier", copier_uuid, 0x9ba00c83, 0xca12, 0x4a83,
-		    0x94, 0x3c, 0x1f, 0xa2, 0xe8, 0x2f, 0x9d, 0xda);
+SOF_DEFINE_REG_UUID(copier);
 
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -13,9 +13,7 @@
 
 LOG_MODULE_REGISTER(ipcgtw, CONFIG_SOF_LOG_LEVEL);
 
-/* a814a1ca-0b83-466c-9587-2f35ff8d12e8 */
-SOF_DEFINE_UUID("ipcgw", ipcgw_uuid, 0xa814a1ca, 0x0b83, 0x466c,
-		    0x95, 0x87, 0x2f, 0x35, 0xff, 0x8d, 0x12, 0xe8);
+SOF_DEFINE_REG_UUID(ipcgw);
 
 DECLARE_TR_CTX(ipcgtw_comp_tr, SOF_UUID(ipcgw_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -14,7 +14,7 @@
 LOG_MODULE_REGISTER(ipcgtw, CONFIG_SOF_LOG_LEVEL);
 
 /* a814a1ca-0b83-466c-9587-2f35ff8d12e8 */
-DECLARE_SOF_RT_UUID("ipcgw", ipcgtw_comp_uuid, 0xa814a1ca, 0x0b83, 0x466c,
+SOF_DEFINE_UUID("ipcgw", ipcgtw_comp_uuid, 0xa814a1ca, 0x0b83, 0x466c,
 		    0x95, 0x87, 0x2f, 0x35, 0xff, 0x8d, 0x12, 0xe8);
 
 DECLARE_TR_CTX(ipcgtw_comp_tr, SOF_UUID(ipcgtw_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -14,10 +14,10 @@
 LOG_MODULE_REGISTER(ipcgtw, CONFIG_SOF_LOG_LEVEL);
 
 /* a814a1ca-0b83-466c-9587-2f35ff8d12e8 */
-SOF_DEFINE_UUID("ipcgw", ipcgtw_comp_uuid, 0xa814a1ca, 0x0b83, 0x466c,
+SOF_DEFINE_UUID("ipcgw", ipcgw_uuid, 0xa814a1ca, 0x0b83, 0x466c,
 		    0x95, 0x87, 0x2f, 0x35, 0xff, 0x8d, 0x12, 0xe8);
 
-DECLARE_TR_CTX(ipcgtw_comp_tr, SOF_UUID(ipcgtw_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(ipcgtw_comp_tr, SOF_UUID(ipcgw_uuid), LOG_LEVEL_INFO);
 
 /* List of existing IPC gateways */
 static struct list_item ipcgtw_list_head = LIST_INIT(ipcgtw_list_head);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -40,9 +40,7 @@
 
 LOG_MODULE_REGISTER(crossover, CONFIG_SOF_LOG_LEVEL);
 
-/* 948c9ad1-806a-4131-ad6c-b2bda9e35a9f */
-SOF_DEFINE_UUID("crossover", crossover_uuid, 0x948c9ad1, 0x806a, 0x4131,
-		    0xad, 0x6c, 0xb2, 0xbd, 0xa9, 0xe3, 0x5a, 0x9f);
+SOF_DEFINE_REG_UUID(crossover);
 
 DECLARE_TR_CTX(crossover_tr, SOF_UUID(crossover_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -41,7 +41,7 @@
 LOG_MODULE_REGISTER(crossover, CONFIG_SOF_LOG_LEVEL);
 
 /* 948c9ad1-806a-4131-ad6c-b2bda9e35a9f */
-DECLARE_SOF_RT_UUID("crossover", crossover_uuid, 0x948c9ad1, 0x806a, 0x4131,
+SOF_DEFINE_UUID("crossover", crossover_uuid, 0x948c9ad1, 0x806a, 0x4131,
 		    0xad, 0x6c, 0xb2, 0xbd, 0xa9, 0xe3, 0x5a, 0x9f);
 
 DECLARE_TR_CTX(crossover_tr, SOF_UUID(crossover_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -40,10 +40,10 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai_legacy", dai_legacy_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
-DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_legacy_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
@@ -1112,7 +1112,7 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
-	.uid	= SOF_RT_UUID(dai_comp_uuid),
+	.uid	= SOF_RT_UUID(dai_legacy_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
 		.create				= dai_new,

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -39,9 +39,7 @@ static const struct comp_driver comp_dai;
 
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
-/* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai", dai_uuid, 0xc2b00d27, 0xffbc, 0x4150,
-		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
+SOF_DEFINE_REG_UUID(dai);
 
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -40,7 +40,7 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-DECLARE_SOF_RT_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -40,10 +40,10 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai_legacy", dai_legacy_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai", dai_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		 0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
-DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_legacy_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
@@ -1112,7 +1112,7 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
-	.uid	= SOF_RT_UUID(dai_legacy_uuid),
+	.uid	= SOF_RT_UUID(dai_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
 		.create				= dai_new,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -53,9 +53,7 @@ static const struct comp_driver comp_dai;
 
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
-/* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai", dai_uuid, 0xc2b00d27, 0xffbc, 0x4150,
-		    0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
+SOF_DEFINE_REG_UUID(dai);
 
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -54,7 +54,7 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-DECLARE_SOF_RT_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		    0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -54,10 +54,10 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai", dai_comp_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai_zephyr", dai_zephyr_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		    0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
-DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_comp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_zephyr_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
@@ -1777,7 +1777,7 @@ int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
-	.uid	= SOF_RT_UUID(dai_comp_uuid),
+	.uid	= SOF_RT_UUID(dai_zephyr_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
 		.create				= dai_new,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -54,10 +54,10 @@ static const struct comp_driver comp_dai;
 LOG_MODULE_REGISTER(dai_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* c2b00d27-ffbc-4150-a51a-245c79c5e54b */
-SOF_DEFINE_UUID("dai_zephyr", dai_zephyr_uuid, 0xc2b00d27, 0xffbc, 0x4150,
+SOF_DEFINE_UUID("dai", dai_uuid, 0xc2b00d27, 0xffbc, 0x4150,
 		    0xa5, 0x1a, 0x24, 0x5c, 0x79, 0xc5, 0xe5, 0x4b);
 
-DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_zephyr_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_COMP_DAI_GROUP
 
@@ -1777,7 +1777,7 @@ int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
-	.uid	= SOF_RT_UUID(dai_zephyr_uuid),
+	.uid	= SOF_RT_UUID(dai_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
 		.create				= dai_new,

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(dcblock, CONFIG_SOF_LOG_LEVEL);
 
 /* b809efaf-5681-42b1-9ed6-04bb012dd384 */
-DECLARE_SOF_RT_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
+SOF_DEFINE_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
 		 0x9e, 0xd6, 0x04, 0xbb, 0x01, 0x2d, 0xd3, 0x84);
 
 DECLARE_TR_CTX(dcblock_tr, SOF_UUID(dcblock_uuid), LOG_LEVEL_INFO);

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -35,9 +35,7 @@
 
 LOG_MODULE_REGISTER(dcblock, CONFIG_SOF_LOG_LEVEL);
 
-/* b809efaf-5681-42b1-9ed6-04bb012dd384 */
-SOF_DEFINE_UUID("dcblock", dcblock_uuid, 0xb809efaf, 0x5681, 0x42b1,
-		 0x9e, 0xd6, 0x04, 0xbb, 0x01, 0x2d, 0xd3, 0x84);
+SOF_DEFINE_REG_UUID(dcblock);
 
 DECLARE_TR_CTX(dcblock_tr, SOF_UUID(dcblock_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/dp_queue.c
+++ b/src/audio/dp_queue.c
@@ -14,9 +14,7 @@
 
 LOG_MODULE_REGISTER(dp_queue, CONFIG_SOF_LOG_LEVEL);
 
-/* 393608d8-4188-11ee-be56-0242ac120002 */
-SOF_DEFINE_UUID("dp_queue", dp_queue_uuid, 0x393608d8, 0x4188, 0x11ee,
-		    0xbe, 0x56, 0x02, 0x42, 0xac, 0x12, 0x20, 0x02);
+SOF_DEFINE_REG_UUID(dp_queue);
 DECLARE_TR_CTX(dp_queue_tr, SOF_UUID(dp_queue_uuid), LOG_LEVEL_INFO);
 
 static inline uint8_t __sparse_cache *dp_queue_buffer_end(struct dp_queue *dp_queue)

--- a/src/audio/dp_queue.c
+++ b/src/audio/dp_queue.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(dp_queue, CONFIG_SOF_LOG_LEVEL);
 
 /* 393608d8-4188-11ee-be56-0242ac120002 */
-DECLARE_SOF_RT_UUID("dp_queue", dp_queue_uuid, 0x393608d8, 0x4188, 0x11ee,
+SOF_DEFINE_UUID("dp_queue", dp_queue_uuid, 0x393608d8, 0x4188, 0x11ee,
 		    0xbe, 0x56, 0x02, 0x42, 0xac, 0x12, 0x20, 0x02);
 DECLARE_TR_CTX(dp_queue_tr, SOF_UUID(dp_queue_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -38,9 +38,7 @@
 
 LOG_MODULE_REGISTER(drc, CONFIG_SOF_LOG_LEVEL);
 
-/* b36ee4da-006f-47f9-a06d-fecbe2d8b6ce */
-SOF_DEFINE_UUID("drc", drc_uuid, 0xb36ee4da, 0x006f, 0x47f9,
-		    0xa0, 0x6d, 0xfe, 0xcb, 0xe2, 0xd8, 0xb6, 0xce);
+SOF_DEFINE_REG_UUID(drc);
 
 DECLARE_TR_CTX(drc_tr, SOF_UUID(drc_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -39,7 +39,7 @@
 LOG_MODULE_REGISTER(drc, CONFIG_SOF_LOG_LEVEL);
 
 /* b36ee4da-006f-47f9-a06d-fecbe2d8b6ce */
-DECLARE_SOF_RT_UUID("drc", drc_uuid, 0xb36ee4da, 0x006f, 0x47f9,
+SOF_DEFINE_UUID("drc", drc_uuid, 0xb36ee4da, 0x006f, 0x47f9,
 		    0xa0, 0x6d, 0xfe, 0xcb, 0xe2, 0xd8, 0xb6, 0xce);
 
 DECLARE_TR_CTX(drc_tr, SOF_UUID(drc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -41,7 +41,7 @@
 LOG_MODULE_REGISTER(eq_fir, CONFIG_SOF_LOG_LEVEL);
 
 /* 43a90ce7-f3a5-41df-ac06-ba98651ae6a3 */
-DECLARE_SOF_RT_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
+SOF_DEFINE_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
 		 0xac, 0x06, 0xba, 0x98, 0x65, 0x1a, 0xe6, 0xa3);
 
 DECLARE_TR_CTX(eq_fir_tr, SOF_UUID(eq_fir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -41,7 +41,7 @@
 LOG_MODULE_REGISTER(eq_fir, CONFIG_SOF_LOG_LEVEL);
 
 /* 43a90ce7-f3a5-41df-ac06-ba98651ae6a3 */
-SOF_DEFINE_UUID("eq-fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
+SOF_DEFINE_UUID("eq_fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
 		 0xac, 0x06, 0xba, 0x98, 0x65, 0x1a, 0xe6, 0xa3);
 
 DECLARE_TR_CTX(eq_fir_tr, SOF_UUID(eq_fir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -40,9 +40,7 @@
 
 LOG_MODULE_REGISTER(eq_fir, CONFIG_SOF_LOG_LEVEL);
 
-/* 43a90ce7-f3a5-41df-ac06-ba98651ae6a3 */
-SOF_DEFINE_UUID("eq_fir", eq_fir_uuid, 0x43a90ce7, 0xf3a5, 0x41df,
-		 0xac, 0x06, 0xba, 0x98, 0x65, 0x1a, 0xe6, 0xa3);
+SOF_DEFINE_REG_UUID(eq_fir);
 
 DECLARE_TR_CTX(eq_fir_tr, SOF_UUID(eq_fir_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -38,7 +38,7 @@
 LOG_MODULE_REGISTER(eq_iir, CONFIG_SOF_LOG_LEVEL);
 
 /* 5150c0e6-27f9-4ec8-8351-c705b642d12f */
-SOF_DEFINE_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
+SOF_DEFINE_UUID("eq_iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
 		 0x83, 0x51, 0xc7, 0x05, 0xb6, 0x42, 0xd1, 0x2f);
 
 DECLARE_TR_CTX(eq_iir_tr, SOF_UUID(eq_iir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -37,9 +37,7 @@
 
 LOG_MODULE_REGISTER(eq_iir, CONFIG_SOF_LOG_LEVEL);
 
-/* 5150c0e6-27f9-4ec8-8351-c705b642d12f */
-SOF_DEFINE_UUID("eq_iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
-		 0x83, 0x51, 0xc7, 0x05, 0xb6, 0x42, 0xd1, 0x2f);
+SOF_DEFINE_REG_UUID(eq_iir);
 
 DECLARE_TR_CTX(eq_iir_tr, SOF_UUID(eq_iir_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -38,7 +38,7 @@
 LOG_MODULE_REGISTER(eq_iir, CONFIG_SOF_LOG_LEVEL);
 
 /* 5150c0e6-27f9-4ec8-8351-c705b642d12f */
-DECLARE_SOF_RT_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
+SOF_DEFINE_UUID("eq-iir", eq_iir_uuid, 0x5150c0e6, 0x27f9, 0x4ec8,
 		 0x83, 0x51, 0xc7, 0x05, 0xb6, 0x42, 0xd1, 0x2f);
 
 DECLARE_TR_CTX(eq_iir_tr, SOF_UUID(eq_iir_uuid), LOG_LEVEL_INFO);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -44,10 +44,7 @@ static const struct comp_driver ghd_driver;
 
 LOG_MODULE_REGISTER(google_hotword_detect, CONFIG_SOF_LOG_LEVEL);
 
-/* c3c74249-058e-414f-8240-4da5f3fc2389 */
-SOF_DEFINE_UUID("google_hotword", google_hotword_uuid,
-		    0xc3c74249, 0x058e, 0x414f,
-		    0x82, 0x40, 0x4d, 0xa5, 0xf3, 0xfc, 0x23, 0x89);
+SOF_DEFINE_REG_UUID(google_hotword);
 DECLARE_TR_CTX(ghd_tr, SOF_UUID(ghd_uuid), LOG_LEVEL_INFO);
 
 struct comp_data {

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -45,7 +45,7 @@ static const struct comp_driver ghd_driver;
 LOG_MODULE_REGISTER(google_hotword_detect, CONFIG_SOF_LOG_LEVEL);
 
 /* c3c74249-058e-414f-8240-4da5f3fc2389 */
-SOF_DEFINE_UUID("google-hotword-detect", ghd_uuid,
+SOF_DEFINE_UUID("google_hotword", google_hotword_uuid,
 		    0xc3c74249, 0x058e, 0x414f,
 		    0x82, 0x40, 0x4d, 0xa5, 0xf3, 0xfc, 0x23, 0x89);
 DECLARE_TR_CTX(ghd_tr, SOF_UUID(ghd_uuid), LOG_LEVEL_INFO);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -45,7 +45,7 @@ static const struct comp_driver ghd_driver;
 LOG_MODULE_REGISTER(google_hotword_detect, CONFIG_SOF_LOG_LEVEL);
 
 /* c3c74249-058e-414f-8240-4da5f3fc2389 */
-DECLARE_SOF_RT_UUID("google-hotword-detect", ghd_uuid,
+SOF_DEFINE_UUID("google-hotword-detect", ghd_uuid,
 		    0xc3c74249, 0x058e, 0x414f,
 		    0x82, 0x40, 0x4d, 0xa5, 0xf3, 0xfc, 0x23, 0x89);
 DECLARE_TR_CTX(ghd_tr, SOF_UUID(ghd_uuid), LOG_LEVEL_INFO);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -56,7 +56,7 @@
 LOG_MODULE_REGISTER(google_rtc_audio_processing, CONFIG_SOF_LOG_LEVEL);
 
 /* b780a0a6-269f-466f-b477-23dfa05af758 */
-SOF_DEFINE_UUID("google-rtc-audio-processing", google_rtc_audio_processing_uuid,
+SOF_DEFINE_UUID("google_rtc_audio_processing", google_rtc_audio_processing_uuid,
 					0xb780a0a6, 0x269f, 0x466f, 0xb4, 0x77, 0x23, 0xdf, 0xa0,
 					0x5a, 0xf7, 0x58);
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -56,7 +56,7 @@
 LOG_MODULE_REGISTER(google_rtc_audio_processing, CONFIG_SOF_LOG_LEVEL);
 
 /* b780a0a6-269f-466f-b477-23dfa05af758 */
-DECLARE_SOF_RT_UUID("google-rtc-audio-processing", google_rtc_audio_processing_uuid,
+SOF_DEFINE_UUID("google-rtc-audio-processing", google_rtc_audio_processing_uuid,
 					0xb780a0a6, 0x269f, 0x466f, 0xb4, 0x77, 0x23, 0xdf, 0xa0,
 					0x5a, 0xf7, 0x58);
 

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -55,10 +55,7 @@
 
 LOG_MODULE_REGISTER(google_rtc_audio_processing, CONFIG_SOF_LOG_LEVEL);
 
-/* b780a0a6-269f-466f-b477-23dfa05af758 */
-SOF_DEFINE_UUID("google_rtc_audio_processing", google_rtc_audio_processing_uuid,
-					0xb780a0a6, 0x269f, 0x466f, 0xb4, 0x77, 0x23, 0xdf, 0xa0,
-					0x5a, 0xf7, 0x58);
+SOF_DEFINE_REG_UUID(google_rtc_audio_processing);
 
 DECLARE_TR_CTX(google_rtc_audio_processing_tr, SOF_UUID(google_rtc_audio_processing_uuid),
 			   LOG_LEVEL_INFO);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -39,7 +39,7 @@ static const struct comp_driver comp_host;
 LOG_MODULE_REGISTER(host, CONFIG_SOF_LOG_LEVEL);
 
 /* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
-DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
+SOF_DEFINE_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		 0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -38,9 +38,7 @@ static const struct comp_driver comp_host;
 
 LOG_MODULE_REGISTER(host, CONFIG_SOF_LOG_LEVEL);
 
-/* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
-SOF_DEFINE_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
-		 0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
+SOF_DEFINE_REG_UUID(host);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -39,9 +39,7 @@ static const struct comp_driver comp_host;
 
 LOG_MODULE_REGISTER(host_comp, CONFIG_SOF_LOG_LEVEL);
 
-/* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
-SOF_DEFINE_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
-		    0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
+SOF_DEFINE_REG_UUID(host);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -40,7 +40,7 @@ static const struct comp_driver comp_host;
 LOG_MODULE_REGISTER(host_comp, CONFIG_SOF_LOG_LEVEL);
 
 /* 8b9d100c-6d78-418f-90a3-e0e805d0852b */
-DECLARE_SOF_RT_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
+SOF_DEFINE_UUID("host", host_uuid, 0x8b9d100c, 0x6d78, 0x418f,
 		    0x90, 0xa3, 0xe0, 0xe8, 0x05, 0xd0, 0x85, 0x2b);
 
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -45,7 +45,7 @@ enum IGO_NR_ENUM {
 LOG_MODULE_REGISTER(igo_nr, CONFIG_SOF_LOG_LEVEL);
 
 /* 696ae2bc-2877-11eb-adc1-0242ac120002 */
-DECLARE_SOF_RT_UUID("igo-nr", igo_nr_uuid,  0x696ae2bc, 0x2877, 0x11eb, 0xad, 0xc1,
+SOF_DEFINE_UUID("igo-nr", igo_nr_uuid,  0x696ae2bc, 0x2877, 0x11eb, 0xad, 0xc1,
 		    0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
 
 DECLARE_TR_CTX(igo_nr_tr, SOF_UUID(igo_nr_uuid), LOG_LEVEL_INFO);

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -44,9 +44,7 @@ enum IGO_NR_ENUM {
 
 LOG_MODULE_REGISTER(igo_nr, CONFIG_SOF_LOG_LEVEL);
 
-/* 696ae2bc-2877-11eb-adc1-0242ac120002 */
-SOF_DEFINE_UUID("igo_nr", igo_nr_uuid,  0x696ae2bc, 0x2877, 0x11eb, 0xad, 0xc1,
-		    0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+SOF_DEFINE_REG_UUID(igo_nr);
 
 DECLARE_TR_CTX(igo_nr_tr, SOF_UUID(igo_nr_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -45,7 +45,7 @@ enum IGO_NR_ENUM {
 LOG_MODULE_REGISTER(igo_nr, CONFIG_SOF_LOG_LEVEL);
 
 /* 696ae2bc-2877-11eb-adc1-0242ac120002 */
-SOF_DEFINE_UUID("igo-nr", igo_nr_uuid,  0x696ae2bc, 0x2877, 0x11eb, 0xad, 0xc1,
+SOF_DEFINE_UUID("igo_nr", igo_nr_uuid,  0x696ae2bc, 0x2877, 0x11eb, 0xad, 0xc1,
 		    0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
 
 DECLARE_TR_CTX(igo_nr_tr, SOF_UUID(igo_nr_uuid), LOG_LEVEL_INFO);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -71,7 +71,7 @@ SOF_DEFINE_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 DECLARE_TR_CTX(kpb_tr, SOF_UUID(kpb_uuid), LOG_LEVEL_INFO);
 
 /* e50057a5-8b27-4db4-bd79-9a639cee5f50 */
-SOF_DEFINE_UUID("kpb-task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
+SOF_DEFINE_UUID("kpb_task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
 		 0xbd, 0x79, 0x9a, 0x63, 0x9c, 0xee, 0x5f, 0x50);
 
 /* KPB private data, runtime data */

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -60,15 +60,17 @@ static const struct comp_driver comp_kpb;
 LOG_MODULE_REGISTER(kpb, CONFIG_SOF_LOG_LEVEL);
 #if CONFIG_IPC_MAJOR_4
 /* A8A0CB32-4A77-4DB1-85C7-53D7EE07BCE6 */
-SOF_DEFINE_UUID("kpb", kpb_uuid, 0xA8A0CB32, 0x4A77, 0x4DB1,
+SOF_DEFINE_UUID("kpb4", kpb4_uuid, 0xA8A0CB32, 0x4A77, 0x4DB1,
 		    0x85, 0xC7, 0x53, 0xD7, 0xEE, 0x07, 0xBC, 0xE6);
+#define KPB_UUID kpb4_uuid
 #else
 /* d8218443-5ff3-4a4c-b388-6cfe07b9562e */
 SOF_DEFINE_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);
+#define KPB_UUID kpb_uuid
 #endif
 
-DECLARE_TR_CTX(kpb_tr, SOF_UUID(kpb_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(kpb_tr, SOF_UUID(KPB_UUID), LOG_LEVEL_INFO);
 
 /* e50057a5-8b27-4db4-bd79-9a639cee5f50 */
 SOF_DEFINE_UUID("kpb_task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
@@ -2597,7 +2599,7 @@ static int kpb_set_large_config(struct comp_dev *dev, uint32_t param_id,
 
 static const struct comp_driver comp_kpb = {
 	.type = SOF_COMP_KPB,
-	.uid = SOF_RT_UUID(kpb_uuid),
+	.uid = SOF_RT_UUID(KPB_UUID),
 	.tctx = &kpb_tr,
 	.ops = {
 		.create		= kpb_new,

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -59,22 +59,16 @@ static const struct comp_driver comp_kpb;
 
 LOG_MODULE_REGISTER(kpb, CONFIG_SOF_LOG_LEVEL);
 #if CONFIG_IPC_MAJOR_4
-/* A8A0CB32-4A77-4DB1-85C7-53D7EE07BCE6 */
-SOF_DEFINE_UUID("kpb4", kpb4_uuid, 0xA8A0CB32, 0x4A77, 0x4DB1,
-		    0x85, 0xC7, 0x53, 0xD7, 0xEE, 0x07, 0xBC, 0xE6);
+SOF_DEFINE_REG_UUID(kpb4);
 #define KPB_UUID kpb4_uuid
 #else
-/* d8218443-5ff3-4a4c-b388-6cfe07b9562e */
-SOF_DEFINE_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
-		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);
+SOF_DEFINE_REG_UUID(kpb);
 #define KPB_UUID kpb_uuid
 #endif
 
 DECLARE_TR_CTX(kpb_tr, SOF_UUID(KPB_UUID), LOG_LEVEL_INFO);
 
-/* e50057a5-8b27-4db4-bd79-9a639cee5f50 */
-SOF_DEFINE_UUID("kpb_task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
-		 0xbd, 0x79, 0x9a, 0x63, 0x9c, 0xee, 0x5f, 0x50);
+SOF_DEFINE_REG_UUID(kpb_task);
 
 /* KPB private data, runtime data */
 struct comp_data {

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -60,18 +60,18 @@ static const struct comp_driver comp_kpb;
 LOG_MODULE_REGISTER(kpb, CONFIG_SOF_LOG_LEVEL);
 #if CONFIG_IPC_MAJOR_4
 /* A8A0CB32-4A77-4DB1-85C7-53D7EE07BCE6 */
-DECLARE_SOF_RT_UUID("kpb", kpb_uuid, 0xA8A0CB32, 0x4A77, 0x4DB1,
+SOF_DEFINE_UUID("kpb", kpb_uuid, 0xA8A0CB32, 0x4A77, 0x4DB1,
 		    0x85, 0xC7, 0x53, 0xD7, 0xEE, 0x07, 0xBC, 0xE6);
 #else
 /* d8218443-5ff3-4a4c-b388-6cfe07b9562e */
-DECLARE_SOF_RT_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
+SOF_DEFINE_UUID("kpb", kpb_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0x2e);
 #endif
 
 DECLARE_TR_CTX(kpb_tr, SOF_UUID(kpb_uuid), LOG_LEVEL_INFO);
 
 /* e50057a5-8b27-4db4-bd79-9a639cee5f50 */
-DECLARE_SOF_UUID("kpb-task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
+SOF_DEFINE_UUID("kpb-task", kpb_task_uuid, 0xe50057a5, 0x8b27, 0x4db4,
 		 0xbd, 0x79, 0x9a, 0x63, 0x9c, 0xee, 0x5f, 0x50);
 
 /* KPB private data, runtime data */

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -35,7 +35,7 @@
 LOG_MODULE_REGISTER(mfcc, CONFIG_SOF_LOG_LEVEL);
 
 /* db10a773-1aa4-4cea-a21f-2d57a5c982eb */
-DECLARE_SOF_RT_UUID("mfcc", mfcc_uuid, 0xdb10a773, 0x1aa4, 0x4cea,
+SOF_DEFINE_UUID("mfcc", mfcc_uuid, 0xdb10a773, 0x1aa4, 0x4cea,
 		    0xa2, 0x1f, 0x2d, 0x57, 0xa5, 0xc9, 0x82, 0xeb);
 
 DECLARE_TR_CTX(mfcc_tr, SOF_UUID(mfcc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -34,9 +34,7 @@
 
 LOG_MODULE_REGISTER(mfcc, CONFIG_SOF_LOG_LEVEL);
 
-/* db10a773-1aa4-4cea-a21f-2d57a5c982eb */
-SOF_DEFINE_UUID("mfcc", mfcc_uuid, 0xdb10a773, 0x1aa4, 0x4cea,
-		    0xa2, 0x1f, 0x2d, 0x57, 0xa5, 0xc9, 0x82, 0xeb);
+SOF_DEFINE_REG_UUID(mfcc);
 
 DECLARE_TR_CTX(mfcc_tr, SOF_UUID(mfcc_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -35,9 +35,7 @@
 
 LOG_MODULE_REGISTER(mixer, CONFIG_SOF_LOG_LEVEL);
 
-/* bc06c037-12aa-417c-9a97-89282e321a76 */
-SOF_DEFINE_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,
-		 0x9a, 0x97, 0x89, 0x28, 0x2e, 0x32, 0x1a, 0x76);
+SOF_DEFINE_REG_UUID(mixer);
 
 DECLARE_TR_CTX(mixer_tr, SOF_UUID(mixer_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(mixer, CONFIG_SOF_LOG_LEVEL);
 
 /* bc06c037-12aa-417c-9a97-89282e321a76 */
-DECLARE_SOF_RT_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,
+SOF_DEFINE_UUID("mixer", mixer_uuid, 0xbc06c037, 0x12aa, 0x417c,
 		 0x9a, 0x97, 0x89, 0x28, 0x2e, 0x32, 0x1a, 0x76);
 
 DECLARE_TR_CTX(mixer_tr, SOF_UUID(mixer_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -34,13 +34,11 @@
 LOG_MODULE_REGISTER(mixin_mixout, CONFIG_SOF_LOG_LEVEL);
 
 /* mixin 39656eb2-3b71-4049-8d3f-f92cd5c43c09 */
-SOF_DEFINE_UUID("mixin", mixin_uuid, 0x39656eb2, 0x3b71, 0x4049,
-		    0x8d, 0x3f, 0xf9, 0x2c, 0xd5, 0xc4, 0x3c, 0x09);
+SOF_DEFINE_REG_UUID(mixin);
 DECLARE_TR_CTX(mixin_tr, SOF_UUID(mixin_uuid), LOG_LEVEL_INFO);
 
 /* mixout 3c56505a-24d7-418f-bddc-c1f5a3ac2ae0 */
-SOF_DEFINE_UUID("mixout", mixout_uuid, 0x3c56505a, 0x24d7, 0x418f,
-		    0xbd, 0xdc, 0xc1, 0xf5, 0xa3, 0xac, 0x2a, 0xe0);
+SOF_DEFINE_REG_UUID(mixout);
 DECLARE_TR_CTX(mixout_tr, SOF_UUID(mixout_uuid), LOG_LEVEL_INFO);
 
 #define MIXIN_MAX_SINKS IPC4_MIXIN_MODULE_MAX_OUTPUT_QUEUES

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -34,12 +34,12 @@
 LOG_MODULE_REGISTER(mixin_mixout, CONFIG_SOF_LOG_LEVEL);
 
 /* mixin 39656eb2-3b71-4049-8d3f-f92cd5c43c09 */
-DECLARE_SOF_RT_UUID("mix_in", mixin_uuid, 0x39656eb2, 0x3b71, 0x4049,
+SOF_DEFINE_UUID("mix_in", mixin_uuid, 0x39656eb2, 0x3b71, 0x4049,
 		    0x8d, 0x3f, 0xf9, 0x2c, 0xd5, 0xc4, 0x3c, 0x09);
 DECLARE_TR_CTX(mixin_tr, SOF_UUID(mixin_uuid), LOG_LEVEL_INFO);
 
 /* mixout 3c56505a-24d7-418f-bddc-c1f5a3ac2ae0 */
-DECLARE_SOF_RT_UUID("mix_out", mixout_uuid, 0x3c56505a, 0x24d7, 0x418f,
+SOF_DEFINE_UUID("mix_out", mixout_uuid, 0x3c56505a, 0x24d7, 0x418f,
 		    0xbd, 0xdc, 0xc1, 0xf5, 0xa3, 0xac, 0x2a, 0xe0);
 DECLARE_TR_CTX(mixout_tr, SOF_UUID(mixout_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -34,12 +34,12 @@
 LOG_MODULE_REGISTER(mixin_mixout, CONFIG_SOF_LOG_LEVEL);
 
 /* mixin 39656eb2-3b71-4049-8d3f-f92cd5c43c09 */
-SOF_DEFINE_UUID("mix_in", mixin_uuid, 0x39656eb2, 0x3b71, 0x4049,
+SOF_DEFINE_UUID("mixin", mixin_uuid, 0x39656eb2, 0x3b71, 0x4049,
 		    0x8d, 0x3f, 0xf9, 0x2c, 0xd5, 0xc4, 0x3c, 0x09);
 DECLARE_TR_CTX(mixin_tr, SOF_UUID(mixin_uuid), LOG_LEVEL_INFO);
 
 /* mixout 3c56505a-24d7-418f-bddc-c1f5a3ac2ae0 */
-SOF_DEFINE_UUID("mix_out", mixout_uuid, 0x3c56505a, 0x24d7, 0x418f,
+SOF_DEFINE_UUID("mixout", mixout_uuid, 0x3c56505a, 0x24d7, 0x418f,
 		    0xbd, 0xdc, 0xc1, 0xf5, 0xa3, 0xac, 0x2a, 0xe0);
 DECLARE_TR_CTX(mixout_tr, SOF_UUID(mixout_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -19,7 +19,7 @@
 LOG_MODULE_REGISTER(cadence, CONFIG_SOF_LOG_LEVEL);
 
 /* d8218443-5ff3-4a4c-b388-6cfe07b956aa */
-DECLARE_SOF_RT_UUID("cadence_codec", cadence_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
+SOF_DEFINE_UUID("cadence_codec", cadence_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0xaa);
 
 DECLARE_TR_CTX(cadence_tr, SOF_UUID(cadence_uuid), LOG_LEVEL_INFO);

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -18,9 +18,7 @@
 
 LOG_MODULE_REGISTER(cadence, CONFIG_SOF_LOG_LEVEL);
 
-/* d8218443-5ff3-4a4c-b388-6cfe07b956aa */
-SOF_DEFINE_UUID("cadence_codec", cadence_codec_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
-		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0xaa);
+SOF_DEFINE_REG_UUID(cadence_codec);
 
 DECLARE_TR_CTX(cadence_tr, SOF_UUID(cadence_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -19,7 +19,7 @@
 LOG_MODULE_REGISTER(cadence, CONFIG_SOF_LOG_LEVEL);
 
 /* d8218443-5ff3-4a4c-b388-6cfe07b956aa */
-SOF_DEFINE_UUID("cadence_codec", cadence_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
+SOF_DEFINE_UUID("cadence_codec", cadence_codec_uuid, 0xd8218443, 0x5ff3, 0x4a4c,
 		    0xb3, 0x88, 0x6c, 0xfe, 0x07, 0xb9, 0x56, 0xaa);
 
 DECLARE_TR_CTX(cadence_tr, SOF_UUID(cadence_uuid), LOG_LEVEL_INFO);

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -43,7 +43,7 @@
 
 LOG_MODULE_REGISTER(sof_modules, CONFIG_SOF_LOG_LEVEL);
 /* ee2585f2-e7d8-43dc-90ab-4224e00c3e84 */
-DECLARE_SOF_RT_UUID("modules", intel_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
+SOF_DEFINE_UUID("modules", intel_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
 		    0x90, 0xab, 0x42, 0x24, 0xe0, 0x0c, 0x3e, 0x84);
 DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(intel_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -43,9 +43,9 @@
 
 LOG_MODULE_REGISTER(sof_modules, CONFIG_SOF_LOG_LEVEL);
 /* ee2585f2-e7d8-43dc-90ab-4224e00c3e84 */
-SOF_DEFINE_UUID("modules", intel_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
+SOF_DEFINE_UUID("modules", modules_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
 		    0x90, 0xab, 0x42, 0x24, 0xe0, 0x0c, 0x3e, 0x84);
-DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(intel_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(modules_uuid), LOG_LEVEL_INFO);
 
 /**
  * \brief modules_init.

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -42,9 +42,7 @@
  */
 
 LOG_MODULE_REGISTER(sof_modules, CONFIG_SOF_LOG_LEVEL);
-/* ee2585f2-e7d8-43dc-90ab-4224e00c3e84 */
-SOF_DEFINE_UUID("modules", modules_uuid, 0xee2585f2, 0xe7d8, 0x43dc,
-		    0x90, 0xab, 0x42, 0x24, 0xe0, 0x0c, 0x3e, 0x84);
+SOF_DEFINE_REG_UUID(modules);
 DECLARE_TR_CTX(intel_codec_tr, SOF_UUID(modules_uuid), LOG_LEVEL_INFO);
 
 /**

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(passthrough, CONFIG_SOF_LOG_LEVEL);
 
 /* 376b5e44-9c82-4ec2-bc83-10ea101afa8f */
-DECLARE_SOF_RT_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
+SOF_DEFINE_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
 		    0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
 DECLARE_TR_CTX(passthrough_tr, SOF_UUID(passthrough_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -11,9 +11,7 @@
 
 LOG_MODULE_REGISTER(passthrough, CONFIG_SOF_LOG_LEVEL);
 
-/* 376b5e44-9c82-4ec2-bc83-10ea101afa8f */
-SOF_DEFINE_UUID("passthrough", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
-		    0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
+SOF_DEFINE_REG_UUID(passthrough);
 DECLARE_TR_CTX(passthrough_tr, SOF_UUID(passthrough_uuid), LOG_LEVEL_INFO);
 
 static int passthrough_codec_init(struct processing_module *mod)

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -12,7 +12,7 @@
 LOG_MODULE_REGISTER(passthrough, CONFIG_SOF_LOG_LEVEL);
 
 /* 376b5e44-9c82-4ec2-bc83-10ea101afa8f */
-SOF_DEFINE_UUID("passthrough_codec", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
+SOF_DEFINE_UUID("passthrough", passthrough_uuid, 0x376b5e44, 0x9c82, 0x4ec2,
 		    0xbc, 0x83, 0x10, 0xea, 0x10, 0x1a, 0xf8, 0x8f);
 DECLARE_TR_CTX(passthrough_tr, SOF_UUID(passthrough_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -19,7 +19,7 @@
 #define NUM_IO_STREAMS (1)
 
 /* d944281a-afe9-4695-a043-d7f62b89538e*/
-SOF_DEFINE_UUID("waves_codec", waves_uuid, 0xd944281a, 0xafe9, 0x4695,
+SOF_DEFINE_UUID("waves", waves_uuid, 0xd944281a, 0xafe9, 0x4695,
 		    0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
 DECLARE_TR_CTX(waves_tr, SOF_UUID(waves_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -19,7 +19,7 @@
 #define NUM_IO_STREAMS (1)
 
 /* d944281a-afe9-4695-a043-d7f62b89538e*/
-DECLARE_SOF_RT_UUID("waves_codec", waves_uuid, 0xd944281a, 0xafe9, 0x4695,
+SOF_DEFINE_UUID("waves_codec", waves_uuid, 0xd944281a, 0xafe9, 0x4695,
 		    0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
 DECLARE_TR_CTX(waves_tr, SOF_UUID(waves_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -18,9 +18,7 @@
 #define MAX_CONFIG_SIZE_BYTES (8192)
 #define NUM_IO_STREAMS (1)
 
-/* d944281a-afe9-4695-a043-d7f62b89538e*/
-SOF_DEFINE_UUID("waves", waves_uuid, 0xd944281a, 0xafe9, 0x4695,
-		    0xa0, 0x43, 0xd7, 0xf6, 0x2b, 0x89, 0x53, 0x8e);
+SOF_DEFINE_REG_UUID(waves);
 DECLARE_TR_CTX(waves_tr, SOF_UUID(waves_uuid), LOG_LEVEL_INFO);
 
 struct waves_codec_data {

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -37,9 +37,7 @@
 
 LOG_MODULE_REGISTER(multiband_drc, CONFIG_SOF_LOG_LEVEL);
 
-/* 0d9f2256-8e4f-47b3-8448-239a334f1191 */
-SOF_DEFINE_UUID("multiband_drc", multiband_drc_uuid, 0x0d9f2256, 0x8e4f, 0x47b3,
-		    0x84, 0x48, 0x23, 0x9a, 0x33, 0x4f, 0x11, 0x91);
+SOF_DEFINE_REG_UUID(multiband_drc);
 
 DECLARE_TR_CTX(multiband_drc_tr, SOF_UUID(multiband_drc_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -38,7 +38,7 @@
 LOG_MODULE_REGISTER(multiband_drc, CONFIG_SOF_LOG_LEVEL);
 
 /* 0d9f2256-8e4f-47b3-8448-239a334f1191 */
-DECLARE_SOF_RT_UUID("multiband_drc", multiband_drc_uuid, 0x0d9f2256, 0x8e4f, 0x47b3,
+SOF_DEFINE_UUID("multiband_drc", multiband_drc_uuid, 0x0d9f2256, 0x8e4f, 0x47b3,
 		    0x84, 0x48, 0x23, 0x9a, 0x33, 0x4f, 0x11, 0x91);
 
 DECLARE_TR_CTX(multiband_drc_tr, SOF_UUID(multiband_drc_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -469,7 +469,7 @@ static const struct module_interface mux_interface = {
 	.free = mux_free,
 };
 
-DECLARE_MODULE_ADAPTER(mux_interface, mux_uuid, mux_tr);
+DECLARE_MODULE_ADAPTER(mux_interface, MUX_UUID, mux_tr);
 SOF_MODULE_INIT(mux, sys_comp_module_mux_interface_init);
 
 static const struct module_interface demux_interface = {

--- a/src/audio/mux/mux.h
+++ b/src/audio/mux/mux.h
@@ -216,13 +216,19 @@ void sys_comp_module_demux_interface_init(void);
 #define MUX_BLOB_STREAMS_SIZE	(MUX_MAX_STREAMS * sizeof(struct mux_stream_data))
 #define MUX_BLOB_MAX_SIZE	(sizeof(struct sof_mux_config) + MUX_BLOB_STREAMS_SIZE)
 
-extern const struct sof_uuid mux_uuid;
 extern const struct sof_uuid demux_uuid;
 extern struct tr_ctx mux_tr;
 extern struct tr_ctx demux_tr;
 
 bool mux_mix_check(struct sof_mux_config *cfg);
 int mux_params(struct processing_module *mod);
+
+#ifdef CONFIG_IPC_MAJOR_4
+#define MUX_UUID mux4_uuid
+#else
+#define MUX_UUID mux_uuid
+#endif
+extern const struct sof_uuid MUX_UUID;
 
 #endif /* CONFIG_COMP_MUX */
 

--- a/src/audio/mux/mux_ipc3.c
+++ b/src/audio/mux/mux_ipc3.c
@@ -22,15 +22,11 @@
 
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
-/* c607ff4d-9cb6-49dc-b678-7da3c63ea557 */
-SOF_DEFINE_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
-		    0xb6, 0x78, 0x7d, 0xa3, 0xc6, 0x3e, 0xa5, 0x57);
+SOF_DEFINE_REG_UUID(mux);
 
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
 
-/* c4b26868-1430-470e-a089-15d1c77f851a */
-SOF_DEFINE_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
-		    0xa0, 0x89, 0x15, 0xd1, 0xc7, 0x7f, 0x85, 0x1a);
+SOF_DEFINE_REG_UUID(demux);
 
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/mux/mux_ipc3.c
+++ b/src/audio/mux/mux_ipc3.c
@@ -23,13 +23,13 @@
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
 /* c607ff4d-9cb6-49dc-b678-7da3c63ea557 */
-DECLARE_SOF_RT_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
+SOF_DEFINE_UUID("mux", mux_uuid, 0xc607ff4d, 0x9cb6, 0x49dc,
 		    0xb6, 0x78, 0x7d, 0xa3, 0xc6, 0x3e, 0xa5, 0x57);
 
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
 
 /* c4b26868-1430-470e-a089-15d1c77f851a */
-DECLARE_SOF_RT_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
+SOF_DEFINE_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
 		    0xa0, 0x89, 0x15, 0xd1, 0xc7, 0x7f, 0x85, 0x1a);
 
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -23,15 +23,11 @@
 
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
-/* 64ce6e35-857a-4878-ace8-e2a2f42e3069 */
-SOF_DEFINE_UUID("mux4", mux4_uuid, 0x64ce6e35, 0x857a, 0x4878,
-		    0xac, 0xe8, 0xe2, 0xa2, 0xf4, 0x2e, 0x30, 0x69);
+SOF_DEFINE_REG_UUID(mux4);
 
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux4_uuid), LOG_LEVEL_INFO);
 
-/* c4b26868-1430-470e-a089-15d1c77f851a */
-SOF_DEFINE_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
-		    0xa0, 0x89, 0x15, 0xd1, 0xc7, 0x7f, 0x85, 0x1a);
+SOF_DEFINE_REG_UUID(demux);
 
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -24,13 +24,13 @@
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
 /* 64ce6e35-857a-4878-ace8-e2a2f42e3069 */
-DECLARE_SOF_RT_UUID("mux", mux_uuid, 0x64ce6e35, 0x857a, 0x4878,
+SOF_DEFINE_UUID("mux", mux_uuid, 0x64ce6e35, 0x857a, 0x4878,
 		    0xac, 0xe8, 0xe2, 0xa2, 0xf4, 0x2e, 0x30, 0x69);
 
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
 
 /* c4b26868-1430-470e-a089-15d1c77f851a */
-DECLARE_SOF_RT_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
+SOF_DEFINE_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,
 		    0xa0, 0x89, 0x15, 0xd1, 0xc7, 0x7f, 0x85, 0x1a);
 
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -24,10 +24,10 @@
 LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
 /* 64ce6e35-857a-4878-ace8-e2a2f42e3069 */
-SOF_DEFINE_UUID("mux", mux_uuid, 0x64ce6e35, 0x857a, 0x4878,
+SOF_DEFINE_UUID("mux4", mux4_uuid, 0x64ce6e35, 0x857a, 0x4878,
 		    0xac, 0xe8, 0xe2, 0xa2, 0xf4, 0x2e, 0x30, 0x69);
 
-DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(mux_tr, SOF_UUID(mux4_uuid), LOG_LEVEL_INFO);
 
 /* c4b26868-1430-470e-a089-15d1c77f851a */
 SOF_DEFINE_UUID("demux", demux_uuid, 0xc4b26868, 0x1430, 0x470e,

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -28,9 +28,7 @@
 
 LOG_MODULE_REGISTER(pipe, CONFIG_SOF_LOG_LEVEL);
 
-/* 4e934adb-b0ec-4d33-a086-c1022f921321 */
-SOF_DEFINE_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
-		    0xa0, 0x86, 0xc1, 0x02, 0x2f, 0x92, 0x13, 0x21);
+SOF_DEFINE_REG_UUID(pipe);
 
 DECLARE_TR_CTX(pipe_tr, SOF_UUID(pipe_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -29,7 +29,7 @@
 LOG_MODULE_REGISTER(pipe, CONFIG_SOF_LOG_LEVEL);
 
 /* 4e934adb-b0ec-4d33-a086-c1022f921321 */
-DECLARE_SOF_RT_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
+SOF_DEFINE_UUID("pipe", pipe_uuid, 0x4e934adb, 0xb0ec, 0x4d33,
 		    0xa0, 0x86, 0xc1, 0x02, 0x2f, 0x92, 0x13, 0x21);
 
 DECLARE_TR_CTX(pipe_tr, SOF_UUID(pipe_uuid), LOG_LEVEL_INFO);

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -29,15 +29,11 @@
 
 LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
 
-/* f11818eb-e92e-4082-82a3-dc54c604ebb3 */
-SOF_DEFINE_UUID("pipe_task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
-		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);
+SOF_DEFINE_REG_UUID(pipe_task);
 
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 
-/* ee755917-96b9-4130-b49e-37b9d0501993 */
-SOF_DEFINE_UUID("dp_task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
-		 0xb4,  0x9e, 0x37, 0xb9, 0xd0, 0x50, 0x19, 0x93);
+SOF_DEFINE_REG_UUID(dp_task);
 
 /**
  * current static stack size for each DP component

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -30,13 +30,13 @@
 LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
 
 /* f11818eb-e92e-4082-82a3-dc54c604ebb3 */
-SOF_DEFINE_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
+SOF_DEFINE_UUID("pipe_task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
 		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);
 
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 
 /* ee755917-96b9-4130-b49e-37b9d0501993 */
-SOF_DEFINE_UUID("dp-task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
+SOF_DEFINE_UUID("dp_task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
 		 0xb4,  0x9e, 0x37, 0xb9, 0xd0, 0x50, 0x19, 0x93);
 
 /**

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -30,13 +30,13 @@
 LOG_MODULE_DECLARE(pipe, CONFIG_SOF_LOG_LEVEL);
 
 /* f11818eb-e92e-4082-82a3-dc54c604ebb3 */
-DECLARE_SOF_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
+SOF_DEFINE_UUID("pipe-task", pipe_task_uuid, 0xf11818eb, 0xe92e, 0x4082,
 		 0x82,  0xa3, 0xdc, 0x54, 0xc6, 0x04, 0xeb, 0xb3);
 
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 
 /* ee755917-96b9-4130-b49e-37b9d0501993 */
-DECLARE_SOF_UUID("dp-task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
+SOF_DEFINE_UUID("dp-task", dp_task_uuid, 0xee755917, 0x96b9, 0x4130,
 		 0xb4,  0x9e, 0x37, 0xb9, 0xd0, 0x50, 0x19, 0x93);
 
 /**

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -60,7 +60,7 @@ struct rtnr_func_map {
 LOG_MODULE_REGISTER(rtnr, CONFIG_SOF_LOG_LEVEL);
 
 /* UUID 5c7ca334-e15d-11eb-ba80-0242ac130004 */
-DECLARE_SOF_RT_UUID("rtnr", rtnr_uuid, 0x5c7ca334, 0xe15d, 0x11eb, 0xba, 0x80,
+SOF_DEFINE_UUID("rtnr", rtnr_uuid, 0x5c7ca334, 0xe15d, 0x11eb, 0xba, 0x80,
 		    0x02, 0x42, 0xac, 0x13, 0x00, 0x04);
 
 DECLARE_TR_CTX(rtnr_tr, SOF_UUID(rtnr_uuid), LOG_LEVEL_INFO);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -60,8 +60,7 @@ struct rtnr_func_map {
 LOG_MODULE_REGISTER(rtnr, CONFIG_SOF_LOG_LEVEL);
 
 /* UUID 5c7ca334-e15d-11eb-ba80-0242ac130004 */
-SOF_DEFINE_UUID("rtnr", rtnr_uuid, 0x5c7ca334, 0xe15d, 0x11eb, 0xba, 0x80,
-		    0x02, 0x42, 0xac, 0x13, 0x00, 0x04);
+SOF_DEFINE_REG_UUID(rtnr);
 
 DECLARE_TR_CTX(rtnr_tr, SOF_UUID(rtnr_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -45,14 +45,15 @@ static const struct comp_driver comp_selector;
 /* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
 SOF_DEFINE_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
 		    0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);
+#define SELECTOR_UUID selector_uuid
 #else
 /* 32fe92c1-1e17-4fc2-9758-c7f3542e980a */
-SOF_DEFINE_UUID("selector", selector_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
+SOF_DEFINE_UUID("selector4", selector4_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
 		    0x97, 0x58, 0xc7, 0xf3, 0x54, 0x2e, 0x98, 0x0a);
-
+#define SELECTOR_UUID selector4_uuid
 #endif
 
-DECLARE_TR_CTX(selector_tr, SOF_UUID(selector_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(selector_tr, SOF_UUID(SELECTOR_UUID), LOG_LEVEL_INFO);
 
 #if CONFIG_IPC_MAJOR_3
 static int selector_verify_params(struct comp_dev *dev,
@@ -521,7 +522,7 @@ static int selector_reset(struct comp_dev *dev)
 /** \brief Selector component definition. */
 static const struct comp_driver comp_selector = {
 	.type	= SOF_COMP_SELECTOR,
-	.uid	= SOF_RT_UUID(selector_uuid),
+	.uid	= SOF_RT_UUID(SELECTOR_UUID),
 	.tctx	= &selector_tr,
 	.ops	= {
 		.create		= selector_new,
@@ -930,6 +931,6 @@ static const struct module_interface selector_interface = {
 	.free			= selector_free
 };
 
-DECLARE_MODULE_ADAPTER(selector_interface, selector_uuid, selector_tr);
+DECLARE_MODULE_ADAPTER(selector_interface, SELECTOR_UUID, selector_tr);
 SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);
 #endif

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -43,11 +43,11 @@ LOG_MODULE_REGISTER(selector, CONFIG_SOF_LOG_LEVEL);
 static const struct comp_driver comp_selector;
 
 /* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
-DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
+SOF_DEFINE_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
 		    0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);
 #else
 /* 32fe92c1-1e17-4fc2-9758-c7f3542e980a */
-DECLARE_SOF_RT_UUID("selector", selector_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
+SOF_DEFINE_UUID("selector", selector_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
 		    0x97, 0x58, 0xc7, 0xf3, 0x54, 0x2e, 0x98, 0x0a);
 
 #endif

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -42,14 +42,10 @@ LOG_MODULE_REGISTER(selector, CONFIG_SOF_LOG_LEVEL);
 #if CONFIG_IPC_MAJOR_3
 static const struct comp_driver comp_selector;
 
-/* 55a88ed5-3d18-46ca-88f1-0ee6eae9930f */
-SOF_DEFINE_UUID("selector", selector_uuid, 0x55a88ed5, 0x3d18, 0x46ca,
-		    0x88, 0xf1, 0x0e, 0xe6, 0xea, 0xe9, 0x93, 0x0f);
+SOF_DEFINE_REG_UUID(selector);
 #define SELECTOR_UUID selector_uuid
 #else
-/* 32fe92c1-1e17-4fc2-9758-c7f3542e980a */
-SOF_DEFINE_UUID("selector4", selector4_uuid, 0x32fe92c1, 0x1e17, 0x4fc2,
-		    0x97, 0x58, 0xc7, 0xf3, 0x54, 0x2e, 0x98, 0x0a);
+SOF_DEFINE_REG_UUID(selector4);
 #define SELECTOR_UUID selector4_uuid
 #endif
 

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -22,12 +22,12 @@ static const struct comp_driver comp_smart_amp;
 
 #if CONFIG_MAXIM_DSM
 /* 0cd84e80-ebd3-11ea-adc1-0242ac120002 */
-DECLARE_SOF_RT_UUID("Maxim DSM", smart_amp_comp_uuid, 0x0cd84e80, 0xebd3,
+SOF_DEFINE_UUID("Maxim DSM", smart_amp_comp_uuid, 0x0cd84e80, 0xebd3,
 		    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
 
 #else /* Passthrough */
 /* 64a794f0-55d3-4bca-9d5b-7b588badd037 */
-DECLARE_SOF_RT_UUID("Passthru Amp", smart_amp_comp_uuid, 0x64a794f0, 0x55d3,
+SOF_DEFINE_UUID("Passthru Amp", smart_amp_comp_uuid, 0x64a794f0, 0x55d3,
 		    0x4bca, 0x9d, 0x5b, 0x7b, 0x58, 0x8b, 0xad, 0xd0, 0x37);
 
 #endif

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -20,18 +20,23 @@
 
 static const struct comp_driver comp_smart_amp;
 
+/* NOTE: this code builds itself with one of two distinct UUIDs
+ * depending on configuration!
+ */
 #if CONFIG_MAXIM_DSM
 /* 0cd84e80-ebd3-11ea-adc1-0242ac120002 */
-SOF_DEFINE_UUID("Maxim DSM", smart_amp_comp_uuid, 0x0cd84e80, 0xebd3,
+SOF_DEFINE_UUID("maxim_dsm", maxim_dsm_uuid, 0x0cd84e80, 0xebd3,
 		    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+#define UUID_SYM maxim_dsm_uuid
 
 #else /* Passthrough */
 /* 64a794f0-55d3-4bca-9d5b-7b588badd037 */
-SOF_DEFINE_UUID("Passthru Amp", smart_amp_comp_uuid, 0x64a794f0, 0x55d3,
+SOF_DEFINE_UUID("passthru_smart_amp", passthru_smart_amp_uuid, 0x64a794f0, 0x55d3,
 		    0x4bca, 0x9d, 0x5b, 0x7b, 0x58, 0x8b, 0xad, 0xd0, 0x37);
+#define UUID_SYM passthru_smart_amp
 
 #endif
-DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(smart_amp_comp_uuid),
+DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(UUID_SYM),
 	       LOG_LEVEL_INFO);
 
 /* Amp configuration & model calibration data for tuning/debug */
@@ -808,7 +813,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_smart_amp = {
 	.type = SOF_COMP_SMART_AMP,
-	.uid = SOF_RT_UUID(smart_amp_comp_uuid),
+	.uid = SOF_RT_UUID(UUID_SYM),
 	.tctx = &smart_amp_comp_tr,
 	.ops = {
 		.create = smart_amp_new,

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -24,15 +24,11 @@ static const struct comp_driver comp_smart_amp;
  * depending on configuration!
  */
 #if CONFIG_MAXIM_DSM
-/* 0cd84e80-ebd3-11ea-adc1-0242ac120002 */
-SOF_DEFINE_UUID("maxim_dsm", maxim_dsm_uuid, 0x0cd84e80, 0xebd3,
-		    0x11ea, 0xad, 0xc1, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+SOF_DEFINE_REG_UUID(maxim_dsm);
 #define UUID_SYM maxim_dsm_uuid
 
 #else /* Passthrough */
-/* 64a794f0-55d3-4bca-9d5b-7b588badd037 */
-SOF_DEFINE_UUID("passthru_smart_amp", passthru_smart_amp_uuid, 0x64a794f0, 0x55d3,
-		    0x4bca, 0x9d, 0x5b, 0x7b, 0x58, 0x8b, 0xad, 0xd0, 0x37);
+SOF_DEFINE_REG_UUID(passthru_smart_amp);
 #define UUID_SYM passthru_smart_amp
 
 #endif

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -721,5 +721,5 @@ static const struct module_interface src_interface = {
 	.free = src_free,
 };
 
-DECLARE_MODULE_ADAPTER(src_interface, src_uuid, src_tr);
+DECLARE_MODULE_ADAPTER(src_interface, SRC_UUID, src_tr);
 SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);

--- a/src/audio/src/src.h
+++ b/src/audio/src/src.h
@@ -252,6 +252,12 @@ int src_get_config(struct processing_module *mod, uint32_t config_id,
 		   uint32_t *data_offset_size, uint8_t *fragment, size_t fragment_size);
 int src_free(struct processing_module *mod);
 int src_reset(struct processing_module *mod);
-extern const struct sof_uuid src_uuid;
 extern struct tr_ctx src_tr;
+
+#ifdef CONFIG_IPC_MAJOR_4
+#define SRC_UUID src4_uuid
+#else
+#define SRC_UUID src_uuid
+#endif
+extern const struct sof_uuid SRC_UUID;
 

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -41,9 +41,7 @@
 #include "src.h"
 #include "src_config.h"
 
-/* c1c5326d-8390-46b4-aa47-95c3beca6550 */
-SOF_DEFINE_UUID("src", src_uuid, 0xc1c5326d, 0x8390, 0x46b4,
-		    0xaa, 0x47, 0x95, 0xc3, 0xbe, 0xca, 0x65, 0x50);
+SOF_DEFINE_REG_UUID(src);
 
 DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -42,7 +42,7 @@
 #include "src_config.h"
 
 /* c1c5326d-8390-46b4-aa47-95c3beca6550 */
-DECLARE_SOF_RT_UUID("src", src_uuid, 0xc1c5326d, 0x8390, 0x46b4,
+SOF_DEFINE_UUID("src", src_uuid, 0xc1c5326d, 0x8390, 0x46b4,
 		    0xaa, 0x47, 0x95, 0xc3, 0xbe, 0xca, 0x65, 0x50);
 
 DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -41,9 +41,7 @@
 #include "src.h"
 #include "src_config.h"
 
-/* e61bb28d-149a-4c1f-b709-46823ef5f5a3 */
-SOF_DEFINE_UUID("src4", src4_uuid, 0xe61bb28d, 0x149a, 0x4c1f,
-		    0xb7, 0x09, 0x46, 0x82, 0x3e, 0xf5, 0xf5, 0xae);
+SOF_DEFINE_REG_UUID(src4);
 
 DECLARE_TR_CTX(src_tr, SOF_UUID(src4_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -42,10 +42,10 @@
 #include "src_config.h"
 
 /* e61bb28d-149a-4c1f-b709-46823ef5f5a3 */
-SOF_DEFINE_UUID("src", src_uuid, 0xe61bb28d, 0x149a, 0x4c1f,
+SOF_DEFINE_UUID("src4", src4_uuid, 0xe61bb28d, 0x149a, 0x4c1f,
 		    0xb7, 0x09, 0x46, 0x82, 0x3e, 0xf5, 0xf5, 0xae);
 
-DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(src_tr, SOF_UUID(src4_uuid), LOG_LEVEL_INFO);
 
 LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -42,7 +42,7 @@
 #include "src_config.h"
 
 /* e61bb28d-149a-4c1f-b709-46823ef5f5a3 */
-DECLARE_SOF_RT_UUID("src", src_uuid, 0xe61bb28d, 0x149a, 0x4c1f,
+SOF_DEFINE_UUID("src", src_uuid, 0xe61bb28d, 0x149a, 0x4c1f,
 		    0xb7, 0x09, 0x46, 0x82, 0x3e, 0xf5, 0xf5, 0xae);
 
 DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);

--- a/src/audio/src/src_lite.c
+++ b/src/audio/src/src_lite.c
@@ -60,7 +60,7 @@ static const struct module_interface src_lite_interface = {
 	.free = src_free,
 };
 
-DECLARE_SOF_RT_UUID("src_lite", src_lite_uuid, 0x33441051, 0x44CD, 0x466A,
+SOF_DEFINE_UUID("src_lite", src_lite_uuid, 0x33441051, 0x44CD, 0x466A,
 		    0x83, 0xA3, 0x17, 0x84, 0x78, 0x70, 0x8A, 0xEA);
 
 DECLARE_TR_CTX(src_lite_tr, SOF_UUID(src_lite_uuid), LOG_LEVEL_INFO);

--- a/src/audio/src/src_lite.c
+++ b/src/audio/src/src_lite.c
@@ -60,8 +60,7 @@ static const struct module_interface src_lite_interface = {
 	.free = src_free,
 };
 
-SOF_DEFINE_UUID("src_lite", src_lite_uuid, 0x33441051, 0x44CD, 0x466A,
-		    0x83, 0xA3, 0x17, 0x84, 0x78, 0x70, 0x8A, 0xEA);
+SOF_DEFINE_REG_UUID(src_lite);
 
 DECLARE_TR_CTX(src_lite_tr, SOF_UUID(src_lite_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -44,7 +44,7 @@
 LOG_MODULE_REGISTER(tdfb, CONFIG_SOF_LOG_LEVEL);
 
 /* dd511749-d9fa-455c-b3a7-13585693f1af */
-DECLARE_SOF_RT_UUID("tdfb", tdfb_uuid,  0xdd511749, 0xd9fa, 0x455c, 0xb3, 0xa7,
+SOF_DEFINE_UUID("tdfb", tdfb_uuid,  0xdd511749, 0xd9fa, 0x455c, 0xb3, 0xa7,
 		    0x13, 0x58, 0x56, 0x93, 0xf1, 0xaf);
 
 DECLARE_TR_CTX(tdfb_tr, SOF_UUID(tdfb_uuid), LOG_LEVEL_INFO);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -43,9 +43,7 @@
 
 LOG_MODULE_REGISTER(tdfb, CONFIG_SOF_LOG_LEVEL);
 
-/* dd511749-d9fa-455c-b3a7-13585693f1af */
-SOF_DEFINE_UUID("tdfb", tdfb_uuid,  0xdd511749, 0xd9fa, 0x455c, 0xb3, 0xa7,
-		    0x13, 0x58, 0x56, 0x93, 0xf1, 0xaf);
+SOF_DEFINE_REG_UUID(tdfb);
 
 DECLARE_TR_CTX(tdfb_tr, SOF_UUID(tdfb_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -50,7 +50,7 @@ static const struct comp_driver comp_tone;
 LOG_MODULE_REGISTER(tone, CONFIG_SOF_LOG_LEVEL);
 
 /* 04e3f894-2c5c-4f2e-8dc1-694eeaab53fa */
-DECLARE_SOF_RT_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
+SOF_DEFINE_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
 		 0x8d, 0xc1, 0x69, 0x4e, 0xea, 0xab, 0x53, 0xfa);
 
 DECLARE_TR_CTX(tone_tr, SOF_UUID(tone_uuid), LOG_LEVEL_INFO);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -49,9 +49,7 @@ static const struct comp_driver comp_tone;
 
 LOG_MODULE_REGISTER(tone, CONFIG_SOF_LOG_LEVEL);
 
-/* 04e3f894-2c5c-4f2e-8dc1-694eeaab53fa */
-SOF_DEFINE_UUID("tone", tone_uuid, 0x04e3f894, 0x2c5c, 0x4f2e,
-		 0x8d, 0xc1, 0x69, 0x4e, 0xea, 0xab, 0x53, 0xfa);
+SOF_DEFINE_REG_UUID(tone);
 
 DECLARE_TR_CTX(tone_tr, SOF_UUID(tone_uuid), LOG_LEVEL_INFO);
 

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -32,9 +32,7 @@
 LOG_MODULE_REGISTER(up_down_mixer, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
-/* 42f8060c-832f-4dbf-b247-51e961997b34 */
-SOF_DEFINE_UUID("up_down_mixer", up_down_mixer_uuid, 0x42f8060c, 0x832f,
-		    0x4dbf, 0xb2, 0x47, 0x51, 0xe9, 0x61, 0x99, 0x7b, 0x34);
+SOF_DEFINE_REG_UUID(up_down_mixer);
 
 DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_uuid),
 	       LOG_LEVEL_INFO);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -33,10 +33,10 @@ LOG_MODULE_REGISTER(up_down_mixer, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
 /* 42f8060c-832f-4dbf-b247-51e961997b34 */
-SOF_DEFINE_UUID("up_down_mixer", up_down_mixer_comp_uuid, 0x42f8060c, 0x832f,
+SOF_DEFINE_UUID("up_down_mixer", up_down_mixer_uuid, 0x42f8060c, 0x832f,
 		    0x4dbf, 0xb2, 0x47, 0x51, 0xe9, 0x61, 0x99, 0x7b, 0x34);
 
-DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_comp_uuid),
+DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_uuid),
 	       LOG_LEVEL_INFO);
 
 int32_t custom_coeffs[UP_DOWN_MIX_COEFFS_LENGTH];
@@ -451,5 +451,5 @@ static const struct module_interface up_down_mixer_interface = {
 	.free = up_down_mixer_free
 };
 
-DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_comp_uuid, up_down_mixer_comp_tr);
+DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_uuid, up_down_mixer_comp_tr);
 SOF_MODULE_INIT(up_down_mixer, sys_comp_module_up_down_mixer_interface_init);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -33,7 +33,7 @@ LOG_MODULE_REGISTER(up_down_mixer, CONFIG_SOF_LOG_LEVEL);
 
 /* these ids aligns windows driver requirement to support windows driver */
 /* 42f8060c-832f-4dbf-b247-51e961997b34 */
-DECLARE_SOF_RT_UUID("up_down_mixer", up_down_mixer_comp_uuid, 0x42f8060c, 0x832f,
+SOF_DEFINE_UUID("up_down_mixer", up_down_mixer_comp_uuid, 0x42f8060c, 0x832f,
 		    0x4dbf, 0xb2, 0x47, 0x51, 0xe9, 0x61, 0x99, 0x7b, 0x34);
 
 DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_comp_uuid),

--- a/src/audio/volume/volume_uuid.h
+++ b/src/audio/volume/volume_uuid.h
@@ -13,16 +13,16 @@
 
 #if CONFIG_IPC_MAJOR_3
 /* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
-DECLARE_SOF_RT_UUID("pga", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
+SOF_DEFINE_UUID("pga", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
 		    0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
 #else
 /* these ids aligns windows driver requirement to support windows driver */
 /* 8a171323-94a3-4e1d-afe9-fe5dbaa4c393 */
-DECLARE_SOF_RT_UUID("pga", volume_uuid, 0x8a171323, 0x94a3, 0x4e1d,
+SOF_DEFINE_UUID("pga", volume_uuid, 0x8a171323, 0x94a3, 0x4e1d,
 		    0xaf, 0xe9, 0xfe, 0x5d, 0xba, 0xa4, 0xc3, 0x93);
 
 /* 61bca9a8-18d0-4a18-8e7b-2639219804b7 */
-DECLARE_SOF_RT_UUID("gain", gain_uuid, 0x61bca9a8, 0x18d0, 0x4a18,
+SOF_DEFINE_UUID("gain", gain_uuid, 0x61bca9a8, 0x18d0, 0x4a18,
 		    0x8e, 0x7b, 0x26, 0x39, 0x21, 0x98, 0x04, 0xb7);
 
 DECLARE_TR_CTX(gain_tr, SOF_UUID(gain_uuid), LOG_LEVEL_INFO);

--- a/src/audio/volume/volume_uuid.h
+++ b/src/audio/volume/volume_uuid.h
@@ -13,13 +13,14 @@
 
 #if CONFIG_IPC_MAJOR_3
 /* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
-SOF_DEFINE_UUID("pga", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
+SOF_DEFINE_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
 		    0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
 #else
 /* these ids aligns windows driver requirement to support windows driver */
 /* 8a171323-94a3-4e1d-afe9-fe5dbaa4c393 */
-SOF_DEFINE_UUID("pga", volume_uuid, 0x8a171323, 0x94a3, 0x4e1d,
+SOF_DEFINE_UUID("volume4", volume4_uuid, 0x8a171323, 0x94a3, 0x4e1d,
 		    0xaf, 0xe9, 0xfe, 0x5d, 0xba, 0xa4, 0xc3, 0x93);
+#define volume_uuid volume4_uuid
 
 /* 61bca9a8-18d0-4a18-8e7b-2639219804b7 */
 SOF_DEFINE_UUID("gain", gain_uuid, 0x61bca9a8, 0x18d0, 0x4a18,

--- a/src/audio/volume/volume_uuid.h
+++ b/src/audio/volume/volume_uuid.h
@@ -12,19 +12,13 @@
 #include <sof/trace/trace.h>
 
 #if CONFIG_IPC_MAJOR_3
-/* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
-SOF_DEFINE_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
-		    0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
+SOF_DEFINE_REG_UUID(volume);
 #else
 /* these ids aligns windows driver requirement to support windows driver */
-/* 8a171323-94a3-4e1d-afe9-fe5dbaa4c393 */
-SOF_DEFINE_UUID("volume4", volume4_uuid, 0x8a171323, 0x94a3, 0x4e1d,
-		    0xaf, 0xe9, 0xfe, 0x5d, 0xba, 0xa4, 0xc3, 0x93);
+SOF_DEFINE_REG_UUID(volume4);
 #define volume_uuid volume4_uuid
 
-/* 61bca9a8-18d0-4a18-8e7b-2639219804b7 */
-SOF_DEFINE_UUID("gain", gain_uuid, 0x61bca9a8, 0x18d0, 0x4a18,
-		    0x8e, 0x7b, 0x26, 0x39, 0x21, 0x98, 0x04, 0xb7);
+SOF_DEFINE_REG_UUID(gain);
 
 DECLARE_TR_CTX(gain_tr, SOF_UUID(gain_uuid), LOG_LEVEL_INFO);
 #endif

--- a/src/drivers/amd/common/acp_bt_dai.c
+++ b/src/drivers/amd/common/acp_bt_dai.c
@@ -18,9 +18,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 20865bfe-b833-4ff9-b22a-0482c3477497 */
-SOF_DEFINE_UUID("btdai", btdai_uuid, 0x20865bfe, 0xb833, 0x4ff9,
-		 0xb2, 0x2a, 0x04, 0x82, 0xc3, 0x47, 0x74, 0x97);
+SOF_DEFINE_REG_UUID(btdai);
 
 DECLARE_TR_CTX(btdai_tr, SOF_UUID(btdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/common/acp_bt_dai.c
+++ b/src/drivers/amd/common/acp_bt_dai.c
@@ -19,7 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 20865bfe-b833-4ff9-b22a-0482c3477497 */
-DECLARE_SOF_UUID("btdai", btdai_uuid, 0x20865bfe, 0xb833, 0x4ff9,
+SOF_DEFINE_UUID("btdai", btdai_uuid, 0x20865bfe, 0xb833, 0x4ff9,
 		 0xb2, 0x2a, 0x04, 0x82, 0xc3, 0x47, 0x74, 0x97);
 
 DECLARE_TR_CTX(btdai_tr, SOF_UUID(btdai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/common/acp_dma.c
+++ b/src/drivers/amd/common/acp_dma.c
@@ -24,8 +24,7 @@
 #include <platform/acp_dma.h>
 #include <sof/probe/probe.h>
 
-SOF_DEFINE_UUID("acpdma", acpdma_uuid, 0x70f2d3f2, 0xcbb6, 0x4984,
-		 0xa2, 0xd8, 0x0d, 0xd5, 0x14, 0xb8, 0x0b, 0xc2);
+SOF_DEFINE_REG_UUID(acpdma);
 DECLARE_TR_CTX(acpdma_tr, SOF_UUID(acpdma_uuid), LOG_LEVEL_INFO);
 #define PROBE_UPDATE_POS_MASK	0x80000000
 #define PROBE_BUFFER_WATERMARK	(16 * 1024)

--- a/src/drivers/amd/common/acp_dma.c
+++ b/src/drivers/amd/common/acp_dma.c
@@ -24,7 +24,7 @@
 #include <platform/acp_dma.h>
 #include <sof/probe/probe.h>
 
-DECLARE_SOF_UUID("acpdma", acpdma_uuid, 0x70f2d3f2, 0xcbb6, 0x4984,
+SOF_DEFINE_UUID("acpdma", acpdma_uuid, 0x70f2d3f2, 0xcbb6, 0x4984,
 		 0xa2, 0xd8, 0x0d, 0xd5, 0x14, 0xb8, 0x0b, 0xc2);
 DECLARE_TR_CTX(acpdma_tr, SOF_UUID(acpdma_uuid), LOG_LEVEL_INFO);
 #define PROBE_UPDATE_POS_MASK	0x80000000

--- a/src/drivers/amd/common/acp_dmic_dai.c
+++ b/src/drivers/amd/common/acp_dmic_dai.c
@@ -22,7 +22,7 @@
 extern struct acp_dmic_silence acp_initsilence;
 
 /*0ae40946-dfd2-4140-91-52-0d-d5-a3-ea-ae-81*/
-DECLARE_SOF_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
+SOF_DEFINE_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
 		0x91, 0x52, 0x0d, 0xd5, 0xa3, 0xea, 0xae, 0x81);
 
 DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/common/acp_dmic_dai.c
+++ b/src/drivers/amd/common/acp_dmic_dai.c
@@ -21,9 +21,7 @@
 
 extern struct acp_dmic_silence acp_initsilence;
 
-/*0ae40946-dfd2-4140-91-52-0d-d5-a3-ea-ae-81*/
-SOF_DEFINE_UUID("acp_dmic_dai", acp_dmic_dai_uuid, 0x0ae40946, 0xdfd2, 0x4140,
-		0x91, 0x52, 0x0d, 0xd5, 0xa3, 0xea, 0xae, 0x81);
+SOF_DEFINE_REG_UUID(acp_dmic_dai);
 
 DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/common/acp_dmic_dma.c
+++ b/src/drivers/amd/common/acp_dmic_dma.c
@@ -37,7 +37,7 @@ extern uint32_t dmic_rngbuff_size;
 struct acp_dmic_silence acp_initsilence;
 
 /* dc2199ea-cdae-4d23-a413-ffe442f785f2 */
-DECLARE_SOF_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0xdc2199ea, 0xcdae, 0x4d23,
+SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0xdc2199ea, 0xcdae, 0x4d23,
 		 0xa4, 0x13, 0xff, 0xe4, 0x42, 0xf7, 0x85, 0xf2);
 DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/common/acp_dmic_dma.c
+++ b/src/drivers/amd/common/acp_dmic_dma.c
@@ -37,9 +37,9 @@ extern uint32_t dmic_rngbuff_size;
 struct acp_dmic_silence acp_initsilence;
 
 /* dc2199ea-cdae-4d23-a413-ffe442f785f2 */
-SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0xdc2199ea, 0xcdae, 0x4d23,
+SOF_DEFINE_UUID("acp_dmic_dma_common", acp_dmic_dma_common_uuid, 0xdc2199ea, 0xcdae, 0x4d23,
 		 0xa4, 0x13, 0xff, 0xe4, 0x42, 0xf7, 0x85, 0xf2);
-DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */
 static struct dma_chan_data *acp_dmic_dma_channel_get(struct dma *dma,

--- a/src/drivers/amd/common/acp_dmic_dma.c
+++ b/src/drivers/amd/common/acp_dmic_dma.c
@@ -36,9 +36,7 @@
 extern uint32_t dmic_rngbuff_size;
 struct acp_dmic_silence acp_initsilence;
 
-/* dc2199ea-cdae-4d23-a413-ffe442f785f2 */
-SOF_DEFINE_UUID("acp_dmic_dma_common", acp_dmic_dma_common_uuid, 0xdc2199ea, 0xcdae, 0x4d23,
-		 0xa4, 0x13, 0xff, 0xe4, 0x42, 0xf7, 0x85, 0xf2);
+SOF_DEFINE_REG_UUID(acp_dmic_dma_common);
 DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */

--- a/src/drivers/amd/common/acp_sp_dma.c
+++ b/src/drivers/amd/common/acp_sp_dma.c
@@ -33,9 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_sp_dma.h>
 
-/* 2ef92c66-78a4-41f7-b52f-5539707a9382 */
-SOF_DEFINE_UUID("acp_sp_common", acp_sp_common_uuid, 0x2ef92c66, 0x78a4, 0x41f7,
-		 0xb5, 0x2f, 0x55, 0x39, 0x70, 0x7a, 0x93, 0x82);
+SOF_DEFINE_REG_UUID(acp_sp_common);
 DECLARE_TR_CTX(acp_sp_tr, SOF_UUID(acp_sp_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */

--- a/src/drivers/amd/common/acp_sp_dma.c
+++ b/src/drivers/amd/common/acp_sp_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 /* 2ef92c66-78a4-41f7-b52f-5539707a9382 */
-DECLARE_SOF_UUID("acp-sp", acp_sp_uuid, 0x2ef92c66, 0x78a4, 0x41f7,
+SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x2ef92c66, 0x78a4, 0x41f7,
 		 0xb5, 0x2f, 0x55, 0x39, 0x70, 0x7a, 0x93, 0x82);
 DECLARE_TR_CTX(acp_sp_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/common/acp_sp_dma.c
+++ b/src/drivers/amd/common/acp_sp_dma.c
@@ -34,9 +34,9 @@
 #include <platform/acp_sp_dma.h>
 
 /* 2ef92c66-78a4-41f7-b52f-5539707a9382 */
-SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x2ef92c66, 0x78a4, 0x41f7,
+SOF_DEFINE_UUID("acp_sp_common", acp_sp_common_uuid, 0x2ef92c66, 0x78a4, 0x41f7,
 		 0xb5, 0x2f, 0x55, 0x39, 0x70, 0x7a, 0x93, 0x82);
-DECLARE_TR_CTX(acp_sp_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(acp_sp_tr, SOF_UUID(acp_sp_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */
 static struct dma_chan_data *acp_dai_sp_dma_channel_get(struct dma *dma,

--- a/src/drivers/amd/common/ipc.c
+++ b/src/drivers/amd/common/ipc.c
@@ -33,9 +33,7 @@
 #include <platform/platform.h>
 #include <platform/ipc.h>
 
-/* 49be8ff3-71a3-4456-bb7e-4723f2e5730c */
-SOF_DEFINE_UUID("ipc_task_amd", ipc_task_amd_uuid, 0x49be8ff3, 0x71a3, 0x4456,
-		 0xbb, 0x7e, 0x47, 0x23, 0xf2, 0xe5, 0x73, 0x0c);
+SOF_DEFINE_REG_UUID(ipc_task_amd);
 
 extern volatile acp_scratch_mem_config_t *pscratch_mem_cfg;
 

--- a/src/drivers/amd/common/ipc.c
+++ b/src/drivers/amd/common/ipc.c
@@ -34,7 +34,7 @@
 #include <platform/ipc.h>
 
 /* 49be8ff3-71a3-4456-bb7e-4723f2e5730c */
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x49be8ff3, 0x71a3, 0x4456,
+SOF_DEFINE_UUID("ipc_task_amd", ipc_task_amd_uuid, 0x49be8ff3, 0x71a3, 0x4456,
 		 0xbb, 0x7e, 0x47, 0x23, 0xf2, 0xe5, 0x73, 0x0c);
 
 extern volatile acp_scratch_mem_config_t *pscratch_mem_cfg;
@@ -92,7 +92,7 @@ int platform_ipc_init(struct ipc *ipc)
 {
 	ipc_set_drvdata(ipc, NULL);
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_amd_uuid),
 			       &ipc_task_ops, ipc, 0, 0);
 	arch_interrupt_clear(IRQ_NUM_EXT_LEVEL3);
 	interrupt_register(IRQ_NUM_EXT_LEVEL3, amd_irq_handler, ipc);

--- a/src/drivers/amd/common/ipc.c
+++ b/src/drivers/amd/common/ipc.c
@@ -34,7 +34,7 @@
 #include <platform/ipc.h>
 
 /* 49be8ff3-71a3-4456-bb7e-4723f2e5730c */
-DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x49be8ff3, 0x71a3, 0x4456,
+SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x49be8ff3, 0x71a3, 0x4456,
 		 0xbb, 0x7e, 0x47, 0x23, 0xf2, 0xe5, 0x73, 0x0c);
 
 extern volatile acp_scratch_mem_config_t *pscratch_mem_cfg;

--- a/src/drivers/amd/common/ipc.c
+++ b/src/drivers/amd/common/ipc.c
@@ -34,7 +34,7 @@
 #include <platform/ipc.h>
 
 /* 49be8ff3-71a3-4456-bb7e-4723f2e5730c */
-SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x49be8ff3, 0x71a3, 0x4456,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x49be8ff3, 0x71a3, 0x4456,
 		 0xbb, 0x7e, 0x47, 0x23, 0xf2, 0xe5, 0x73, 0x0c);
 
 extern volatile acp_scratch_mem_config_t *pscratch_mem_cfg;

--- a/src/drivers/amd/rembrandt/acp_bt_dma.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-DECLARE_SOF_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/rembrandt/acp_bt_dma.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/rembrandt/acp_bt_dma.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dma.c
@@ -32,9 +32,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
-		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
+SOF_DEFINE_REG_UUID(acp_bt_dma);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_dmic_dma.c
+++ b/src/drivers/amd/rembrandt/acp_dmic_dma.c
@@ -33,9 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_dmic_dma.h>
 
-/* 109c7aba-a7ba-43c3-b9-42-59-e2-0a-66-11-be */
-SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
-		0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
+SOF_DEFINE_REG_UUID(acp_dmic_dma);
 DECLARE_TR_CTX(acp_dmic_dma_rmb_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/rembrandt/acp_dmic_dma.c
+++ b/src/drivers/amd/rembrandt/acp_dmic_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_dmic_dma.h>
 
 /* 109c7aba-a7ba-43c3-b9-42-59-e2-0a-66-11-be */
-DECLARE_SOF_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
+SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
 		0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
 DECLARE_TR_CTX(acp_dmic_dma_rmb_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_hs_dai.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dai.c
@@ -19,7 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-DECLARE_SOF_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
+SOF_DEFINE_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
 		0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_hs_dai.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dai.c
@@ -18,9 +18,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-SOF_DEFINE_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
-		0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
+SOF_DEFINE_REG_UUID(hsdai);
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 
 static inline int hsdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/rembrandt/acp_hs_dma.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dma.c
@@ -32,9 +32,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp_hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
-		0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
+SOF_DEFINE_REG_UUID(acp_hs);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 
 #define HS_FIFO_SIZE		512

--- a/src/drivers/amd/rembrandt/acp_hs_dma.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp_hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_hs_dma.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-DECLARE_SOF_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sp_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dai.c
@@ -19,7 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-DECLARE_SOF_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
+SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 		0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sp_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dai.c
@@ -18,9 +18,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
-		0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
+SOF_DEFINE_REG_UUID(spdai);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/rembrandt/acp_sp_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dma.c
@@ -33,9 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_sp_dma.h>
 
-/*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
-		0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
+SOF_DEFINE_REG_UUID(acp_sp);
 DECLARE_TR_CTX(acp_sp_rmb_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 #define SP_TX_FIFO_ADDR		(SP_FIFO_SIZE * 2)

--- a/src/drivers/amd/rembrandt/acp_sp_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-DECLARE_SOF_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_rmb_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sp_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_rmb_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
@@ -10,7 +10,7 @@
 #include <sof/trace/trace.h>
 
 /* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-DECLARE_SOF_UUID("swaudiodai", swaudiodai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
+SOF_DEFINE_UUID("swaudiodai", swaudiodai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
 		 0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
 DECLARE_TR_CTX(swaudiodai_tr, SOF_UUID(swaudiodai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
@@ -9,9 +9,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
 
-/* eb0bd14b-7d5e-4dfa-bbe2-7762adb279f0 */
-SOF_DEFINE_UUID("swaudiodai", swaudiodai_uuid, 0xeb0bd14b, 0x7d5e, 0x4dfa,
-		0xbb, 0xe2, 0x77, 0x62, 0xad, 0xb2, 0x79, 0xf0);
+SOF_DEFINE_REG_UUID(swaudiodai);
 
 DECLARE_TR_CTX(swaudiodai_tr, SOF_UUID(swaudiodai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
@@ -9,9 +9,10 @@
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
 
-/* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-SOF_DEFINE_UUID("swaudiodai", swaudiodai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
-		 0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
+/* eb0bd14b-7d5e-4dfa-bbe2-7762adb279f0 */
+SOF_DEFINE_UUID("swaudiodai", swaudiodai_uuid, 0xeb0bd14b, 0x7d5e, 0x4dfa,
+		0xbb, 0xe2, 0x77, 0x62, 0xad, 0xb2, 0x79, 0xf0);
+
 DECLARE_TR_CTX(swaudiodai_tr, SOF_UUID(swaudiodai_uuid), LOG_LEVEL_INFO);
 
 static inline int swaudiodai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
@@ -14,7 +14,7 @@
 
 #ifdef CONFIG_ACP_6_3
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp-sw-audio", acp_sw_audio_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp_sw_audio", acp_sw_audio_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_sw_audio_tr, SOF_UUID(acp_sw_audio_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
@@ -13,9 +13,11 @@
 #include <sof/trace/trace.h>
 
 #ifdef CONFIG_ACP_6_3
-/*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp_sw_audio", acp_sw_audio_uuid, 0xb414df09, 0x9e31, 0x4c59,
-		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
+
+/* 5871f3ca-dd92-4edb-8a94-d651dd208b1e */
+SOF_DEFINE_UUID("acp_sw_audio", acp_sw_audio_uuid, 0x5871f3ca, 0xdd92, 0x4edb,
+		0x8a, 0x94, 0xd6, 0x51, 0xdd, 0x20, 0x8b, 0x1e);
+
 DECLARE_TR_CTX(acp_sw_audio_tr, SOF_UUID(acp_sw_audio_uuid), LOG_LEVEL_INFO);
 
 //initialization of soundwire-0 fifos(Audio, BT and HS)

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
@@ -14,9 +14,7 @@
 
 #ifdef CONFIG_ACP_6_3
 
-/* 5871f3ca-dd92-4edb-8a94-d651dd208b1e */
-SOF_DEFINE_UUID("acp_sw_audio", acp_sw_audio_uuid, 0x5871f3ca, 0xdd92, 0x4edb,
-		0x8a, 0x94, 0xd6, 0x51, 0xdd, 0x20, 0x8b, 0x1e);
+SOF_DEFINE_REG_UUID(acp_sw_audio);
 
 DECLARE_TR_CTX(acp_sw_audio_tr, SOF_UUID(acp_sw_audio_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
@@ -14,7 +14,7 @@
 
 #ifdef CONFIG_ACP_6_3
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-DECLARE_SOF_UUID("acp-sw-audio", acp_sw_audio_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp-sw-audio", acp_sw_audio_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_sw_audio_tr, SOF_UUID(acp_sw_audio_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/rembrandt/interrupt.c
+++ b/src/drivers/amd/rembrandt/interrupt.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/rembrandt/interrupt.c
+++ b/src/drivers/amd/rembrandt/interrupt.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-DECLARE_SOF_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/rembrandt/interrupt.c
+++ b/src/drivers/amd/rembrandt/interrupt.c
@@ -25,9 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
-		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
+SOF_DEFINE_REG_UUID(irq_acp);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/acp_bt_dma.c
+++ b/src/drivers/amd/renoir/acp_bt_dma.c
@@ -34,7 +34,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-DECLARE_SOF_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/renoir/acp_bt_dma.c
+++ b/src/drivers/amd/renoir/acp_bt_dma.c
@@ -33,9 +33,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
-		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
+SOF_DEFINE_REG_UUID(acp_bt_dma);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/acp_bt_dma.c
+++ b/src/drivers/amd/renoir/acp_bt_dma.c
@@ -34,7 +34,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -33,8 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_dmic_dma.h>
 
-SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
-		0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
+SOF_DEFINE_REG_UUID(acp_dmic_dma);
 DECLARE_TR_CTX(acp_dmic_dma_rn_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_dmic_dma.h>
 
-DECLARE_SOF_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
+SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
 		0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
 DECLARE_TR_CTX(acp_dmic_dma_rn_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/acp_sp_dai.c
+++ b/src/drivers/amd/renoir/acp_sp_dai.c
@@ -19,9 +19,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
-		0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
+SOF_DEFINE_REG_UUID(spdai);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/renoir/acp_sp_dai.c
+++ b/src/drivers/amd/renoir/acp_sp_dai.c
@@ -20,7 +20,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-DECLARE_SOF_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
+SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 		0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/acp_sp_dma.c
+++ b/src/drivers/amd/renoir/acp_sp_dma.c
@@ -34,9 +34,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_sp_dma.h>
 
-/*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
-		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
+SOF_DEFINE_REG_UUID(acp_sp);
 DECLARE_TR_CTX(acp_sp_rn_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 static uint64_t prev_tx_pos;

--- a/src/drivers/amd/renoir/acp_sp_dma.c
+++ b/src/drivers/amd/renoir/acp_sp_dma.c
@@ -35,7 +35,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_rn_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/acp_sp_dma.c
+++ b/src/drivers/amd/renoir/acp_sp_dma.c
@@ -35,7 +35,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-DECLARE_SOF_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_rn_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/interrupt.c
+++ b/src/drivers/amd/renoir/interrupt.c
@@ -26,9 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
-		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
+SOF_DEFINE_REG_UUID(irq_acp);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/renoir/interrupt.c
+++ b/src/drivers/amd/renoir/interrupt.c
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/renoir/interrupt.c
+++ b/src/drivers/amd/renoir/interrupt.c
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-DECLARE_SOF_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/vangogh/acp_bt_dma.c
+++ b/src/drivers/amd/vangogh/acp_bt_dma.c
@@ -32,9 +32,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
-		 0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
+SOF_DEFINE_REG_UUID(acp_bt_dma);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_bt_dma.c
+++ b/src/drivers/amd/vangogh/acp_bt_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp_bt_dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		 0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/vangogh/acp_bt_dma.c
+++ b/src/drivers/amd/vangogh/acp_bt_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /* ee12fa71-4579-45d7-bde2-b32c6893a122 */
-DECLARE_SOF_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
+SOF_DEFINE_UUID("acp-bt-dma", acp_bt_dma_uuid, 0xab01db67, 0x84b0, 0x4d2d,
 		 0x93, 0xd3, 0x0e, 0x61, 0x96, 0x80, 0x57, 0x6e);
 
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/vangogh/acp_dmic_dma.c
+++ b/src/drivers/amd/vangogh/acp_dmic_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_dmic_dma.h>
 
-DECLARE_SOF_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
+SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
 		 0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
 DECLARE_TR_CTX(acp_dmic_dma_vgh_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_dmic_dma.c
+++ b/src/drivers/amd/vangogh/acp_dmic_dma.c
@@ -33,8 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_dmic_dma.h>
 
-SOF_DEFINE_UUID("acp_dmic_dma", acp_dmic_dma_uuid, 0x109c7aba, 0xa7ba, 0x43c3,
-		 0xb9, 0x42, 0x59, 0xe2, 0x0a, 0x66, 0x11, 0xbe);
+SOF_DEFINE_REG_UUID(acp_dmic_dma);
 DECLARE_TR_CTX(acp_dmic_dma_vgh_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/vangogh/acp_hs_dai.c
+++ b/src/drivers/amd/vangogh/acp_hs_dai.c
@@ -18,9 +18,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-SOF_DEFINE_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
-		 0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
+SOF_DEFINE_REG_UUID(hsdai);
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 
 static inline int hsdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/vangogh/acp_hs_dai.c
+++ b/src/drivers/amd/vangogh/acp_hs_dai.c
@@ -19,7 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 8f00c3bb-e835-4767-9a34-b8ec1041e56b */
-DECLARE_SOF_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
+SOF_DEFINE_UUID("hsdai", hsdai_uuid, 0x8f00c3bb, 0xe835, 0x4767,
 		 0x9a, 0x34, 0xb8, 0xec, 0x10, 0x41, 0xe5, 0x6b);
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_hs_dma.c
+++ b/src/drivers/amd/vangogh/acp_hs_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-DECLARE_SOF_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_hs_dma.c
+++ b/src/drivers/amd/vangogh/acp_hs_dma.c
@@ -32,9 +32,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp_hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
-		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
+SOF_DEFINE_REG_UUID(acp_hs);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 
 #define HS_FIFO_SIZE		512

--- a/src/drivers/amd/vangogh/acp_hs_dma.c
+++ b/src/drivers/amd/vangogh/acp_hs_dma.c
@@ -33,7 +33,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp-hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp_hs", acp_hs_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_sp_dai.c
+++ b/src/drivers/amd/vangogh/acp_sp_dai.c
@@ -19,7 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 /* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-DECLARE_SOF_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
+SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
 		 0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_sp_dai.c
+++ b/src/drivers/amd/vangogh/acp_sp_dai.c
@@ -18,9 +18,7 @@
 #include <sof/lib/io.h>
 #include <platform/chip_offset_byte.h>
 
-/* 4abd71ba-8619-458a-b33f-160fc0cf809b */
-SOF_DEFINE_UUID("spdai", spdai_uuid, 0x4abd71ba, 0x8619, 0x458a,
-		 0xb3, 0x3f, 0x16, 0x0f, 0xc0, 0xcf, 0x80, 0x9b);
+SOF_DEFINE_REG_UUID(spdai);
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,

--- a/src/drivers/amd/vangogh/acp_sp_dma.c
+++ b/src/drivers/amd/vangogh/acp_sp_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-DECLARE_SOF_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_vgh_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/acp_sp_dma.c
+++ b/src/drivers/amd/vangogh/acp_sp_dma.c
@@ -33,9 +33,7 @@
 #include <platform/chip_registers.h>
 #include <platform/acp_sp_dma.h>
 
-/*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
-		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
+SOF_DEFINE_REG_UUID(acp_sp);
 DECLARE_TR_CTX(acp_sp_vgh_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 /* Vangogh hw specific addr map */

--- a/src/drivers/amd/vangogh/acp_sp_dma.c
+++ b/src/drivers/amd/vangogh/acp_sp_dma.c
@@ -34,7 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 /*3ac07334-41ce-4447-a2c5-dff0d1fa1392*/
-SOF_DEFINE_UUID("acp-sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
+SOF_DEFINE_UUID("acp_sp", acp_sp_uuid, 0x3ac07334, 0x41ce, 0x4447,
 		 0xa2, 0xc5, 0xdf, 0xf0, 0xd1, 0xfa, 0x13, 0x92);
 DECLARE_TR_CTX(acp_sp_vgh_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/amd/vangogh/interrupt.c
+++ b/src/drivers/amd/vangogh/interrupt.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		 0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/vangogh/interrupt.c
+++ b/src/drivers/amd/vangogh/interrupt.c
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /*  6533d0eb-b785-4709-84f5-347c81720189*/
-DECLARE_SOF_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
+SOF_DEFINE_UUID("irq-acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
 		 0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/amd/vangogh/interrupt.c
+++ b/src/drivers/amd/vangogh/interrupt.c
@@ -25,9 +25,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/*  6533d0eb-b785-4709-84f5-347c81720189*/
-SOF_DEFINE_UUID("irq_acp", irq_acp_uuid, 0x6533d0eb, 0xb785, 0x4709,
-		 0x84, 0xf5, 0x34, 0x7c, 0x81, 0x72, 0x01, 0x89);
+SOF_DEFINE_REG_UUID(irq_acp);
 
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -46,9 +46,7 @@
 
 LOG_MODULE_REGISTER(dw_dma, CONFIG_SOF_LOG_LEVEL);
 
-/* 298873bc-d532-4d93-a540-95ee6bcf3456 */
-SOF_DEFINE_UUID("dw_dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
-		 0xa5, 0x40, 0x95, 0xee, 0x6b, 0xcf, 0x34, 0x56);
+SOF_DEFINE_REG_UUID(dw_dma);
 
 DECLARE_TR_CTX(dwdma_tr, SOF_UUID(dw_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -47,7 +47,7 @@
 LOG_MODULE_REGISTER(dw_dma, CONFIG_SOF_LOG_LEVEL);
 
 /* 298873bc-d532-4d93-a540-95ee6bcf3456 */
-SOF_DEFINE_UUID("dw-dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
+SOF_DEFINE_UUID("dw_dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
 		 0xa5, 0x40, 0x95, 0xee, 0x6b, 0xcf, 0x34, 0x56);
 
 DECLARE_TR_CTX(dwdma_tr, SOF_UUID(dw_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -47,7 +47,7 @@
 LOG_MODULE_REGISTER(dw_dma, CONFIG_SOF_LOG_LEVEL);
 
 /* 298873bc-d532-4d93-a540-95ee6bcf3456 */
-DECLARE_SOF_UUID("dw-dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
+SOF_DEFINE_UUID("dw-dma", dw_dma_uuid, 0x298873bc, 0xd532, 0x4d93,
 		 0xa5, 0x40, 0x95, 0xee, 0x6b, 0xcf, 0x34, 0x56);
 
 DECLARE_TR_CTX(dwdma_tr, SOF_UUID(dw_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 
 /* a417b6fb-459d-4cf9-be65-d38dc9057b80 */
-SOF_DEFINE_UUID("spi-completion", spi_compl_task_uuid, 0xa417b6fb,
+SOF_DEFINE_UUID("spi_completion", spi_completion_uuid, 0xa417b6fb,
 		 0x459d, 0x4cf9,
 		 0xbe, 0x65, 0xd3, 0x8d, 0xc9, 0x05, 0x7b, 0x80);
 

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -30,10 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* a417b6fb-459d-4cf9-be65-d38dc9057b80 */
-SOF_DEFINE_UUID("spi_completion", spi_completion_uuid, 0xa417b6fb,
-		 0x459d, 0x4cf9,
-		 0xbe, 0x65, 0xd3, 0x8d, 0xc9, 0x05, 0x7b, 0x80);
+SOF_DEFINE_REG_UUID(spi_completion);
 
 #define	SPI_REG_CTRLR0		0x00
 #define	SPI_REG_CTRLR1		0x04

--- a/src/drivers/dw/ssi-spi.c
+++ b/src/drivers/dw/ssi-spi.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 
 /* a417b6fb-459d-4cf9-be65-d38dc9057b80 */
-DECLARE_SOF_UUID("spi-completion", spi_compl_task_uuid, 0xa417b6fb,
+SOF_DEFINE_UUID("spi-completion", spi_compl_task_uuid, 0xa417b6fb,
 		 0x459d, 0x4cf9,
 		 0xbe, 0x65, 0xd3, 0x8d, 0xc9, 0x05, 0x7b, 0x80);
 

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -49,7 +49,7 @@
 LOG_MODULE_REGISTER(dummy_dma, CONFIG_SOF_LOG_LEVEL);
 
 /* f6d15ad3-b122-458c-ae9b-0ab0b5867aa0 */
-DECLARE_SOF_UUID("dummy-dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
+SOF_DEFINE_UUID("dummy-dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
 		 0xae, 0x9b, 0x0a, 0xb0, 0xb5, 0x86, 0x7a, 0xa0);
 
 DECLARE_TR_CTX(ddma_tr, SOF_UUID(dummy_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -48,9 +48,7 @@
 
 LOG_MODULE_REGISTER(dummy_dma, CONFIG_SOF_LOG_LEVEL);
 
-/* f6d15ad3-b122-458c-ae9b-0ab0b5867aa0 */
-SOF_DEFINE_UUID("dummy_dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
-		 0xae, 0x9b, 0x0a, 0xb0, 0xb5, 0x86, 0x7a, 0xa0);
+SOF_DEFINE_REG_UUID(dummy_dma);
 
 DECLARE_TR_CTX(ddma_tr, SOF_UUID(dummy_dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -49,7 +49,7 @@
 LOG_MODULE_REGISTER(dummy_dma, CONFIG_SOF_LOG_LEVEL);
 
 /* f6d15ad3-b122-458c-ae9b-0ab0b5867aa0 */
-SOF_DEFINE_UUID("dummy-dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
+SOF_DEFINE_UUID("dummy_dma", dummy_dma_uuid, 0xf6d15ad3, 0xb122, 0x458c,
 		 0xae, 0x9b, 0x0a, 0xb0, 0xb5, 0x86, 0x7a, 0xa0);
 
 DECLARE_TR_CTX(ddma_tr, SOF_UUID(dummy_dma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -21,9 +21,7 @@
 
 LOG_MODULE_REGISTER(edma, CONFIG_SOF_LOG_LEVEL);
 
-/* 3d73a110-0930-457f-be51-34453e56287b */
-SOF_DEFINE_UUID("edma", edma_uuid, 0x3d73a110, 0x0930, 0x457f,
-		 0xbe, 0x51, 0x34, 0x45, 0x3e, 0x56, 0x28, 0x7b);
+SOF_DEFINE_REG_UUID(edma);
 
 DECLARE_TR_CTX(edma_tr, SOF_UUID(edma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(edma, CONFIG_SOF_LOG_LEVEL);
 
 /* 3d73a110-0930-457f-be51-34453e56287b */
-DECLARE_SOF_UUID("edma", edma_uuid, 0x3d73a110, 0x0930, 0x457f,
+SOF_DEFINE_UUID("edma", edma_uuid, 0x3d73a110, 0x0930, 0x457f,
 		 0xbe, 0x51, 0x34, 0x45, 0x3e, 0x56, 0x28, 0x7b);
 
 DECLARE_TR_CTX(edma_tr, SOF_UUID(edma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(esai, CONFIG_SOF_LOG_LEVEL);
 
-/* 889f6dcd-ddcd-4e05-aa5b-0d39f8bca961 */
-SOF_DEFINE_UUID("esai", esai_uuid, 0x889f6dcd, 0xddcd, 0x4e05,
-		 0xaa, 0x5b, 0x0d, 0x39, 0xf8, 0xbc, 0xa9, 0x61);
+SOF_DEFINE_REG_UUID(esai);
 
 DECLARE_TR_CTX(esai_tr, SOF_UUID(esai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(esai, CONFIG_SOF_LOG_LEVEL);
 
 /* 889f6dcd-ddcd-4e05-aa5b-0d39f8bca961 */
-DECLARE_SOF_UUID("esai", esai_uuid, 0x889f6dcd, 0xddcd, 0x4e05,
+SOF_DEFINE_UUID("esai", esai_uuid, 0x889f6dcd, 0xddcd, 0x4e05,
 		 0xaa, 0x5b, 0x0d, 0x39, 0xf8, 0xbc, 0xa9, 0x61);
 
 DECLARE_TR_CTX(esai_tr, SOF_UUID(esai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("generic-irq-imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("generic_irq_imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(generic_irq_imx_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-DECLARE_SOF_UUID("generic-irq-imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("generic-irq-imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(generic_irq_imx_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -21,10 +21,10 @@
 LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("generic_irq_imx", generic_irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
-DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(generic_irq_imx_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /* this is needed because i.MX8 implementation assumes all boards have an irqsteer.
  * Needs to be fixed.

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
 
-/* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
-		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
+SOF_DEFINE_REG_UUID(interrupt);
 
 DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -22,10 +22,10 @@
 LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("irq_imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
-DECLARE_TR_CTX(irq_i_tr, SOF_UUID(irq_imx_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(irq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /*
  * The IRQ_STEER module takes 512 shared interrupts and delivers them

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -21,9 +21,7 @@
 
 LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
 
-/* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
-		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
+SOF_DEFINE_REG_UUID(interrupt);
 
 DECLARE_TR_CTX(irq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-DECLARE_SOF_UUID("irq-imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("irq-imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(irq_i_tr, SOF_UUID(irq_imx_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("irq-imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("irq_imx", irq_imx_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(irq_i_tr, SOF_UUID(irq_imx_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(ipc_task, CONFIG_SOF_LOG_LEVEL);
 #endif /* CONFIG_IMX8M */
 
 /* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
+SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
 		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
 
 struct ipc_data {

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -43,9 +43,7 @@ LOG_MODULE_REGISTER(ipc_task, CONFIG_SOF_LOG_LEVEL);
 #define interrupt_clear(irq)
 #endif /* CONFIG_IMX8M */
 
-/* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
-		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
+SOF_DEFINE_REG_UUID(ipc_task);
 
 struct ipc_data {
 	struct ipc_data_host_buffer dh_buffer;

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(ipc_task, CONFIG_SOF_LOG_LEVEL);
 #endif /* CONFIG_IMX8M */
 
 /* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
 		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
 
 struct ipc_data {

--- a/src/drivers/imx/micfil.c
+++ b/src/drivers/imx/micfil.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(micfil_dai, CONFIG_SOF_LOG_LEVEL);
 
-/* dd400475-35d7-4045-ab03-0c34957d7a08 */
-SOF_DEFINE_UUID("micfil", micfil_uuid, 0xdd400475, 0x35d7, 0x4045,
-		 0xab, 0x03, 0x0c, 0x34, 0x95, 0x7d, 0x7a, 0x08);
+SOF_DEFINE_REG_UUID(micfil);
 
 DECLARE_TR_CTX(micfil_tr, SOF_UUID(micfil_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/micfil.c
+++ b/src/drivers/imx/micfil.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(micfil_dai, CONFIG_SOF_LOG_LEVEL);
 
 /* dd400475-35d7-4045-ab03-0c34957d7a08 */
-DECLARE_SOF_UUID("micfil-dai", micfil_uuid, 0xdd400475, 0x35d7, 0x4045,
+SOF_DEFINE_UUID("micfil-dai", micfil_uuid, 0xdd400475, 0x35d7, 0x4045,
 		 0xab, 0x03, 0x0c, 0x34, 0x95, 0x7d, 0x7a, 0x08);
 
 DECLARE_TR_CTX(micfil_tr, SOF_UUID(micfil_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/micfil.c
+++ b/src/drivers/imx/micfil.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(micfil_dai, CONFIG_SOF_LOG_LEVEL);
 
 /* dd400475-35d7-4045-ab03-0c34957d7a08 */
-SOF_DEFINE_UUID("micfil-dai", micfil_uuid, 0xdd400475, 0x35d7, 0x4045,
+SOF_DEFINE_UUID("micfil", micfil_uuid, 0xdd400475, 0x35d7, 0x4045,
 		 0xab, 0x03, 0x0c, 0x34, 0x95, 0x7d, 0x7a, 0x08);
 
 DECLARE_TR_CTX(micfil_tr, SOF_UUID(micfil_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(sai, CONFIG_SOF_LOG_LEVEL);
 
-/* 9302adf5-88be-4234-a0a7-dca538ef81f4 */
-SOF_DEFINE_UUID("sai", sai_uuid, 0x9302adf5, 0x88be, 0x4234,
-		 0xa0, 0xa7, 0xdc, 0xa5, 0x38, 0xef, 0x81, 0xf4);
+SOF_DEFINE_REG_UUID(sai);
 
 DECLARE_TR_CTX(sai_tr, SOF_UUID(sai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(sai, CONFIG_SOF_LOG_LEVEL);
 
 /* 9302adf5-88be-4234-a0a7-dca538ef81f4 */
-DECLARE_SOF_UUID("sai", sai_uuid, 0x9302adf5, 0x88be, 0x4234,
+SOF_DEFINE_UUID("sai", sai_uuid, 0x9302adf5, 0x88be, 0x4234,
 		 0xa0, 0xa7, 0xdc, 0xa5, 0x38, 0xef, 0x81, 0xf4);
 
 DECLARE_TR_CTX(sai_tr, SOF_UUID(sai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(sdma, CONFIG_SOF_LOG_LEVEL);
 
 /* 70d223ef-2b91-4aac-b444-d89a0db2793a */
-DECLARE_SOF_UUID("sdma", sdma_uuid, 0x70d223ef, 0x2b91, 0x4aac,
+SOF_DEFINE_UUID("sdma", sdma_uuid, 0x70d223ef, 0x2b91, 0x4aac,
 		 0xb4, 0x44, 0xd8, 0x9a, 0x0d, 0xb2, 0x79, 0x3a);
 
 DECLARE_TR_CTX(sdma_tr, SOF_UUID(sdma_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(sdma, CONFIG_SOF_LOG_LEVEL);
 
-/* 70d223ef-2b91-4aac-b444-d89a0db2793a */
-SOF_DEFINE_UUID("sdma", sdma_uuid, 0x70d223ef, 0x2b91, 0x4aac,
-		 0xb4, 0x44, 0xd8, 0x9a, 0x0d, 0xb2, 0x79, 0x3a);
+SOF_DEFINE_REG_UUID(sdma);
 
 DECLARE_TR_CTX(sdma_tr, SOF_UUID(sdma_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(irq, CONFIG_SOF_LOG_LEVEL);
 
 /* 1862d39a-3a84-4d64-8c91-dce1dfc122db */
 
-DECLARE_SOF_UUID("irq", irq_uuid, 0x1862d39a, 0x3a84, 0x4d64,
+SOF_DEFINE_UUID("irq", irq_uuid, 0x1862d39a, 0x3a84, 0x4d64,
 		 0x8c, 0x91, 0xdc, 0xe1, 0xdf, 0xc1, 0x22, 0xdb);
 
 DECLARE_TR_CTX(irq_tr, SOF_UUID(irq_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -24,8 +24,7 @@ LOG_MODULE_REGISTER(irq, CONFIG_SOF_LOG_LEVEL);
 
 /* 1862d39a-3a84-4d64-8c91-dce1dfc122db */
 
-SOF_DEFINE_UUID("irq", irq_uuid, 0x1862d39a, 0x3a84, 0x4d64,
-		 0x8c, 0x91, 0xdc, 0xe1, 0xdf, 0xc1, 0x22, 0xdb);
+SOF_DEFINE_REG_UUID(irq);
 
 DECLARE_TR_CTX(irq_tr, SOF_UUID(irq_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/afe-dai.c
+++ b/src/drivers/mediatek/afe/afe-dai.c
@@ -24,9 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* 30290c76-6a05-4784-8464-c21f09cee87e */
-SOF_DEFINE_UUID("afe_dai", afe_dai_uuid, 0x30290c76, 0x6a05, 0x4784,
-		 0x84, 0x64, 0xc2, 0x1f, 0x09, 0xce, 0xe8, 0x7e);
+SOF_DEFINE_REG_UUID(afe_dai);
 
 DECLARE_TR_CTX(afe_dai_tr, SOF_UUID(afe_dai_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/afe-dai.c
+++ b/src/drivers/mediatek/afe/afe-dai.c
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 /* 30290c76-6a05-4784-8464-c21f09cee87e */
-DECLARE_SOF_UUID("afe-dai", afe_dai_uuid, 0x30290c76, 0x6a05, 0x4784,
+SOF_DEFINE_UUID("afe-dai", afe_dai_uuid, 0x30290c76, 0x6a05, 0x4784,
 		 0x84, 0x64, 0xc2, 0x1f, 0x09, 0xce, 0xe8, 0x7e);
 
 DECLARE_TR_CTX(afe_dai_tr, SOF_UUID(afe_dai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/afe-dai.c
+++ b/src/drivers/mediatek/afe/afe-dai.c
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 /* 30290c76-6a05-4784-8464-c21f09cee87e */
-SOF_DEFINE_UUID("afe-dai", afe_dai_uuid, 0x30290c76, 0x6a05, 0x4784,
+SOF_DEFINE_UUID("afe_dai", afe_dai_uuid, 0x30290c76, 0x6a05, 0x4784,
 		 0x84, 0x64, 0xc2, 0x1f, 0x09, 0xce, 0xe8, 0x7e);
 
 DECLARE_TR_CTX(afe_dai_tr, SOF_UUID(afe_dai_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/afe-drv.c
+++ b/src/drivers/mediatek/afe/afe-drv.c
@@ -26,8 +26,7 @@ static struct mtk_base_afe mtk_afe;
 #define printf(format, ...)
 #endif
 
-SOF_DEFINE_UUID("afedrv", afedrv_uuid, 0x4e8f16d1, 0xe935, 0x41f4,
-		 0xb9, 0x9e, 0x42, 0xc5, 0x7e, 0x74, 0x57, 0x84);
+SOF_DEFINE_REG_UUID(afedrv);
 
 DECLARE_TR_CTX(afedrv_tr, SOF_UUID(afedrv_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/afe-drv.c
+++ b/src/drivers/mediatek/afe/afe-drv.c
@@ -26,7 +26,7 @@ static struct mtk_base_afe mtk_afe;
 #define printf(format, ...)
 #endif
 
-DECLARE_SOF_UUID("afedrv", afedrv_uuid, 0x4e8f16d1, 0xe935, 0x41f4,
+SOF_DEFINE_UUID("afedrv", afedrv_uuid, 0x4e8f16d1, 0xe935, 0x41f4,
 		 0xb9, 0x9e, 0x42, 0xc5, 0x7e, 0x74, 0x57, 0x84);
 
 DECLARE_TR_CTX(afedrv_tr, SOF_UUID(afedrv_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/afe-memif.c
+++ b/src/drivers/mediatek/afe/afe-memif.c
@@ -27,7 +27,7 @@
 #include <stdint.h>
 
 /* df5e94d7-fd93-42e9-bb94-ab40becc7151 */
-DECLARE_SOF_UUID("memif", memif_uuid, 0xdf5e94d7, 0xfd93, 0x42e9,
+SOF_DEFINE_UUID("memif", memif_uuid, 0xdf5e94d7, 0xfd93, 0x42e9,
 		 0xbb, 0x94, 0xab, 0x40, 0xbe, 0xcc, 0x71, 0x51);
 
 DECLARE_TR_CTX(memif_tr, SOF_UUID(memif_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/afe-memif.c
+++ b/src/drivers/mediatek/afe/afe-memif.c
@@ -26,9 +26,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* df5e94d7-fd93-42e9-bb94-ab40becc7151 */
-SOF_DEFINE_UUID("memif", memif_uuid, 0xdf5e94d7, 0xfd93, 0x42e9,
-		 0xbb, 0x94, 0xab, 0x40, 0xbe, 0xcc, 0x71, 0x51);
+SOF_DEFINE_REG_UUID(memif);
 
 DECLARE_TR_CTX(memif_tr, SOF_UUID(memif_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/mt8186/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8186/afe-sgen.c
@@ -15,7 +15,7 @@
 #include <mt8186-afe-common.h>
 
 /* cf90d851-68a2-4987-a2de-85aed0c8531c */
-DECLARE_SOF_UUID("sgen", sgen_uuid, 0xcf90d851, 0x68a2, 0x4987,
+SOF_DEFINE_UUID("sgen", sgen_uuid, 0xcf90d851, 0x68a2, 0x4987,
 		 0xa2, 0xde, 0x85, 0xae, 0xd0, 0xc8, 0x53, 0x1c);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/mt8186/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8186/afe-sgen.c
@@ -14,9 +14,7 @@
 #include <mt8186-afe-regs.h>
 #include <mt8186-afe-common.h>
 
-/* cf90d851-68a2-4987-a2de-85aed0c8531c */
-SOF_DEFINE_UUID("sgen_mt8186", sgen_mt8186_uuid, 0xcf90d851, 0x68a2, 0x4987,
-		 0xa2, 0xde, 0x85, 0xae, 0xd0, 0xc8, 0x53, 0x1c);
+SOF_DEFINE_REG_UUID(sgen_mt8186);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8186_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/mt8186/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8186/afe-sgen.c
@@ -15,10 +15,10 @@
 #include <mt8186-afe-common.h>
 
 /* cf90d851-68a2-4987-a2de-85aed0c8531c */
-SOF_DEFINE_UUID("sgen", sgen_uuid, 0xcf90d851, 0x68a2, 0x4987,
+SOF_DEFINE_UUID("sgen_mt8186", sgen_mt8186_uuid, 0xcf90d851, 0x68a2, 0x4987,
 		 0xa2, 0xde, 0x85, 0xae, 0xd0, 0xc8, 0x53, 0x1c);
 
-DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8186_uuid), LOG_LEVEL_INFO);
 
 /*
  * Note: TEST_SGEN for test only

--- a/src/drivers/mediatek/afe/mt8188/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8188/afe-sgen.c
@@ -16,10 +16,10 @@
 #include <mt8188-afe-common.h>
 
 /* 99316bd9-07b9-4665-8179-6e048d67cb45 */
-SOF_DEFINE_UUID("sgen", sgen_uuid, 0x99316bd9, 0x07b9, 0x4665,
+SOF_DEFINE_UUID("sgen_mt8188", sgen_mt8188_uuid, 0x99316bd9, 0x07b9, 0x4665,
 		 0x81, 0x79, 0x6e, 0x04, 0x8d, 0x67, 0xcb, 0x45);
 
-DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8188_uuid), LOG_LEVEL_INFO);
 
 /*
  * Note: TEST_SGEN for test only

--- a/src/drivers/mediatek/afe/mt8188/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8188/afe-sgen.c
@@ -15,9 +15,7 @@
 #include <mt8188-afe-reg.h>
 #include <mt8188-afe-common.h>
 
-/* 99316bd9-07b9-4665-8179-6e048d67cb45 */
-SOF_DEFINE_UUID("sgen_mt8188", sgen_mt8188_uuid, 0x99316bd9, 0x07b9, 0x4665,
-		 0x81, 0x79, 0x6e, 0x04, 0x8d, 0x67, 0xcb, 0x45);
+SOF_DEFINE_REG_UUID(sgen_mt8188);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8188_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/mt8188/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8188/afe-sgen.c
@@ -16,7 +16,7 @@
 #include <mt8188-afe-common.h>
 
 /* 99316bd9-07b9-4665-8179-6e048d67cb45 */
-DECLARE_SOF_UUID("sgen", sgen_uuid, 0x99316bd9, 0x07b9, 0x4665,
+SOF_DEFINE_UUID("sgen", sgen_uuid, 0x99316bd9, 0x07b9, 0x4665,
 		 0x81, 0x79, 0x6e, 0x04, 0x8d, 0x67, 0xcb, 0x45);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/mt8195/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8195/afe-sgen.c
@@ -16,7 +16,7 @@
 #include <mt8195-afe-common.h>
 
 /* 9eb1a55b-fc20-4442-9613-1ff1023be493 */
-DECLARE_SOF_UUID("sgen", sgen_uuid, 0x9eb1a55b, 0xfc20, 0x4442,
+SOF_DEFINE_UUID("sgen", sgen_uuid, 0x9eb1a55b, 0xfc20, 0x4442,
 		 0x96, 0x13, 0x1f, 0xf1, 0x02, 0x3b, 0xe4, 0x93);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/afe/mt8195/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8195/afe-sgen.c
@@ -15,9 +15,7 @@
 #include <mt8195-afe-regs.h>
 #include <mt8195-afe-common.h>
 
-/* 9eb1a55b-fc20-4442-9613-1ff1023be493 */
-SOF_DEFINE_UUID("sgen_mt8195", sgen_mt8195_uuid, 0x9eb1a55b, 0xfc20, 0x4442,
-		 0x96, 0x13, 0x1f, 0xf1, 0x02, 0x3b, 0xe4, 0x93);
+SOF_DEFINE_REG_UUID(sgen_mt8195);
 
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8195_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/afe/mt8195/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8195/afe-sgen.c
@@ -16,10 +16,10 @@
 #include <mt8195-afe-common.h>
 
 /* 9eb1a55b-fc20-4442-9613-1ff1023be493 */
-SOF_DEFINE_UUID("sgen", sgen_uuid, 0x9eb1a55b, 0xfc20, 0x4442,
+SOF_DEFINE_UUID("sgen_mt8195", sgen_mt8195_uuid, 0x9eb1a55b, 0xfc20, 0x4442,
 		 0x96, 0x13, 0x1f, 0xf1, 0x02, 0x3b, 0xe4, 0x93);
 
-DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8195_uuid), LOG_LEVEL_INFO);
 
 /*
  * Note: TEST_SGEN for test only

--- a/src/drivers/mediatek/mt818x/interrupt.c
+++ b/src/drivers/mediatek/mt818x/interrupt.c
@@ -23,9 +23,7 @@
 
 #define PENDING_IRQ_INDEX_MAX 32
 
-/* d2e3f730-df39-42ee-81a8-39bfb4d024c2 */
-SOF_DEFINE_UUID("irq_mt818x", irq_mt818x_uuid, 0xd2e3f730, 0xdf39, 0x42ee,
-		 0x81, 0xa8, 0x39, 0xbf, 0xb4, 0xd0, 0x24, 0xc2);
+SOF_DEFINE_REG_UUID(irq_mt818x);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt818x_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/mt818x/interrupt.c
+++ b/src/drivers/mediatek/mt818x/interrupt.c
@@ -24,7 +24,7 @@
 #define PENDING_IRQ_INDEX_MAX 32
 
 /* d2e3f730-df39-42ee-81a8-39bfb4d024c2 */
-DECLARE_SOF_UUID("irq-818x", irq_mt818x_uuid, 0xd2e3f730, 0xdf39, 0x42ee,
+SOF_DEFINE_UUID("irq-818x", irq_mt818x_uuid, 0xd2e3f730, 0xdf39, 0x42ee,
 		 0x81, 0xa8, 0x39, 0xbf, 0xb4, 0xd0, 0x24, 0xc2);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt818x_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/mt818x/interrupt.c
+++ b/src/drivers/mediatek/mt818x/interrupt.c
@@ -24,7 +24,7 @@
 #define PENDING_IRQ_INDEX_MAX 32
 
 /* d2e3f730-df39-42ee-81a8-39bfb4d024c2 */
-SOF_DEFINE_UUID("irq-818x", irq_mt818x_uuid, 0xd2e3f730, 0xdf39, 0x42ee,
+SOF_DEFINE_UUID("irq_mt818x", irq_mt818x_uuid, 0xd2e3f730, 0xdf39, 0x42ee,
 		 0x81, 0xa8, 0x39, 0xbf, 0xb4, 0xd0, 0x24, 0xc2);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt818x_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/mt818x/ipc.c
+++ b/src/drivers/mediatek/mt818x/ipc.c
@@ -36,7 +36,7 @@
 #define IPC_DSPMBOX_DSP_REQ 1
 
 /* a3fe3bf2-39a4-4fc3-b341-8a96e0a26759 */
-SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
 		 0xb3, 0x41, 0x8a, 0x96, 0xe0, 0xa2, 0x67, 0x59);
 
 static struct ipc *local_ipc;

--- a/src/drivers/mediatek/mt818x/ipc.c
+++ b/src/drivers/mediatek/mt818x/ipc.c
@@ -36,7 +36,7 @@
 #define IPC_DSPMBOX_DSP_REQ 1
 
 /* a3fe3bf2-39a4-4fc3-b341-8a96e0a26759 */
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
+SOF_DEFINE_UUID("ipc_task_mt818x", ipc_task_mt818x_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
 		 0xb3, 0x41, 0x8a, 0x96, 0xe0, 0xa2, 0x67, 0x59);
 
 static struct ipc *local_ipc;
@@ -138,7 +138,8 @@ int platform_ipc_init(struct ipc *ipc)
 	local_ipc = ipc;
 
 	/* schedule */
-	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid), &ipc_task_ops, ipc, 0, 0);
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_mt818x_uuid),
+			       &ipc_task_ops, ipc, 0, 0);
 
 #if CONFIG_HOST_PTABLE
 	/* allocate page table buffer */

--- a/src/drivers/mediatek/mt818x/ipc.c
+++ b/src/drivers/mediatek/mt818x/ipc.c
@@ -35,9 +35,7 @@
 #define IPC_DSPMBOX_DSP_RSP 0
 #define IPC_DSPMBOX_DSP_REQ 1
 
-/* a3fe3bf2-39a4-4fc3-b341-8a96e0a26759 */
-SOF_DEFINE_UUID("ipc_task_mt818x", ipc_task_mt818x_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
-		 0xb3, 0x41, 0x8a, 0x96, 0xe0, 0xa2, 0x67, 0x59);
+SOF_DEFINE_REG_UUID(ipc_task_mt818x);
 
 static struct ipc *local_ipc;
 

--- a/src/drivers/mediatek/mt818x/ipc.c
+++ b/src/drivers/mediatek/mt818x/ipc.c
@@ -36,7 +36,7 @@
 #define IPC_DSPMBOX_DSP_REQ 1
 
 /* a3fe3bf2-39a4-4fc3-b341-8a96e0a26759 */
-DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
+SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0xa3fe3bf2, 0x39a4, 0x4fc3,
 		 0xb3, 0x41, 0x8a, 0x96, 0xe0, 0xa2, 0x67, 0x59);
 
 static struct ipc *local_ipc;

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("irq-mt8195", irq_mt8195_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("irq_mt8195", irq_mt8195_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt8195_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -20,9 +20,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
-		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
+SOF_DEFINE_REG_UUID(interrupt);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-DECLARE_SOF_UUID("irq-mt8195", irq_mt8195_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("irq-mt8195", irq_mt8195_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt8195_uuid), LOG_LEVEL_INFO);

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -21,10 +21,10 @@
 #include <stdint.h>
 
 /* fa00558c-d653-4851-a03a-b21f125a9524 */
-SOF_DEFINE_UUID("irq_mt8195", irq_mt8195_uuid, 0xfa00558c, 0xd653, 0x4851,
+SOF_DEFINE_UUID("interrupt", interrupt_uuid, 0xfa00558c, 0xd653, 0x4851,
 		 0xa0, 0x3a, 0xb2, 0x1f, 0x12, 0x5a, 0x95, 0x24);
 
-DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt8195_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(int_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /* os timer reg value * 77ns 13M os timer
  * 1  ms: 12987* 1.5ms: 19436

--- a/src/drivers/mediatek/mt8195/ipc.c
+++ b/src/drivers/mediatek/mt8195/ipc.c
@@ -34,9 +34,7 @@
 #define IPC_DSPMBOX_DSP_RSP 0
 #define IPC_DSPMBOX_DSP_REQ 1
 
-/* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
-		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
+SOF_DEFINE_REG_UUID(ipc_task);
 
 static struct ipc *local_ipc;
 

--- a/src/drivers/mediatek/mt8195/ipc.c
+++ b/src/drivers/mediatek/mt8195/ipc.c
@@ -35,7 +35,7 @@
 #define IPC_DSPMBOX_DSP_REQ 1
 
 /* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
 		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
 
 static struct ipc *local_ipc;

--- a/src/drivers/mediatek/mt8195/ipc.c
+++ b/src/drivers/mediatek/mt8195/ipc.c
@@ -35,7 +35,7 @@
 #define IPC_DSPMBOX_DSP_REQ 1
 
 /* 389c9186-5a7d-4ad1-a02c-a02ecdadfb33 */
-DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
+SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x389c9186, 0x5a7d, 0x4ad1,
 		 0xa0, 0x2c, 0xa0, 0x2e, 0xcd, 0xad, 0xfb, 0x33);
 
 static struct ipc *local_ipc;

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -46,12 +46,12 @@ SOF_DEFINE_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
 DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
 
 /* b90f5a4e-5537-4375-a1df-95485472ff9e */
-SOF_DEFINE_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
+SOF_DEFINE_UUID("idc_task", idc_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
 		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
 
 #ifndef __ZEPHYR__
 /* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
-SOF_DEFINE_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
+SOF_DEFINE_UUID("idc_cmd_task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
 		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
 #endif
 
@@ -232,7 +232,7 @@ static int idc_prepare(uint32_t comp_id)
 		}
 
 		ret = schedule_task_init_ll(dev->task,
-					    SOF_UUID(idc_comp_task_uuid),
+					    SOF_UUID(idc_task_uuid),
 					    SOF_SCHEDULE_LL_TIMER,
 					    dev->priority, comp_task, dev,
 					    dev->ipc_config.core, 0);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -39,20 +39,14 @@ LOG_MODULE_REGISTER(idc, CONFIG_SOF_LOG_LEVEL);
 /** \brief IDC message payload per core. */
 static SHARED_DATA struct idc_payload static_payload[CONFIG_CORE_COUNT];
 
-/* 379a60ae-cedb-4777-aaf2-5659b0a85735 */
-SOF_DEFINE_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
-		 0xaa, 0xf2, 0x56, 0x59, 0xb0, 0xa8, 0x57, 0x35);
+SOF_DEFINE_REG_UUID(idc);
 
 DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
 
-/* b90f5a4e-5537-4375-a1df-95485472ff9e */
-SOF_DEFINE_UUID("idc_task", idc_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
-		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
+SOF_DEFINE_REG_UUID(idc_task);
 
 #ifndef __ZEPHYR__
-/* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
-SOF_DEFINE_UUID("idc_cmd_task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
-		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
+SOF_DEFINE_REG_UUID(idc_cmd_task);
 #endif
 
 /**

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -40,18 +40,18 @@ LOG_MODULE_REGISTER(idc, CONFIG_SOF_LOG_LEVEL);
 static SHARED_DATA struct idc_payload static_payload[CONFIG_CORE_COUNT];
 
 /* 379a60ae-cedb-4777-aaf2-5659b0a85735 */
-DECLARE_SOF_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
+SOF_DEFINE_UUID("idc", idc_uuid, 0x379a60ae, 0xcedb, 0x4777,
 		 0xaa, 0xf2, 0x56, 0x59, 0xb0, 0xa8, 0x57, 0x35);
 
 DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
 
 /* b90f5a4e-5537-4375-a1df-95485472ff9e */
-DECLARE_SOF_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
+SOF_DEFINE_UUID("comp-task", idc_comp_task_uuid, 0xb90f5a4e, 0x5537, 0x4375,
 		 0xa1, 0xdf, 0x95, 0x48, 0x54, 0x72, 0xff, 0x9e);
 
 #ifndef __ZEPHYR__
 /* a5dacb0e-88dc-415c-a1b5-3e8df77f1976 */
-DECLARE_SOF_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
+SOF_DEFINE_UUID("idc-cmd-task", idc_cmd_task_uuid, 0xa5dacb0e, 0x88dc, 0x415c,
 		 0xa1, 0xb5, 0x3e, 0x8d, 0xf7, 0x7f, 0x19, 0x76);
 #endif
 

--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(zephyr_idc, CONFIG_SOF_LOG_LEVEL);
 
 /* 5f1ec3f8-faaf-4099-903c-cee98351f169 */
-SOF_DEFINE_UUID("zephyr-idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
+SOF_DEFINE_UUID("zephyr_idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
 		 0x90, 0x3c, 0xce, 0xe9, 0x83, 0x51, 0xf1, 0x69);
 
 DECLARE_TR_CTX(zephyr_idc_tr, SOF_UUID(zephyr_idc_uuid), LOG_LEVEL_INFO);

--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -35,9 +35,7 @@
 
 LOG_MODULE_REGISTER(zephyr_idc, CONFIG_SOF_LOG_LEVEL);
 
-/* 5f1ec3f8-faaf-4099-903c-cee98351f169 */
-SOF_DEFINE_UUID("zephyr_idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
-		 0x90, 0x3c, 0xce, 0xe9, 0x83, 0x51, 0xf1, 0x69);
+SOF_DEFINE_REG_UUID(zephyr_idc);
 
 DECLARE_TR_CTX(zephyr_idc_tr, SOF_UUID(zephyr_idc_uuid), LOG_LEVEL_INFO);
 

--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(zephyr_idc, CONFIG_SOF_LOG_LEVEL);
 
 /* 5f1ec3f8-faaf-4099-903c-cee98351f169 */
-DECLARE_SOF_UUID("zephyr-idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
+SOF_DEFINE_UUID("zephyr-idc", zephyr_idc_uuid, 0x5f1ec3f8, 0xfaaf, 0x4099,
 		 0x90, 0x3c, 0xce, 0xe9, 0x83, 0x51, 0xf1, 0x69);
 
 DECLARE_TR_CTX(zephyr_idc_tr, SOF_UUID(zephyr_idc_uuid), LOG_LEVEL_INFO);

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -9,6 +9,7 @@
 #define __SOF_LIB_UUID_H__
 
 #include <sof/common.h>
+#include <uuid-registry.h>
 
 #ifdef __ZEPHYR__
 #include <zephyr/sys/iterable_sections.h>
@@ -122,6 +123,18 @@ struct sof_uuid_entry {
 			vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
 	_DEF_UUID(entity_name, uuid_name,			\
 		  _UUID_INIT(va, vb, vc, vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7))
+
+/** \brief Defines UUID sourced from the fixed SOF registry
+ *
+ * As for SOF_DEFINE_UUID(), but the ID value is sourced by name from
+ * the uuid-registry.txt file distributed with the source tree. The
+ * string name field will be identical with the name passed (which is
+ * passed as a symbol!), runtime symbol (e.g. the "uuid_name" argument
+ * to SOF_DEFINE_UUID()) will be the same, postfixed with a "_uuid".
+ *
+ * \param name Name of the UUID, must match an entry in uuid-registry.txt
+ */
+#define SOF_DEFINE_REG_UUID(name) _DEF_UUID(#name, name##_uuid, _UUIDREG_##name)
 
 /** \brief Creates local unique 32-bit representation of UUID structure.
  *

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -35,6 +35,14 @@
  *
  * UUID for a new component may be generated with uuidgen Linux tool, part
  * of the util-linux package.
+ *
+ * FIXME: this struct scheme has an endianness bug.  On BE systems,
+ * the same initialier for the a/b/c fields will produce different
+ * memory layout than on LE systems.  Within C code, that's fine, but
+ * when compared with external representations (c.f. topology) that
+ * pass UUIDs as a linear array of bytes, only one endianness will
+ * work.  If SOF ever ships on a BE system all use of sof_uuid will
+ * need to be modified to byte swap the a/b/c values.
  */
 struct sof_uuid {
 	uint32_t a;
@@ -81,7 +89,7 @@ struct sof_uuid_entry {
 	static const struct sof_uuid_entry uuid_name ## _ldc = {	\
 		{.a = va, .b = vb, .c = vc,				\
 		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
-		entity_name "\0"					\
+		entity_name						\
 	}
 
 /** \brief Declares runtime UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -82,9 +82,9 @@ struct sof_uuid_entry {
  * \param vd6 d6 value.
  * \param vd7 d7 value.
  */
-#define DECLARE_SOF_RT_UUID(entity_name, uuid_name,			\
-			 va, vb, vc,					\
-			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
+#define SOF_DEFINE_UUID(entity_name, uuid_name,				\
+			va, vb, vc,					\
+			vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)		\
 	__section(".static_uuids")					\
 	static const struct sof_uuid_entry uuid_name ## _ldc = {	\
 		{.a = va, .b = vb, .c = vc,				\
@@ -108,9 +108,6 @@ struct sof_uuid_entry {
  * \param uuid_name UUID symbol name declared with DECLARE_SOF_RT_UUID().
  */
 #define SOF_RT_UUID(uuid_name) (&(uuid_name))
-
-#define DECLARE_SOF_UUID(...) DECLARE_SOF_RT_UUID(__VA_ARGS__)
-#define SOF_UUID(uuid_name) (&(uuid_name ## _ldc))
 
 /** @}*/
 

--- a/src/include/sof/lib/uuid.h
+++ b/src/include/sof/lib/uuid.h
@@ -63,35 +63,6 @@ struct sof_uuid_entry {
 	const char name[UUID_NAME_MAX_LEN];
 };
 
-/** \brief Declares UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.
- *
- * UUID value from variables declared with this macro are unaccessible in
- * runtime code - UUID dictionary from ldc file is needed get UUID value.
- *
- * \param entity_name Name of the object pinted by the software tools.
- * \param uuid_name Uuid symbol name used with SOF_UUID().
- * \param va aaaaaaaa value.
- * \param vb bbbb value.
- * \param vc cccc value.
- * \param vd0 d0 value (note how d0 and d1 are grouped in formatted uuid)
- * \param vd1 d1 value.
- * \param vd2 d2 value.
- * \param vd3 d3 value.
- * \param vd4 d4 value.
- * \param vd5 d5 value.
- * \param vd6 d6 value.
- * \param vd7 d7 value.
- */
-#define DECLARE_SOF_UUID(entity_name, uuid_name,			\
-			 va, vb, vc,					\
-			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
-	__section(".static_uuids")					\
-	static const struct sof_uuid_entry uuid_name ## _ldc = {	\
-		{.a = va, .b = vb, .c = vc,				\
-		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
-		entity_name						\
-	}
-
 /** \brief Declares runtime UUID (aaaaaaaa-bbbb-cccc-d0d1-d2d3d4d5d6d7) and name.
  *
  * UUID value from variables declared with this macro are accessible in
@@ -114,9 +85,12 @@ struct sof_uuid_entry {
 #define DECLARE_SOF_RT_UUID(entity_name, uuid_name,			\
 			 va, vb, vc,					\
 			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7)	\
-	DECLARE_SOF_UUID(entity_name, uuid_name,			\
-			 va, vb, vc,					\
-			 vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7);	\
+	__section(".static_uuids")					\
+	static const struct sof_uuid_entry uuid_name ## _ldc = {	\
+		{.a = va, .b = vb, .c = vc,				\
+		 .d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}},	\
+		entity_name						\
+	};								\
 	const struct sof_uuid uuid_name = {				\
 		.a = va, .b = vb, .c = vc,				\
 		.d = {vd0, vd1, vd2, vd3, vd4, vd5, vd6, vd7}		\
@@ -125,7 +99,7 @@ struct sof_uuid_entry {
 /** \brief Creates local unique 32-bit representation of UUID structure.
  *
  * \param uuid_name UUID symbol name declared with DECLARE_SOF_UUID() or
- *		    DECLARE_SOF_RT_UUID().
+ *                 DECLARE_SOF_RT_UUID().
  */
 #define SOF_UUID(uuid_name) (&(uuid_name ## _ldc))
 
@@ -134,6 +108,9 @@ struct sof_uuid_entry {
  * \param uuid_name UUID symbol name declared with DECLARE_SOF_RT_UUID().
  */
 #define SOF_RT_UUID(uuid_name) (&(uuid_name))
+
+#define DECLARE_SOF_UUID(...) DECLARE_SOF_RT_UUID(__VA_ARGS__)
+#define SOF_UUID(uuid_name) (&(uuid_name ## _ldc))
 
 /** @}*/
 

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -20,9 +20,7 @@
 /* tracing */
 LOG_MODULE_REGISTER(dma_copy, CONFIG_SOF_LOG_LEVEL);
 
-/* 729bf8b5-e873-4bf5-9690-8e2a3fd33911 */
-SOF_DEFINE_UUID("dma_copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,
-		 0x96, 0x90, 0x8e, 0x2a, 0x3f, 0xd3, 0x39, 0x11);
+SOF_DEFINE_REG_UUID(dma_copy);
 
 DECLARE_TR_CTX(dmacpy_tr, SOF_UUID(dma_copy_uuid), LOG_LEVEL_INFO);
 

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(dma_copy, CONFIG_SOF_LOG_LEVEL);
 
 /* 729bf8b5-e873-4bf5-9690-8e2a3fd33911 */
-SOF_DEFINE_UUID("dma-copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,
+SOF_DEFINE_UUID("dma_copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,
 		 0x96, 0x90, 0x8e, 0x2a, 0x3f, 0xd3, 0x39, 0x11);
 
 DECLARE_TR_CTX(dmacpy_tr, SOF_UUID(dma_copy_uuid), LOG_LEVEL_INFO);

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(dma_copy, CONFIG_SOF_LOG_LEVEL);
 
 /* 729bf8b5-e873-4bf5-9690-8e2a3fd33911 */
-DECLARE_SOF_UUID("dma-copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,
+SOF_DEFINE_UUID("dma-copy", dma_copy_uuid, 0x729bf8b5, 0xe873, 0x4bf5,
 		 0x96, 0x90, 0x8e, 0x2a, 0x3f, 0xd3, 0x39, 0x11);
 
 DECLARE_TR_CTX(dmacpy_tr, SOF_UUID(dma_copy_uuid), LOG_LEVEL_INFO);

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -34,9 +34,7 @@
 
 LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
 
-/* be60f97d-78df-4796-a0ee-435cb56b720a */
-SOF_DEFINE_UUID("ipc", ipc_uuid, 0xbe60f97d, 0x78df, 0x4796,
-		 0xa0, 0xee, 0x43, 0x5c, 0xb5, 0x6b, 0x72, 0x0a);
+SOF_DEFINE_REG_UUID(ipc);
 
 DECLARE_TR_CTX(ipc_tr, SOF_UUID(ipc_uuid), LOG_LEVEL_INFO);
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -35,7 +35,7 @@
 LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
 
 /* be60f97d-78df-4796-a0ee-435cb56b720a */
-DECLARE_SOF_UUID("ipc", ipc_uuid, 0xbe60f97d, 0x78df, 0x4796,
+SOF_DEFINE_UUID("ipc", ipc_uuid, 0xbe60f97d, 0x78df, 0x4796,
 		 0xa0, 0xee, 0x43, 0x5c, 0xb5, 0x6b, 0x72, 0x0a);
 
 DECLARE_TR_CTX(ipc_tr, SOF_UUID(ipc_uuid), LOG_LEVEL_INFO);

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -42,9 +42,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* 8fa1d42f-bc6f-464b-867f-547af08834da */
-SOF_DEFINE_UUID("zipc_task", zipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
-		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
+SOF_DEFINE_REG_UUID(zipc_task);
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -43,7 +43,7 @@
 #include <stdint.h>
 
 /* 8fa1d42f-bc6f-464b-867f-547af08834da */
-SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
 		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -43,7 +43,7 @@
 #include <stdint.h>
 
 /* 8fa1d42f-bc6f-464b-867f-547af08834da */
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
+SOF_DEFINE_UUID("zipc_task", zipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
 		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
@@ -162,7 +162,7 @@ static int ipc_device_resume_handler(const struct device *dev, void *arg)
 	intel_adsp_ipc_set_message_handler(INTEL_ADSP_IPC_HOST_DEV, message_handler, ipc);
 
 	/* schedule task */
-	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(zipc_task_uuid),
 			       &ipc_task_ops, ipc, 0, 0);
 
 	return 0;
@@ -280,7 +280,7 @@ int platform_ipc_init(struct ipc *ipc)
 	ipc_set_drvdata(ipc, NULL);
 
 	/* schedule task */
-	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(zipc_task_uuid),
 			       &ipc_task_ops, ipc, 0, 0);
 
 	/* configure interrupt - work is done internally by Zephyr API */

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -43,7 +43,7 @@
 #include <stdint.h>
 
 /* 8fa1d42f-bc6f-464b-867f-547af08834da */
-DECLARE_SOF_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
+SOF_DEFINE_UUID("ipc-task", ipc_task_uuid, 0x8fa1d42f, 0xbc6f, 0x464b,
 		 0x86, 0x7f, 0x54, 0x7a, 0xf0, 0x88, 0x34, 0xda);
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);

--- a/src/ipc/ipc4/logging.c
+++ b/src/ipc/ipc4/logging.c
@@ -51,9 +51,7 @@ LOG_MODULE_REGISTER(mtrace, CONFIG_SOF_LOG_LEVEL);
  */
 #define IPC4_MTRACE_AGING_TIMER_MIN_MS 100
 
-/* bb2aa22e-1ab6-4650-8501-6e67fcc04f4e */
-SOF_DEFINE_UUID("mtrace_task", mtrace_task_uuid, 0xbb2aa22e, 0x1ab6, 0x4650,
-		 0x85, 0x01, 0x6e, 0x67, 0xfc, 0xc0, 0x4f, 0x4e);
+SOF_DEFINE_REG_UUID(mtrace_task);
 
 static uint64_t mtrace_notify_last_sent;
 

--- a/src/ipc/ipc4/logging.c
+++ b/src/ipc/ipc4/logging.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(mtrace, CONFIG_SOF_LOG_LEVEL);
 #define IPC4_MTRACE_AGING_TIMER_MIN_MS 100
 
 /* bb2aa22e-1ab6-4650-8501-6e67fcc04f4e */
-DECLARE_SOF_UUID("mtrace-task", mtrace_task_uuid, 0xbb2aa22e, 0x1ab6, 0x4650,
+SOF_DEFINE_UUID("mtrace-task", mtrace_task_uuid, 0xbb2aa22e, 0x1ab6, 0x4650,
 		 0x85, 0x01, 0x6e, 0x67, 0xfc, 0xc0, 0x4f, 0x4e);
 
 static uint64_t mtrace_notify_last_sent;

--- a/src/ipc/ipc4/logging.c
+++ b/src/ipc/ipc4/logging.c
@@ -52,7 +52,7 @@ LOG_MODULE_REGISTER(mtrace, CONFIG_SOF_LOG_LEVEL);
 #define IPC4_MTRACE_AGING_TIMER_MIN_MS 100
 
 /* bb2aa22e-1ab6-4650-8501-6e67fcc04f4e */
-SOF_DEFINE_UUID("mtrace-task", mtrace_task_uuid, 0xbb2aa22e, 0x1ab6, 0x4650,
+SOF_DEFINE_UUID("mtrace_task", mtrace_task_uuid, 0xbb2aa22e, 0x1ab6, 0x4650,
 		 0x85, 0x01, 0x6e, 0x67, 0xfc, 0xc0, 0x4f, 0x4e);
 
 static uint64_t mtrace_notify_last_sent;

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -37,15 +37,11 @@
 
 LOG_MODULE_REGISTER(sa, CONFIG_SOF_LOG_LEVEL);
 
-/* 5276b491-5b64-464e-8984-dc228ef9e6a1 */
-SOF_DEFINE_UUID("sa", sa_uuid, 0x5276b491, 0x5b64, 0x464e,
-		 0x89, 0x84, 0xdc, 0x22, 0x8e, 0xf9, 0xe6, 0xa1);
+SOF_DEFINE_REG_UUID(sa);
 
 DECLARE_TR_CTX(sa_tr, SOF_UUID(sa_uuid), LOG_LEVEL_INFO);
 
-/* c63c4e75-8f61-4420-9319-1395932efa9e */
-SOF_DEFINE_UUID("agent_work", agent_work_uuid, 0xc63c4e75, 0x8f61, 0x4420,
-		 0x93, 0x19, 0x13, 0x95, 0x93, 0x2e, 0xfa, 0x9e);
+SOF_DEFINE_REG_UUID(agent_work);
 
 #if CONFIG_PERFORMANCE_COUNTERS
 static void perf_sa_trace(struct perf_cnt_data *pcd, int ignored)

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -44,7 +44,7 @@ SOF_DEFINE_UUID("sa", sa_uuid, 0x5276b491, 0x5b64, 0x464e,
 DECLARE_TR_CTX(sa_tr, SOF_UUID(sa_uuid), LOG_LEVEL_INFO);
 
 /* c63c4e75-8f61-4420-9319-1395932efa9e */
-SOF_DEFINE_UUID("agent-work", agent_work_task_uuid, 0xc63c4e75, 0x8f61, 0x4420,
+SOF_DEFINE_UUID("agent_work", agent_work_uuid, 0xc63c4e75, 0x8f61, 0x4420,
 		 0x93, 0x19, 0x13, 0x95, 0x93, 0x2e, 0xfa, 0x9e);
 
 #if CONFIG_PERFORMANCE_COUNTERS
@@ -128,7 +128,7 @@ void sa_init(struct sof *sof, uint64_t timeout)
 			(unsigned int)ticks, (unsigned int)sof->sa->warn_timeout,
 			(unsigned int)sof->sa->panic_timeout);
 
-	schedule_task_init_ll(&sof->sa->work, SOF_UUID(agent_work_task_uuid),
+	schedule_task_init_ll(&sof->sa->work, SOF_UUID(agent_work_uuid),
 			      SOF_SCHEDULE_LL_TIMER,
 			      SOF_TASK_PRI_HIGH, validate, sof->sa, 0, 0);
 

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -38,13 +38,13 @@
 LOG_MODULE_REGISTER(sa, CONFIG_SOF_LOG_LEVEL);
 
 /* 5276b491-5b64-464e-8984-dc228ef9e6a1 */
-DECLARE_SOF_UUID("sa", sa_uuid, 0x5276b491, 0x5b64, 0x464e,
+SOF_DEFINE_UUID("sa", sa_uuid, 0x5276b491, 0x5b64, 0x464e,
 		 0x89, 0x84, 0xdc, 0x22, 0x8e, 0xf9, 0xe6, 0xa1);
 
 DECLARE_TR_CTX(sa_tr, SOF_UUID(sa_uuid), LOG_LEVEL_INFO);
 
 /* c63c4e75-8f61-4420-9319-1395932efa9e */
-DECLARE_SOF_UUID("agent-work", agent_work_task_uuid, 0xc63c4e75, 0x8f61, 0x4420,
+SOF_DEFINE_UUID("agent-work", agent_work_task_uuid, 0xc63c4e75, 0x8f61, 0x4420,
 		 0x93, 0x19, 0x13, 0x95, 0x93, 0x2e, 0xfa, 0x9e);
 
 #if CONFIG_PERFORMANCE_COUNTERS

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -27,7 +27,7 @@
 LOG_MODULE_REGISTER(memory, CONFIG_SOF_LOG_LEVEL);
 
 /* 425d6e68-145c-4455-b0b2-c7260b0600a5 */
-DECLARE_SOF_UUID("memory", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
+SOF_DEFINE_UUID("memory", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
 		 0xb0, 0xb2, 0xc7, 0x26, 0x0b, 0x06, 0x00, 0xa5);
 
 DECLARE_TR_CTX(mem_tr, SOF_UUID(mem_uuid), LOG_LEVEL_INFO);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -27,7 +27,7 @@
 LOG_MODULE_REGISTER(memory, CONFIG_SOF_LOG_LEVEL);
 
 /* 425d6e68-145c-4455-b0b2-c7260b0600a5 */
-SOF_DEFINE_UUID("memory", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
+SOF_DEFINE_UUID("mem", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
 		 0xb0, 0xb2, 0xc7, 0x26, 0x0b, 0x06, 0x00, 0xa5);
 
 DECLARE_TR_CTX(mem_tr, SOF_UUID(mem_uuid), LOG_LEVEL_INFO);

--- a/src/lib/alloc.c
+++ b/src/lib/alloc.c
@@ -26,9 +26,7 @@
 
 LOG_MODULE_REGISTER(memory, CONFIG_SOF_LOG_LEVEL);
 
-/* 425d6e68-145c-4455-b0b2-c7260b0600a5 */
-SOF_DEFINE_UUID("mem", mem_uuid, 0x425d6e68, 0x145c, 0x4455,
-		 0xb0, 0xb2, 0xc7, 0x26, 0x0b, 0x06, 0x00, 0xa5);
+SOF_DEFINE_REG_UUID(mem);
 
 DECLARE_TR_CTX(mem_tr, SOF_UUID(mem_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/ams.c
+++ b/src/lib/ams.c
@@ -26,8 +26,7 @@
 
 LOG_MODULE_REGISTER(ams, CONFIG_SOF_LOG_LEVEL);
 
-SOF_DEFINE_UUID("ams", ams_uuid, 0xea9c4bca, 0x5b7d, 0x48c6,
-		 0x95, 0x86, 0x55, 0x3e, 0x27, 0x23, 0x5b, 0xeb);
+SOF_DEFINE_REG_UUID(ams);
 
 DECLARE_TR_CTX(ams_tr, SOF_UUID(ams_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/ams.c
+++ b/src/lib/ams.c
@@ -26,7 +26,7 @@
 
 LOG_MODULE_REGISTER(ams, CONFIG_SOF_LOG_LEVEL);
 
-DECLARE_SOF_UUID("ams", ams_uuid, 0xea9c4bca, 0x5b7d, 0x48c6,
+SOF_DEFINE_UUID("ams", ams_uuid, 0xea9c4bca, 0x5b7d, 0x48c6,
 		 0x95, 0x86, 0x55, 0x3e, 0x27, 0x23, 0x5b, 0xeb);
 
 DECLARE_TR_CTX(ams_tr, SOF_UUID(ams_uuid), LOG_LEVEL_INFO);

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -20,9 +20,7 @@
 
 LOG_MODULE_REGISTER(clock, CONFIG_SOF_LOG_LEVEL);
 
-/* 8890ea76-0df9-44ae-87e6-994f4c15e9fa */
-SOF_DEFINE_UUID("clock", clock_uuid, 0x8890ea76, 0x0df9, 0x44ae,
-		 0x87, 0xe6, 0x99, 0x4f, 0x4c, 0x15, 0xe9, 0xfa);
+SOF_DEFINE_REG_UUID(clock);
 
 DECLARE_TR_CTX(clock_tr, SOF_UUID(clock_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -21,7 +21,7 @@
 LOG_MODULE_REGISTER(clock, CONFIG_SOF_LOG_LEVEL);
 
 /* 8890ea76-0df9-44ae-87e6-994f4c15e9fa */
-DECLARE_SOF_UUID("clock", clock_uuid, 0x8890ea76, 0x0df9, 0x44ae,
+SOF_DEFINE_UUID("clock", clock_uuid, 0x8890ea76, 0x0df9, 0x44ae,
 		 0x87, 0xe6, 0x99, 0x4f, 0x4c, 0x15, 0xe9, 0xfa);
 
 DECLARE_TR_CTX(clock_tr, SOF_UUID(clock_uuid), LOG_LEVEL_INFO);

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -25,7 +25,7 @@
 LOG_MODULE_REGISTER(dai, CONFIG_SOF_LOG_LEVEL);
 
 /* 06711c94-d37d-4a76-b302-bbf6944fdd2b */
-DECLARE_SOF_UUID("dai", dai_uuid, 0x06711c94, 0xd37d, 0x4a76,
+SOF_DEFINE_UUID("dai", dai_uuid, 0x06711c94, 0xd37d, 0x4a76,
 		 0xb3, 0x02, 0xbb, 0xf6, 0x94, 0x4f, 0xdd, 0x2b);
 
 DECLARE_TR_CTX(dai_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -25,10 +25,10 @@
 LOG_MODULE_REGISTER(dai, CONFIG_SOF_LOG_LEVEL);
 
 /* 06711c94-d37d-4a76-b302-bbf6944fdd2b */
-SOF_DEFINE_UUID("dai", dai_uuid, 0x06711c94, 0xd37d, 0x4a76,
+SOF_DEFINE_UUID("dai_lib", dai_lib_uuid, 0x06711c94, 0xd37d, 0x4a76,
 		 0xb3, 0x02, 0xbb, 0xf6, 0x94, 0x4f, 0xdd, 0x2b);
 
-DECLARE_TR_CTX(dai_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(dai_tr, SOF_UUID(dai_lib_uuid), LOG_LEVEL_INFO);
 
 struct dai_group_list {
 	struct list_item list;

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -24,9 +24,7 @@
 #endif
 LOG_MODULE_REGISTER(dai, CONFIG_SOF_LOG_LEVEL);
 
-/* 06711c94-d37d-4a76-b302-bbf6944fdd2b */
-SOF_DEFINE_UUID("dai_lib", dai_lib_uuid, 0x06711c94, 0xd37d, 0x4a76,
-		 0xb3, 0x02, 0xbb, 0xf6, 0x94, 0x4f, 0xdd, 0x2b);
+SOF_DEFINE_REG_UUID(dai_lib);
 
 DECLARE_TR_CTX(dai_tr, SOF_UUID(dai_lib_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -22,9 +22,7 @@
 
 LOG_MODULE_REGISTER(dma, CONFIG_SOF_LOG_LEVEL);
 
-/* bc3526a7-9b86-4ab4-84a5-2e02ae70cc10 */
-SOF_DEFINE_UUID("dma", dma_uuid, 0xbc3526a7, 0x9b86, 0x4ab4,
-		 0x84, 0xa5, 0x2e, 0x02, 0xae, 0x70, 0xcc, 0x10);
+SOF_DEFINE_REG_UUID(dma);
 
 DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -23,7 +23,7 @@
 LOG_MODULE_REGISTER(dma, CONFIG_SOF_LOG_LEVEL);
 
 /* bc3526a7-9b86-4ab4-84a5-2e02ae70cc10 */
-DECLARE_SOF_UUID("dma", dma_uuid, 0xbc3526a7, 0x9b86, 0x4ab4,
+SOF_DEFINE_UUID("dma", dma_uuid, 0xbc3526a7, 0x9b86, 0x4ab4,
 		 0x84, 0xa5, 0x2e, 0x02, 0xae, 0x70, 0xcc, 0x10);
 
 DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(notifier, CONFIG_SOF_LOG_LEVEL);
 
 /* 1fb15a7a-83cd-4c2e-8b32-4da1b2adeeaf */
-DECLARE_SOF_UUID("notifier", notifier_uuid, 0x1fb15a7a, 0x83cd, 0x4c2e,
+SOF_DEFINE_UUID("notifier", notifier_uuid, 0x1fb15a7a, 0x83cd, 0x4c2e,
 		 0x8b, 0x32, 0x4d, 0xa1, 0xb2, 0xad, 0xee, 0xaf);
 
 DECLARE_TR_CTX(nt_tr, SOF_UUID(notifier_uuid), LOG_LEVEL_INFO);

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -21,9 +21,7 @@
 
 LOG_MODULE_REGISTER(notifier, CONFIG_SOF_LOG_LEVEL);
 
-/* 1fb15a7a-83cd-4c2e-8b32-4da1b2adeeaf */
-SOF_DEFINE_UUID("notifier", notifier_uuid, 0x1fb15a7a, 0x83cd, 0x4c2e,
-		 0x8b, 0x32, 0x4d, 0xa1, 0xb2, 0xad, 0xee, 0xaf);
+SOF_DEFINE_REG_UUID(notifier);
 
 DECLARE_TR_CTX(nt_tr, SOF_UUID(notifier_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -27,7 +27,7 @@
 LOG_MODULE_REGISTER(pm_runtime, CONFIG_SOF_LOG_LEVEL);
 
 /* d7f6712d-131c-45a7-82ed-6aa9dc2291ea */
-DECLARE_SOF_UUID("pm-runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
+SOF_DEFINE_UUID("pm-runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
 		 0x82, 0xed, 0x6a, 0xa9, 0xdc, 0x22, 0x91, 0xea);
 
 DECLARE_TR_CTX(pm_tr, SOF_UUID(pm_runtime_uuid), LOG_LEVEL_INFO);

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -26,9 +26,7 @@
 
 LOG_MODULE_REGISTER(pm_runtime, CONFIG_SOF_LOG_LEVEL);
 
-/* d7f6712d-131c-45a7-82ed-6aa9dc2291ea */
-SOF_DEFINE_UUID("pm_runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
-		 0x82, 0xed, 0x6a, 0xa9, 0xdc, 0x22, 0x91, 0xea);
+SOF_DEFINE_REG_UUID(pm_runtime);
 
 DECLARE_TR_CTX(pm_tr, SOF_UUID(pm_runtime_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/pm_runtime.c
+++ b/src/lib/pm_runtime.c
@@ -27,7 +27,7 @@
 LOG_MODULE_REGISTER(pm_runtime, CONFIG_SOF_LOG_LEVEL);
 
 /* d7f6712d-131c-45a7-82ed-6aa9dc2291ea */
-SOF_DEFINE_UUID("pm-runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
+SOF_DEFINE_UUID("pm_runtime", pm_runtime_uuid, 0xd7f6712d, 0x131c, 0x45a7,
 		 0x82, 0xed, 0x6a, 0xa9, 0xdc, 0x22, 0x91, 0xea);
 
 DECLARE_TR_CTX(pm_tr, SOF_UUID(pm_runtime_uuid), LOG_LEVEL_INFO);

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -22,9 +22,7 @@
 
 LOG_MODULE_REGISTER(wait, CONFIG_SOF_LOG_LEVEL);
 
-/* 1028070e-04e8-46ab-8d81-10a0116ce738 */
-SOF_DEFINE_UUID("wait", wait_uuid, 0x1028070e, 0x04e8, 0x46ab,
-		 0x8d, 0x81, 0x10, 0xa0, 0x11, 0x6c, 0xe7, 0x38);
+SOF_DEFINE_REG_UUID(wait);
 
 DECLARE_TR_CTX(wait_tr, SOF_UUID(wait_uuid), LOG_LEVEL_INFO);
 

--- a/src/lib/wait.c
+++ b/src/lib/wait.c
@@ -23,7 +23,7 @@
 LOG_MODULE_REGISTER(wait, CONFIG_SOF_LOG_LEVEL);
 
 /* 1028070e-04e8-46ab-8d81-10a0116ce738 */
-DECLARE_SOF_UUID("wait", wait_uuid, 0x1028070e, 0x04e8, 0x46ab,
+SOF_DEFINE_UUID("wait", wait_uuid, 0x1028070e, 0x04e8, 0x46ab,
 		 0x8d, 0x81, 0x10, 0xa0, 0x11, 0x6c, 0xe7, 0x38);
 
 DECLARE_TR_CTX(wait_tr, SOF_UUID(wait_uuid), LOG_LEVEL_INFO);

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -45,8 +45,7 @@
 LOG_MODULE_REGISTER(lib_manager, CONFIG_SOF_LOG_LEVEL);
 /* 54cf5598-8b29-11ec-a8a3-0242ac120002 */
 
-SOF_DEFINE_UUID("lib_manager", lib_manager_uuid, 0x54cf5598, 0x8b29, 0x11ec,
-		 0xa8, 0xa3, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
+SOF_DEFINE_REG_UUID(lib_manager);
 
 DECLARE_TR_CTX(lib_manager_tr, SOF_UUID(lib_manager_uuid), LOG_LEVEL_INFO);
 

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -45,7 +45,7 @@
 LOG_MODULE_REGISTER(lib_manager, CONFIG_SOF_LOG_LEVEL);
 /* 54cf5598-8b29-11ec-a8a3-0242ac120002 */
 
-DECLARE_SOF_UUID("lib_manager", lib_manager_uuid, 0x54cf5598, 0x8b29, 0x11ec,
+SOF_DEFINE_UUID("lib_manager", lib_manager_uuid, 0x54cf5598, 0x8b29, 0x11ec,
 		 0xa8, 0xa3, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02);
 
 DECLARE_TR_CTX(lib_manager_tr, SOF_UUID(lib_manager_uuid), LOG_LEVEL_INFO);

--- a/src/math/power.c
+++ b/src/math/power.c
@@ -15,9 +15,7 @@
 #include <user/trace.h>
 #include <stdint.h>
 
-/* d23cf8d0-8dfe-497c-8202-5f909cf72735 */
-SOF_DEFINE_UUID("math_power", math_power_uuid, 0xd23cf8d0, 0x8dfe, 0x497c,
-		 0x82, 0x02, 0x5f, 0x90, 0x9c, 0xf7, 0x27, 0x35);
+SOF_DEFINE_REG_UUID(math_power);
 
 DECLARE_TR_CTX(math_power_tr, SOF_UUID(math_power_uuid), LOG_LEVEL_INFO);
 /* define constant */

--- a/src/math/power.c
+++ b/src/math/power.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 
 /* d23cf8d0-8dfe-497c-8202-5f909cf72735 */
-DECLARE_SOF_UUID("math_power", math_power_uuid, 0xd23cf8d0, 0x8dfe, 0x497c,
+SOF_DEFINE_UUID("math_power", math_power_uuid, 0xd23cf8d0, 0x8dfe, 0x497c,
 		 0x82, 0x02, 0x5f, 0x90, 0x9c, 0xf7, 0x27, 0x35);
 
 DECLARE_TR_CTX(math_power_tr, SOF_UUID(math_power_uuid), LOG_LEVEL_INFO);

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -41,7 +41,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp-clk", acp_clk_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp_clk", acp_clk_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -41,7 +41,7 @@
 #include <platform/chip_registers.h>
 
 /*b414df09-9e31-4c59-8657-7afc8deba70c*/
-DECLARE_SOF_UUID("acp-clk", acp_clk_uuid, 0xb414df09, 0x9e31, 0x4c59,
+SOF_DEFINE_UUID("acp-clk", acp_clk_uuid, 0xb414df09, 0x9e31, 0x4c59,
 		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -40,9 +40,7 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/* f8a7091c-7d2d-4410-9bb5-55278378d59f */
-SOF_DEFINE_UUID("acp_clk", acp_clk_uuid, 0xf8a7091c, 0x7d2d, 0x4410,
-		0x9b, 0xb5, 0x55, 0x27, 0x83, 0x78, 0xd5, 0x9f);
+SOF_DEFINE_REG_UUID(acp_clk);
 
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -40,9 +40,10 @@
 #include <platform/fw_scratch_mem.h>
 #include <platform/chip_registers.h>
 
-/*b414df09-9e31-4c59-8657-7afc8deba70c*/
-SOF_DEFINE_UUID("acp_clk", acp_clk_uuid, 0xb414df09, 0x9e31, 0x4c59,
-		 0x86, 0x57, 0x7a, 0xfc, 0x8d, 0xeb, 0xa7, 0x0c);
+/* f8a7091c-7d2d-4410-9bb5-55278378d59f */
+SOF_DEFINE_UUID("acp_clk", acp_clk_uuid, 0xf8a7091c, 0x7d2d, 0x4410,
+		0x9b, 0xb5, 0x55, 0x27, 0x83, 0x78, 0xd5, 0x9f);
+
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/intel/ace/lib/watchdog.c
+++ b/src/platform/intel/ace/lib/watchdog.c
@@ -21,9 +21,7 @@
 
 LOG_MODULE_REGISTER(wdt, CONFIG_SOF_LOG_LEVEL);
 
-/* 13c8bc59-c4fa-4ad1-b93a-ce97cd30acc7 */
-SOF_DEFINE_UUID("wdt", wdt_uuid, 0x13c8bc59, 0xc4fa, 0x4ad1,
-		 0xb9, 0x3a, 0xce, 0x97, 0xcd, 0x30, 0xac, 0xc7);
+SOF_DEFINE_REG_UUID(wdt);
 
 DECLARE_TR_CTX(wdt_tr, SOF_UUID(wdt_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/intel/ace/lib/watchdog.c
+++ b/src/platform/intel/ace/lib/watchdog.c
@@ -22,7 +22,7 @@
 LOG_MODULE_REGISTER(wdt, CONFIG_SOF_LOG_LEVEL);
 
 /* 13c8bc59-c4fa-4ad1-b93a-ce97cd30acc7 */
-DECLARE_SOF_UUID("wdt", wdt_uuid, 0x13c8bc59, 0xc4fa, 0x4ad1,
+SOF_DEFINE_UUID("wdt", wdt_uuid, 0x13c8bc59, 0xc4fa, 0x4ad1,
 		 0xb9, 0x3a, 0xce, 0x97, 0xcd, 0x30, 0xac, 0xc7);
 
 DECLARE_TR_CTX(wdt_tr, SOF_UUID(wdt_uuid), LOG_LEVEL_INFO);

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -13,9 +13,7 @@
 
  /* scheduler testbench definition */
 
-/* 5dbc3672-e290-43d8-91f8-81aafe453d5b */
-SOF_DEFINE_UUID("edf_sched_lib", edf_sched_lib_uuid, 0x5dbc3672, 0xe290, 0x43d8,
-		0x91, 0xf8, 0x81, 0xaa, 0xfe, 0x45, 0x3d, 0x5b);
+SOF_DEFINE_REG_UUID(edf_sched_lib);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_lib_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -13,11 +13,11 @@
 
  /* scheduler testbench definition */
 
-/* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("edf_sched", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
-		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
+/* 5dbc3672-e290-43d8-91f8-81aafe453d5b */
+SOF_DEFINE_UUID("edf_sched_lib", edf_sched_lib_uuid, 0x5dbc3672, 0xe290, 0x43d8,
+		0x91, 0xf8, 0x81, 0xaa, 0xfe, 0x45, 0x3d, 0x5b);
 
-DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_lib_uuid), LOG_LEVEL_INFO);
 
 struct edf_schedule_data {
 	struct list_item list; /* list of tasks in priority queue */

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -14,7 +14,7 @@
  /* scheduler testbench definition */
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("edf_sched", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);

--- a/src/platform/library/schedule/edf_schedule.c
+++ b/src/platform/library/schedule/edf_schedule.c
@@ -14,7 +14,7 @@
  /* scheduler testbench definition */
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-DECLARE_SOF_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -20,9 +20,9 @@
 
  /* scheduler testbench definition */
 
-/* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("ll_sched_lib", ll_sched_lib_uuid, 0x77de2074, 0x828c, 0x4044,
-		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
+/* 9f130ed8-2bbf-421c-836a-d5269147c9e7 */
+SOF_DEFINE_UUID("ll_sched_lib", ll_sched_lib_uuid, 0x9f130ed8, 0x2bbf, 0x421c,
+		0x83, 0x6a, 0xd5, 0x26, 0x91, 0x47, 0xc9, 0xe7);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_lib_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -21,7 +21,7 @@
  /* scheduler testbench definition */
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-DECLARE_SOF_UUID("ll-schedule", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("ll-schedule", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -20,9 +20,7 @@
 
  /* scheduler testbench definition */
 
-/* 9f130ed8-2bbf-421c-836a-d5269147c9e7 */
-SOF_DEFINE_UUID("ll_sched_lib", ll_sched_lib_uuid, 0x9f130ed8, 0x2bbf, 0x421c,
-		0x83, 0x6a, 0xd5, 0x26, 0x91, 0x47, 0xc9, 0xe7);
+SOF_DEFINE_REG_UUID(ll_sched_lib);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_lib_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -21,7 +21,7 @@
  /* scheduler testbench definition */
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("ll-schedule", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("ll_sched", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/platform/library/schedule/ll_schedule.c
+++ b/src/platform/library/schedule/ll_schedule.c
@@ -21,10 +21,10 @@
  /* scheduler testbench definition */
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("ll_sched", ll_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("ll_sched_lib", ll_sched_lib_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
-DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_lib_uuid), LOG_LEVEL_INFO);
 
 /* list of all tasks */
 static struct list_item sched_list;

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -19,7 +19,7 @@
 #include <sof/trace/trace.h>
 
 /* 53863428-9a72-44df-af0f-fe45ea2348ba */
-DECLARE_SOF_UUID("clkdrv", clkdrv_uuid, 0x53863428, 0x9a72, 0x44df,
+SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x53863428, 0x9a72, 0x44df,
 		 0xaf, 0x0f, 0xfe, 0x45, 0xea, 0x23, 0x48, 0xba);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -19,10 +19,10 @@
 #include <sof/trace/trace.h>
 
 /* 53863428-9a72-44df-af0f-fe45ea2348ba */
-SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x53863428, 0x9a72, 0x44df,
+SOF_DEFINE_UUID("clkdrv_mt8186", clkdrv_mt8186_uuid, 0x53863428, 0x9a72, 0x44df,
 		 0xaf, 0x0f, 0xfe, 0x45, 0xea, 0x23, 0x48, 0xba);
 
-DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8186_uuid), LOG_LEVEL_INFO);
 
 /* default voltage is 0.8V */
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -18,9 +18,7 @@
 #include <rtos/sof.h>
 #include <sof/trace/trace.h>
 
-/* 53863428-9a72-44df-af0f-fe45ea2348ba */
-SOF_DEFINE_UUID("clkdrv_mt8186", clkdrv_mt8186_uuid, 0x53863428, 0x9a72, 0x44df,
-		 0xaf, 0x0f, 0xfe, 0x45, 0xea, 0x23, 0x48, 0xba);
+SOF_DEFINE_REG_UUID(clkdrv_mt8186);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8186_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -18,9 +18,7 @@
 #include <rtos/sof.h>
 #include <sof/trace/trace.h>
 
-/* 19d4e680-4479-48cc-af86-9f63d8b0098b */
-SOF_DEFINE_UUID("clkdrv_mt8188", clkdrv_mt8188_uuid, 0x19d4e680, 0x4479, 0x48cc,
-		 0xaf, 0x86, 0x9f, 0x63, 0xd8, 0xb0, 0x09, 0x8b);
+SOF_DEFINE_REG_UUID(clkdrv_mt8188);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8188_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -19,7 +19,7 @@
 #include <sof/trace/trace.h>
 
 /* 19d4e680-4479-48cc-af86-9f63d8b0098b */
-DECLARE_SOF_UUID("clkdrv", clkdrv_uuid, 0x19d4e680, 0x4479, 0x48cc,
+SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x19d4e680, 0x4479, 0x48cc,
 		 0xaf, 0x86, 0x9f, 0x63, 0xd8, 0xb0, 0x09, 0x8b);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -19,10 +19,10 @@
 #include <sof/trace/trace.h>
 
 /* 19d4e680-4479-48cc-af86-9f63d8b0098b */
-SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x19d4e680, 0x4479, 0x48cc,
+SOF_DEFINE_UUID("clkdrv_mt8188", clkdrv_mt8188_uuid, 0x19d4e680, 0x4479, 0x48cc,
 		 0xaf, 0x86, 0x9f, 0x63, 0xd8, 0xb0, 0x09, 0x8b);
 
-DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8188_uuid), LOG_LEVEL_INFO);
 
 /* default voltage is 0.75V */
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -14,7 +14,7 @@
 #include <rtos/wait.h>
 #include <rtos/sof.h>
 
-DECLARE_SOF_UUID("clkdrv", clkdrv_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
+SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
 		 0xa2, 0xb3, 0x23, 0x1a, 0xb7, 0xdc, 0xdc, 0x70);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -14,10 +14,10 @@
 #include <rtos/wait.h>
 #include <rtos/sof.h>
 
-SOF_DEFINE_UUID("clkdrv", clkdrv_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
+SOF_DEFINE_UUID("clkdrv_mt8195", clkdrv_mt8195_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
 		 0xa2, 0xb3, 0x23, 0x1a, 0xb7, 0xdc, 0xdc, 0x70);
 
-DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8195_uuid), LOG_LEVEL_INFO);
 
 static int dsppll_enable; /* default no adsp clock*/
 static int adsp_clock;

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -14,8 +14,7 @@
 #include <rtos/wait.h>
 #include <rtos/sof.h>
 
-SOF_DEFINE_UUID("clkdrv_mt8195", clkdrv_mt8195_uuid, 0x23b12fd5, 0xc2a9, 0x41a8,
-		 0xa2, 0xb3, 0x23, 0x1a, 0xb7, 0xdc, 0xdc, 0x70);
+SOF_DEFINE_REG_UUID(clkdrv_mt8195);
 
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8195_uuid), LOG_LEVEL_INFO);
 

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -10,7 +10,7 @@
 #include <sof/audio/component_ext.h>
 
 // 6c8f0d53-ff77-4ca1-b825-c0c4e1b0d322
-SOF_DEFINE_UUID("posix-ipc-task", ipc_task_uuid,
+SOF_DEFINE_UUID("ipc_task", ipc_task_uuid,
 		 0x6c8f0d53, 0xff77, 0x4ca1,
 		 0xb8, 0x25, 0xc0, 0xc4, 0xe1, 0xb0, 0xd3, 0x22);
 

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -10,7 +10,7 @@
 #include <sof/audio/component_ext.h>
 
 // 6c8f0d53-ff77-4ca1-b825-c0c4e1b0d322
-SOF_DEFINE_UUID("ipc_task", ipc_task_uuid,
+SOF_DEFINE_UUID("ipc_task_posix", ipc_task_posix_uuid,
 		 0x6c8f0d53, 0xff77, 0x4ca1,
 		 0xb8, 0x25, 0xc0, 0xc4, 0xe1, 0xb0, 0xd3, 0x22);
 
@@ -207,7 +207,7 @@ int platform_ipc_init(struct ipc *ipc)
 	irq_enable(CONFIG_ZEPHYR_POSIX_FUZZ_IRQ);
 
 	global_ipc = ipc;
-	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_uuid),
+	schedule_task_init_edf(&ipc->ipc_task, SOF_UUID(ipc_task_posix_uuid),
 			       &ipc_task_ops, ipc, 0, 0);
 
 	return 0;

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -10,7 +10,7 @@
 #include <sof/audio/component_ext.h>
 
 // 6c8f0d53-ff77-4ca1-b825-c0c4e1b0d322
-DECLARE_SOF_UUID("posix-ipc-task", ipc_task_uuid,
+SOF_DEFINE_UUID("posix-ipc-task", ipc_task_uuid,
 		 0x6c8f0d53, 0xff77, 0x4ca1,
 		 0xb8, 0x25, 0xc0, 0xc4, 0xe1, 0xb0, 0xd3, 0x22);
 

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -10,9 +10,7 @@
 #include <sof/audio/component_ext.h>
 
 // 6c8f0d53-ff77-4ca1-b825-c0c4e1b0d322
-SOF_DEFINE_UUID("ipc_task_posix", ipc_task_posix_uuid,
-		 0x6c8f0d53, 0xff77, 0x4ca1,
-		 0xb8, 0x25, 0xc0, 0xc4, 0xe1, 0xb0, 0xd3, 0x22);
+SOF_DEFINE_REG_UUID(ipc_task_posix);
 
 static struct ipc *global_ipc;
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -30,13 +30,13 @@
 #include <sof/ut.h>
 
 /* 7CAD0808-AB10-CD23-EF45-12AB34CD56EF */
-DECLARE_SOF_RT_UUID("probe", probe_uuid, 0x7CAD0808, 0xAB10, 0xCD23,
+SOF_DEFINE_UUID("probe", probe_uuid, 0x7CAD0808, 0xAB10, 0xCD23,
 		    0xEF, 0x45, 0x12, 0xAB, 0x34, 0xCD, 0x56, 0xEF);
 
 static const struct comp_driver comp_probe;
 #elif CONFIG_IPC_MAJOR_3
 /* 9d1fb66e-4ffb-497f-994b-17719686596e */
-DECLARE_SOF_RT_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
+SOF_DEFINE_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
 		    0x99, 0x4b, 0x17, 0x71, 0x96, 0x86, 0x59, 0x6e);
 #else
 #error "No or invalid IPC MAJOR version selected."
@@ -45,7 +45,7 @@ DECLARE_SOF_RT_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
 DECLARE_TR_CTX(pr_tr, SOF_UUID(probe_uuid), LOG_LEVEL_INFO);
 
 /* 2f0b1901-cac0-4b87-812f-f2d5e4f19e4a */
-DECLARE_SOF_UUID("probe-task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
+SOF_DEFINE_UUID("probe-task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
 		 0x81, 0x2f, 0xf2, 0xd5, 0xe4, 0xf1, 0x9e, 0x4a);
 
 LOG_MODULE_REGISTER(probe, CONFIG_SOF_LOG_LEVEL);

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -45,7 +45,7 @@ SOF_DEFINE_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
 DECLARE_TR_CTX(pr_tr, SOF_UUID(probe_uuid), LOG_LEVEL_INFO);
 
 /* 2f0b1901-cac0-4b87-812f-f2d5e4f19e4a */
-SOF_DEFINE_UUID("probe-task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
+SOF_DEFINE_UUID("probe_task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
 		 0x81, 0x2f, 0xf2, 0xd5, 0xe4, 0xf1, 0x9e, 0x4a);
 
 LOG_MODULE_REGISTER(probe, CONFIG_SOF_LOG_LEVEL);

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -29,16 +29,12 @@
 #include <sof/audio/component_ext.h>
 #include <sof/ut.h>
 
-/* 7CAD0808-AB10-CD23-EF45-12AB34CD56EF */
-SOF_DEFINE_UUID("probe4", probe4_uuid, 0x7CAD0808, 0xAB10, 0xCD23,
-		    0xEF, 0x45, 0x12, 0xAB, 0x34, 0xCD, 0x56, 0xEF);
+SOF_DEFINE_REG_UUID(probe4);
 #define PROBE_UUID probe4_uuid
 
 static const struct comp_driver comp_probe;
 #elif CONFIG_IPC_MAJOR_3
-/* 9d1fb66e-4ffb-497f-994b-17719686596e */
-SOF_DEFINE_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
-		    0x99, 0x4b, 0x17, 0x71, 0x96, 0x86, 0x59, 0x6e);
+SOF_DEFINE_REG_UUID(probe);
 #define PROBE_UUID probe_uuid
 
 #else
@@ -47,9 +43,7 @@ SOF_DEFINE_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
 
 DECLARE_TR_CTX(pr_tr, SOF_UUID(PROBE_UUID), LOG_LEVEL_INFO);
 
-/* 2f0b1901-cac0-4b87-812f-f2d5e4f19e4a */
-SOF_DEFINE_UUID("probe_task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
-		 0x81, 0x2f, 0xf2, 0xd5, 0xe4, 0xf1, 0x9e, 0x4a);
+SOF_DEFINE_REG_UUID(probe_task);
 
 LOG_MODULE_REGISTER(probe, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -30,19 +30,22 @@
 #include <sof/ut.h>
 
 /* 7CAD0808-AB10-CD23-EF45-12AB34CD56EF */
-SOF_DEFINE_UUID("probe", probe_uuid, 0x7CAD0808, 0xAB10, 0xCD23,
+SOF_DEFINE_UUID("probe4", probe4_uuid, 0x7CAD0808, 0xAB10, 0xCD23,
 		    0xEF, 0x45, 0x12, 0xAB, 0x34, 0xCD, 0x56, 0xEF);
+#define PROBE_UUID probe4_uuid
 
 static const struct comp_driver comp_probe;
 #elif CONFIG_IPC_MAJOR_3
 /* 9d1fb66e-4ffb-497f-994b-17719686596e */
 SOF_DEFINE_UUID("probe", probe_uuid, 0x9d1fb66e, 0x4ffb, 0x497f,
 		    0x99, 0x4b, 0x17, 0x71, 0x96, 0x86, 0x59, 0x6e);
+#define PROBE_UUID probe_uuid
+
 #else
 #error "No or invalid IPC MAJOR version selected."
 #endif /* CONFIG_IPC_MAJOR_4 */
 
-DECLARE_TR_CTX(pr_tr, SOF_UUID(probe_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(pr_tr, SOF_UUID(PROBE_UUID), LOG_LEVEL_INFO);
 
 /* 2f0b1901-cac0-4b87-812f-f2d5e4f19e4a */
 SOF_DEFINE_UUID("probe_task", probe_task_uuid, 0x2f0b1901, 0xcac0, 0x4b87,
@@ -1509,7 +1512,7 @@ static int probe_get_large_config(struct comp_dev *dev, uint32_t param_id,
 }
 
 static const struct comp_driver comp_probe = {
-	.uid	= SOF_RT_UUID(probe_uuid),
+	.uid	= SOF_RT_UUID(PROBE_UUID),
 	.tctx	= &pr_tr,
 	.ops	= {
 		.create			= probe_new,

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -69,9 +69,7 @@ static const struct comp_driver comp_keyword;
 
 LOG_MODULE_REGISTER(kd_test, CONFIG_SOF_LOG_LEVEL);
 
-/* eba8d51f-7827-47b5-82ee-de6e7743af67 */
-SOF_DEFINE_UUID("keyword", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
-		 0x82, 0xee, 0xde, 0x6e, 0x77, 0x43, 0xaf, 0x67);
+SOF_DEFINE_REG_UUID(keyword);
 
 DECLARE_TR_CTX(keyword_tr, SOF_UUID(keyword_uuid), LOG_LEVEL_INFO);
 

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -70,7 +70,7 @@ static const struct comp_driver comp_keyword;
 LOG_MODULE_REGISTER(kd_test, CONFIG_SOF_LOG_LEVEL);
 
 /* eba8d51f-7827-47b5-82ee-de6e7743af67 */
-DECLARE_SOF_RT_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
+SOF_DEFINE_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
 		 0x82, 0xee, 0xde, 0x6e, 0x77, 0x43, 0xaf, 0x67);
 
 DECLARE_TR_CTX(keyword_tr, SOF_UUID(keyword_uuid), LOG_LEVEL_INFO);

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -70,7 +70,7 @@ static const struct comp_driver comp_keyword;
 LOG_MODULE_REGISTER(kd_test, CONFIG_SOF_LOG_LEVEL);
 
 /* eba8d51f-7827-47b5-82ee-de6e7743af67 */
-SOF_DEFINE_UUID("kd-test", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
+SOF_DEFINE_UUID("keyword", keyword_uuid, 0xeba8d51f, 0x7827, 0x47b5,
 		 0x82, 0xee, 0xde, 0x6e, 0x77, 0x43, 0xaf, 0x67);
 
 DECLARE_TR_CTX(keyword_tr, SOF_UUID(keyword_uuid), LOG_LEVEL_INFO);

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -21,7 +21,7 @@ static const struct comp_driver comp_smart_amp;
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
+SOF_DEFINE_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -21,10 +21,10 @@ static const struct comp_driver comp_smart_amp;
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-SOF_DEFINE_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
+SOF_DEFINE_UUID("smart_amp_test", smart_amp_test_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
-DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),
+DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);
 
 typedef int(*smart_amp_proc)(struct comp_dev *dev,
@@ -537,7 +537,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 
 static const struct comp_driver comp_smart_amp = {
 	.type = SOF_COMP_SMART_AMP,
-	.uid = SOF_RT_UUID(smart_amp_test_comp_uuid),
+	.uid = SOF_RT_UUID(smart_amp_test_uuid),
 	.tctx = &smart_amp_test_comp_tr,
 	.ops = {
 		.create			= smart_amp_new,

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -20,9 +20,7 @@ static const struct comp_driver comp_smart_amp;
 
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
-/* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-SOF_DEFINE_UUID("smart_amp_test", smart_amp_test_uuid, 0x167a961e, 0x8ae4,
-		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
+SOF_DEFINE_REG_UUID(smart_amp_test);
 
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -21,9 +21,7 @@
 LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 #include <zephyr/logging/log.h>
 
-/* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-SOF_DEFINE_UUID("smart_amp_test", smart_amp_test_uuid, 0x167a961e, 0x8ae4,
-		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
+SOF_DEFINE_REG_UUID(smart_amp_test);
 
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -22,10 +22,10 @@ LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 #include <zephyr/logging/log.h>
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-SOF_DEFINE_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
+SOF_DEFINE_UUID("smart_amp_test", smart_amp_test_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
-DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),
+DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);
 #else
 #include <string.h>
@@ -396,7 +396,7 @@ static const struct module_interface smart_amp_test_interface = {
 #ifndef __SOF_MODULE_SERVICE_BUILD__
 /* All builds except system-service API */
 
-DECLARE_MODULE_ADAPTER(smart_amp_test_interface, smart_amp_test_comp_uuid, smart_amp_test_comp_tr);
+DECLARE_MODULE_ADAPTER(smart_amp_test_interface, smart_amp_test_uuid, smart_amp_test_comp_tr);
 /* DECLARE_MODULE_ADAPTER() creates
  * "sys_comp_module_<smart_amp_test_interface>_init()" (and a lot more)
  */

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 #include <zephyr/logging/log.h>
 
 /* 167a961e-8ae4-11ea-89f1-000c29ce1635 */
-DECLARE_SOF_RT_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
+SOF_DEFINE_UUID("smart_amp-test", smart_amp_test_comp_uuid, 0x167a961e, 0x8ae4,
 		    0x11ea, 0x89, 0xf1, 0x00, 0x0c, 0x29, 0xce, 0x16, 0x35);
 
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_comp_uuid),

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -23,9 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("edf_sched", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
-		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
+SOF_DEFINE_REG_UUID(edf_sched);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);
 

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-DECLARE_SOF_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/edf_schedule.c
+++ b/src/schedule/edf_schedule.c
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 /* 77de2074-828c-4044-a40b-420b72749e8b */
-SOF_DEFINE_UUID("edf-schedule", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
+SOF_DEFINE_UUID("edf_sched", edf_sched_uuid, 0x77de2074, 0x828c, 0x4044,
 		 0xa4, 0x0b, 0x42, 0x0b, 0x72, 0x74, 0x9e, 0x8b);
 
 DECLARE_TR_CTX(edf_tr, SOF_UUID(edf_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 4f9c3ec7-7b55-400c-86b3-502b4420e625 */
-SOF_DEFINE_UUID("ll-schedule", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
+SOF_DEFINE_UUID("ll_sched", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
 		 0x86, 0xb3, 0x50, 0x2b, 0x44, 0x20, 0xe6, 0x25);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -36,7 +36,7 @@
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 4f9c3ec7-7b55-400c-86b3-502b4420e625 */
-DECLARE_SOF_UUID("ll-schedule", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
+SOF_DEFINE_UUID("ll-schedule", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
 		 0x86, 0xb3, 0x50, 0x2b, 0x44, 0x20, 0xe6, 0x25);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -35,9 +35,7 @@
 
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
-/* 4f9c3ec7-7b55-400c-86b3-502b4420e625 */
-SOF_DEFINE_UUID("ll_sched", ll_sched_uuid, 0x4f9c3ec7, 0x7b55, 0x400c,
-		 0x86, 0xb3, 0x50, 0x2b, 0x44, 0x20, 0xe6, 0x25);
+SOF_DEFINE_REG_UUID(ll_sched);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);
 

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -19,7 +19,7 @@
 LOG_MODULE_REGISTER(schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 3dee06de-f25a-4e10-ae1f-abc9573873ea */
-DECLARE_SOF_UUID("schedule", sch_uuid, 0x3dee06de, 0xf25a, 0x4e10,
+SOF_DEFINE_UUID("schedule", sch_uuid, 0x3dee06de, 0xf25a, 0x4e10,
 		 0xae, 0x1f, 0xab, 0xc9, 0x57, 0x38, 0x73, 0xea);
 
 DECLARE_TR_CTX(sch_tr, SOF_UUID(sch_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -18,9 +18,7 @@
 
 LOG_MODULE_REGISTER(schedule, CONFIG_SOF_LOG_LEVEL);
 
-/* 3dee06de-f25a-4e10-ae1f-abc9573873ea */
-SOF_DEFINE_UUID("schedule", schedule_uuid, 0x3dee06de, 0xf25a, 0x4e10,
-		 0xae, 0x1f, 0xab, 0xc9, 0x57, 0x38, 0x73, 0xea);
+SOF_DEFINE_REG_UUID(schedule);
 
 DECLARE_TR_CTX(sch_tr, SOF_UUID(schedule_uuid), LOG_LEVEL_INFO);
 

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -19,10 +19,10 @@
 LOG_MODULE_REGISTER(schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 3dee06de-f25a-4e10-ae1f-abc9573873ea */
-SOF_DEFINE_UUID("schedule", sch_uuid, 0x3dee06de, 0xf25a, 0x4e10,
+SOF_DEFINE_UUID("schedule", schedule_uuid, 0x3dee06de, 0xf25a, 0x4e10,
 		 0xae, 0x1f, 0xab, 0xc9, 0x57, 0x38, 0x73, 0xea);
 
-DECLARE_TR_CTX(sch_tr, SOF_UUID(sch_uuid), LOG_LEVEL_INFO);
+DECLARE_TR_CTX(sch_tr, SOF_UUID(schedule_uuid), LOG_LEVEL_INFO);
 
 int schedule_task_init(struct task *task,
 		       const struct sof_uuid_entry *uid, uint16_t type,

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -31,7 +31,7 @@
 typedef enum task_state (*task_main)(void *);
 
 /* 37f1d41f-252d-448d-b9c4-1e2bee8e1bf1 */
-DECLARE_SOF_UUID("main-task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
+SOF_DEFINE_UUID("main-task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
 		 0xb9, 0xc4, 0x1e, 0x2b, 0xee, 0x8e, 0x1b, 0xf1);
 
 static void sys_module_init(void)

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -31,7 +31,7 @@
 typedef enum task_state (*task_main)(void *);
 
 /* 37f1d41f-252d-448d-b9c4-1e2bee8e1bf1 */
-SOF_DEFINE_UUID("main-task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
+SOF_DEFINE_UUID("main_task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
 		 0xb9, 0xc4, 0x1e, 0x2b, 0xee, 0x8e, 0x1b, 0xf1);
 
 static void sys_module_init(void)

--- a/src/schedule/task.c
+++ b/src/schedule/task.c
@@ -30,9 +30,7 @@
 
 typedef enum task_state (*task_main)(void *);
 
-/* 37f1d41f-252d-448d-b9c4-1e2bee8e1bf1 */
-SOF_DEFINE_UUID("main_task", main_task_uuid, 0x37f1d41f, 0x252d, 0x448d,
-		 0xb9, 0xc4, 0x1e, 0x2b, 0xee, 0x8e, 0x1b, 0xf1);
+SOF_DEFINE_REG_UUID(main_task);
 
 static void sys_module_init(void)
 {

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -24,7 +24,7 @@
 
 LOG_MODULE_REGISTER(dp_schedule, CONFIG_SOF_LOG_LEVEL);
 /* 87858bc2-baa9-40b6-8e4c-2c95ba8b1545 */
-SOF_DEFINE_UUID("dp-schedule", dp_sched_uuid, 0x87858bc2, 0xbaa9, 0x40b6,
+SOF_DEFINE_UUID("dp_sched", dp_sched_uuid, 0x87858bc2, 0xbaa9, 0x40b6,
 		 0x8e, 0x4c, 0x2c, 0x95, 0xba, 0x8b, 0x15, 0x45);
 
 DECLARE_TR_CTX(dp_tr, SOF_UUID(dp_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -23,9 +23,7 @@
 #include <zephyr/kernel/thread.h>
 
 LOG_MODULE_REGISTER(dp_schedule, CONFIG_SOF_LOG_LEVEL);
-/* 87858bc2-baa9-40b6-8e4c-2c95ba8b1545 */
-SOF_DEFINE_UUID("dp_sched", dp_sched_uuid, 0x87858bc2, 0xbaa9, 0x40b6,
-		 0x8e, 0x4c, 0x2c, 0x95, 0xba, 0x8b, 0x15, 0x45);
+SOF_DEFINE_REG_UUID(dp_sched);
 
 DECLARE_TR_CTX(dp_tr, SOF_UUID(dp_sched_uuid), LOG_LEVEL_INFO);
 

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -24,7 +24,7 @@
 
 LOG_MODULE_REGISTER(dp_schedule, CONFIG_SOF_LOG_LEVEL);
 /* 87858bc2-baa9-40b6-8e4c-2c95ba8b1545 */
-DECLARE_SOF_UUID("dp-schedule", dp_sched_uuid, 0x87858bc2, 0xbaa9, 0x40b6,
+SOF_DEFINE_UUID("dp-schedule", dp_sched_uuid, 0x87858bc2, 0xbaa9, 0x40b6,
 		 0x8e, 0x4c, 0x2c, 0x95, 0xba, 0x8b, 0x15, 0x45);
 
 DECLARE_TR_CTX(dp_tr, SOF_UUID(dp_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -20,7 +20,7 @@
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 1547fe68-de0c-11eb-8461-3158a1294853 */
-DECLARE_SOF_UUID("zll-schedule", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
+SOF_DEFINE_UUID("zll-schedule", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
 		 0x84, 0x61, 0x31, 0x58, 0xa1, 0x29, 0x48, 0x53);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(zll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -19,9 +19,7 @@
 
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
-/* 1547fe68-de0c-11eb-8461-3158a1294853 */
-SOF_DEFINE_UUID("zll_sched", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
-		 0x84, 0x61, 0x31, 0x58, 0xa1, 0x29, 0x48, 0x53);
+SOF_DEFINE_REG_UUID(zll_sched);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(zll_sched_uuid), LOG_LEVEL_INFO);
 

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -20,7 +20,7 @@
 LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 /* 1547fe68-de0c-11eb-8461-3158a1294853 */
-SOF_DEFINE_UUID("zll-schedule", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
+SOF_DEFINE_UUID("zll_sched", zll_sched_uuid, 0x1547fe68, 0xde0c, 0x11eb,
 		 0x84, 0x61, 0x31, 0x58, 0xa1, 0x29, 0x48, 0x53);
 
 DECLARE_TR_CTX(ll_tr, SOF_UUID(zll_sched_uuid), LOG_LEVEL_INFO);

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -14,9 +14,7 @@
 
 #if CONFIG_DEBUG_LOCKS
 
-/* 9d346d98-203d-4791-baee-1770a03d4a71 */
-SOF_DEFINE_UUID("spinlock", spinlock_uuid, 0x9d346d98, 0x203d, 0x4791,
-		 0xba, 0xee, 0x17, 0x70, 0xa0, 0x3d, 0x4a, 0x71);
+SOF_DEFINE_REG_UUID(spinlock);
 
 DECLARE_TR_CTX(sl_tr, SOF_UUID(spinlock_uuid), LOG_LEVEL_INFO);
 

--- a/src/spinlock.c
+++ b/src/spinlock.c
@@ -15,7 +15,7 @@
 #if CONFIG_DEBUG_LOCKS
 
 /* 9d346d98-203d-4791-baee-1770a03d4a71 */
-DECLARE_SOF_UUID("spinlock", spinlock_uuid, 0x9d346d98, 0x203d, 0x4791,
+SOF_DEFINE_UUID("spinlock", spinlock_uuid, 0x9d346d98, 0x203d, 0x4791,
 		 0xba, 0xee, 0x17, 0x70, 0xa0, 0x3d, 0x4a, 0x71);
 
 DECLARE_TR_CTX(sl_tr, SOF_UUID(spinlock_uuid), LOG_LEVEL_INFO);

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -39,15 +39,11 @@
 
 LOG_MODULE_REGISTER(dma_trace, CONFIG_SOF_LOG_LEVEL);
 
-/* 58782c63-1326-4185-8459-22272e12d1f1 */
-SOF_DEFINE_UUID("dma_trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
-		 0x84, 0x59, 0x22, 0x27, 0x2e, 0x12, 0xd1, 0xf1);
+SOF_DEFINE_REG_UUID(dma_trace);
 
 DECLARE_TR_CTX(dt_tr, SOF_UUID(dma_trace_uuid), LOG_LEVEL_INFO);
 
-/* 2b972272-c5b1-4b7e-926f-0fc5cb4c4690 */
-SOF_DEFINE_UUID("dma_trace_task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
-		 0x4b7e, 0x92, 0x6f, 0x0f, 0xc5, 0xcb, 0x4c, 0x46, 0x90);
+SOF_DEFINE_REG_UUID(dma_trace_task);
 
 static int dma_trace_get_avail_data(struct dma_trace_data *d,
 				    struct dma_trace_buf *buffer,

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -40,13 +40,13 @@
 LOG_MODULE_REGISTER(dma_trace, CONFIG_SOF_LOG_LEVEL);
 
 /* 58782c63-1326-4185-8459-22272e12d1f1 */
-DECLARE_SOF_UUID("dma-trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
+SOF_DEFINE_UUID("dma-trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
 		 0x84, 0x59, 0x22, 0x27, 0x2e, 0x12, 0xd1, 0xf1);
 
 DECLARE_TR_CTX(dt_tr, SOF_UUID(dma_trace_uuid), LOG_LEVEL_INFO);
 
 /* 2b972272-c5b1-4b7e-926f-0fc5cb4c4690 */
-DECLARE_SOF_UUID("dma-trace-task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
+SOF_DEFINE_UUID("dma-trace-task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
 		 0x4b7e, 0x92, 0x6f, 0x0f, 0xc5, 0xcb, 0x4c, 0x46, 0x90);
 
 static int dma_trace_get_avail_data(struct dma_trace_data *d,

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -40,13 +40,13 @@
 LOG_MODULE_REGISTER(dma_trace, CONFIG_SOF_LOG_LEVEL);
 
 /* 58782c63-1326-4185-8459-22272e12d1f1 */
-SOF_DEFINE_UUID("dma-trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
+SOF_DEFINE_UUID("dma_trace", dma_trace_uuid, 0x58782c63, 0x1326, 0x4185,
 		 0x84, 0x59, 0x22, 0x27, 0x2e, 0x12, 0xd1, 0xf1);
 
 DECLARE_TR_CTX(dt_tr, SOF_UUID(dma_trace_uuid), LOG_LEVEL_INFO);
 
 /* 2b972272-c5b1-4b7e-926f-0fc5cb4c4690 */
-SOF_DEFINE_UUID("dma-trace-task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
+SOF_DEFINE_UUID("dma_trace_task", dma_trace_task_uuid, 0x2b972272, 0xc5b1,
 		 0x4b7e, 0x92, 0x6f, 0x0f, 0xc5, 0xcb, 0x4c, 0x46, 0x90);
 
 static int dma_trace_get_avail_data(struct dma_trace_data *d,

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -15,6 +15,9 @@ add_executable(sof-logger
 	misc.c
 )
 
+include(../../scripts/cmake/misc.cmake)
+include(../../scripts/cmake/uuid-registry.cmake)
+
 if(${CMAKE_HOST_WIN32})
 	cmake_minimum_required(VERSION 3.20)
 	if(DEFINED ENV{MSYS_INSTALL_DIR})

--- a/tools/logger/filter.c
+++ b/tools/logger/filter.c
@@ -135,7 +135,7 @@ static char *filter_parse_component_name(char *input_str, struct filter_element 
  *   `*`
  * Whitespace is possible at the begin, end and after `name`.
  * `name` must refer to values from given UUID dictionary,
- *        (so name comes from DECLARE_SOF_UUID macro usage)
+ *        (so name comes from SOF_DEFINE_UUID macro usage)
 
  * @param input_str formatted component definition
  * @param out element where component definition should be saved

--- a/tools/plugin/modules/alsa.c
+++ b/tools/plugin/modules/alsa.c
@@ -30,14 +30,10 @@
 
 #include "pipe.h"
 
-/* 66def9f0-39f2-11ed-89f7-af98a6440cc4 */
-SOF_DEFINE_UUID("arecord", arecord_uuid, 0x66def9f0, 0x39f2, 0x11ed,
-		    0xf7, 0x89, 0xaf, 0x98, 0xa6, 0x44, 0x0c, 0xc4);
+SOF_DEFINE_REG_UUID(arecord);
 DECLARE_TR_CTX(arecord_tr, SOF_UUID(arecord_uuid), LOG_LEVEL_INFO);
 
-/* 72cee996-39f2-11ed-a08f-97fcc42eaaeb */
-SOF_DEFINE_UUID("aplay", aplay_uuid, 0x72cee996, 0x39f2, 0x11ed,
-		    0xa0, 0x8f, 0x97, 0xfc, 0xc4, 0x2e, 0xaa, 0xeb);
+SOF_DEFINE_REG_UUID(aplay);
 DECLARE_TR_CTX(aplay_tr, SOF_UUID(aplay_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_arecord;

--- a/tools/plugin/modules/alsa.c
+++ b/tools/plugin/modules/alsa.c
@@ -31,12 +31,12 @@
 #include "pipe.h"
 
 /* 66def9f0-39f2-11ed-89f7-af98a6440cc4 */
-DECLARE_SOF_RT_UUID("arecord", arecord_uuid, 0x66def9f0, 0x39f2, 0x11ed,
+SOF_DEFINE_UUID("arecord", arecord_uuid, 0x66def9f0, 0x39f2, 0x11ed,
 		    0xf7, 0x89, 0xaf, 0x98, 0xa6, 0x44, 0x0c, 0xc4);
 DECLARE_TR_CTX(arecord_tr, SOF_UUID(arecord_uuid), LOG_LEVEL_INFO);
 
 /* 72cee996-39f2-11ed-a08f-97fcc42eaaeb */
-DECLARE_SOF_RT_UUID("aplay", aplay_uuid, 0x72cee996, 0x39f2, 0x11ed,
+SOF_DEFINE_UUID("aplay", aplay_uuid, 0x72cee996, 0x39f2, 0x11ed,
 		    0xa0, 0x8f, 0x97, 0xfc, 0xc4, 0x2e, 0xaa, 0xeb);
 DECLARE_TR_CTX(aplay_tr, SOF_UUID(aplay_uuid), LOG_LEVEL_INFO);
 

--- a/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
+++ b/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
@@ -30,7 +30,7 @@
 LOG_MODULE_REGISTER(ns, CONFIG_SOF_LOG_LEVEL);
 
 /* 7ae671a7-4617-4a09-bf6d-9d29c998dbc1 */
-DECLARE_SOF_RT_UUID("ns", ns_comp_uuid, 0x7ae671a7, 0x4617,
+SOF_DEFINE_UUID("ns", ns_comp_uuid, 0x7ae671a7, 0x4617,
 		    0x4a09, 0xbf, 0x6d, 0x9d, 0x29, 0xc9, 0x98, 0xdb, 0xc1);
 
 DECLARE_TR_CTX(ns_comp_tr, SOF_UUID(ns_comp_uuid), LOG_LEVEL_INFO);

--- a/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
+++ b/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
@@ -30,7 +30,7 @@
 LOG_MODULE_REGISTER(ns, CONFIG_SOF_LOG_LEVEL);
 
 /* 7ae671a7-4617-4a09-bf6d-9d29c998dbc1 */
-SOF_DEFINE_UUID("ns", ns_comp_uuid, 0x7ae671a7, 0x4617,
+SOF_DEFINE_UUID("ns", ns_uuid, 0x7ae671a7, 0x4617,
 		    0x4a09, 0xbf, 0x6d, 0x9d, 0x29, 0xc9, 0x98, 0xdb, 0xc1);
 
 DECLARE_TR_CTX(ns_comp_tr, SOF_UUID(ns_comp_uuid), LOG_LEVEL_INFO);

--- a/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
+++ b/tools/plugin/modules/ov_noise_suppression/noise_suppression.c
@@ -29,9 +29,7 @@
 
 LOG_MODULE_REGISTER(ns, CONFIG_SOF_LOG_LEVEL);
 
-/* 7ae671a7-4617-4a09-bf6d-9d29c998dbc1 */
-SOF_DEFINE_UUID("ns", ns_uuid, 0x7ae671a7, 0x4617,
-		    0x4a09, 0xbf, 0x6d, 0x9d, 0x29, 0xc9, 0x98, 0xdb, 0xc1);
+SOF_DEFINE_REG_UUID(ns);
 
 DECLARE_TR_CTX(ns_comp_tr, SOF_UUID(ns_comp_uuid), LOG_LEVEL_INFO);
 

--- a/tools/plugin/modules/shm.c
+++ b/tools/plugin/modules/shm.c
@@ -30,12 +30,12 @@
 #include "pipe.h"
 
 /* 1488beda-e847-ed11-b309-a58b974fecce */
-DECLARE_SOF_RT_UUID("shmread", shmread_uuid, 0xdabe8814, 0x47e8, 0x11ed,
+SOF_DEFINE_UUID("shmread", shmread_uuid, 0xdabe8814, 0x47e8, 0x11ed,
 		    0xa5, 0x8b, 0xb3, 0x09, 0x97, 0x4f, 0xec, 0xce);
 DECLARE_TR_CTX(shmread_tr, SOF_UUID(shmread_uuid), LOG_LEVEL_INFO);
 
 /* 1c03b6e2-e847-ed11-7f80-07a91b6efa6c */
-DECLARE_SOF_RT_UUID("shmwrite", shmwrite_uuid, 0xe2b6031c, 0x47e8, 0x11ed,
+SOF_DEFINE_UUID("shmwrite", shmwrite_uuid, 0xe2b6031c, 0x47e8, 0x11ed,
 		    0x07, 0xa9, 0x7f, 0x80, 0x1b, 0x6e, 0xfa, 0x6c);
 DECLARE_TR_CTX(shmwrite_tr, SOF_UUID(shmwrite_uuid), LOG_LEVEL_INFO);
 

--- a/tools/plugin/modules/shm.c
+++ b/tools/plugin/modules/shm.c
@@ -29,14 +29,10 @@
 
 #include "pipe.h"
 
-/* 1488beda-e847-ed11-b309-a58b974fecce */
-SOF_DEFINE_UUID("shmread", shmread_uuid, 0xdabe8814, 0x47e8, 0x11ed,
-		    0xa5, 0x8b, 0xb3, 0x09, 0x97, 0x4f, 0xec, 0xce);
+SOF_DEFINE_REG_UUID(shmread);
 DECLARE_TR_CTX(shmread_tr, SOF_UUID(shmread_uuid), LOG_LEVEL_INFO);
 
-/* 1c03b6e2-e847-ed11-7f80-07a91b6efa6c */
-SOF_DEFINE_UUID("shmwrite", shmwrite_uuid, 0xe2b6031c, 0x47e8, 0x11ed,
-		    0x07, 0xa9, 0x7f, 0x80, 0x1b, 0x6e, 0xfa, 0x6c);
+SOF_DEFINE_REG_UUID(shmwrite);
 DECLARE_TR_CTX(shmwrite_tr, SOF_UUID(shmwrite_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_shmread;

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -23,9 +23,7 @@
 #include "testbench/common_test.h"
 #include "testbench/file.h"
 
-/* bfc7488c-75aa-4ce8-9bde-d8da08a698c2 */
-SOF_DEFINE_UUID("file", file_uuid, 0xbfc7488c, 0x75aa, 0x4ce8,
-		    0x9d, 0xbe, 0xd8, 0xda, 0x08, 0xa6, 0x98, 0xc2);
+SOF_DEFINE_REG_UUID(file);
 DECLARE_TR_CTX(file_tr, SOF_UUID(file_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_file_dai;

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -24,7 +24,7 @@
 #include "testbench/file.h"
 
 /* bfc7488c-75aa-4ce8-9bde-d8da08a698c2 */
-DECLARE_SOF_RT_UUID("file", file_uuid, 0xbfc7488c, 0x75aa, 0x4ce8,
+SOF_DEFINE_UUID("file", file_uuid, 0xbfc7488c, 0x75aa, 0x4ce8,
 		    0x9d, 0xbe, 0xd8, 0xda, 0x08, 0xa6, 0x98, 0xc2);
 DECLARE_TR_CTX(file_tr, SOF_UUID(file_uuid), LOG_LEVEL_INFO);
 

--- a/tools/tplg_parser/CMakeLists.txt
+++ b/tools/tplg_parser/CMakeLists.txt
@@ -70,6 +70,8 @@ target_compile_options(sof_tplg_parser PRIVATE
 
 target_link_libraries(sof_tplg_parser PRIVATE -lm)
 
+include(../../scripts/cmake/uuid-registry.cmake)
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tplg_parser
 	DESTINATION include
 	PATTERN "*.h"

--- a/uuid-registry.txt
+++ b/uuid-registry.txt
@@ -1,0 +1,158 @@
+#
+# Global UUID/name registry for SOF components.  All IDs used in
+# shipped binary artifacts must appear in this list.  All names must
+# be unique.  All names must be legal C identifiers of at most 31
+# characters.  No change to a previously distributed mapping is
+# allowed, ever.
+#
+# Simple format: "#" indicates a comment to end of line.  Remaining
+# lines must be entirely empty/whitespace, or two whitespace-separated
+# fields of: <UUID> <name>
+#
+# NOTE: the UUID is in a SOF-unique format to match the (nonstandard
+# and endian-ambiguous) representation in struct sof_uuid: the first
+# three entries are specified as little endian dword/word values, the
+# last as an ordered array of 8 bytes.  If you have a value from
+# e.g. an RFC-4122 compliant tool, swap the order of the two bytes in
+# the fourth cluster and prepend it to the last.  Most of the time you
+# are just using random values and won't care about the byte swap.
+#
+
+ab01db67-84b0-4d2d-93d30e619680576e acp_bt_dma
+f8a7091c-7d2d-4410-9bb555278378d59f acp_clk
+70f2d3f2-cbb6-4984-a2d80dd514b80bc2 acpdma
+0ae40946-dfd2-4140-91520dd5a3eaae81 acp_dmic_dai
+109c7aba-a7ba-43c3-b94259e20a6611be acp_dmic_dma
+dc2199ea-cdae-4d23-a413ffe442f785f2 acp_dmic_dma_common
+b414df09-9e31-4c59-86577afc8deba70c acp_hs
+3ac07334-41ce-4447-a2c5dff0d1fa1392 acp_sp
+2ef92c66-78a4-41f7-b52f5539707a9382 acp_sp_common
+5871f3ca-dd92-4edb-8a94d651dd208b1e acp_sw_audio
+30290c76-6a05-4784-8464c21f09cee87e afe_dai
+4e8f16d1-e935-41f4-b99e42c57e745784 afedrv
+c63c4e75-8f61-4420-93191395932efa9e agent_work
+ea9c4bca-5b7d-48c6-9586553e27235beb ams
+72cee996-39f2-11ed-a08f97fcc42eaaeb aplay
+66def9f0-39f2-11ed-f789af98a6440cc4 arecord
+99f7166d-372c-43ef-81f622007aa15f03 aria
+c8ec72f6-8526-4faf-9d39a23d0b541de2 asrc
+66b4402d-b468-42f2-81a7b37121863dd4 asrc4
+0e398c32-5ade-ba4b-93b1c50432280ee4 basefw
+20865bfe-b833-4ff9-b22a0482c3477497 btdai
+42544c92-8e92-4e41-b67934519f1c1d28 buffer
+d8218443-5ff3-4a4c-b3886cfe07b956aa cadence_codec
+6a0a274f-27cc-4afb-a3e73444723f432e chain_dma
+ec290e95-4a20-47eb-bbffd9c888431831 chmap
+53863428-9a72-44df-af0ffe45ea2348ba clkdrv_mt8186
+19d4e680-4479-48cc-af869f63d8b0098b clkdrv_mt8188
+23b12fd5-c2a9-41a8-a2b3231ab7dcdc70 clkdrv_mt8195
+8890ea76-0df9-44ae-87e6994f4c15e9fa clock
+7c42ce8b-0108-43d0-913756d660478c5f component
+9ba00c83-ca12-4a83-943c1fa2e82f9dda copier
+948c9ad1-806a-4131-ad6cb2bda9e35a9f crossover
+c2b00d27-ffbc-4150-a51a245c79c5e54b dai
+06711c94-d37d-4a76-b302bbf6944fdd2b dai_lib
+b809efaf-5681-42b1-9ed604bb012dd384 dcblock
+c4b26868-1430-470e-a08915d1c77f851a demux
+bc3526a7-9b86-4ab4-84a52e02ae70cc10 dma
+729bf8b5-e873-4bf5-96908e2a3fd33911 dma_copy
+58782c63-1326-4185-845922272e12d1f1 dma_trace
+2b972272-c5b1-4b7e-926f0fc5cb4c4690 dma_trace_task
+393608d8-4188-11ee-be560242ac122002 dp_queue
+87858bc2-baa9-40b6-8e4c2c95ba8b1545 dp_sched
+ee755917-96b9-4130-b49e37b9d0501993 dp_task
+b36ee4da-006f-47f9-a06dfecbe2d8b6ce drc
+d95fc34f-370f-4ac7-bc86bfdc5be241e6 dts
+f6d15ad3-b122-458c-ae9b0ab0b5867aa0 dummy_dma
+298873bc-d532-4d93-a54095ee6bcf3456 dw_dma
+77de2074-828c-4044-a40b420b72749e8b edf_sched
+5dbc3672-e290-43d8-91f881aafe453d5b edf_sched_lib
+3d73a110-0930-457f-be5134453e56287b edma
+43a90ce7-f3a5-41df-ac06ba98651ae6a3 eq_fir
+5150c0e6-27f9-4ec8-8351c705b642d12f eq_iir
+889f6dcd-ddcd-4e05-aa5b0d39f8bca961 esai
+bfc7488c-75aa-4ce8-9dbed8da08a698c2 file
+61bca9a8-18d0-4a18-8e7b2639219804b7 gain
+c3c74249-058e-414f-82404da5f3fc2389 google_hotword
+b780a0a6-269f-466f-b47723dfa05af758 google_rtc_audio_processing
+8b9d100c-6d78-418f-90a3e0e805d0852b host
+8f00c3bb-e835-4767-9a34b8ec1041e56b hsdai
+379a60ae-cedb-4777-aaf25659b0a85735 idc
+a5dacb0e-88dc-415c-a1b53e8df77f1976 idc_cmd_task
+b90f5a4e-5537-4375-a1df95485472ff9e idc_task
+696ae2bc-2877-11eb-adc10242ac120002 igo_nr
+fa00558c-d653-4851-a03ab21f125a9524 interrupt
+be60f97d-78df-4796-a0ee435cb56b720a ipc
+a814a1ca-0b83-466c-95872f35ff8d12e8 ipcgw
+389c9186-5a7d-4ad1-a02ca02ecdadfb33 ipc_task
+49be8ff3-71a3-4456-bb7e4723f2e5730c ipc_task_amd
+a3fe3bf2-39a4-4fc3-b3418a96e0a26759 ipc_task_mt818x
+6c8f0d53-ff77-4ca1-b825c0c4e1b0d322 ipc_task_posix
+1862d39a-3a84-4d64-8c91dce1dfc122db irq
+6533d0eb-b785-4709-84f5347c81720189 irq_acp
+d2e3f730-df39-42ee-81a839bfb4d024c2 irq_mt818x
+eba8d51f-7827-47b5-82eede6e7743af67 keyword
+d8218443-5ff3-4a4c-b3886cfe07b9562e kpb
+a8a0cb32-4a77-4db1-85c753d7ee07bce6 kpb4
+e50057a5-8b27-4db4-bd799a639cee5f50 kpb_task
+54cf5598-8b29-11ec-a8a30242ac120002 lib_manager
+4f9c3ec7-7b55-400c-86b3502b4420e625 ll_sched
+9f130ed8-2bbf-421c-836ad5269147c9e7 ll_sched_lib
+37f1d41f-252d-448d-b9c41e2bee8e1bf1 main_task
+d23cf8d0-8dfe-497c-82025f909cf72735 math_power
+0cd84e80-ebd3-11ea-adc10242ac120002 maxim_dsm
+425d6e68-145c-4455-b0b2c7260b0600a5 mem
+df5e94d7-fd93-42e9-bb94ab40becc7151 memif
+db10a773-1aa4-4cea-a21f2d57a5c982eb mfcc
+dd400475-35d7-4045-ab030c34957d7a08 micfil
+bc06c037-12aa-417c-9a9789282e321a76 mixer
+39656eb2-3b71-4049-8d3ff92cd5c43c09 mixin
+3c56505a-24d7-418f-bddcc1f5a3ac2ae0 mixout
+ee2585f2-e7d8-43dc-90ab4224e00c3e84 modules
+bb2aa22e-1ab6-4650-85016e67fcc04f4e mtrace_task
+0d9f2256-8e4f-47b3-8448239a334f1191 multiband_drc
+c607ff4d-9cb6-49dc-b6787da3c63ea557 mux
+64ce6e35-857a-4878-ace8e2a2f42e3069 mux4
+1fb15a7a-83cd-4c2e-8b324da1b2adeeaf notifier
+7ae671a7-4617-4a09-bf6d9d29c998dbc1 ns
+376b5e44-9c82-4ec2-bc8310ea101af88f passthrough
+64a794f0-55d3-4bca-9d5b7b588badd037 passthru_smart_amp
+4e934adb-b0ec-4d33-a086c1022f921321 pipe
+f11818eb-e92e-4082-82a3dc54c604ebb3 pipe_task
+d7f6712d-131c-45a7-82ed6aa9dc2291ea pm_runtime
+76cc9773-440c-4df9-95a872defe7796fc power
+9d1fb66e-4ffb-497f-994b17719686596e probe
+7cad0808-ab10-cd23-ef4512ab34cd56ef probe4
+2f0b1901-cac0-4b87-812ff2d5e4f19e4a probe_task
+5c7ca334-e15d-11eb-ba800242ac130004 rtnr
+5276b491-5b64-464e-8984dc228ef9e6a1 sa
+9302adf5-88be-4234-a0a7dca538ef81f4 sai
+3dee06de-f25a-4e10-ae1fabc9573873ea schedule
+70d223ef-2b91-4aac-b444d89a0db2793a sdma
+55a88ed5-3d18-46ca-88f10ee6eae9930f selector
+32fe92c1-1e17-4fc2-9758c7f3542e980a selector4
+cf90d851-68a2-4987-a2de85aed0c8531c sgen_mt8186
+99316bd9-07b9-4665-81796e048d67cb45 sgen_mt8188
+9eb1a55b-fc20-4442-96131ff1023be493 sgen_mt8195
+dabe8814-47e8-11ed-a58bb309974fecce shmread
+e2b6031c-47e8-11ed-07a97f801b6efa6c shmwrite
+167a961e-8ae4-11ea-89f1000c29ce1635 smart_amp_test
+4abd71ba-8619-458a-b33f160fc0cf809b spdai
+a417b6fb-459d-4cf9-be65d38dc9057b80 spi_completion
+9d346d98-203d-4791-baee1770a03d4a71 spinlock
+c1c5326d-8390-46b4-aa4795c3beca6550 src
+e61bb28d-149a-4c1f-b70946823ef5f5ae src4
+33441051-44cd-466a-83a3178478708aea src_lite
+eb0bd14b-7d5e-4dfa-bbe27762adb279f0 swaudiodai
+dd511749-d9fa-455c-b3a713585693f1af tdfb
+04e3f894-2c5c-4f2e-8dc1694eeaab53fa tone
+42f8060c-832f-4dbf-b24751e961997b34 up_down_mixer
+b77e677e-5ff4-4188-af14fba8bdbf8682 volume
+8a171323-94a3-4e1d-afe9fe5dbaa4c393 volume4
+1028070e-04e8-46ab-8d8110a0116ce738 wait
+d944281a-afe9-4695-a043d7f62b89538e waves
+13c8bc59-c4fa-4ad1-b93ace97cd30acc7 wdt
+300aaad4-45d2-8313-25d05e1d6086cdd1 zephyr
+5f1ec3f8-faaf-4099-903ccee98351f169 zephyr_idc
+8fa1d42f-bc6f-464b-867f547af08834da zipc_task
+1547fe68-de0c-11eb-84613158a1294853 zll_sched

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -921,6 +921,8 @@ add_definitions(-DXCC_TOOLS_VERSION="${ZEPHYR_TOOLCHAIN_VARIANT}" -DCC_OPTIMIZE_
 # create version information
 include(../scripts/cmake/version.cmake)
 
+include(../scripts/cmake/uuid-registry.cmake)
+
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -891,6 +891,9 @@ zephyr_library_sources_ifdef(CONFIG_SHELL
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)
 
+# Linker snippet for the UUID table
+zephyr_linker_sources("ROM_SECTIONS" uuid-snippet.ld)
+
 # Setup SOF directories
 set(SOF_ROOT_SOURCE_DIRECTORY ${sof_top_dir})
 set(SOF_ROOT_BINARY_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -128,27 +128,6 @@ set(RIMAGE_TOP ${sof_top_dir}/tools/rimage)
 set(RIMAGE_CONFIG_PATH ${RIMAGE_TOP}/config CACHE PATH
     " Path to rimage board configuration files")
 
-include(ExternalProject)
-
-ExternalProject_Add(smex_ep
-	SOURCE_DIR "${ZEPHYR_SOF_MODULE_DIR}/smex/"
-	# The default paths are very "deep"
-	PREFIX     "${PROJECT_BINARY_DIR}/smex_ep"
-	BINARY_DIR "${PROJECT_BINARY_DIR}/smex_ep/build"
-	BUILD_ALWAYS 1
-	INSTALL_COMMAND "" # need smex only at build time
-)
-
-ExternalProject_Add(sof_logger_ep
-	SOURCE_DIR "${ZEPHYR_SOF_MODULE_DIR}/tools/"
-	# The default paths are very "deep"
-	PREFIX     "${PROJECT_BINARY_DIR}/sof-logger_ep"
-	BINARY_DIR "${PROJECT_BINARY_DIR}/sof-logger_ep/build"
-	BUILD_COMMAND cmake --build . --target sof-logger
-	BUILD_ALWAYS 1
-	INSTALL_COMMAND ""
-)
-
 # default SOF includes
 target_include_directories(SOF INTERFACE ${RIMAGE_TOP}/src/include)
 target_include_directories(SOF INTERFACE ${SOF_SRC_PATH}/include)

--- a/zephyr/lib/pm_runtime.c
+++ b/zephyr/lib/pm_runtime.c
@@ -15,7 +15,7 @@
 LOG_MODULE_REGISTER(power, CONFIG_SOF_LOG_LEVEL);
 
 /* 76cc9773-440c-4df9-95a8-72defe7796fc */
-DECLARE_SOF_UUID("power", power_uuid, 0x76cc9773, 0x440c, 0x4df9,
+SOF_DEFINE_UUID("power", power_uuid, 0x76cc9773, 0x440c, 0x4df9,
 		 0x95, 0xa8, 0x72, 0xde, 0xfe, 0x77, 0x96, 0xfc);
 
 DECLARE_TR_CTX(power_tr, SOF_UUID(power_uuid), LOG_LEVEL_INFO);

--- a/zephyr/lib/pm_runtime.c
+++ b/zephyr/lib/pm_runtime.c
@@ -14,9 +14,7 @@
 
 LOG_MODULE_REGISTER(power, CONFIG_SOF_LOG_LEVEL);
 
-/* 76cc9773-440c-4df9-95a8-72defe7796fc */
-SOF_DEFINE_UUID("power", power_uuid, 0x76cc9773, 0x440c, 0x4df9,
-		 0x95, 0xa8, 0x72, 0xde, 0xfe, 0x77, 0x96, 0xfc);
+SOF_DEFINE_REG_UUID(power);
 
 DECLARE_TR_CTX(power_tr, SOF_UUID(power_uuid), LOG_LEVEL_INFO);
 

--- a/zephyr/uuid-snippet.ld
+++ b/zephyr/uuid-snippet.ld
@@ -1,0 +1,6 @@
+/* This is a Zephyr linker "snippet"
+ * See zephyr_linker_sources() cmake function
+ */
+
+/* Runtime UUID table. */
+ITERABLE_SECTION_ROM(sof_uuid_entry, 4)

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -39,7 +39,7 @@ extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
 /* 300aaad4-45d2-8313-25d0-5e1d6086cdd1 */
-DECLARE_SOF_RT_UUID("zephyr", zephyr_uuid, 0x300aaad4, 0x45d2, 0x8313,
+SOF_DEFINE_UUID("zephyr", zephyr_uuid, 0x300aaad4, 0x45d2, 0x8313,
 		 0x25, 0xd0, 0x5e, 0x1d, 0x60, 0x86, 0xcd, 0xd1);
 
 DECLARE_TR_CTX(zephyr_tr, SOF_UUID(zephyr_uuid), LOG_LEVEL_INFO);

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -38,9 +38,7 @@ LOG_MODULE_REGISTER(zephyr, CONFIG_SOF_LOG_LEVEL);
 extern K_KERNEL_STACK_ARRAY_DEFINE(z_interrupt_stacks, CONFIG_MP_MAX_NUM_CPUS,
 				   CONFIG_ISR_STACK_SIZE);
 
-/* 300aaad4-45d2-8313-25d0-5e1d6086cdd1 */
-SOF_DEFINE_UUID("zephyr", zephyr_uuid, 0x300aaad4, 0x45d2, 0x8313,
-		 0x25, 0xd0, 0x5e, 0x1d, 0x60, 0x86, 0xcd, 0xd1);
+SOF_DEFINE_REG_UUID(zephyr);
 
 DECLARE_TR_CTX(zephyr_tr, SOF_UUID(zephyr_uuid), LOG_LEVEL_INFO);
 


### PR DESCRIPTION
This is a situation where scratching an itch (trying to get a clean mapping of component "names" I could track with some topology tooling I was experimenting with) turned into a big bleeding wound.  But the healing is probably worth it.

Basically SOF's UUID hygiene had broken down in a bunch of places, and the cleanup led to a global registry that should be simpler to maintain in the long term.  There's lots of code motion here but no signficant behavior changes, just a new and cleaner API.  Please read the commit messages carefully, but the executive summary is:

* No more typing UUIDs into C code.  All IDs are defined with unique names via `SOF_DEFINE_REG_UUID(name);`

* A handful of spots where we had colliding names and (gulp) IDs have been corrected.

* IDs are specified in a minimally complicated text file at the top of the source tree.  The build time C header generation automatically validates this file so it will stay clean.

* UUID string names (for IDs referenced by the build) are available at runtime in Zephyr builds via the pre-existing sof_uuid_entry struct, and you can enumerate over them via the Zephyr iterable sections API.  XTOS builds remain compatible, but don't get the new feature.  (This does have an image size cost of ~1-2k in existing firmware builds.)

* There remain a few spots where separate components share UUIDs.  These have been left in place for compatibility, though obviously they can't (and haven't been) be built into a single image.  The names of those IDs have been unified, however.

Longer term the hope is that this can be unified with things like topology and manifest generation, both to prevent errors due to miscopied IDs and to simplify tooling by giving users the ability to use a plaintext name instead.

~~Note also that this requires a Zephyr PR to build successfully, which corrects some mistakes with "snippets" in the Intel and NXP linker scripts.  Builds without them drop the runtime UUID structs into invalid or orphan addresses (which are linker warnings, but not errors) and will cause crashes at runtime:  https://github.com/zephyrproject-rtos/zephyr/pull/75055~~

Actually all that's needed is the ROM_SECTIONS PR that already merged upstream, my fixup crossed, and there's no reason not to use the variant that merged.  The next Zephyr uprev (e.g. to the 3.7.0 LTS version which is mere hours from shipping) should catch this automatically