### PR TITLE
Few LMDK fixes

### DIFF
--- a/lmdk/README.md
+++ b/lmdk/README.md
@@ -5,7 +5,7 @@
 To build dummy loadable library execute:
 
     cd libraries/dummy
-    cmake -B build -G <Ninja/Makefile> -DRIMAGE_INSTALL_DIR="path/where/rimage/executable/is" -DSNIGNING_KEY="path/to/key"
+    cmake -B build -G <Ninja/Makefile> -DRIMAGE_INSTALL_DIR="path/where/rimage/executable/is" -DSIGNING_KEY="path/to/key"
     cd --build build
 
 
@@ -14,4 +14,4 @@ signing key for rimage. If RIMAGE_INSTALL_DIR is not provided, rimage will be se
 where SOF project installs it. Dummy module sets up toolchain file in the project file.
 However, in your library you can select toolchain file in the configure step command:
 
-    cmake -B build -G <Ninja/Makefile> --toolchain "../../cmake/xtensa-toolchain.cmake" -DSNIGNING_KEY="path/to/key"
+    cmake -B build -G <Ninja/Makefile> --toolchain "../../cmake/xtensa-toolchain.cmake" -DSIGNING_KEY="path/to/key"

--- a/lmdk/cmake/ldscripts/data_linker_script.txt
+++ b/lmdk/cmake/ldscripts/data_linker_script.txt
@@ -25,7 +25,7 @@ SECTIONS {
     } >HPSRAM_seg : rodata_phdr
 
     /* Module manifest is here */
-    .module 0 : {
+    .module : {
         KEEP(*(.module))
-    }
+    } >HPSRAM_seg : rodata_phdr
 }

--- a/lmdk/modules/smart_amp_test/CMakeLists.txt
+++ b/lmdk/modules/smart_amp_test/CMakeLists.txt
@@ -10,4 +10,7 @@ target_compile_definitions(smart_amp_test PRIVATE
 	CONFIG_IPC_MAJOR_4=1
 )
 
-target_include_directories(smart_amp_test PRIVATE "${SOF_BASE}/src/include")
+target_include_directories(smart_amp_test PRIVATE
+    "${SOF_BASE}/src/include"
+    "${SOF_BASE}/posix/include"
+)

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -5,7 +5,6 @@
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
 
 #ifndef __SOF_MODULE_SERVICE_BUILD__
-#include <sof/compiler_attributes.h>
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/ipc-config.h>
 #include <sof/trace/trace.h>
@@ -38,6 +37,7 @@ DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 #include <ipc4/module.h>
 #include <sof/math/numbers.h>
 #endif
+#include <sof/compiler_attributes.h>
 #include <sof/samples/audio/smart_amp_test.h>
 #include <module/module/api_ver.h>
 #include <rimage/sof/user/manifest.h>


### PR DESCRIPTION
* Fix typo in README.md
* Fix compilation error when building smart_amp_test as loadable module using LMDK.
* Fix linker script: specifying 0 address for .module section results in few GB binary file. Instead, put .module section near .text or .rodata.