### PR TITLE
src: dai: update dai init flow

### DIFF
--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -135,7 +135,8 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 		   const void *spec_config)
 {
 	const struct device *dev = dai->dev;
-	const struct sof_ipc_dai_config *sof_cfg = spec_config;
+	const struct ipc4_copier_gateway_cfg *gtw_cfg = spec_config;
+	const struct sof_ipc_dai_config *sof_cfg = (void *)gtw_cfg->config_data;
 	struct dai_config cfg;
 	const void *cfg_params;
 	bool is_blob;
@@ -149,7 +150,7 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 	switch (common_config->type) {
 	case SOF_DAI_INTEL_SSP:
 		cfg.type = is_blob ? DAI_INTEL_SSP_NHLT : DAI_INTEL_SSP;
-		cfg_params = is_blob ? spec_config : &sof_cfg->ssp;
+		cfg_params = is_blob ? (void *)gtw_cfg : &sof_cfg->ssp;
 		dai_set_link_hda_config(&cfg.link_config,
 					common_config, cfg_params);
 		/* Store tdm slot group index*/
@@ -157,17 +158,17 @@ int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
 		break;
 	case SOF_DAI_INTEL_ALH:
 		cfg.type = is_blob ? DAI_INTEL_ALH_NHLT : DAI_INTEL_ALH;
-		cfg_params = is_blob ? spec_config : &sof_cfg->alh;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : &sof_cfg->alh;
 		break;
 	case SOF_DAI_INTEL_DMIC:
 		cfg.type = is_blob ? DAI_INTEL_DMIC_NHLT : DAI_INTEL_DMIC;
-		cfg_params = is_blob ? spec_config : &sof_cfg->dmic;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : &sof_cfg->dmic;
 		dai_set_link_hda_config(&cfg.link_config,
 					common_config, cfg_params);
 		break;
 	case SOF_DAI_INTEL_HDA:
 		cfg.type = is_blob ? DAI_INTEL_HDA_NHLT : DAI_INTEL_HDA;
-		cfg_params = is_blob ? spec_config : &sof_cfg->hda;
+		cfg_params = is_blob ? (void *)&gtw_cfg->config_data : &sof_cfg->hda;
 		break;
 	case SOF_DAI_IMX_SAI:
 		cfg.type = DAI_IMX_SAI;

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -393,7 +393,7 @@ int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai 
 	if (ret < 0)
 		return ret;
 
-	return dai_set_config(dd->dai, common_config, copier_cfg->gtw_cfg.config_data);
+	return dai_set_config(dd->dai, common_config, &copier_cfg->gtw_cfg);
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 740d7f735e234499222345ae276b115e8b7fc958
+      revision: pull/76258/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Added the ability to pass the full contents of the GTW configuration to individual DAI modules. This allows for parsing a greater number of details such as Node_id or the size of the GTW configuration in the appropriate drivers.

This is needed to support clock select : https://github.com/zephyrproject-rtos/zephyr/pull/76258