### PR TITLE
smart_amp: fix return errors

### DIFF
--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -111,8 +111,12 @@ static ssize_t smart_amp_alloc_mod_memblk(struct smart_amp_data *sad,
 
 	/* query the required size from inner model. */
 	ret = mod->mod_ops->query_memblk_size(mod, blk);
-	if (ret <= 0)
+	if (ret < 0)
 		goto error;
+
+	/* no memory required */
+	if (ret == 0)
+		return 0;
 
 	/* allocate the memory block when returned size > 0. */
 	size = ret;

--- a/src/include/sof/audio/smart_amp/smart_amp.h
+++ b/src/include/sof/audio/smart_amp/smart_amp.h
@@ -197,6 +197,7 @@ struct inner_model_ops {
 	 *    blk - the memblk usage type.
 	 * Returns:
 	 *    The bytesize or negative error code.
+	 *    0 means no memory required
 	 */
 	int (*query_memblk_size)(struct smart_amp_mod_data_base *mod,
 				 enum smart_amp_mod_memblk blk);


### PR DESCRIPTION
If 0 is a error then override it so the outer function doesn't think we ran successfully and then hit a null ptr after we freed everything.