### PR TITLE
[SKIP SOF-TEST][DNM] LLEXT: switch to LLEXT modules

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -968,7 +968,7 @@ def install_lib(sof_lib_dir, abs_build_dir, platform_wconfig):
 				    "-e", "-c", str(rimage_cfg),
 				    "-k", str(signing_key), "-l", "-r",
 				    str(llext_input)]
-			execute_command(sign_cmd, cwd=west_top)
+			subprocess.run(sign_cmd, cwd=west_top)
 
 			# An intuitive way to make this multiline would be
 			# with (open(dst, 'wb') as fdst, open(llext_output, 'rb') as fllext,

--- a/src/audio/eq_iir/Kconfig
+++ b/src/audio/eq_iir/Kconfig
@@ -3,6 +3,7 @@
 config COMP_IIR
 	tristate "IIR component"
 	select COMP_BLOB
+	default m if METEORLAKE
 	default y
 	depends on COMP_MODULE_ADAPTER
 	select MATH_IIR_DF1

--- a/src/audio/mixin_mixout/Kconfig
+++ b/src/audio/mixin_mixout/Kconfig
@@ -3,6 +3,7 @@
 config COMP_MIXIN_MIXOUT
 	tristate "Mixin_mixout component"
 	depends on IPC_MAJOR_4
+	default m if METEORLAKE
 	default y
 	help
 	  Select for Mixin_mixout component

--- a/src/samples/audio/Kconfig
+++ b/src/samples/audio/Kconfig
@@ -4,6 +4,7 @@ menu "Audio component samples"
 
         config SAMPLE_SMART_AMP
 	        tristate "Smart amplifier test component"
+		default m if METEORLAKE
 	        default y
 	        help
 	                Select for test smart amplifier component

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -90,7 +90,7 @@ function(sof_llext_build module)
 	get_target_property(proc_out_file ${module} pkg_input)
 	add_llext_command(TARGET ${module}
 		POST_BUILD
-		COMMAND ${SOF_BASE}scripts/llext_link_helper.py
+		COMMAND ${PYTHON_EXECUTABLE} ${SOF_BASE}scripts/llext_link_helper.py
 			--text-addr="${SOF_LLEXT_TEXT_ADDR}" -f ${proc_in_file} ${CMAKE_C_COMPILER} --
 			-o ${proc_out_file} ${EXTRA_LINKER_PARAMS}
 	                $<TARGET_OBJECTS:${module}_llext_lib>


### PR DESCRIPTION
Test-only: just to reproduce a Windows rimage signing failure
Switch eq-iir, mixin-mixout and smart-amp-test to LLEXT modules on MTL.