### PR TITLE
[SKIP SOF-TEST] native_sim_libfuzzer.conf: override some incompatible hardware options

### DIFF
--- a/app/boards/native_sim_libfuzzer.conf
+++ b/app/boards/native_sim_libfuzzer.conf
@@ -9,3 +9,9 @@ CONFIG_ZEPHYR_NATIVE_DRIVERS=y
 CONFIG_ARCH_POSIX_LIBFUZZER=y
 CONFIG_ZEPHYR_POSIX_FUZZ_TICKS=100
 CONFIG_ASAN=y
+
+# Override incompatible options found in sof/app/prj.conf
+# to silence build time warnings
+# (strange why these are in app/prj.conf but not our problem here)
+CONFIG_SMP_BOOT_DELAY=n
+CONFIG_SCHED_CPU_MASK_PIN_ONLY=n


### PR DESCRIPTION
Override incompatible options CONFIG_SMP_BOOT_DELAY and CONFIG_SCHED_CPU_MASK_PIN_ONLY found in `sof/app/prj.conf` to silence build time warnings. Strange why these are in `app/prj.conf` but not our problem here.

```
warning: SCHED_CPU_MASK_PIN_ONLY (defined at kernel/Kconfig:139) was
assigned the value 'y' but got the value 'n'. Check these unsatisfied
dependencies: SMP (=n).

warning: SMP_BOOT_DELAY (defined at kernel/Kconfig.smp:32) was assigned
the value 'y' but got the value 'n'. Check these unsatisfied
dependencies: SMP (=n).
```
cc:
- #9386 