### PR TITLE
west.ytml: update to Zephyr 650227d8c47f (July 3rd)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 97a97c744a294ba14278a1f436d46eaa2d488354
+      revision: 650227d8c47f183b8c520b9abbbada2515982d05
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr baseline to 650227d8c47f

Change affecting SOF build targets:

32d05d360b93 intel_adsp/ace: power: fix firmware panic on MTL
a3835041bd36 intel_adsp/ace: power: Use MMU reinit API on core context restore
a983a5e399fd dts: xtensa: intel: Remove non-existent power domains from ACE30 PTL DTS
a2eada74c663 dts: xtensa: intel: Remove ALH nodes from ACE 3.0 PTL DTS
442e697a8ff7 dts: xtensa: intel: Reorder power domains by bit position in ACE30
d1b5d7092e5a intel_adsp: ace30: Correct power control register bitfield definitions
31c96cf3957b xtensa: check stack boundaries during backtrace
5b84bb4f4a55 xtensa: check stack frame pointer before dumping registers
cb9f8b1019f1 xtensa: separate FATAL EXCEPTION printout into two
e9c23274afa2 Revert "soc: intel_adsp: only implement FW_STATUS boot protocol for cavs"
1198c7ec295b Drivers: DAI: Intel: Move ACE DMIC start reset clear to earlier
78920e839e71 Drivers: DAI: Intel: Reduce traces dai_dmic_start()
9db580357bc6 Drivers: DAI: Intel: Remove trace from dai_dmic_update_bits()
f91700e62968 linker: nxp: adsp: add orphan linker section

- https://github.com/thesofproject/sof/issues/9268
- https://github.com/thesofproject/sof/issues/9243
- https://github.com/thesofproject/sof/issues/9205

Also:
- https://github.com/thesofproject/sof/issues/9245