### PR TITLE
[DNM] west: update zephyr manifest for memory test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 740d7f735e234499222345ae276b115e8b7fc958
+      revision: pull/73431/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
This pulls in the changes to rollback memory mappings if there are failures.