### PR TITLE
copier: Add bind function to configure source/sink buffers params

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -662,8 +662,6 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	const struct ipc4_copier_config_set_sink_format *sink_fmt = data;
 	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	struct list_item *sink_list;
-	struct comp_buffer *sink;
 
 	if (max_data_size < sizeof(*sink_fmt)) {
 		comp_err(dev, "error: max_data_size %d should be bigger than %d", max_data_size,
@@ -692,19 +690,6 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	cd->converter[sink_fmt->sink_id] = get_converter_func(&sink_fmt->source_fmt,
 							      &sink_fmt->sink_fmt, ipc4_gtw_none,
 							      ipc4_bidirection);
-
-	/* update corresponding sink format */
-	list_for_item(sink_list, &dev->bsink_list) {
-		int sink_id;
-
-		sink = container_of(sink_list, struct comp_buffer, source_list);
-
-		sink_id = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
-		if (sink_id == sink_fmt->sink_id) {
-			ipc4_update_buffer_format(sink, &sink_fmt->sink_fmt);
-			break;
-		}
-	}
 
 	return 0;
 }

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -61,7 +61,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 			  struct sof_ipc_stream_params *params)
 {
-	struct comp_buffer *sink, *source;
+	struct comp_buffer *sink;
 	struct list_item *sink_list;
 
 	memset(params, 0, sizeof(*params));
@@ -88,19 +88,6 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 		j = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
 
 		ipc4_update_buffer_format(sink, &cd->out_fmt[j]);
-	}
-
-	/*
-	 * force update the source buffer format to cover cases where the source module
-	 * fails to set the sink buffer params
-	 */
-	if (!list_is_empty(&dev->bsource_list)) {
-		struct ipc4_audio_format *in_fmt;
-
-		source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-
-		in_fmt = &cd->config.base.audio_fmt;
-		ipc4_update_buffer_format(source, in_fmt);
 	}
 
 	/* update params for the DMA buffer */


### PR DESCRIPTION
Setting the source/sink buffers parameters in the copier_update_params function is not sufficient. If a sink buffer is attached during copier operation, the module will not set buffers parameters. Move the buffer parameter configurations to the new copier_bind bind function. Delete the sink buffers configurations from the copier_module_copy function. There is no need to configure sink buffers parameters on each copy. We are assured that they were configured at the time of bind.

Fixes: #9123