### PR TITLE
west.yml: update zephyr to f29377a12cb5 (Aug 26th)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 795ac34f291c2f9895e7a3a03eafc053ad1d36f2
+      revision: f29377a12cb5dd2ee845f21b8319c0c4ee2cca40
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 845 commits.

Changes include:

746ddccf54ca intel_adsp: debug_window: Add slot type for debug-stream
	     transport
8a4b3a4b618a xtensa: include xtensa-types.h for xt-clang e0be5801cd70 drivers: dai: esai: don't reset ESAI on init 32cf0e0f9f2c intel_adsp: ace: Fix undefined reference 8fb592dfff6c soc: intel_adsp: DCACHE_LINE_SIZE was not defined 85758444f7d8 intel_adsp: clk: Configure correct cardinal clock divider
	     for PTL
784bc06e7ecd soc: intel_adsp: ace: set xtensa ccount per platform b0185189ad7e xtensa: mmu: fix page table initialization f2840910731d xtensa: core: Remove constant branch