### PR TITLE
topology2: cavs-sdw: Add cs42l43 and cs35l56 support on ADL/RPL, MTL/ARL, LNL

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -72,12 +72,37 @@ SDW_DMIC_STREAM=SDW0-Capture"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+"cavs-sdw\;sof-mtl-cs42l43-l0\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
 "cavs-sdw\;sof-mtl-cs42l43-l0-cs35l56-l12\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
 SDW_SPK_STREAM=Playback-SmartAmp,SDW_SPK_IN_STREAM=Capture-SmartAmp,\
 SDW_DMIC_STREAM=Capture-SmartMic,SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
 SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 "cavs-sdw\;sof-mtl-cs42l43-l0-cs35l56-l23\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+# ARL has the same DSP generation. So reuse the platform = mtl.
+"cavs-sdw\;sof-arl-cs42l43-l0\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-arl-cs42l43-l0-cs35l56-l2\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-arl-cs42l43-l0-cs35l56-l23\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-arl-cs42l43-l2\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-arl-cs42l43-l2-cs35l56-l3\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 

--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -21,4 +21,17 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 # No SDW Jack. SDW DMIC+SPK
 "cavs-sdw\;sof-lnl-rt1318-l12-rt714-l0\;PLATFORM=lnl,SDW_JACK=false,SDW_DMIC=1,\
 NUM_SDW_AMP_LINKS=2,SDW_DMIC_STREAM=SDW0-Capture"
+
+# SDW bridge to SPK and SDW Jack+DMIC+SPK
+"cavs-sdw\;sof-lnl-cs42l43-l0\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-lnl-cs42l43-l0-cs35l56-l3\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-lnl-cs42l43-l0-cs35l56-l23\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 )

--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -24,7 +24,16 @@ SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false
 DMIC1_ID=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,SDW_AMP_FEEDBACK=false,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1308-4ch.bin"
 
+# ICP4 topology for TGL/ADL cs42l43 Jack + DMIC + cs35l56 Amp and RPL cs42l43 bridge to SPK
 "cavs-sdw\;sof-tgl-cs42l43-l3-cs35l56-l01\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-adl-cs42l43-l0-cs35l56-l23\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-rpl-cs42l43-l0\;NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 

--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -24,10 +24,9 @@ SDW_SPK_STREAM=SDW2-Playback,SDW_DMIC_STREAM=SDW0-Capture,SDW_AMP_FEEDBACK=false
 DMIC1_ID=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,SDW_AMP_FEEDBACK=false,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-rt711-rt1308-4ch.bin"
 
-"cavs-sdw\;sof-tgl-cs42l43-l3-cs35l56-l01\;PLATFORM=tgl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
-SDW_SPK_STREAM=Playback-SmartAmp,SDW_SPK_IN_STREAM=Capture-SmartAmp,\
-SDW_DMIC_STREAM=Capture-SmartMic,SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
-SDW_JACK_IN_STREAM=Capture-SimpleJack,SDW_AMP_FMT_24=true,SDW_JACK_FMT_24=true"
+"cavs-sdw\;sof-tgl-cs42l43-l3-cs35l56-l01\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 # IPC4 topology for TGL rt712 Headset, Amp and DMIC
 "cavs-sdw\;sof-tgl-rt712\;SDW_JACK_OUT_STREAM=Playback-SimpleJack,\


### PR DESCRIPTION
SoundWire#
  ├── link 0: cs42l43 Audio Jack and DMICs/Bridge to amplifiers.
      |  |     -> sof-rpl-cs42l43-l0.tplg
     │ │     -> sof-mtl-cs42l43-l0.tplg
     │ │     -> sof-arl-cs42l43-l0.tplg
     │ │     -> sof-lnl-cs42l43-l0.tplg
      │ │
      │ ├── link 2: cs35l56 Left and Right Amplifier.
      │	            -> sof-arl-cs42l43-l0-cs35l56-l2.tplg
      │
      ├──── link 2: cs35l56 Right/Rightx2 Amplifier.
      ├──── link 3: cs35l56 Left/Leftx2 Amplifier.
                    -> sof-adl-cs42l43-l0-cs35l56-l23.tplg
                    -> sof-arl-cs42l43-l0-cs35l56-l23.tplg
                    -> sof-lnl-cs42l43-l0-cs35l56-l23.tplg

SoundWire#
  ├── link 2: cs42l43 Audio Jack and DMICs.
      │       -> sof-arl-cs42l43-l2.tplg
      │ 
      ├──── link 3: cs35l56 Left and Right Amplifier.
                    -> sof-arl-cs42l43-l2-cs35l56-l3.tplg