### PR TITLE
Audio: Volume: Fix problem with Hifi4

### DIFF
--- a/src/audio/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/volume/volume_hifi3_with_peakvol.c
@@ -21,9 +21,7 @@ LOG_MODULE_DECLARE(volume_hifi3, CONFIG_SOF_LOG_LEVEL);
 
 #include "volume.h"
 
-// Hifi4 is disabled, see bug https://github.com/thesofproject/sof/issues/9213
-// Hifi5 is not there yet.
-#if SOF_USE_HIFI(3, VOLUME) || SOF_USE_HIFI(4, VOLUME) || SOF_USE_HIFI(5, VOLUME)
+#if SOF_USE_HIFI(3, VOLUME)
 
 #if CONFIG_COMP_PEAK_VOL
 


### PR DESCRIPTION
This patch fixes an issue with gain and peakvolume processing with s16 sample format and with sample rates where period is not multiple of four samples SIMD processing assumption. With 44.1 kHz rate the period is normally 44 frames but every 10th is 45. However, the value of 45 was not handled correctly. A Glitch appeared to output when this happened.

The fixed code adds sample-by-sample volume process code for the remaining amount of up to 3 samples to process.

The earlier workaround (87571f337c10 "audio: volume: disable HIFI4 optimizations") is reverted.