### PR TITLE
Audio: Volume: Clear peak meter channel max values in prepare()

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -377,6 +377,10 @@ void volume_reset_state(struct vol_data *cd)
 	cd->sample_rate_inv = 0;
 	cd->copy_gain = true;
 	cd->is_passthrough = false;
+
+#if CONFIG_COMP_PEAK_VOL
+	memset(cd->peak_regs.peak_meter, 0, sizeof(cd->peak_regs.peak_meter));
+#endif
 }
 
 void volume_prepare_ramp(struct comp_dev *dev, struct vol_data *cd)

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -139,7 +139,7 @@ int volume_init(struct processing_module *mod)
 	/* malloc memory to store temp peak volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->peak_vol = rmalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, vol_size);
+	cd->peak_vol = rzalloc(SOF_MEM_ZONE_RUNTIME, 0, SOF_MEM_CAPS_RAM, vol_size);
 	if (!cd->peak_vol) {
 		rfree(cd->vol);
 		rfree(cd);


### PR DESCRIPTION
This patch avoids garbage values to be sent to mailbox by peak_vol_update() as very first peak volume measurement in stream start. The data structures cd->peak_vol and cd->peak_regs.peak_meter were not cleared.