### PR TITLE
[STABLE-v2.2] topology1: sof-hda-generic: support BT offload pipelines

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TPLGS
 	"sof-hda-generic\;sof-hda-generic-2ch-pdm1\;-DPDM1\;-DCHANNELS=2\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic\;sof-hda-generic-3ch\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
 	"sof-hda-generic\;sof-hda-generic-4ch\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1"
+	"sof-hda-generic\;sof-hda-generic-4ch-bt\;-DCHANNELS=4\;-DHSPROC=volume\;-DDMICPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_48khz.m4\;-DDMIC16KPROC_FILTER1=eq_iir_coef_highpass_40hz_20db_16khz.m4\;-DDYNAMIC=1\;-DBT_OFFLOAD"
 	## end HDaudio codec topologies
 
 	"sof-hda-generic-idisp\;sof-hda-generic-idisp\;-DCHANNELS=0\;-DDYNAMIC=1"

--- a/tools/topology/topology1/sof-hda-generic.m4
+++ b/tools/topology/topology1/sof-hda-generic.m4
@@ -37,6 +37,15 @@ include(`platform/intel/intel-generic-dmic.m4')
 '
 )
 
+ifdef(`BT_OFFLOAD', `
+# BT offload support
+define(`BT_PIPELINE_PB_ID', `12')
+define(`BT_PIPELINE_CP_ID', `13')
+define(`BT_DAI_LINK_ID', 8)
+define(`BT_PCM_ID', `8')
+define(`HW_CONFIG_ID', 8)
+include(`platform/intel/intel-generic-bt.m4')')
+
 # The pipeline naming notation is pipe-mixer-PROCESSING-dai-DIRECTION.m4
 # HSPROC is set by makefile, if not the default above is applied
 define(PIPE_HEADSET_PLAYBACK, `sof/pipe-mixer-`HSPROC'-dai-playback.m4')


### PR DESCRIPTION
Add new pipelines to sof-hda-generic.m4 to support BT audio offload on SSP2 and also add an new topology sof-hda-generic-4ch-bt.tplg with BT audio offload enabled.