### PR TITLE
Tools: Topology2: DMIC: Bug fix 4ch host copier channels count

### DIFF
--- a/tools/topology/topology2/platform/intel/dmic-default.conf
+++ b/tools/topology/topology2/platform/intel/dmic-default.conf
@@ -43,5 +43,7 @@ Define {
 
 	# TDFB and DRC pipeline
 	DMIC0_ENHANCED_CAPTURE		"false"
-	DMIC0_PCM_CHANNELS		2
+
+	# Note: This will be redefined in dmic-generic.conf if not set from cmake
+	DMIC0_PCM_CHANNELS		0
 }

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -2,6 +2,27 @@ Define {
        DMIC0_PCM_NAME	"DMIC Raw"
 }
 
+
+# If DMIC0_PCM_CHANNELS is zero, copy it from NUM_DMICS. This
+# allows by setting both NUM_DMICS and DMIC0_PCM_CHANNELS to
+# have a different channels count in DAI and host.
+IncludeByKey.DMIC0_PCM_CHANNELS {
+	"0" {
+		IncludeByKey.NUM_DMICS {
+			"2" {
+				Define {
+					DMIC0_PCM_CHANNELS 2
+				}
+			}
+			"4" {
+				Define {
+					DMIC0_PCM_CHANNELS 4
+				}
+			}
+		}
+	}
+}
+
 Object.Dai.DMIC [
 	{
 		dai_index 0


### PR DESCRIPTION
The NUM_DMICS=4 controls DAI channels count, while recently added DMIC0_PCM_CHANNELS controls host copier channels count. But in most topologies built the DMIC0_PCM_CHANNELS remained in default 2 setting if it was not set in cmake target definitions.

As result the "arecord -c 4" attempt failed e.g. with common sof-hda-generic-4ch.tplg.

Fixes: 88366121b3f50a4fe86675860af9426b8b946240 ("Tools: Topology2:
       Add DMIC Enhanced Audio Capture development tplg")