### PR TITLE
topology2: hda: add passthrough option as well as CHAIN_DMA

### DIFF
--- a/tools/topology/topology2/cavs-passthrough-hda.conf
+++ b/tools/topology/topology2/cavs-passthrough-hda.conf
@@ -1,0 +1,362 @@
+Define {
+	ANALOG_PLAYBACK_PCM		'Analog Playback'
+	ANALOG_CAPTURE_PCM		'Analog Capture'
+	HDA_ANALOG_DAI_NAME      	'Analog'
+	CODEC_HDA_CHAIN_DMA		'false'
+}
+
+Object.Dai.HDA [
+	{
+		name $HDA_ANALOG_DAI_NAME
+		dai_index 0
+		id 4
+		default_hw_conf_id 4
+		Object.Base.hw_config.1 {
+			name	"HDA0"
+		}
+		direction duplex
+	}
+]
+
+Object.Pipeline {
+
+	host-gateway-playback [
+		{
+			index	0
+			use_chain_dma $CODEC_HDA_CHAIN_DMA
+
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_PLAYBACK_PCM
+				pcm_id 0
+				num_output_pins 1
+				IncludeByKey.CODEC_HDA_CHAIN_DMA {
+					"false" {
+						num_input_audio_formats 3
+						num_output_audio_formats 3
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      24
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      24
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+					}
+					"true" {
+						num_input_audio_formats 2
+						num_output_audio_formats 2
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+
+					}
+				}
+			}
+		}
+	]
+	io-gateway [
+		{
+			direction	"playback"
+			index 1
+			use_chain_dma $CODEC_HDA_CHAIN_DMA
+
+			Object.Widget.dai-copier.1 {
+				dai_type 	"HDA"
+				type		"dai_in"
+				copier_type	"HDA"
+				stream_name	$HDA_ANALOG_DAI_NAME
+				node_type	$HDA_LINK_OUTPUT_CLASS
+				direction 	playback
+				num_input_pins 1
+				IncludeByKey.CODEC_HDA_CHAIN_DMA {
+					"false" {
+						num_input_audio_formats 3
+						num_output_audio_formats 3
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      24
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      24
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+					}
+					"true" {
+						num_input_audio_formats 2
+						num_output_audio_formats 2
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+
+					}
+				}
+			}
+		}
+		{
+			direction	"capture"
+			index 2
+			use_chain_dma $CODEC_HDA_CHAIN_DMA
+
+			Object.Widget.dai-copier.1 {
+				dai_type 	"HDA"
+				type		"dai_out"
+				copier_type	"HDA"
+				stream_name	$HDA_ANALOG_DAI_NAME
+				node_type	$HDA_LINK_INPUT_CLASS
+				direction 	capture
+				num_output_pins 1
+				IncludeByKey.CODEC_HDA_CHAIN_DMA {
+					"false" {
+						num_input_audio_formats 3
+						num_output_audio_formats 3
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      24
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      24
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+					}
+					"true" {
+						num_input_audio_formats 2
+						num_output_audio_formats 2
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+
+					}
+				}
+			}
+		}
+	]
+	host-gateway-capture [
+		{
+			index 	3
+			use_chain_dma $CODEC_HDA_CHAIN_DMA
+
+			Object.Widget.host-copier.1 {
+				stream_name $ANALOG_CAPTURE_PCM
+				pcm_id 0
+				num_input_pins 1
+				IncludeByKey.CODEC_HDA_CHAIN_DMA {
+					"false" {
+						num_input_audio_formats 3
+						num_output_audio_formats 3
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      24
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      24
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+					}
+					"true" {
+						num_input_audio_formats 2
+						num_output_audio_formats 2
+						Object.Base.input_audio_format [
+							{
+								in_bit_depth            16
+								in_valid_bit_depth      16
+							}
+							{
+								in_bit_depth            32
+								in_valid_bit_depth      32
+							}
+						]
+						Object.Base.output_audio_format [
+							{
+								out_bit_depth            16
+								out_valid_bit_depth      16
+							}
+							{
+								out_bit_depth            32
+								out_valid_bit_depth      32
+							}
+						]
+
+					}
+				}
+			}
+		}
+	]
+}
+
+Object.PCM.pcm [
+	{
+		id 0
+		name 'HDA Analog'
+		Object.Base.fe_dai.1 {
+			name "HDA Analog"
+		}
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name $ANALOG_PLAYBACK_PCM
+			IncludeByKey.CODEC_HDA_CHAIN_DMA {
+				"true" {
+					formats 'S32_LE,S16_LE'
+				}
+				"false" {
+					formats 'S32_LE,S24_LE,S16_LE'
+				 }
+			}
+		}
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name $ANALOG_CAPTURE_PCM
+			IncludeByKey.CODEC_HDA_CHAIN_DMA {
+				"true" {
+					formats 'S32_LE,S16_LE'
+				}
+				"false" {
+					formats 'S32_LE,S24_LE,S16_LE'
+				 }
+			}
+		}
+		direction duplex
+	}
+]
+
+# top-level pipeline connections
+Object.Base.route [
+	{
+		sink 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.playback'
+		source 'host-copier.0.playback'
+	}
+	{
+		source 'dai-copier.HDA.$HDA_ANALOG_DAI_NAME.capture'
+		sink 'host-copier.0.capture'
+	}
+]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -55,6 +55,11 @@ NHLT_BIN=nhlt-sof-lnl-nocodec-fpga-4ch.bin,PASSTHROUGH=true,DMIC_IO_CLK=19200000
 
 "cavs-sdw\;sof-lnl-fpga-rt711-l0\;PLATFORM=lnl,NUM_HDMIS=0,PASSTHROUGH=true"
 
+# HDA topology with passthrough analog codec pipelines
+"sof-hda-generic\;sof-hda-passthrough\;HDA_CONFIG=passthrough"
+# HDA topology with passthrough analog codec pipelines using CHAIN_DMA
+"sof-hda-generic\;sof-hda-passthrough-chain-dma\;HDA_CONFIG=passthrough\;CODEC_HDA_CHAIN_DMA=true"
+
 # CAVS HDA topology with mixer-based efx eq pipelines for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-efx-generic\;HDA_CONFIG=efx,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,EFX_DRC_PARAMS=passthrough"

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -66,6 +66,7 @@ IncludeByKey.HDA_CONFIG {
 	"efx"		"cavs-mixin-mixout-efx-hda.conf"
 	"src"		"cavs-src-mixin-mixout-hda.conf"
 	"benchmark"	"cavs-benchmark-hda.conf"
+	"passthrough"	"cavs-passthrough-hda.conf"
 }
 
 # include DMIC config if needed.


### PR DESCRIPTION
Reviving an old branch I had in 2023 to test LNL, this PR adds support for ultra-simple pipelines for the HDA codec and the option to use the CHAIN_DMA for minimal firmware involvement.

When I tried last year, the CHAIN_DMA capture didn't work, let's see if this is still a problem