### PR TITLE
intel_adsp_ace15_mtpm.conf: temporarily disable CONFIG_MODULES

### DIFF
--- a/app/boards/intel_adsp_ace15_mtpm.conf
+++ b/app/boards/intel_adsp_ace15_mtpm.conf
@@ -86,7 +86,10 @@ CONFIG_MEMORY_WIN_2_SIZE=12288
 
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y
-CONFIG_MODULES=y
+
+# temporarily disabled to get MTL working again
+# https://github.com/thesofproject/sof/issues/9308
+CONFIG_MODULES=n
 
 # Temporary disabled options
 CONFIG_TRACE=n


### PR DESCRIPTION
Temporarily disable CONFIG_MODULES to get MTL working again.

Avoids crash https://github.com/thesofproject/sof/issues/9308