### PR TITLE
zephyr: posix: use library trace

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -231,7 +231,7 @@ void _log_sofdict(log_func_t sofdict_logf, bool atomic, const void *log_entry,
 
 /* _log_message() */
 
-#ifdef CONFIG_LIBRARY
+#ifdef CONFIG_LIBRARY || CONFIG_ZEPHYR_POSIX
 
 #include <sys/time.h>
 


### PR DESCRIPTION
No need to use the trace subsystem, also it breaks when we switch to 64bit builds.