### PR TITLE
Audio: MFCC: Fix 64 bit build issue

### DIFF
--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -84,7 +84,7 @@ static int mfcc_init(struct processing_module *mod)
 
 	/* Check first that configuration blob size is sane */
 	if (bs > SOF_MFCC_CONFIG_MAX_SIZE) {
-		comp_err(dev, "mfcc_init() error: configuration blob size %u exceeds %d",
+		comp_err(dev, "mfcc_init() error: configuration blob size %zu exceeds %d",
 			 bs, SOF_MFCC_CONFIG_MAX_SIZE);
 		return -EINVAL;
 	}


### PR DESCRIPTION
The comp_err() trace in mfcc_init() causes an error:

sof/src/audio/mfcc/mfcc.c: In function 'mfcc_init': sof/src/include/sof/audio/component.h:160:20:
  error: format '%u' expects argument of type 'unsigned int',
  but argument 4 has type 'size_t' {aka 'long unsigned int'}
  [-Werror=format=]
