### PR TITLE
topology2: force all SoundWire link-side copiers to use S24_LE

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -79,6 +79,7 @@ Define {
 	PASSTHROUGH	false
 	SDW_JACK_CAPTURE_CH 2
 	ADD_BT  false
+	SDW_LINK_VALID_BITS	24
 }
 
 # override defaults with platform-specific config

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -9,7 +9,6 @@ Define {
 	SDW_AMP_IN_BE_ID 3
 	AMP_FEEDBACK_CH 2
 	SDW_AMP_FEEDBACK true
-	SDW_AMP_FMT_24 false
 }
 
 Object.Dai.ALH [
@@ -55,19 +54,15 @@ IncludeByKey.PASSTHROUGH {
 				Object.Widget.alh-copier.1 {
 					stream_name $SDW_SPK_STREAM
 					node_type $ALH_LINK_OUTPUT_CLASS
-					IncludeByKey.SDW_AMP_FMT_24 {
-					"true"	{
-							num_output_audio_formats 1
-							Object.Base.output_audio_format [
-								{
-									out_bit_depth           32
-									out_valid_bit_depth     24
-									out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-									out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-								}
-							]
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     $SDW_LINK_VALID_BITS
+							out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 						}
-					}
+					]
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
@@ -150,44 +145,15 @@ IncludeByKey.PASSTHROUGH {
 						in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 					}
 				]
-				IncludeByKey.SDW_AMP_FMT_24 {
-				"true"	{
-						num_output_audio_formats 1
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     24
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-
-							}
-						]
+				num_output_audio_formats 1
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     $SDW_LINK_VALID_BITS
+						out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+						out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 					}
-				"false"	{
-						num_output_audio_formats 3
-						num_output_audio_formats 3
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth           16
-								out_valid_bit_depth     16
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     24
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     32
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-						]
-					}
-				}
+				]
 			}
 		]
 		pipeline [
@@ -229,28 +195,14 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 							in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 						}
 					]
-					IncludeByKey.SDW_AMP_FMT_24 {
-					"true"	{
-							Object.Base.output_audio_format [
-								{
-									out_bit_depth            32
-									out_valid_bit_depth      24
-									out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-									out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-								}
-							]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth            32
+							out_valid_bit_depth      $SDW_LINK_VALID_BITS
+							out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 						}
-					"false"	{
-							Object.Base.output_audio_format [
-								{
-									out_bit_depth            32
-									out_valid_bit_depth      32
-									out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-									out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-								}
-							]
-						}
-					}
+					]
 				}
 			]
 			IncludeByKey.SDW_AMP_FEEDBACK {
@@ -268,28 +220,14 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 							num_output_audio_formats 1
 							num_output_pins 1
 
-							IncludeByKey.SDW_AMP_FMT_24 {
-							"true"	{
-									Object.Base.input_audio_format [
-										{
-											in_bit_depth            32
-											in_valid_bit_depth      24
-											in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-											in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
-										}
-									]
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth            32
+									in_valid_bit_depth      $SDW_LINK_VALID_BITS
+									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+									in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 								}
-							"false"	{
-									Object.Base.input_audio_format [
-										{
-											in_bit_depth            32
-											in_valid_bit_depth      32
-											in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-											in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
-										}
-									]
-								}
-							}
+							]
 							Object.Base.output_audio_format [
 								{
 									out_bit_depth            32
@@ -449,7 +387,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 								{
 									in_channels		4
 									in_bit_depth		32
-									in_valid_bit_depth	32
+									in_valid_bit_depth	$SDW_LINK_VALID_BITS
 									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									in_ch_map	$CHANNEL_MAP_3_POINT_1
 									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
@@ -473,7 +411,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 						Object.Base.input_audio_format [
 							{
 								in_bit_depth            32
-								in_valid_bit_depth      32
+								in_valid_bit_depth      $SDW_LINK_VALID_BITS
 								in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 								in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 							}
@@ -482,7 +420,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 							{
 								out_bit_depth            32
 								out_valid_bit_depth      32
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+								out_sample_type		 $SAMPLE_TYPE_MSB_INTEGER
 								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 							}
 						]
@@ -510,7 +448,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 
 				Object.PCM.pcm_caps.1 {
 					name "amp feedback"
-					formats 'S16_LE,S32_LE'
+					formats 'S16_LE,S24_LE,S32_LE'
 					channels_min $AMP_FEEDBACK_CH
 					channels_max $AMP_FEEDBACK_CH
 				}

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -52,7 +52,7 @@ Object.Widget {
 			Object.Base.input_audio_format [
 				{
 					in_bit_depth            32
-					in_valid_bit_depth      32
+					in_valid_bit_depth      $SDW_LINK_VALID_BITS
 					in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 					in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 				}

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -10,7 +10,6 @@ IncludeByKey.PASSTHROUGH {
 Define {
 	JACK_PLAYBACK_PCM_NAME	"Jack Out"
 	JACK_CAPTURE_PCM_NAME	"Jack In"
-	SDW_JACK_FMT_24		"false"
 }
 
 #
@@ -76,19 +75,15 @@ IncludeByKey.PASSTHROUGH {
 				Object.Widget.alh-copier.1 {
 					stream_name $SDW_JACK_OUT_STREAM
 					node_type $ALH_LINK_OUTPUT_CLASS
-					IncludeByKey.SDW_JACK_FMT_24 {
-					"true"	{
-							num_output_audio_formats 1
-							Object.Base.output_audio_format [
-								{
-									out_bit_depth           32
-									out_valid_bit_depth     24
-									out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-									out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256)) | ($out_sample_type * 65536)]"
-								}
-							]
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     $SDW_LINK_VALID_BITS
+							out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256)) | ($out_sample_type * 65536)]"
 						}
-					}
+					]
 				}
 				Object.Widget.gain.1 {
 					Object.Control.mixer.1 {
@@ -170,42 +165,15 @@ IncludeByKey.PASSTHROUGH {
 						in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 					}
 				]
-				IncludeByKey.SDW_JACK_FMT_24 {
-				"true"	{
-						num_output_audio_formats 1
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     24
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-						]
+				num_output_audio_formats 1
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth           32
+						out_valid_bit_depth     $SDW_LINK_VALID_BITS
+						out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+						out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
 					}
-				"false" {
-						num_output_audio_formats 3
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth           16
-								out_valid_bit_depth     16
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     24
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-							{
-								out_bit_depth           32
-								out_valid_bit_depth     32
-								out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-							}
-						]
-					}
-				}
+				]
 			}
 		]
 		pipeline [
@@ -323,28 +291,14 @@ Object.Widget {
 			num_output_audio_formats 1
 			num_output_pins 1
 
-			IncludeByKey.SDW_JACK_FMT_24 {
-			"true"	{
-					Object.Base.input_audio_format [
-						{
-							in_bit_depth		32
-							in_valid_bit_depth	24
-							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-							in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
-						}
-					]
+			Object.Base.input_audio_format [
+				{
+					in_bit_depth		32
+					in_valid_bit_depth	$SDW_LINK_VALID_BITS
+					in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+					in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 				}
-			"false"	{
-					Object.Base.input_audio_format [
-						{
-							in_bit_depth		32
-							in_valid_bit_depth	32
-							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-							in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
-						}
-					]
-				}
-			}
+			]
 			Object.Base.output_audio_format [
 				{
 					out_bit_depth		32

--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -57,12 +57,11 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 "cavs-sdw\;sof-mtl-cs42l43-l0-cs35l56-l12\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
 SDW_SPK_STREAM=Playback-SmartAmp,SDW_SPK_IN_STREAM=Capture-SmartAmp,\
 SDW_DMIC_STREAM=Capture-SmartMic,SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
-SDW_JACK_IN_STREAM=Capture-SimpleJack,SDW_AMP_FMT_24=true,SDW_JACK_FMT_24=true"
+SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 "cavs-sdw\;sof-mtl-cs42l43-l0-cs35l56-l23\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
-SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
-SDW_AMP_FMT_24=true,SDW_JACK_FMT_24=true"
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 # Below topologies are used on Chromebooks
 
@@ -149,5 +148,5 @@ PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-sdw-cs42l42-l0-max98363-l2.bin,\
 BT_NAME=SSP1-BT,BT_INDEX=1,BT_PCM_ID=20,BT_ID=8,BT_PCM_NAME=Bluetooth,ADD_BT=true,\
 NUM_SDW_AMP_LINKS=1,SDW_SPK_STREAM=SDW2-Playback,SDW_AMP_FEEDBACK=false,\
-SDW_JACK_CAPTURE_CH=1,SDW_AMP_FMT_24=true"
+SDW_JACK_CAPTURE_CH=1"
 )


### PR DESCRIPTION
Using S32_LE wastes bandwdith for no good reason, we should use 24 bits on the link to maximize bus efficiency with the 9.6 MHz bus clock.

~~FIXME: it's likely we need a kernel-side change as well to configure the hw_params to S24_LE, currently the stream/port is configured with~~

~~sconfig.bps = snd_pcm_format_width(params_format(params));~~

Link: https://github.com/thesofproject/sof/issues/8960