### PR TITLE
Tools: test: Audio: Fix src_test.m run error

### DIFF
--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -23,7 +23,7 @@ function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out
 
 addpath('std_utils');
 addpath('test_utils');
-addpath('../../tune/src');
+addpath('../../../src/audio/src/tune');
 mkdir_check('plots');
 mkdir_check('reports');
 


### PR DESCRIPTION
The SRC module tools have moved, so the path to retrieve SRC filter spec has changed.