### PR TITLE
topology2: sdw-dmic-generic: add eqiir to control DC offset

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -1,8 +1,10 @@
 # route and pipeline index start from pcm id * 10
 
 Define {
+	SDW_DMIC_CAPTURE_PCM_NAME	"Microphone"
 	SDW_DMIC_STREAM 'SDW3-Capture'
 	SDW_DMIC_BE_ID 4
+	SDW_DMIC_PASSTHROUGH "false"
 }
 
 Object.Dai.ALH [
@@ -73,6 +75,35 @@ Object.Widget {
 			priority	0
 			lp_mode	0
 			dynamic_pipeline 1
+
+			IncludeByKey.SDW_DMIC_PASSTHROUGH {
+				"false" {
+					Object.Widget.eqiir [
+						{
+							num_input_audio_formats 1
+							num_output_audio_formats 1
+							# index 41 is in	herited from the pipeline definition
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+							]
+
+							Object.Control.bytes."1" {
+								<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+								name '$SDW_DMIC_CAPTURE_PCM_NAME Capture IIR Eq'
+							}
+						}
+					]
+				}
+			}
 		}
 	]
 }
@@ -93,9 +124,25 @@ Object.PCM.pcm [
 	}
 ]
 
-Object.Base.route [
-	{
-		source	"alh-copier.$SDW_DMIC_STREAM.0"
-		sink	"host-copier.4.capture"
+IncludeByKey.SDW_DMIC_PASSTHROUGH {
+	"true" {
+		Object.Base.route [
+			{
+				source	"alh-copier.$SDW_DMIC_STREAM.0"
+				sink	"host-copier.4.capture"
+			}
+		]
 	}
-]
+	"false" {
+		Object.Base.route [
+			{
+				source	"alh-copier.$SDW_DMIC_STREAM.0"
+				sink	"eqiir.41.0"
+			}
+			{
+				source "eqiir.41.0"
+				sink	"host-copier.4.capture"
+			}
+		]
+	}
+}

--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -316,37 +316,38 @@ Object.Widget {
 			priority		0
 			lp_mode		0
 			dynamic_pipeline	1
-		}
-	]
-}
 
-IncludeByKey.PASSTHROUGH {
-"false" {
-	Object.Widget.eqiir [
-		{
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-			index		11
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
+			IncludeByKey.PASSTHROUGH {
+				"false" {
+					Object.Widget.eqiir [
+						{
+							num_input_audio_formats 1
+							num_output_audio_formats 1
+							# index 11 is inherited from the pipeline definition
+							# the instance number is automatically generated as '0'
+							Object.Base.input_audio_format [
+								{
+									in_bit_depth		32
+									in_valid_bit_depth	32
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_bit_depth		32
+									out_valid_bit_depth	32
+								}
+							]
 
-			Object.Control.bytes."1" {
-				<include/components/eqiir/highpass_40hz_0db_48khz.conf>
-				name '$JACK_CAPTURE_PCM_NAME Capture IIR Eq'
+							Object.Control.bytes."1" {
+								<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+								name '$JACK_CAPTURE_PCM_NAME Capture IIR Eq'
+							}
+						}
+					]
+				}
 			}
 		}
 	]
-	}
 }
 
 Object.PCM.pcm [


### PR DESCRIPTION
For some reason we had the EQIIR for topology1/IPC3 but we didn't add it for topology2/IPC4.  All recordings show there's a strong DC offset with RT722 and other codecs, so let's add this component by default in the non-passthrough cases.

FIXME: the instance numbers for eqiir don't look quite right, for some reason we cannot use eqiir.41.0, as if the instance number was global and not in the scope of a pipeline?