### PR TITLE
[SKIP SOF-TEST] platform/posix: Port fuzzer to upstream "native_sim" board

### DIFF
--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -34,7 +34,7 @@ with the -b option.
 
 Simple wrapper around a libfuzzer test run, as much for
 documentation as direct use.  The idea here is really simple: build
-for the Zephyr "native_posix" board (which is a just a x86
+for the Zephyr "native_sim" board (which is a just a x86
 executable for the build host, not an emulated device) and run the
 resulting zephyr.exe file.  This specifies a "fuzz_corpus" directory
 to save the seeds that produce useful coverage output for use in
@@ -124,7 +124,7 @@ main()
   (set -x
    # When passing conflicting -DVAR='VAL UE1' -DVAR='VAL UE2' to CMake,
    # the last 'VAL UE2' wins. Previous ones are silently ignored.
-  west build -d build-fuzz -b native_posix "$SOF_TOP"/app/ -- \
+  west build -d build-fuzz -b native_sim "$SOF_TOP"/app/ -- \
       "${fuzz_configs[@]}" "$@"
   )
 

--- a/src/platform/posix/fuzz.c
+++ b/src/platform/posix/fuzz.c
@@ -8,10 +8,8 @@
 
 #include <irq_ctrl.h>
 #include <zephyr/sys/time_units.h>
-
-/* Zephyr arch APIs, not in a header (native_sim has them though) */
-void posix_init(int argc, char *argv[]);
-void posix_exec_for(uint64_t us);
+#include <nsi_cpu_if.h>
+#include <nsi_main_semipublic.h>
 
 const uint8_t *posix_fuzz_buf;
 size_t posix_fuzz_sz;
@@ -23,12 +21,13 @@ size_t posix_fuzz_sz;
  * "long enough" to handle the event and reach a quiescent state
  * again)
  */
+NATIVE_SIMULATOR_IF
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t sz)
 {
 	static bool runner_initialized;
 
 	if (!runner_initialized) {
-		posix_init(0, NULL);
+		nsi_init(0, NULL);
 		runner_initialized = true;
 	}
 
@@ -42,6 +41,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t sz)
 	/* Give the OS time to process whatever happened in that
 	 * interrupt and reach an idle state.
 	 */
-	posix_exec_for(k_ticks_to_us_ceil64(CONFIG_ZEPHYR_POSIX_FUZZ_TICKS));
+	nsi_exec_for(k_ticks_to_us_ceil64(CONFIG_ZEPHYR_POSIX_FUZZ_TICKS));
 	return 0;
 }


### PR DESCRIPTION
The older native_posix board is being deprecated, use native_sim, which is the future-proof API.  In theory this should be as simple as just swapping the board name at the west level, but there are a few changes:

The C API is broadly identical between the two, modulo some prefix renaming.

Unfortunately linkage is more of a hassle, as the fuzzing framework inverts the sense of "entry point" and causes some trouble with the way native_sim does its two-stage link.  We have to add some hackery:

  1. Make sure the fuzz entry point doesn't get dropped during the initial zephyr.elf link, as it calls OS/sim layer and not the reverse.

  2. Force it to be a global symbol in the final stage, so it can be seen by the code in libfuzzer that needs to call it (normally all Zephyr-side symbols are forced to be library-private to prevent collisions with the global Linux/glibc namespace environment)