### PR TITLE
west.yml: update zephyr to 795ac34f291

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 3bcaa6f8d63136ffc2ae37b6e77ee4e1cda6964f
+      revision: 795ac34f291c2f9895e7a3a03eafc053ad1d36f2
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 553 commits.

Changes include:

2fcdbba534b intel_adsp/ace: power: pad the hpsram_mask passed to power_down
d590c186728 intel_adsp: ace: call soc_num_cpus_init early
c79bbfadbbd xtensa: move arch_kernel_init code into prep_c
dbfbf0edbad xtensa: adapt soc code to use prep_c
42396735bf7 xtensa: introduce prep_c for xtensa
299dddfdce1 xtensa: remove mention of crt0-app.S
ed31037d5fd drivers: ssp: fix program of MLCS register
cbb9613d83b dai: intel/ssp: Use proper flexible array