### PR TITLE
topology2: sof-hda-generic: support BT offload pipelines

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
@@ -11,8 +11,15 @@ list(APPEND TPLGS
 # passthrough pipelines for HDMI and
 # 2 or 4 DMIC, no NHLT blob included in topology
 "sof-hda-generic\;sof-hda-generic-2ch\;HDA_CONFIG=mix,NUM_DMICS=2"
+"sof-hda-generic\;sof-hda-generic-2ch-bt-ssp2\;HDA_CONFIG=mix,NUM_DMICS=2,\
+PLATFORM=mtl,INCLUDE_BT_OFFLOAD=true,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-2ch-bt-ssp2.bin"
 "sof-hda-generic\;sof-hda-generic-4ch\;HDA_CONFIG=mix,NUM_DMICS=4,\
 PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1"
+"sof-hda-generic\;sof-hda-generic-4ch-bt-ssp2\;HDA_CONFIG=mix,NUM_DMICS=4,\
+PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PLATFORM=mtl,INCLUDE_BT_OFFLOAD=true,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-4ch-bt-ssp2.bin"
 
 # HDA topology with mixer-based pipelines for HDA and
 # passthrough pipelines for HDMI and

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -30,6 +30,8 @@
 <pcm.conf>
 <pcm_caps.conf>
 <fe_dai.conf>
+<ssp.conf>
+<intel/hw_config_cardinal_clk.conf>
 <hda.conf>
 <dmic.conf>
 <pdm_config.conf>
@@ -39,6 +41,7 @@
 <common_definitions.conf>
 <dmic-default.conf>
 <hdmi-default.conf>
+<bt-default.conf>
 <module-copier.conf>
 
 Define {
@@ -52,6 +55,15 @@ Define {
 	DMIC0_DAI_GAIN 'eqiir.12.1'
 	DMIC0_DAI_EQIIR "highpass_40hz_20db"
 	DMIC0_PCM_CAPS 'Gain Capture 11'
+	# override BT default definitions
+	BT_PB_HOST_PIPELINE_ID 9
+	BT_PB_DAI_PIPELINE_ID 10
+	BT_PB_DAI_PIPELINE_SRC "copier.host.9.1"
+	BT_PB_PIPELINE_STREAM_NAME "dai-copier.SSP.10.1"
+	BT_ID 8
+	BT_PCM_ID 8
+	BT_PCM_NAME "Bluetooth"
+	INCLUDE_BT_OFFLOAD false
 }
 
 # override defaults with platform-specific config
@@ -71,6 +83,10 @@ IncludeByKey.HDA_CONFIG {
 # include DMIC config if needed.
 IncludeByKey.NUM_DMICS {
 	"[1-4]"	"platform/intel/dmic-generic.conf"
+}
+
+IncludeByKey.INCLUDE_BT_OFFLOAD {
+	"true"	"platform/intel/bt-generic.conf"
 }
 
 Define {


### PR DESCRIPTION
Add pipelines for BT offload on SSP2. The topology file name will be sof-hda-generic-2ch-bt-ssp2.tplg or sof-hda-generic-4ch-bt-ssp2.tplg according to DMIC PCM channel number.

cc:
- #9336 (stable-v2.2)