### PR TITLE
Include xtensa-types.h header file to support the ACP_7_0 platform's build.

### DIFF
--- a/src/arch/xtensa/include/xtensa/config/core.h
+++ b/src/arch/xtensa/include/xtensa/config/core.h
@@ -37,22 +37,28 @@
 #define XTENSA_CONFIG_CORE_H
 
 /*
- * This define is used by the new 2023 xt-clang toolchain and, while there are a few definitions
+ * This define is used by Assembly files of platform ACP_7_0's toolchain.
+ * Else condition has new 2023 xt-clang toolchain and, while there are a few definitions
  * (identical to this one) in various implementations such as newlib, none of them is in use when
  * building SOF with Zephyr and XtensaTools.
  */
 
-#if defined(__ZEPHYR__)
+#if defined (_ASMLANGUAGE) || defined (__ASSEMBLER__)
+
+#ifndef UINT32_C
+#define UINT32_C(x) x
+#endif
+
+#else
 
 #ifndef __UINT32_C
 #define __UINT32_C(x) x ## U
 #endif
-
 #ifndef UINT32_C
 #define UINT32_C(x) __UINT32_C(x)
 #endif
 
-#endif
+#endif /*_ASMLANGUAGE or __ASSEMBLER__*/
 
 /*  CONFIGURATION INDEPENDENT DEFINITIONS:  */
 #ifdef __XTENSA__

--- a/src/arch/xtensa/xtos/exc-sethandler.c
+++ b/src/arch/xtensa/xtos/exc-sethandler.c
@@ -24,8 +24,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <xtensa/config/core.h>
 #include "xtos-internal.h"
+#include <xtensa/config/core.h>
 
 
 #if XCHAL_HAVE_EXCEPTIONS


### PR DESCRIPTION
Add the inclusion of `xtensa-types.h` header file to accommodate the definition of macro UINT32_C which is required by the core file `tie.h` in platform ACP_7_0. ACP7_0 uses the new xt-clang compiler.