### PR TITLE
Move log and system_service headers to module directory

### DIFF
--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -15,11 +15,12 @@
 #include <rtos/string.h>
 #include <utilities/array.h>
 #include <module/iadk/adsp_error_code.h>
-#include <native_system_service.h>
+#include <system_service.h>
 #include <system_agent_interface.h>
 #include <module_initial_settings_concrete.h>
 #include <iadk_module_adapter.h>
 #include <system_agent.h>
+#include <sof/audio/module_adapter/library/native_system_service.h>
 
 using namespace intel_adsp;
 using namespace intel_adsp::system;
@@ -28,31 +29,6 @@ using namespace dsp_fw;
 void* operator new(size_t size, intel_adsp::ModuleHandle *placeholder) throw()
 {
 	return placeholder;
-}
-
-extern "C" {
-	void native_system_service_log_message (AdspLogPriority log_priority, uint32_t log_entry,
-						AdspLogHandle const* log_handle, uint32_t param1,
-						uint32_t param2, uint32_t param3, uint32_t param4);
-
-	AdspErrorCode native_system_service_safe_memcpy(void *RESTRICT dst, size_t maxlen,
-					      const void *RESTRICT src, size_t len);
-
-	AdspErrorCode native_system_service_safe_memmove(void *dst, size_t maxlen,
-					       const void *src, size_t len);
-
-	void *native_system_service_vec_memset(void *dst, int c, size_t len);
-
-	AdspErrorCode native_system_service_create_notification(notification_params *params,
-						      uint8_t *notification_buffer,
-						      uint32_t notification_buffer_size,
-						      adsp_notification_handle *handle);
-
-	AdspErrorCode native_system_service_send_notif_msg(adsp_notification_target notification_target,
-							   adsp_notification_handle message,
-							   uint32_t actual_payload_size);
-
-	AdspErrorCode native_system_service_get_interface(adsp_iface_id id, system_service_iface **iface);
 }
 
 namespace intel_adsp

--- a/src/audio/module_adapter/library/native_system_service.c
+++ b/src/audio/module_adapter/library/native_system_service.c
@@ -17,13 +17,44 @@
 #include <sof/ipc/msg.h>
 #include <native_system_service.h>
 #include <sof/lib_manager.h>
+#include <module/module/logger.h>
 
 #define RSIZE_MAX 0x7FFFFFFF
+
+ /*! Module log level priority to sof log level conversion array */
+const int log_priority_map[L_MAX] = {
+	/*! Critical message. */
+	[L_CRITICAL] = LOG_LEVEL_CRITICAL,
+	/*! Error message. */
+	[L_ERROR] = LOG_LEVEL_ERROR,
+	/*! High importance log level. */
+	[L_HIGH] = LOG_LEVEL_ERROR,
+	/*! Warning message. */
+	[L_WARNING] = LOG_LEVEL_WARNING,
+	/*! Medium importance log level. */
+	[L_MEDIUM] = LOG_LEVEL_WARNING,
+	/*! Low importance log level. */
+	[L_LOW] = LOG_LEVEL_INFO,
+	/*! Information. */
+	[L_INFO] = LOG_LEVEL_INFO,
+	/*! Verbose message. */
+	[L_VERBOSE] = LOG_LEVEL_VERBOSE,
+	[L_DEBUG] = LOG_LEVEL_DEBUG
+};
+
+static int log_priority_to_sof_level(enum log_priority log_priority)
+{
+	if ((uint32_t)log_priority >= L_DEBUG)
+		return LOG_LEVEL_DEBUG;
+
+	return log_priority_map[log_priority];
+}
 
 void native_system_service_log_message(AdspLogPriority log_priority, uint32_t log_entry,
 				       AdspLogHandle const *log_handle, uint32_t param1,
 				       uint32_t param2, uint32_t param3, uint32_t param4)
 {
+	log_priority_to_sof_level(log_priority);
 	uint32_t argc = (log_entry & 0x7);
 	/* TODO: Need to call here function like _log_sofdict, since we do not have format */
 	/*       passed from library */

--- a/src/include/module/module/logger.h
+++ b/src/include/module/module/logger.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2024 Intel Corporation. All rights reserved.
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#ifndef __MODULE_MODULE_LOGGER_H__
+#define __MODULE_MODULE_LOGGER_H__
+
+/* Log level priority enumeration. */
+enum log_priority {
+	L_CRITICAL,	/* Critical message. */
+	L_ERROR,	/* Error message. */
+	L_HIGH,		/* High importance log level. */
+	L_WARNING,	/* Warning message. */
+	L_MEDIUM,	/* Medium importance log level. */
+	L_LOW,		/* Low importance log level. */
+	L_INFO,		/* Information. */
+	L_VERBOSE,	/* Verbose message. */
+	L_DEBUG,
+	L_MAX,
+};
+
+/* struct log_handle identifies the log message sender.
+ *
+ * struct log_handle instance is passed to the system_service::log_message function.
+ * This struct should not be used directly.
+ */
+struct log_handle;
+
+#endif /* __MODULE_MODULE_LOGGER_H__ */

--- a/src/include/module/module/system_service.h
+++ b/src/include/module/module/system_service.h
@@ -1,0 +1,113 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2024 Intel Corporation. All rights reserved.
+ *
+ * Author: Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#ifndef MODULE_MODULE_SYSTEM_SERVICE_H
+#define MODULE_MODULE_SYSTEM_SERVICE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "logger.h"
+#include "../iadk/adsp_error_code.h"
+
+#ifdef __XTENSA__
+	#define RESTRICT __restrict
+#else
+	#define RESTRICT
+#endif
+
+/*! This struct defines the obfuscating type for notifications. */
+struct notification_handle;
+
+/* Defines parameters used by ADSP system during notification creation. */
+struct notification_params {
+	uint32_t type;              /*!< Notification type */
+	uint16_t user_val_1;        /*!< 16 bits user value available directly in IPC header
+				     * for some notifications
+				     */
+	uint32_t user_val_2;        /*!< 30 bits user value available directly in IPC header
+				     * for some notifications
+				     */
+	uint32_t max_payload_size;  /*!< Data size of payload (NotificationCreate updates this
+				     * value to max possible payload size)
+				     */
+	uint8_t *payload;           /*!< Pointer on the payload */
+};
+
+/* Defines parameters used by ADSP system during Module Event notification creation. */
+struct module_event_notification {
+	uint32_t module_instance_id; /*!< Module ID (MS word) + Module Instance ID (LS word) */
+	uint32_t event_id;           /*!< Module specific event ID. */
+	uint32_t event_data_size;    /*!< Size of event_data array in bytes. May be set to 0
+				      * in case there is no data.
+				      */
+	uint32_t event_data[];       /*!< Optional event data (size set to 0 as it is optional
+				      * data)
+				      */
+};
+
+/* Defines notification targets supported by ADSP system
+ * FW defines only two notification targets, HOST and ISH (Integrated Sensor Hub).
+ */
+enum notification_target {
+	NOTIFICATION_TARGET_DSP_TO_HOST = 1,	/* Notification target is HOST */
+	NOTIFICATION_TARGET_DSP_TO_ISH = 2	/* Notification target is ISH */
+};
+
+/* Defines notification types supported by ADSP system
+ * FW use reserved first 20 positions describing types of notifications.
+ */
+enum notification_type {
+	/* corresponding to PHRASE_DETECTED notification */
+	NOTIFICATION_TYPE_VOICE_COMMAND_NOTIFICATION = 4,
+
+	/* corresponding to FW_AUD_CLASS_RESULT notification */
+	NOTIFICATION_TYPE_AUDIO_CLASSIFIER_RESULTS = 9,
+
+	/* corresponding to MODULE_NOTIFICATION notification */
+	NOTIFICATION_TYPE_MODULE_EVENT_NOTIFICATION = 12,
+};
+
+/* Defines extended interfaces for IADK modules */
+enum interface_id {
+	INTERFACE_ID_GNA = 0x1000,			/* Reserved for ADSP system */
+	INTERFACE_ID_INFERENCE_SERVICE = 0x1001,	/* See InferenceServiceInterface */
+	INTERFACE_ID_SDCA = 0x1002,			/* See SdcaInterface */
+	INTERFACE_ID_ASYNC_MESSAGE_SERVICE = 0x1003,	/* See AsyncMessageInterface */
+	INTERFACE_ID_AM_SERVICE = 0x1005,		/* Reserved for ADSP system */
+	INTERFACE_ID_KPB_SERVICE = 0x1006		/* See KpbInterface */
+};
+
+/* sub interface definition.
+ * This type may contain generic interface properties like id or struct size if needed.
+ */
+struct system_service_iface;
+
+struct system_service {
+	void (*log_message)(enum log_priority log_priority, uint32_t log_entry,
+			    struct log_handle const *log_handle, uint32_t param1,
+			    uint32_t param2, uint32_t param3, uint32_t param4);
+
+	AdspErrorCode (*safe_memcpy)(void *RESTRICT dst, size_t maxlen,
+				     const void *RESTRICT src, size_t len);
+
+	AdspErrorCode (*safe_memmove)(void *dst, size_t maxlen,
+				      const void *src, size_t len);
+
+	void* (*vec_memset)(void *dst, int c, size_t len);
+
+	AdspErrorCode (*notification_create)(struct notification_params *params,
+					     uint8_t *notification_buffer,
+					     uint32_t notification_buffer_size,
+					     struct notification_handle **handle);
+	AdspErrorCode (*notification_send)(enum notification_target notification_target,
+					   struct notification_handle *message,
+					   uint32_t actual_payload_size);
+
+	AdspErrorCode (*get_interface)(enum interface_id id, struct system_service_iface **iface);
+};
+#endif /* MODULE_MODULE_SYSTEM_SERVICE_H */

--- a/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
+++ b/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
@@ -8,12 +8,13 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <user/trace.h>
 #include <rtos/string.h>
 
 #ifdef __ZEPHYR__
 #include <zephyr/sys/util.h>
 #endif /* __ZEPHYR__ */
+
+#include <module/module/logger.h>
 
 #ifdef __XTENSA__
   #define RESTRICT __restrict
@@ -21,30 +22,10 @@
   #define RESTRICT
 #endif
 
+
 /*! Log level priority enumeration. */
-typedef enum log_priority {
-	/*! Critical message. */
-	L_CRITICAL = LOG_LEVEL_CRITICAL,
-	/*! Error message. */
-	L_ERROR = LOG_LEVEL_ERROR,
-	/*! High importance log level. */
-	L_HIGH = LOG_LEVEL_ERROR,
-	/*! Warning message. */
-	L_WARNING = LOG_LEVEL_WARNING,
-	/*! Medium importance log level. */
-	L_MEDIUM = LOG_LEVEL_WARNING,
-	/*! Low importance log level. */
-	L_LOW = LOG_LEVEL_INFO,
-	/*! Information. */
-	L_INFO = LOG_LEVEL_INFO,
-	/*! Verbose message. */
-	L_VERBOSE = LOG_LEVEL_VERBOSE,
-	L_DEBUG   = LOG_LEVEL_DEBUG,
-	L_MAX     = LOG_LEVEL_DEBUG,
-} AdspLogPriority,
-	log_priority_e;
-struct AdspLogHandle;
-typedef struct AdspLogHandle AdspLogHandle;
+typedef enum log_priority AdspLogPriority, log_priority_e;
+typedef struct log_handle AdspLogHandle;
 
 #ifdef __cplusplus
 namespace intel_adsp

--- a/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
+++ b/src/include/sof/audio/module_adapter/iadk/adsp_stddef.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- *
- * Copyright(c) 2022 Intel Corporation. All rights reserved.
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2022 - 2024 Intel Corporation. All rights reserved.
  */
 
 #ifndef _ADSP_STDDEF_H_
@@ -15,13 +15,6 @@
 #endif /* __ZEPHYR__ */
 
 #include <module/module/logger.h>
-
-#ifdef __XTENSA__
-  #define RESTRICT __restrict
-#else
-  #define RESTRICT
-#endif
-
 
 /*! Log level priority enumeration. */
 typedef enum log_priority AdspLogPriority, log_priority_e;

--- a/src/include/sof/audio/module_adapter/iadk/system_service.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_service.h
@@ -1,16 +1,16 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- *
- * Copyright(c) 2022 Intel Corporation. All rights reserved.
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2022 - 2024 Intel Corporation. All rights reserved.
  */
 /*! \file system_service.h */
 
 #ifndef _ADSP_SYSTEM_SERVICE_H_
 #define _ADSP_SYSTEM_SERVICE_H_
 
+#include <stdint.h>
 #include "adsp_stddef.h"
 #include <module/iadk/adsp_error_code.h>
-#include "native_system_service.h"
-#include <stdint.h>
+#include <native_system_service.h>
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -18,22 +18,13 @@
 #endif //__clang__
 
 #ifdef __cplusplus
-extern "C" {
-#endif
-
-typedef struct native_system_service_api AdspSystemService;
-
-#ifdef __cplusplus
-
 namespace intel_adsp
 {
+typedef struct system_service AdspSystemService;
+
 /*! \brief Alias type of AdspSystemService which can be used in C++.
  */
 struct SystemService : public AdspSystemService {};
-}
-#endif
-
-#ifdef __cplusplus
 }
 #endif
 

--- a/src/include/sof/audio/module_adapter/library/native_system_agent.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_agent.h
@@ -12,7 +12,7 @@
 #include <native_system_service.h>
 
 struct native_system_agent {
-	struct native_system_service_api system_service;
+	struct system_service system_service;
 	uint32_t log_handle;
 	uint32_t core_id;
 	uint32_t module_id;

--- a/src/include/sof/audio/module_adapter/library/native_system_service.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_service.h
@@ -1,115 +1,52 @@
-/* SPDX-License-Identifier: BSD-3-Clause
- *
- * Copyright(c) 2023 Intel Corporation. All rights reserved.
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2023 - 2024 Intel Corporation. All rights reserved.
  */
-/*! \file native_system_service.h */
+
 #ifndef NATIVE_SYSTEM_SERVICE_H
 #define NATIVE_SYSTEM_SERVICE_H
 
 #include <stdint.h>
+#include <adsp_stddef.h>
 
-#include "adsp_stddef.h"
-#include <module/iadk/adsp_error_code.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-/*! \brief This struct defines the obfuscating type for notifications. */
-typedef struct _adsp_notification_handle {} *adsp_notification_handle;
+#include <module/module/system_service.h>
 
-/*! \brief Defines parameters used by ADSP system during notification creation. */
-typedef struct _notification_params {
-	uint32_t type;              /*!< Notification type */
-	uint16_t user_val_1;        /*!< 16 bits user value available directly in IPC header
-				     * for some notifications
-				     */
-	uint32_t user_val_2;        /*!< 30 bits user value available directly in IPC header
-				     * for some notifications
-				     */
-	uint32_t max_payload_size;  /*!< Data size of payload (NotificationCreate updates this
-				     * value to max possible payload size)
-				     */
-	uint8_t *payload;           /*!< Pointer on the payload */
-} notification_params;
-
-/*! \brief Defines parameters used by ADSP system during Module Event notification creation. */
-typedef struct _module_event_notification {
-	uint32_t module_instance_id; /*!< Module ID (MS word) + Module Instance ID (LS word) */
-	uint32_t event_id;           /*!< Module specific event ID. */
-	uint32_t event_data_size;    /*!< Size of event_data array in bytes. May be set to 0
-				      * in case there is no data.
-				      */
-	uint32_t event_data[];       /*!< Optional event data (size set to 0 as it is optional
-				      * data)
-				      */
-} module_event_notification;
-
-/*! \brief Defines notification targets supported by ADSP system
- * Legacy FW defines only two notification targets, HOST and ISH (Integrated Sensor Hub).
- */
-typedef enum _notification_target {
-	NOTIFICATION_TARGET_DSP_TO_HOST = 1,  /*!< Notification target is HOST */
-	NOTIFICATION_TARGET_DSP_TO_ISH = 2    /*!< Notification target is ISH */
-} adsp_notification_target;
-
-/*! \brief Defines notification types supported by ADSP system
- * Legacy FW uses reserves first 20 positions descibing types of notifications.
- */
-typedef enum _notification_type {
-	NOTIFICATION_TYPE_VOICE_COMMAND_NOTIFICATION = 4,	/*!< intel_adsp define
-								 * corresponding to PHRASE_DETECTED
-								 * notification
-								 */
-	NOTIFICATION_TYPE_AUDIO_CLASSIFIER_RESULTS = 9,		/*!< intel_adsp define
-								 * corresponding to
-								 * FW_AUD_CLASS_RESULT notification
-								 */
-	NOTIFICATION_TYPE_MODULE_EVENT_NOTIFICATION = 12,	/*!< intel_adsp define
-								 * corresponding to
-								 * MODULE_NOTIFICATION notification
-								 */
-} notification_type;
-
-/*! \brief Defines extended interfaces for IADK modules*/
-typedef enum _adsp_iface_id {
-	INTERFACE_ID_GNA = 0x1000,			/*!< Reserved for ADSP system */
-	INTERFACE_ID_INFERENCE_SERVICE = 0x1001,	/*!< See InferenceServiceInterface */
-	INTERFACE_ID_SDCA = 0x1002,			/*!< See SdcaInterface */
-	INTERFACE_ID_ASYNC_MESSAGE_SERVICE = 0x1003,	/*!< See AsyncMessageInterface */
-	INTERFACE_ID_AM_SERVICE = 0x1005,		/*!< Reserved for ADSP system */
-	INTERFACE_ID_KPB_SERVICE = 0x1006		/*!< See KpbInterface */
-} adsp_iface_id;
-
-/*! \brief sub interface definition.
- * This type may contain generic interface properties like id or struct size if needed.
- */
-typedef struct _system_service_iface {} system_service_iface;
-
-/*! \brief Defines prototype of the "GetInterface" function
- *
- * \param id service id
- * \param iface pointer to retrieved interface
- * \return error if service not supported
- */
-
-struct native_system_service_api {
-	void (*log_message)(AdspLogPriority log_priority, uint32_t log_entry,
-			    AdspLogHandle const *log_handle, uint32_t param1,
-			    uint32_t param2, uint32_t param3, uint32_t param4);
-
-	AdspErrorCode (*safe_memcpy)(void *RESTRICT dst, size_t maxlen,
-				     const void *RESTRICT src, size_t len);
-
-	AdspErrorCode (*safe_memmove)(void *dst, size_t maxlen,
-				      const void *src, size_t len);
-
-	void* (*vec_memset)(void *dst, int c, size_t len);
-
-	AdspErrorCode (*notification_create)(notification_params *params,
-					     uint8_t *notification_buffer,
-					     uint32_t notification_buffer_size,
-					     adsp_notification_handle *handle);
-	AdspErrorCode (*notification_send)(adsp_notification_target notification_target,
-					   adsp_notification_handle message,
-					   uint32_t actual_payload_size);
-
-	AdspErrorCode (*get_interface)(adsp_iface_id id, system_service_iface **iface);
+struct native_system_service {
+	struct system_service basic;
 };
-#endif /*NATIVE_SYSTEM_SERVICE_H*/
+
+void native_system_service_log_message(enum log_priority log_priority, uint32_t log_entry,
+				       struct log_handle const *log_handle, uint32_t param1,
+				       uint32_t param2, uint32_t param3, uint32_t param4);
+
+AdspErrorCode native_system_service_safe_memcpy(void *RESTRICT dst, size_t maxlen,
+						const void *RESTRICT src, size_t len);
+
+AdspErrorCode native_system_service_safe_memmove(void *dst, size_t maxlen,
+						 const void *src, size_t len);
+
+void *native_system_service_vec_memset(void *dst, int c, size_t len);
+
+AdspErrorCode native_system_service_create_notification(struct notification_params *params,
+							uint8_t *notification_buffer,
+							uint32_t notification_buffer_size,
+							struct notification_handle **handle);
+
+AdspErrorCode native_system_service_send_notif_msg(enum notification_target notification_target,
+						   struct notification_handle *message,
+						   uint32_t actual_payload_size);
+
+AdspErrorCode native_system_service_get_interface(enum interface_id id,
+						  struct system_service_iface **iface);
+
+extern const struct native_system_service native_system_service;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* NATIVE_SYSTEM_SERVICE_H */


### PR DESCRIPTION
Move logging priority definitions used by iadk modules to the modules directory so other types of loadable modules can use them. Propose a function to convert log priority used by loadable modules to log level used by sof.

Move definitions of functions exposed by system_service to the modules directory so that loadable modules can use them.