### PR TITLE
platform: imx93_a55: select `CONFIG_IMX`

### DIFF
--- a/Kconfig.sof
+++ b/Kconfig.sof
@@ -108,6 +108,7 @@ config XT_INTERRUPT_LEVEL_5
 config COMPILER_WORKAROUND_CACHE_ATTR
 	bool
 	default n
+	depends on XTENSA
 	help
 	  Select this to activate use of functions instead of macros
 	  to decide whether an address is cacheable or not.

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -153,6 +153,7 @@ config IMX93_A55
 	select BUILD_OUTPUT_BIN
 	select ZEPHYR_LOG
 	select HOST_PTABLE
+	select IMX
 	help
 	 Select if your target platform is imx93-compatible.
 

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -293,7 +293,7 @@ config HOST
 config IMX
 	bool
 	default n
-	select COMPILER_WORKAROUND_CACHE_ATTR
+	select COMPILER_WORKAROUND_CACHE_ATTR if XTENSA
 	help
 	  This has to be selected for every i.MX NXP platform.
 	  It enables NXP platforms-specific features.

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -493,7 +493,7 @@ static int test_keyword_set_config(struct comp_dev *dev,
 	cfg = (struct sof_detect_test_config *)cdata->data->data;
 	bs = cfg->size;
 
-	comp_info(dev, "test_keyword_set_config(), blob size = %u", bs);
+	comp_info(dev, "test_keyword_set_config(), blob size = %zu", bs);
 
 	if (bs != sizeof(struct sof_detect_test_config)) {
 		comp_err(dev, "test_keyword_set_config(): invalid blob size");
@@ -578,7 +578,7 @@ static int test_keyword_get_config(struct comp_dev *dev,
 
 	/* Copy back to user space */
 	bs = cd->config.size;
-	comp_info(dev, "value of block size: %u", bs);
+	comp_info(dev, "value of block size: %zu", bs);
 
 	if (bs == 0 || bs > size)
 		return -EINVAL;

--- a/zephyr/include/rtos/interrupt.h
+++ b/zephyr/include/rtos/interrupt.h
@@ -49,8 +49,7 @@ static inline void interrupt_unregister(uint32_t irq, const void *arg)
 static inline int interrupt_get_irq(unsigned int irq, const char *cascade)
 {
 #if defined(CONFIG_LIBRARY) || defined(CONFIG_ACE) || defined(CONFIG_CAVS) || \
-	defined(CONFIG_ZEPHYR_POSIX) || defined(CONFIG_ARM64) || \
-	defined(CONFIG_IMX8) || defined(CONFIG_IMX8X) || defined(CONFIG_IMX8ULP)
+	defined(CONFIG_ZEPHYR_POSIX) || (defined(CONFIG_IMX) && !defined(CONFIG_IMX8M))
 	return irq;
 #else
 	if (cascade == irq_name_level2)

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -53,6 +53,8 @@ extern struct tr_ctx zephyr_tr;
 /* The Zephyr heap */
 
 #ifdef CONFIG_IMX
+
+#ifdef CONFIG_XTENSA
 #define HEAPMEM_SIZE		(HEAP_SYSTEM_SIZE + HEAP_RUNTIME_SIZE + HEAP_BUFFER_SIZE)
 
 /*
@@ -60,6 +62,20 @@ extern struct tr_ctx zephyr_tr;
  * duplicated in two sections and the sdram0 region overflows.
  */
 __section(".heap_mem") static uint8_t __aligned(64) heapmem[HEAPMEM_SIZE];
+
+#else
+
+/* for ARM64 the heap is placed inside the .bss section.
+ *
+ * This is because we want to avoid introducing new sections in
+ * the arm64 linker script. Also, is there really a need to place
+ * it inside a special section?
+ *
+ * i.MX93 is the only ARM64-based platform so defining the heap this way
+ * for all ARM64-based platforms should be safe.
+ */
+static uint8_t __aligned(PLATFORM_DCACHE_ALIGN) heapmem[HEAPMEM_SIZE];
+#endif /* CONFIG_XTENSA */
 
 #elif CONFIG_ACE
 
@@ -76,18 +92,6 @@ __section(".heap_mem") static uint8_t __aligned(PLATFORM_DCACHE_ALIGN) heapmem[H
 /* Zephyr native_posix links as a host binary and lacks the automated heap markers */
 #define HEAPMEM_SIZE (256 * 1024)
 char __aligned(8) heapmem[HEAPMEM_SIZE];
-
-#elif defined(CONFIG_ARM64)
-/* for ARM64 the heap is placed inside the .bss section.
- *
- * This is because we want to avoid introducing new sections in
- * the arm64 linker script. Also, is there really a need to place
- * it inside a special section?
- *
- * i.MX93 is the only ARM64-based platform so defining the heap this way
- * for all ARM64-based platforms should be safe.
- */
-static uint8_t __aligned(PLATFORM_DCACHE_ALIGN) heapmem[HEAPMEM_SIZE];
 
 #else
 


### PR DESCRIPTION
imx93_a55 is an imx platform so it should select `CONFIG_IMX`. As such, make `CONFIG_IMX93_A55` also select `CONFIG_IMX`. Since `CONFIG_IMX` has only been used for xtensa-based imx platforms, make necessary changes for it to also work on arm-based imx platforms (i.e: imx93_a55).