### PR TITLE
src/audio/module_adapter/CMakeLists.txt: add CADENCE_CODEC_MP3_ENC

### DIFF
--- a/src/audio/module_adapter/CMakeLists.txt
+++ b/src/audio/module_adapter/CMakeLists.txt
@@ -35,6 +35,10 @@ if(NOT CONFIG_COMP_MODULE_SHARED_LIBRARY_BUILD)
 			sof_add_static_library(xa_mp3_dec ${CONFIG_CADENCE_CODEC_MP3_DEC_LIB})
 		endif()
 
+		if(CONFIG_CADENCE_CODEC_MP3_ENC)
+			sof_add_static_library(xa_mp3_enc ${CONFIG_CADENCE_CODEC_MP3_ENC_LIB})
+		endif()
+
 		if(CONFIG_CADENCE_CODEC_SBC_DEC)
 			sof_add_static_library(xa_sbc_dec ${CONFIG_CADENCE_CODEC_SBC_DEC_LIB})
 		endif()


### PR DESCRIPTION
The CADENCE_CODEC_MP3_ENC option was present in `Kconfig` and handled in `module/cadence.c` but missing from `CMakeLists.txt`.

Changes:
- add the CADENCE_CODEC_MP3_ENC option in `src/audio/module_adapter/CMakeLists.txt`.