### PR TITLE
Tools: Topology2: Fix cavs-nocodec.conf SSP2 PCM rates

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -988,16 +988,14 @@ IncludeByKey.PASSTHROUGH {
 					direction	"playback"
 					name "SSP2 Playback"
 					formats 'S16_LE,S24_LE,S32_LE'
-					rate_min 8000
-					rate_max 192000
+					rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
 				}
 
 				Object.PCM.pcm_caps.2 {
 					direction	"capture"
 					name "SSP2 Capture"
 					formats 'S16_LE,S24_LE,S32_LE'
-					rate_min 8000
-					rate_max 192000
+					rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
 				}
 			}
 		]


### PR DESCRIPTION
The rate_min and rate_max no more work with IPC4 topologies. The SSP2 PCM host pipeline contains a sample rate converter so it can support multiple rates. With attempt to play (or capture) with other than 48 kHz the error is printed and resulting playback has wrong pitch:

Warning: rate is not accurate (requested = 44100Hz, got = 48000Hz)
         please, try the plug plugin

Use of rates with list of all rates in topology fixes the issue.