### PR TITLE
Revert "intel_adsp_ace15_mtpm.conf: temporarily disable CONFIG_MODULES"

### DIFF
--- a/app/boards/intel_adsp_ace15_mtpm.conf
+++ b/app/boards/intel_adsp_ace15_mtpm.conf
@@ -86,10 +86,7 @@ CONFIG_MEMORY_WIN_2_SIZE=12288
 
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y
-
-# temporarily disabled to get MTL working again
-# https://github.com/thesofproject/sof/issues/9308
-CONFIG_MODULES=n
+CONFIG_MODULES=y
 
 # Temporary disabled options
 CONFIG_TRACE=n


### PR DESCRIPTION
This reverts commit 8847de0555cd419b6622d4afe37fe4c5086d4a90.

This should now work thanks to the "better" IMR addresses in https://github.com/zephyrproject-rtos/zephyr/pull/76196

Note the longer term issue is still open:
https://github.com/zephyrproject-rtos/zephyr/issues/76247