### PR TITLE
[SKIP SOF-TEST] build: use CONFIG_64BIT for symbol exporting

### DIFF
--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -176,7 +176,7 @@ uint32_t crc32(uint32_t base, const void *data, uint32_t bytes)
 	return ~crc;
 }
 
-#if !CONFIG_SOC_MIMX9352_A55
+#if !CONFIG_64BIT
 uint64_t __udivdi3(uint64_t a, uint64_t b);
 EXPORT_SYMBOL(__udivdi3);
 #endif


### PR DESCRIPTION
Symbols like __udivdi3 aren't available in 64-bit builds, use CONFIG_64BIT to hide them.

This is to test CI so far, should be converted to non-draft after further conflicting LLEXT changes are merged.