### PR TITLE
Tools: Rimage: Config: Add mfcc.toml include for MTL, LNL, PTL

### DIFF
--- a/tools/rimage/config/lnl.toml.h
+++ b/tools/rimage/config/lnl.toml.h
@@ -120,5 +120,9 @@
 #include <audio/igo_nr/igo_nr.toml>
 #endif
 
+#ifdef CONFIG_COMP_MFCC
+#include <audio/mfcc/mfcc.toml>
+#endif
+
 [module]
 count = __COUNTER__

--- a/tools/rimage/config/mtl.toml.h
+++ b/tools/rimage/config/mtl.toml.h
@@ -132,5 +132,9 @@
 #include <audio/igo_nr/igo_nr.toml>
 #endif
 
+#ifdef CONFIG_COMP_MFCC
+#include <audio/mfcc/mfcc.toml>
+#endif
+
 [module]
 count = __COUNTER__

--- a/tools/rimage/config/ptl.toml.h
+++ b/tools/rimage/config/ptl.toml.h
@@ -120,5 +120,9 @@ index = __COUNTER__
 #include <audio/igo_nr/igo_nr.toml>
 #endif
 
+#ifdef CONFIG_COMP_MFCC
+#include <audio/mfcc/mfcc.toml>
+#endif
+
 [module]
 count = __COUNTER__


### PR DESCRIPTION
The MFCC component is not loading in these platforms due to missing edit to <platform>.toml.h.

As editorial change the missing newline in the end of ptl.toml.h is fixed.

Fixes: f7715b814b66
       ("Audio: MFCC: Fix build of component for current SOF")