### PR TITLE
platform: imx93_a55: handle linker additions at SOF level

### DIFF
--- a/src/platform/imx93_a55/linker/data-sections.ld
+++ b/src/platform/imx93_a55/linker/data-sections.ld
@@ -1,0 +1,15 @@
+SECTION_PROLOGUE(.static_uuid_entries,,)
+{
+	*(*.static_uuids)
+} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+SECTION_PROLOGUE(.static_log_entries,,)
+{
+	*(*.static_log*)
+} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+SECTION_PROLOGUE(.fw_metadata,,)
+{
+	KEEP (*(*.fw_metadata))
+	. = ALIGN(16);
+} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/src/platform/imx93_a55/linker/rwdata.ld
+++ b/src/platform/imx93_a55/linker/rwdata.ld
@@ -1,0 +1,3 @@
+_trace_ctx_start = ABSOLUTE(.);
+*(.trace_ctx)
+_trace_ctx_end = ABSOLUTE(.);

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 689d1edee1d57f052b1d4572d67618c0b0e2b8a4
+      revision: dc5f1bfb3f2eee3e3775175232d508660f5d6efe
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -393,6 +393,14 @@ if (CONFIG_SOC_MIMX9352_A55)
 		${SOF_SRC_PATH}/schedule/zephyr_ll.c
 	)
 
+	# SOF-specific linker script additions
+	zephyr_linker_sources(RWDATA
+	  ${sof_top_dir}/src/platform/imx93_a55/linker/rwdata.ld
+	)
+	zephyr_linker_sources(DATA_SECTIONS
+	  ${sof_top_dir}/src/platform/imx93_a55/linker/data-sections.ld
+	)
+
 	set(PLATFORM "imx93_a55")
 endif()
 


### PR DESCRIPTION
SOF requires some additions to the Zephyr linker script. This should be handled inside SOF instead of Zephyr.

Since 8f33d9dc8498 ("soc: imx93: remove custom linker script") removes the custom linker script from Zephyr, this means the custom SOF linker sections will have to be handled on SOF side.

This also includes a Zephyr hash bump to pull/77228/head to pull in the following commits:

8f33d9dc8498 soc: imx93: remove custom linker script

Depends on: https://github.com/zephyrproject-rtos/zephyr/pull/77228