### PR TITLE
Revert "intel_adsp_ace15_mtpm.conf: temporarily disable CONFIG_MODULES"

### DIFF
--- a/app/boards/intel_adsp_ace15_mtpm.conf
+++ b/app/boards/intel_adsp_ace15_mtpm.conf
@@ -86,10 +86,7 @@ CONFIG_MEMORY_WIN_2_SIZE=12288
 
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y
-
-# temporarily disabled to get MTL working again
-# https://github.com/thesofproject/sof/issues/9308
-CONFIG_MODULES=n
+CONFIG_MODULES=y
 
 # Temporary disabled options
 CONFIG_TRACE=n

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 740d7f735e234499222345ae276b115e8b7fc958
+      revision: pull/76196/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
This reverts commit 8847de0555cd419b6622d4afe37fe4c5086d4a90 by testing a Zephyr fix for the original problem.