### PR TITLE
xtensa-build-zephyr.py: create /lib/firmware tarball

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -200,6 +200,7 @@ jobs:
              --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
              --cmake-args=--warn-uninitialized
              --overlay=sof/app/overlays/repro-build.conf
+             --no-tarball
              ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
@@ -366,6 +367,7 @@ jobs:
           --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
           --cmake-args=--warn-uninitialized
           --overlay=sof/app/overlays/repro-build.conf
+          --no-tarball
           ${{ matrix.build_opts }} ${{ matrix.platforms }}
 
       - name: Upload build artifacts


### PR DESCRIPTION
With addition of loadable modules, SOF firmware installation depends much more on symbolic links. Add a step to build script to create a tarball of the installed firmware binaries in the build-staging-sof tree. The created tarball (build-sof-staging/sof/sof.tar.gz) provides a ready structure that can be unpacked to e.g. /lib/firmware on Linux target machines.