### PR TITLE
ipc: replace enum fields with uint32_t in some IPC structures

### DIFF
--- a/src/include/ipc/topology.h
+++ b/src/include/ipc/topology.h
@@ -62,7 +62,8 @@ enum sof_comp_type {
 struct sof_ipc_comp {
 	struct sof_ipc_cmd_hdr hdr;
 	uint32_t id;
-	enum sof_comp_type type;
+	/* holds an "enum sof_comp_type" value. Fixed-size because of #9378 */
+	uint32_t type;
 	uint32_t pipeline_id;
 	uint32_t core;
 

--- a/src/include/kernel/abi.h
+++ b/src/include/kernel/abi.h
@@ -30,7 +30,7 @@
 /** \brief SOF ABI version major, minor and patch numbers */
 #define SOF_ABI_MAJOR 3
 #define SOF_ABI_MINOR 29
-#define SOF_ABI_PATCH 0
+#define SOF_ABI_PATCH 1
 
 /** \brief SOF ABI version number. Format within 32bit word is MMmmmppp */
 #define SOF_ABI_MAJOR_SHIFT	24

--- a/src/include/module/ipc4/base-config.h
+++ b/src/include/module/ipc4/base-config.h
@@ -181,8 +181,10 @@ enum ipc4_base_module_params {
 };
 
 struct ipc4_pin_props {
-	/* type of the connected stream. */
-	enum ipc4_stream_type stream_type;
+	/* type of the connected stream.
+	 * Holds an "enum ipc4_stream_type" value. Fixed-size because of #9378
+	 */
+	uint32_t stream_type;
 
 	/* audio format of the stream. The content is valid in case of ePcm stream_type. */
 	struct ipc4_audio_format format;


### PR DESCRIPTION
Normally, the type of enums is "unsigned int" or "int". GCC has the "-fshort-enums" option, which instructs the compiler to use the smallest data type that can hold all the values in the enum (i.e: char, short, int or their unsigned variants).

According to the GCC documentation, "-fshort-enums" may be default on some targets. This seems to be the case for "arm-zephyr-eabi-gcc", which is used to build Zephyr on ARM platforms.

On Linux, this is not the case (tested with "aarch64-linux-gnu-gcc"), which means enums such as "enum sof_comp_type" will end up having different sizes on Linux and SOF. Since "enum sof_comp_type" is used in IPC-related structures such as "struct sof_ipc_comp", this means the fields of the structures will end up being placed at different offsets. This, in turn, leads to SOF not being able to properly interpret data passed from Linux.

With this in mind, replace "enum sof_comp_type" from "struct sof_ipc_comp" and "enum ipc4_stream_type" from "struct ipc4_pin_props" with "uint32_t".

Fixes https://github.com/thesofproject/sof/issues/9378.
Kernel-side change: https://github.com/thesofproject/linux/pull/5148