### PR TITLE
Avoid  recent MTL regression

### DIFF
--- a/app/boards/intel_adsp_ace15_mtpm.conf
+++ b/app/boards/intel_adsp_ace15_mtpm.conf
@@ -86,10 +86,7 @@ CONFIG_MEMORY_WIN_2_SIZE=12288
 
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y
-
-# temporarily disabled to get MTL working again
-# https://github.com/thesofproject/sof/issues/9308
-CONFIG_MODULES=n
+CONFIG_MODULES=y
 
 # Temporary disabled options
 CONFIG_TRACE=n

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -164,8 +164,6 @@ static int copier_init(struct processing_module *mod)
 
 		dev->direction_set = true;
 	} else {
-		cd->gtw_type = ipc4_gtw_none;
-
 		/* set max sink count for module copier */
 		mod->max_sinks = IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT;
 	}
@@ -246,7 +244,7 @@ static int copier_prepare(struct processing_module *mod,
 		 */
 		cd->converter[0] = get_converter_func(&cd->config.base.audio_fmt,
 							      &cd->config.out_fmt, ipc4_gtw_none,
-							      ipc4_bidirection, DUMMY_CHMAP);
+							      ipc4_bidirection);
 		if (!cd->converter[0]) {
 			comp_err(dev, "can't support for in format %d, out format %d",
 				 cd->config.base.audio_fmt.depth,  cd->config.out_fmt.depth);
@@ -688,7 +686,7 @@ static int copier_set_sink_fmt(struct comp_dev *dev, const void *data,
 	cd->out_fmt[sink_fmt->sink_id] = sink_fmt->sink_fmt;
 	cd->converter[sink_fmt->sink_id] = get_converter_func(&sink_fmt->source_fmt,
 							      &sink_fmt->sink_fmt, ipc4_gtw_none,
-							      ipc4_bidirection, DUMMY_CHMAP);
+							      ipc4_bidirection);
 
 	return 0;
 }

--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -232,7 +232,6 @@ struct copier_data {
 	 */
 	struct ipc4_copier_module_cfg config;
 	void *gtw_cfg;
-	enum ipc4_gateway_type gtw_type;
 	struct comp_dev *endpoint[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	struct comp_buffer *endpoint_buffer[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	uint32_t endpoint_num;
@@ -268,8 +267,7 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 				      const struct ipc4_audio_format *out_fmt,
 				      enum ipc4_gateway_type type,
-				      enum ipc4_direction_type dir,
-				      uint32_t chmap);
+				      enum ipc4_direction_type dir);
 
 struct comp_ipc_config;
 int create_endpoint_buffer(struct comp_dev *dev,

--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -180,12 +180,7 @@ enum ipc4_copier_module_config_params {
 	 * uint32_t. Config is only allowed when output pin is set up for 32bit and
 	 * source is connected to Gateway
 	 */
-	IPC4_COPIER_MODULE_CFG_ATTENUATION = 6,
-	/* Use LARGE_CONFIG_SET to setup new channel map, which allows to map channels
-	 * from gateway buffer to copier with any order.
-	 * Same mapping will be applied for all copier sinks.
-	 */
-	IPC4_COPIER_MODULE_CFG_PARAM_CHANNEL_MAP = 7
+	IPC4_COPIER_MODULE_CFG_ATTENUATION = 6
 };
 
 struct ipc4_copier_config_timestamp_init_data {
@@ -204,13 +199,6 @@ struct ipc4_copier_config_set_sink_format {
 	struct ipc4_audio_format source_fmt;
 	/* Output format used by the sink */
 	struct ipc4_audio_format sink_fmt;
-} __attribute__((packed, aligned(4)));
-
-struct ipc4_copier_config_channel_map {
-	/* Each half-byte of the channel map is an index of the DMA stream channel that
-	 * should be copied to the position determined by this half-byte index.
-	 */
-	uint32_t channel_map;
 } __attribute__((packed, aligned(4)));
 
 #define IPC4_COPIER_DATA_SEGMENT_DISABLE	(0 << 0)

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -164,7 +164,6 @@ static int copier_dai_init(struct comp_dev *dev,
 {
 	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
-	uint32_t chmap;
 	struct dai_data *dd;
 	int ret;
 
@@ -179,7 +178,6 @@ static int copier_dai_init(struct comp_dev *dev,
 		config->frame_fmt = out_frame_fmt;
 		pipeline->sink_comp = dev;
 		cd->bsource_buffer = true;
-		chmap = copier->base.audio_fmt.ch_map;
 	} else {
 		enum sof_ipc_frame in_frame_fmt, in_valid_fmt;
 
@@ -189,7 +187,6 @@ static int copier_dai_init(struct comp_dev *dev,
 					    copier->base.audio_fmt.s_type);
 		config->frame_fmt = in_frame_fmt;
 		pipeline->source_comp = dev;
-		chmap = copier->out_fmt.ch_map;
 	}
 
 	/* save the channel map and count for ALH multi-gateway */
@@ -207,8 +204,6 @@ static int copier_dai_init(struct comp_dev *dev,
 	ret = dai_common_new(dd, dev, dai);
 	if (ret < 0)
 		goto free_dd;
-
-	dd->chmap = chmap;
 
 	pipeline->sched_id = config->id;
 
@@ -454,9 +449,9 @@ static int copy_single_channel_c32(const struct audio_stream *src,
 	return 0;
 }
 
-void copier_dai_adjust_params(const struct copier_data *cd,
-			      struct ipc4_audio_format *in_fmt,
-			      struct ipc4_audio_format *out_fmt)
+static void copier_dai_adjust_params(const struct copier_data *cd,
+				     struct ipc4_audio_format *in_fmt,
+				     struct ipc4_audio_format *out_fmt)
 {
 	struct comp_buffer *dma_buf;
 	int dma_buf_channels;
@@ -524,7 +519,7 @@ int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 			ipc4_playback : ipc4_capture;
 
 		cd->dd[0]->process =
-			get_converter_func(&in_fmt, &out_fmt, cd->gtw_type, dir, cd->dd[0]->chmap);
+			get_converter_func(&in_fmt, &out_fmt, cd->gtw_type, dir, DUMMY_CHMAP);
 
 		return ret;
 	}

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -234,6 +234,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	struct comp_ipc_config *config = &dev->ipc_config;
 	int dai_index[IPC4_ALH_MAX_NUMBER_OF_GTW];
 	union ipc4_connector_node_id node_id;
+	enum ipc4_gateway_type type;
 	struct ipc_config_dai dai;
 	int dai_count;
 	int i, ret;
@@ -254,13 +255,13 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	case ipc4_hda_link_input_class:
 		dai.type = SOF_DAI_INTEL_HDA;
 		dai.is_config_blob = true;
-		cd->gtw_type = ipc4_gtw_link;
+		type = ipc4_gtw_link;
 		break;
 	case ipc4_i2s_link_output_class:
 	case ipc4_i2s_link_input_class:
 		dai.type = SOF_DAI_INTEL_SSP;
 		dai.is_config_blob = true;
-		cd->gtw_type = ipc4_gtw_ssp;
+		type = ipc4_gtw_ssp;
 		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
 					   copier->gtw_cfg.config_length * 4);
 		if (ret != 0) {
@@ -274,11 +275,11 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 #if ACE_VERSION > ACE_VERSION_1_5
 		dai.type = SOF_DAI_INTEL_HDA;
 		dai.is_config_blob = true;
-		cd->gtw_type = ipc4_gtw_link;
+		type = ipc4_gtw_link;
 #else
 		dai.type = SOF_DAI_INTEL_ALH;
 		dai.is_config_blob = true;
-		cd->gtw_type = ipc4_gtw_alh;
+		type = ipc4_gtw_alh;
 #endif /* ACE_VERSION > ACE_VERSION_1_5 */
 		ret = copier_alh_assign_dai_index(dev, cd->gtw_cfg, node_id,
 						  &dai, dai_index, &dai_count);
@@ -288,7 +289,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	case ipc4_dmic_link_input_class:
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
-		cd->gtw_type = ipc4_gtw_dmic;
+		type = ipc4_gtw_dmic;
 		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
 					   copier->gtw_cfg.config_length * 4);
 		if (ret != 0) {
@@ -303,7 +304,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 
 	for (i = 0; i < dai_count; i++) {
 		dai.dai_index = dai_index[i];
-		ret = copier_dai_init(dev, config, copier, pipeline, &dai, cd->gtw_type, i,
+		ret = copier_dai_init(dev, config, copier, pipeline, &dai, type, i,
 				      dai_count);
 		if (ret) {
 			comp_err(dev, "failed to create dai");
@@ -312,11 +313,11 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	}
 
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
-			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, cd->gtw_type,
-					   IPC4_DIRECTION(dai.direction), DUMMY_CHMAP);
+			get_converter_func(&copier->base.audio_fmt, &copier->out_fmt, type,
+					   IPC4_DIRECTION(dai.direction));
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter type %d, dir %d",
-			 cd->gtw_type, dai.direction);
+			 type, dai.direction);
 		return -EINVAL;
 	}
 
@@ -449,81 +450,40 @@ static int copy_single_channel_c32(const struct audio_stream *src,
 	return 0;
 }
 
-static void copier_dai_adjust_params(const struct copier_data *cd,
-				     struct ipc4_audio_format *in_fmt,
-				     struct ipc4_audio_format *out_fmt)
-{
-	struct comp_buffer *dma_buf;
-	int dma_buf_channels;
-	int dma_buf_container_bits, dma_buf_valid_bits;
-
-	/* Call this func only for DAI gateway with already setup DMA buffer */
-	assert(cd->dd[0] && cd->dd[0]->dma_buffer);
-	dma_buf = cd->dd[0]->dma_buffer;
-
-	/* Unfortunately, configuring the gateway DMA buffer format is somewhat confusing.
-	 * The number of channels can come from hardware parameters (extracted from a blob?)
-	 * and also appears in the copier's input/output format. In case the value returned
-	 * by the hardware looks valid, it should take precedence over the value from the
-	 * copier's input/output format.
-	 *
-	 * The frame format comes from the topology as dev->ipc_config.frame_fmt and also
-	 * comes as the copier's input/output format. The logic is confusing: the format
-	 * from the topology takes priority, except when the copier's format container and
-	 * valid sample size are different. Perhaps this is to support the 16-bit valid
-	 * in the 32-bit container format used by SSP, as such a format cannot be specified
-	 * in the topology?
-	 */
-	dma_buf_channels = audio_stream_get_channels(&dma_buf->stream);
-	dma_buf_container_bits = audio_stream_sample_bytes(&dma_buf->stream) * 8;
-	dma_buf_valid_bits = get_sample_bitdepth(audio_stream_get_frm_fmt(&dma_buf->stream));
-
-	if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
-		out_fmt->channels_count = dma_buf_channels;
-
-		if (!(dma_buf_container_bits == out_fmt->depth &&
-		      out_fmt->depth != out_fmt->valid_bit_depth)) {
-			out_fmt->depth = dma_buf_container_bits;
-			out_fmt->valid_bit_depth = dma_buf_valid_bits;
-		}
-	} else {
-		in_fmt->channels_count = dma_buf_channels;
-
-		if (!(dma_buf_container_bits == in_fmt->depth &&
-		      in_fmt->depth != in_fmt->valid_bit_depth)) {
-			in_fmt->depth = dma_buf_container_bits;
-			in_fmt->valid_bit_depth = dma_buf_valid_bits;
-		}
-	}
-}
-
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index)
 {
 	struct sof_ipc_stream_params demuxed_params = *params;
+	const struct ipc4_audio_format *in_fmt = &cd->config.base.audio_fmt;
+	const struct ipc4_audio_format *out_fmt = &cd->config.out_fmt;
+	enum sof_ipc_frame in_bits, in_valid_bits, out_bits, out_valid_bits;
 	int container_size;
 	int j, ret;
 
 	if (cd->endpoint_num == 1) {
-		struct ipc4_audio_format in_fmt = cd->config.base.audio_fmt;
-		struct ipc4_audio_format out_fmt = cd->config.out_fmt;
-		enum ipc4_direction_type dir;
-
 		ret = dai_common_params(cd->dd[0], dev, params);
-		if (ret < 0)
-			return ret;
 
-		copier_dai_adjust_params(cd, &in_fmt, &out_fmt);
+		/*
+		 * dai_zephyr_params assigns the conversion function
+		 * based on the input/output formats but does not take
+		 * the valid bits into account. So change the conversion
+		 * function if the valid bits are different from the
+		 * container size.
+		 */
+		audio_stream_fmt_conversion(in_fmt->depth,
+					    in_fmt->valid_bit_depth,
+					    &in_bits, &in_valid_bits,
+					    in_fmt->s_type);
+		audio_stream_fmt_conversion(out_fmt->depth,
+					    out_fmt->valid_bit_depth,
+					    &out_bits, &out_valid_bits,
+					    out_fmt->s_type);
 
-		dir = (cd->direction == SOF_IPC_STREAM_PLAYBACK) ?
-			ipc4_playback : ipc4_capture;
-
-		cd->dd[0]->process =
-			get_converter_func(&in_fmt, &out_fmt, cd->gtw_type, dir, DUMMY_CHMAP);
-
+		if (in_bits != in_valid_bits || out_bits != out_valid_bits)
+			cd->dd[0]->process =
+				cd->converter[IPC4_COPIER_GATEWAY_PIN];
 		return ret;
 	}
-
 	/* For ALH multi-gateway case, params->channels is a total multiplexed
 	 * number of channels. Demultiplexed number of channels for each individual
 	 * gateway comes in blob's struct ipc4_alh_multi_gtw_cfg.

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -249,26 +249,10 @@ static bool use_no_container_convert_function(enum sof_ipc_frame in,
 	return false;
 }
 
-static bool is_remapping_chmap(uint32_t chmap, size_t out_channel_count)
-{
-	size_t i;
-
-	assert(out_channel_count <= 8);
-
-	for (i = 0; i < out_channel_count; i++) {
-		if ((chmap & 0xf) != i)
-			return true;
-		chmap >>= 4;
-	}
-
-	return false;
-}
-
 pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 				      const struct ipc4_audio_format *out_fmt,
 				      enum ipc4_gateway_type type,
-				      enum ipc4_direction_type dir,
-				      uint32_t chmap)
+				      enum ipc4_direction_type dir)
 {
 	enum sof_ipc_frame in, in_valid, out, out_valid;
 
@@ -315,16 +299,6 @@ pcm_converter_func get_converter_func(const struct ipc4_audio_format *in_fmt,
 		default:
 			break;
 		}
-	}
-
-	if (in_fmt->channels_count != out_fmt->channels_count ||
-	    is_remapping_chmap(chmap, out_fmt->channels_count)) {
-		if (in_valid == SOF_IPC_FRAME_S16_LE && in == SOF_IPC_FRAME_S32_LE)
-			in = SOF_IPC_FRAME_S16_4LE;
-		if (out_valid == SOF_IPC_FRAME_S16_LE && out == SOF_IPC_FRAME_S32_LE)
-			out = SOF_IPC_FRAME_S16_4LE;
-
-		return pcm_get_remap_function(in, out);
 	}
 
 	/* check container & sample size */

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -136,7 +136,6 @@ int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
 	enum sof_ipc_frame in_valid_fmt, out_valid_fmt;
 
 	config->type = SOF_COMP_HOST;
-	cd->gtw_type = ipc4_gtw_host;
 
 	audio_stream_fmt_conversion(copier_cfg->base.audio_fmt.depth,
 				    copier_cfg->base.audio_fmt.valid_bit_depth,
@@ -196,7 +195,7 @@ int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
 		get_converter_func(&copier_cfg->base.audio_fmt,
 				   &copier_cfg->out_fmt,
-				   ipc4_gtw_host, IPC4_DIRECTION(dir), DUMMY_CHMAP);
+				   ipc4_gtw_host, IPC4_DIRECTION(dir));
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter for host, dir %d", dir);
 		ret = -EINVAL;

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -229,7 +229,6 @@ int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	 * IPC gateway should be handled similarly as host gateway.
 	 */
 	config->type = SOF_COMP_HOST;
-	cd->gtw_type = ipc4_gtw_host;
 
 	ret = create_endpoint_buffer(dev, cd, copier, false);
 	if (ret < 0)
@@ -256,7 +255,7 @@ int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =
 		get_converter_func(&copier->base.audio_fmt,
 				   &copier->out_fmt,
-				   ipc4_gtw_host, IPC4_DIRECTION(cd->direction), DUMMY_CHMAP);
+				   ipc4_gtw_host, IPC4_DIRECTION(cd->direction));
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter for IPC gateway, dir %d",
 			 cd->direction);

--- a/src/audio/copier/dai_copier.h
+++ b/src/audio/copier/dai_copier.h
@@ -83,10 +83,6 @@ void copier_dai_free(struct copier_data *cd);
 
 int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd);
 
-void copier_dai_adjust_params(const struct copier_data *cd,
-			      struct ipc4_audio_format *in_fmt,
-			      struct ipc4_audio_format *out_fmt);
-
 int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params, int dai_index);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -269,7 +269,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		ret = dma_buffer_copy_to(dd->local_buffer, dd->dma_buffer,
-					 dd->process, bytes, dd->chmap);
+					 dd->process, bytes, DUMMY_CHMAP);
 	} else {
 		audio_stream_invalidate(&dd->dma_buffer->stream, bytes);
 		/*
@@ -277,7 +277,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 		 * so no need to check the return value of dma_buffer_copy_from_no_consume().
 		 */
 		ret = dma_buffer_copy_from_no_consume(dd->dma_buffer, dd->local_buffer,
-						      dd->process, bytes, dd->chmap);
+						      dd->process, bytes, DUMMY_CHMAP);
 #if CONFIG_IPC_MAJOR_4
 		struct list_item *sink_list;
 		/* Skip in case of endpoint DAI devices created by the copier */
@@ -318,7 +318,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				    sink->hw_params_configured)
 					ret = dma_buffer_copy_from_no_consume(dd->dma_buffer,
 									      sink, converter[j],
-									      bytes, dd->chmap);
+									      bytes, DUMMY_CHMAP);
 			}
 		}
 #endif
@@ -467,8 +467,6 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 	ret = dai_common_new(dd, dev, dai_cfg);
 	if (ret < 0)
 		goto error;
-
-	dd->chmap = DUMMY_CHMAP;
 
 	dev->state = COMP_STATE_READY;
 

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -129,7 +129,6 @@ struct dai_data {
 	int xrun;				/* true if we are doing xrun recovery */
 
 	pcm_converter_func process;		/* processing function */
-	uint32_t chmap;
 
 	channel_copy_func channel_copy;		/* channel copy func used by multi-endpoint
 						 * gateway to mux/demux stream from/to multiple


### PR DESCRIPTION
Yesterday a recent regression on MTL, documented in https://github.com/thesofproject/sof/issues/9308 was addressed in #9313 by disabling `CONFIG_MODULES` on MTL. That approach has multiple drawbacks: (1) it's too broad, even if one wanted to disable using LLEXT modules on MTL, it would have been enough to make the only module component DRC built-in again. (2) PR #9116 that was a suspect in this regression passed daily tests after merging and PR testing on the next day after its merging were passing too, (3) LLEXT has a high cost of maintenance without CI testing, so removing it from the CI returns it to the state where it has to be checked manually for regressions. This PR presents an alternative "fix" for the problem - reverting latest commits which triggered the breakage as identified by bisection.