### PR TITLE
Use the new SubTreeCopy feature in the topology2 compiler

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-dai-copier-playback.conf
@@ -88,10 +88,12 @@ Class.Pipeline."mixout-gain-dai-copier-playback" {
 	}
 
 	Object.Base {
-		route.1 {
-			source mixout.$index.1
-			sink	gain.$index.1
-		}
+		!route [
+			{
+				source mixout.$index.1
+				sink	gain.$index.1
+			}
+		]
 	}
 
 	direction	"playback"

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-dai-copier-playback.conf
@@ -14,178 +14,61 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
-<include/common/input_audio_format.conf>
-<include/common/output_audio_format.conf>
-<include/components/dai-copier.conf>
-<include/components/gain.conf>
-<include/components/mixout.conf>
-<include/components/pipeline.conf>
-<include/controls/bytes.conf>
-<include/components/eqiir.conf>
-<include/components/eqfir.conf>
 <include/components/drc.conf>
 <platform/intel/efx-default.conf>
+<include/pipelines/cavs/mixout-gain-eqiir-eqfir-playback.conf>
 
 Class.Pipeline."mixout-gain-efx-dai-copier-playback" {
 
-	<include/pipelines/pipeline-common.conf>
+	SubTreeCopy.baseclass {
+		# this class extends the mixout-gain-eqiir-eqfir pipeline class.
+		source "Class.Pipeline.mixout-gain-eqiir-eqfir"
 
-	attributes {
-		!constructor [
-			"index"
-		]
+		# target node is not defined which means that the new subtree will be copied to
+		# the parent node containing the SubTreeCopy node i.e in this case the
+		# Class.Pipeline.mixout-gain-efx-dai-copier-playback {} node.
 
-		!immutable [
-			"direction"
-		]
+		# default copy type is to extend the base class ie the widgets and routes
+		# will be added to the existing list of widgets/routes in the base class
 
-		#
-		# mixout-gain-efx-dai-copier-playback objects instantiated within the same alsaconf node must have
-		# unique instance attribute
-		#
-		unique	"instance"
-	}
+		tree {
+			Object.Widget {
+				drc."1" {
+					num_input_audio_formats 1
+					num_output_audio_formats 1
 
-	Object.Widget {
-		mixout."1" {}
-		dai-copier."1" {
-			type dai_in
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-			num_input_pins 1
+					# 32-bit 48KHz 2ch
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
 
-			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-		}
-		gain."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-		}
-		eqiir."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_IIR_PARAMS {
-					"passthrough" "include/components/eqiir/passthrough.conf"
+					Object.Control.bytes."1" {
+						IncludeByKey.EFX_DRC_PARAMS {
+							"passthrough" "include/components/drc/passthrough.conf"
+							"default"     "include/components/drc/default.conf"
+							"enabled"     "include/components/drc/enabled.conf"
+						}
+					}
 				}
 			}
-		}
-		eqfir."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
 
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_FIR_PARAMS {
-					"passthrough" "include/components/eqfir/passthrough.conf"
-				}
+			Object.Base {
+				!route [
+					{
+						source eqfir.$index.1
+						sink	drc.$index.1
+					}
+				]
 			}
 		}
-		drc."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_DRC_PARAMS {
-					"passthrough" "include/components/drc/passthrough.conf"
-					"default"     "include/components/drc/default.conf"
-					"enabled"     "include/components/drc/enabled.conf"
-				}
-			}
-		}
-		pipeline."1" {
-			priority		0
-			lp_mode		0
-		}
 	}
-
-	Object.Base {
-		route.1 {
-			source mixout.$index.1
-			sink	gain.$index.1
-		}
-		route.2 {
-			source gain.$index.1
-			sink	eqiir..1
-		}
-		route.3 {
-			source eqiir.$index.1
-			sink	eqfir.$index.1
-		}
-		route.4 {
-			source eqfir.$index.1
-			sink	drc.$index.1
-		}
-	}
-
-	direction	"playback"
-	dynamic_pipeline 1
-	time_domain	"timer"
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-efx-mbdrc-dai-copier-playback.conf
@@ -14,176 +14,57 @@
 # Where N is the unique pipeline ID within the same alsaconf node.
 #
 
-<include/common/input_audio_format.conf>
-<include/common/output_audio_format.conf>
-<include/components/dai-copier.conf>
-<include/components/gain.conf>
-<include/components/mixout.conf>
-<include/components/pipeline.conf>
-<include/controls/bytes.conf>
-<include/components/eqiir.conf>
-<include/components/eqfir.conf>
 <include/components/multiband_drc.conf>
 <platform/intel/efx-default.conf>
+<include/pipelines/cavs/mixout-gain-eqiir-eqfir-playback.conf>
 
+# this class extends the widgets and overrides the routes in mixout-gain-eqiir-eqfir pipeline class.
 Class.Pipeline."mixout-gain-efx-mbdrc-dai-copier-playback" {
 
-	<include/pipelines/pipeline-common.conf>
+	# extend the base class with the new widget
+	SubTreeCopy.baseclass {
+		source "Class.Pipeline.mixout-gain-eqiir-eqfir"
 
-	attributes {
-		!constructor [
-			"index"
-		]
+		# target node is not defined which means that the new subtree will be copied to
+		# the parent node containing the SubTreeCopy node i.e in this case the
+		# Class.Pipeline.mixout-gain-efx-mbdrc-dai-copier-playback {} node.
 
-		!immutable [
-			"direction"
-		]
+		# default copy type is to extend the base class ie the widgets and routes
+		# will be added to the existing list of widgets/routes in the base class
 
-		#
-		# mixout-gain-efx-mbdrc-dai-copier-playback objects instantiated within the same alsaconf node must have
-		# unique instance attribute
-		#
-		unique	"instance"
-	}
+		tree {
+			Object.Widget.multiband_drc."1" {
+				num_input_audio_formats 1
+				num_output_audio_formats 1
 
-	Object.Widget {
-		mixout."1" {}
-		dai-copier."1" {
-			type dai_in
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-			num_input_pins 1
+				Object.Base.input_audio_format [
+					{
+						in_bit_depth		32
+						in_valid_bit_depth	32
+					}
+				]
+				Object.Base.output_audio_format [
+					{
+						out_bit_depth		32
+						out_valid_bit_depth	32
+					}
+				]
 
-			# copier only supports one format based on mixin/mixout requirements: 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-		}
-		gain."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-		}
-		eqiir."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_IIR_PARAMS {
-					"passthrough" "include/components/eqiir/passthrough.conf"
+				Object.Control.bytes."1" {
+					IncludeByKey.EFX_MBDRC_PARAMS {
+						"passthrough"	"include/components/multiband_drc/passthrough.conf"
+						"default"	"include/components/multiband_drc/default.conf"
+					}
 				}
 			}
-		}
-		eqfir."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			# 32-bit 48KHz 2ch
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_FIR_PARAMS {
-					"passthrough" "include/components/eqfir/passthrough.conf"
-				}
+			Object.Base {
+				!route [
+					{
+						source	eqfir.$index.1
+						sink	multiband_drc.$index.1
+					}
+				]
 			}
 		}
-		multiband_drc."1" {
-			num_input_audio_formats 1
-			num_output_audio_formats 1
-
-			Object.Base.input_audio_format [
-				{
-					in_bit_depth		32
-					in_valid_bit_depth	32
-				}
-			]
-			Object.Base.output_audio_format [
-				{
-					out_bit_depth		32
-					out_valid_bit_depth	32
-				}
-			]
-
-			Object.Control.bytes."1" {
-				IncludeByKey.EFX_MBDRC_PARAMS {
-					"passthrough"	"include/components/multiband_drc/passthrough.conf"
-					"default"	"include/components/multiband_drc/default.conf"
-				}
-			}
-		}
-		pipeline."1" {
-			priority		0
-			lp_mode		0
-		}
 	}
-
-	Object.Base {
-		route.1 {
-			source mixout.$index.1
-			sink	gain.$index.1
-		}
-		route.2 {
-			source gain.$index.1
-			sink	eqiir.$index.1
-		}
-		route.3 {
-			source eqiir.$index.1
-			sink	eqfir.$index.1
-		}
-		route.4 {
-			source eqfir.$index.1
-			sink	multiband_drc.$index.1
-		}
-	}
-
-	direction	"playback"
-	dynamic_pipeline 1
-	time_domain	"timer"
 }

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-eqfir-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-eqfir-playback.conf
@@ -1,0 +1,102 @@
+#
+# BE playback pipeline: mixout-gain-eqiir-eqfir.
+# This pipeline is an extension of the mixout-gain-dai-copier-playback pipeline class
+#
+# All attributes defined herein are namespaced
+# by alsatplg to "Object.Pipeline.mixout-gain-eqiir-eqfir.N.attribute_name"
+#
+# Usage: mixout-gain-efx-dai-copier-playback pipeline object can be instantiated as:
+#
+# Object.Pipeline.mixout-gain-eqiir-eqfir."N" {
+# 	period		1000
+# 	time_domain	"timer"
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/components/eqiir.conf>
+<include/components/eqfir.conf>
+<platform/intel/efx-default.conf>
+<include/pipelines/cavs/mixout-gain-dai-copier-playback.conf>
+
+Class.Pipeline."mixout-gain-eqiir-eqfir" {
+	SubTreeCopy.baseclass {
+
+		# this class extends the mixout-gain-dai-copier-playback class definition
+		source "Class.Pipeline.mixout-gain-dai-copier-playback"
+
+		# target node is not defined which means that the new subtree will be copied to
+		# the parent node containing the SubTreeCopy node i.e in this case the
+		# Class.Pipeline.mixout-gain-eqiir-eqfir {} node.
+
+		# default copy type is to extend the base class ie the widgets and routes
+		# will be added to the existing list of widgets/routes in the base class
+
+		tree {
+			Object.Widget {
+				eqiir."1" {
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+
+					# 32-bit 48KHz 2ch
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
+
+					Object.Control.bytes."1" {
+						IncludeByKey.EFX_IIR_PARAMS {
+							"passthrough" "include/components/eqiir/passthrough.conf"
+						}
+					}
+				}
+				eqfir."1" {
+					num_input_audio_formats 1
+					num_output_audio_formats 1
+
+					# 32-bit 48KHz 2ch
+					Object.Base.input_audio_format [
+						{
+							in_bit_depth		32
+							in_valid_bit_depth	32
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth		32
+							out_valid_bit_depth	32
+						}
+					]
+
+					Object.Control.bytes."1" {
+						IncludeByKey.EFX_FIR_PARAMS {
+							"passthrough" "include/components/eqfir/passthrough.conf"
+						}
+					}
+				}
+			}
+
+			Object.Base {
+				!route [
+					{
+						source	gain.$index.1
+						sink	eqiir.$index.1
+					}
+					{
+						source	eqiir.$index.1
+						sink	eqfir.$index.1
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
Use the new feature in the topology compiler to extend the base class definitions to modify the pipelines that simply extend the pipeline with one or more widgets.