### PR TITLE
Add $SOF_CC_BASE variable for building XTOS with clang-based, Cadence toolchains

### DIFF
--- a/scripts/cmake/xtensa-toolchain.cmake
+++ b/scripts/cmake/xtensa-toolchain.cmake
@@ -49,10 +49,13 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # xt toolchain only partially follows gcc convention
 if(TOOLCHAIN STREQUAL "xt")
 	set(XCC 1)
-	set(CMAKE_C_COMPILER ${CROSS_COMPILE}xcc)
-else()
-	set(CMAKE_C_COMPILER ${CROSS_COMPILE}gcc)
 endif()
+
+if(NOT DEFINED SOF_CC_BASE)
+set(SOF_CC_BASE "gcc")
+endif()
+# e.g.: "xt-" + "xcc"
+set(CMAKE_C_COMPILER ${CROSS_COMPILE}${SOF_CC_BASE})
 
 find_program(CMAKE_LD NAMES "${CROSS_COMPILE}ld" PATHS ENV PATH NO_DEFAULT_PATH)
 find_program(CMAKE_AR NAMES "${CROSS_COMPILE}ar" PATHS ENV PATH NO_DEFAULT_PATH)

--- a/scripts/rebuild-testbench.sh
+++ b/scripts/rebuild-testbench.sh
@@ -75,14 +75,8 @@ setup_xtensa_tools_build()
     test -n "${XTENSA_CORE}" ||
         die "Illegal platform $BUILD_PLATFORM, no XTENSA_CORE found.\n"
 
-    # Zephyr is not part of the testbench at all but let's play nice and
-    # align with that naming convention to keep things simple.
-    case "${ZEPHYR_TOOLCHAIN_VARIANT}" in
-        xcc)       COMPILER=xt-xcc;;
-        xt-clang)  COMPILER=xt-clang;;
-        *) die 'Unknown or undefined ZEPHYR_TOOLCHAIN_VARIANT=%s\n' \
-               "${ZEPHYR_TOOLCHAIN_VARIANT}";;
-    esac
+    # This (local?) variable should probably be inlined
+    COMPILER=xt-"$SOF_CC_BASE"
 
     install_bin=install/tools/$TOOLCHAIN_VER/XtensaTools/bin
     tools_bin=$XTENSA_TOOLS_ROOT/$install_bin

--- a/scripts/set_xtensa_params.sh
+++ b/scripts/set_xtensa_params.sh
@@ -145,15 +145,15 @@ case "$platform" in
 	;;
 esac
 
-# Pre-zephyr "XTOS" build
+# Pre-zephyr "XTOS" build, testbench,...
 case "$platform" in
-    none_yet)
+    mtl|lnl)
 	SOF_CC_BASE='clang';;
     *)
 	SOF_CC_BASE='xcc';;
 esac
 
-# For Zephyr unit tests, testbench,...
+# For Zephyr unit tests
 case "$platform" in
     imx8*|mtl|lnl)
         ZEPHYR_TOOLCHAIN_VARIANT='xt-clang';;

--- a/scripts/set_xtensa_params.sh
+++ b/scripts/set_xtensa_params.sh
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2023 Intel Corporation. All rights reserved.
 
+# Because this is meant to be sourced
+# shellcheck disable=SC2148
+# shellcheck disable=SC2034
+
 ### XTENSA_ toolchain configuration shared across projects ###
 
 # These variables are currently used in/by:

--- a/scripts/set_xtensa_params.sh
+++ b/scripts/set_xtensa_params.sh
@@ -145,6 +145,15 @@ case "$platform" in
 	;;
 esac
 
+# Pre-zephyr "XTOS" build
+case "$platform" in
+    none_yet)
+	SOF_CC_BASE='clang';;
+    *)
+	SOF_CC_BASE='xcc';;
+esac
+
+# For Zephyr unit tests, testbench,...
 case "$platform" in
     imx8*|mtl|lnl)
         ZEPHYR_TOOLCHAIN_VARIANT='xt-clang';;

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -234,15 +234,15 @@ do
 		export XTENSA_SYSTEM=$XTENSA_BUILDS_DIR/$XTENSA_CORE/config
 		printf 'XTENSA_SYSTEM=%s\n' "${XTENSA_SYSTEM}"
 		PATH=$XTENSA_TOOLS_DIR/XtensaTools/bin:$OLDPATH
-		COMPILER="xcc"
+		build_dir_suffix='xcc'
 	else
 		TOOLCHAIN=$HOST
 		PATH=$SOF_TOP/../$HOST/bin:$OLDPATH
-		COMPILER="gcc"
+		build_dir_suffix='gcc'
 		DEFCONFIG_PATCH=""
 	fi
 
-	BUILD_DIR=build_${platform}_${COMPILER}
+	BUILD_DIR=build_${platform}_${build_dir_suffix}
 	printf "Build in %s\n" "$BUILD_DIR"
 
 	# only delete binary related to this build

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -231,6 +231,8 @@ do
 		PATH=$XTENSA_TOOLS_DIR/XtensaTools/bin:$OLDPATH
 		build_dir_suffix='xcc'
 	else
+		# Override SOF_CC_BASE from set_xtensa_params.sh
+		SOF_CC_BASE='gcc'
 		TOOLCHAIN=$HOST
 		PATH=$SOF_TOP/../$HOST/bin:$OLDPATH
 		build_dir_suffix='gcc'
@@ -248,6 +250,7 @@ do
 	printf 'PATH=%s\n' "$PATH"
 	( set -x # log the main commands and their parameters
 	cmake -DTOOLCHAIN="$TOOLCHAIN" \
+		-DSOF_CC_BASE="$SOF_CC_BASE" \
 		-DROOT_DIR="$ROOT" \
 		-DMEU_OPENSSL="${MEU_OPENSSL}" \
 		"${MEU_PATH_OPTION}" \

--- a/scripts/xtensa-build-all.sh
+++ b/scripts/xtensa-build-all.sh
@@ -210,22 +210,17 @@ do
 		XTENSA_TOOLS_DIR="$XTENSA_TOOLS_ROOT/install/tools/$TOOLCHAIN_VER"
 		XTENSA_BUILDS_DIR="$XTENSA_TOOLS_ROOT/install/builds/$TOOLCHAIN_VER"
 
-		# make sure the required version of xtensa tools is installed
-		if [ -d "$XTENSA_TOOLS_DIR" ]
-			then
-				XCC="xt-xcc"
-			else
-				XCC="none"
-				>&2 printf 'WARNING: %s
-\t is not a directory, reverting to gcc\n' "$XTENSA_TOOLS_DIR"
-		fi
+		[ -d "$XTENSA_TOOLS_DIR" ] || {
+			>&2 printf 'ERROR: %s\t is not a directory\n' "$XTENSA_TOOLS_DIR"
+			exit 1
+		}
 	fi
 
 	# CMake uses ROOT_DIR for includes and libraries a bit like
 	# --sysroot would.
 	ROOT="$SOF_TOP/../xtensa-root/$HOST"
 
-	if [ "$XCC" == "xt-xcc" ]
+	if [ -n "$XTENSA_TOOLS_ROOT" ]
 	then
 		TOOLCHAIN=xt
 		ROOT="$XTENSA_BUILDS_DIR/$XTENSA_CORE/xtensa-elf"


### PR DESCRIPTION
As required by ACP_7_0 addition submitted in #9351

Other related cleanups, see commit messages.

Switch rebuild-testbench.sh to new variable.


