### PR TITLE
multiband_drc: instantaneous enabled state switch on processing

### DIFF
--- a/src/audio/multiband_drc/multiband_drc.h
+++ b/src/audio/multiband_drc/multiband_drc.h
@@ -54,6 +54,11 @@ extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap[];
 extern const struct multiband_drc_proc_fnmap multiband_drc_proc_fnmap_pass[];
 extern const size_t multiband_drc_proc_fncount;
 
+void multiband_drc_default_pass(const struct processing_module *mod,
+                                const struct audio_stream *source,
+                                struct audio_stream *sink,
+                                uint32_t frames);
+
 /**
  * \brief Returns Multiband DRC processing function.
  */

--- a/src/audio/multiband_drc/multiband_drc_generic.c
+++ b/src/audio/multiband_drc/multiband_drc_generic.c
@@ -11,10 +11,10 @@
 #include "multiband_drc.h"
 #include "../drc/drc_algorithm.h"
 
-static void multiband_drc_default_pass(const struct processing_module *mod,
-				       const struct audio_stream *source,
-				       struct audio_stream *sink,
-				       uint32_t frames)
+void multiband_drc_default_pass(const struct processing_module *mod,
+				const struct audio_stream *source,
+				struct audio_stream *sink,
+				uint32_t frames)
 {
 	audio_stream_copy(source, 0, sink, 0, audio_stream_get_channels(source) * frames);
 }


### PR DESCRIPTION
(cherry-picked from stable-v2.2)

In present multiband_drc design, the enabled state is determined by the switch control while multiband_drc starts to process. If the switch control toggles while processing, it will take effects on the next time multiband_drc starts to process.

This commit makes change to let the enabled state update instantaneously by the switch control toggle when multiband_drc is processing.