### PR TITLE
Tools: Test: Audio: Mitigate trace flood in process_test.m

### DIFF
--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -116,8 +116,14 @@ run_testbench ()
         # shellcheck disable=SC2086
         $VALGRIND_CMD $CMD
     else
-        # shellcheck disable=SC2086
-        $VALGRIND_CMD $CMD 2> "$FN_TRACE"
+        $VALGRIND_CMD $CMD 2> "$FN_TRACE" || {
+            local ret=$?
+            echo ----------------------------------------------------------
+            cat "$FN_TRACE"
+            echo ----------------------------------------------------------
+            return $ret # "exit" would be for something unexpected and catastrophic,
+                        # not for a "regular" test failure
+        }
     fi
 }
 

--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -411,12 +411,13 @@ function test = test_defaults(t)
 	test.fr_rp_max_db = 0.5;        % Allow 0.5 dB frequency response ripple
 
 	% No need to collect trace
-	test.trace = '';
+	test.trace = [tempname('/tmp') '.txt'];
 end
 
 function test = test_run_process(test)
 	delete_check(1, test.fn_out);
 	test = test_run(test);
+	delete_check(1, test.trace);
 end
 
 function test_result_print(t, testverbose, testacronym, test)


### PR DESCRIPTION
The verbose test trace flood slows down the test to near unusable test times due to a lot of text printed to Octave console. As result also the SOF CI logs become large.

This patch adds redirect of testbench trace into a temporary file instead of standard output in process_test.m. The trace content is printed in comp_run.sh to console only if there has been an error. To prevent growing /tmp the trace file is deleted after test run and possible print to console.