### PR TITLE
IPC: Increase SOF_IPC_MSG_MAX_SIZE for testbench and unit test

### DIFF
--- a/src/include/ipc/header.h
+++ b/src/include/ipc/header.h
@@ -331,6 +331,8 @@ struct ipc_cmd_hdr;
 /** Maximum message size for mailbox Tx/Rx */
 #if CONFIG_IPC_MAJOR_4
 #define SOF_IPC_MSG_MAX_SIZE			0x1000
+#elif CONFIG_LIBRARY_STATIC || UNIT_TEST
+#define SOF_IPC_MSG_MAX_SIZE			0x2000
 #else
 #define SOF_IPC_MSG_MAX_SIZE			384
 #endif


### PR DESCRIPTION
The testbench and unit tests use a simplified simulated IPC that currently doesn't support messages split to multiple parts. As workaround to unblock other SOF development the size is increased from 384 bytes to 8192 bytes.

This allows run of current test set with scripts/host-testbench.sh that is also used in SOF CI. The change can be reverted after the capability is added to testbench.