### PR TITLE
[SKIP SOF-TEST] xtensa-build-zephyr.py: move PTL out of "all" and into "extra".

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -123,6 +123,11 @@ jobs:
             zephyr_revision: mnfst
             IPC_platforms: mtl
 
+          # This is "duplication of effort" but it makes sure no one
+          # breaks --all, see for instance #9262 and previous commit.
+          - zephyr_revision: mnfst
+            IPC_platforms: --all
+
     steps:
       - uses: actions/checkout@v4
         # Download a full clone to fix `git describe`, sof_version.h and

--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -87,6 +87,23 @@ class PlatformConfig:
 	aliases: list = dataclasses.field(default_factory=list)
 	ipc4: bool = False
 
+# These cannot be built by everyone out of the box yet.
+# For instance: there's no open-source toolchain available for them yet.
+extra_platform_configs = {
+	"ptl" : PlatformConfig(
+		"intel", "intel_adsp/ace30_ptl",
+		f"RI-2022.10{xtensa_tools_version_postfix}",
+		"ace30_LX7HiFi4_PIF",
+		ipc4 = True
+	),
+	"ptl-sim" : PlatformConfig(
+		"intel", "intel_adsp/ace30_ptl_sim",
+		f"RI-2022.10{xtensa_tools_version_postfix}",
+		"ace30_LX7HiFi4_PIF",
+		ipc4 = True
+	),
+}
+
 # These can all be built out of the box. --all builds all these.
 # Some of these values are duplicated in sof/scripts/set_xtensa_param.sh: keep them in sync.
 platform_configs_all = {
@@ -120,18 +137,6 @@ platform_configs_all = {
 		"ace10_LX7HiFi4_2022_10",
 		ipc4 = True
 	),
-	"ptl" : PlatformConfig(
-		"intel", "intel_adsp/ace30_ptl",
-		f"RI-2022.10{xtensa_tools_version_postfix}",
-		"ace30_LX7HiFi4_PIF",
-		ipc4 = True
-	),
-	"ptl-sim" : PlatformConfig(
-		"intel", "intel_adsp/ace30_ptl_sim",
-		f"RI-2022.10{xtensa_tools_version_postfix}",
-		"ace30_LX7HiFi4_PIF",
-		ipc4 = True
-	),
 
 	#  NXP platforms
 	"imx8" : PlatformConfig(
@@ -158,10 +163,6 @@ platform_configs_all = {
 		"hifi4_nxp2_s7_v2_1a_prod",
 		RIMAGE_KEY = "key param ignored by imx8ulp"
 	),
-}
-
-# These cannot be built out of the box yet
-extra_platform_configs = {
 }
 
 platform_configs = platform_configs_all.copy()
@@ -327,6 +328,7 @@ IPC4
 
 	args = parser.parse_args()
 
+	# This does NOT include "extra", experimental platforms.
 	if args.all:
 		args.platforms = list(platform_configs_all)
 


### PR DESCRIPTION
As reported in #9262, this fixes the --all option.

Fixes commit https://github.com/thesofproject/sof/commit/05bfc36dacbd1afe55b1e8d73b978713a5f7abfc ("ptl: Add initial PTL configuration")