### PR TITLE
Audio: Volume: Add HiFi5 implementation.

### DIFF
--- a/src/audio/volume/CMakeLists.txt
+++ b/src/audio/volume/CMakeLists.txt
@@ -5,9 +5,11 @@ if(CONFIG_COMP_VOLUME)
 		volume_generic.c
 		volume_hifi3.c
 		volume_hifi4.c
+		volume_hifi5.c
 		volume_generic_with_peakvol.c
 		volume_hifi3_with_peakvol.c
 		volume_hifi4_with_peakvol.c
+		volume_hifi5_with_peakvol.c
 		volume.c)
 	if(CONFIG_IPC_MAJOR_3)
 		add_local_sources(sof volume_ipc3.c)

--- a/src/audio/volume/Kconfig.simd
+++ b/src/audio/volume/Kconfig.simd
@@ -14,6 +14,12 @@ choice "VOLUME_SIMD_LEVEL_SELECT"
 			When this was selected, optimization level will be determined
 			by toolchain pre-defined macros in core isa header file.
 
+	config VOLUME_HIFI_5
+		prompt "choose HIFI5 intrinsic optimized volume module"
+		bool
+		help
+			This option used to build HIFI5 optimized volume code
+
 	config VOLUME_HIFI_4
 		prompt "choose HIFI4 intrinsic optimized volume module"
 		bool

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -646,19 +646,25 @@ static vol_zc_func vol_get_zc_function(struct comp_dev *dev,
 static void volume_set_alignment(struct audio_stream *source,
 				 struct audio_stream *sink)
 {
-#if SOF_USE_HIFI(3, VOLUME) || SOF_USE_HIFI(4, VOLUME) || SOF_USE_HIFI(5, VOLUME)
-	/* Both source and sink buffer in HiFi 3 or HiFi4 processing version,
+	/* Both source and sink buffer in HiFi5  processing version,
+	 * xtensa intrinsics ask for 16-byte aligned.
+	 *
+	 * Both source and sink buffer in HiFi3 or HiFi4 processing version,
 	 * xtensa intrinsics ask for 8-byte aligned. 5.1 format SSE audio
 	 * requires 16-byte aligned.
 	 */
-	const uint32_t byte_align = audio_stream_get_channels(source) == 6 ? 16 : 8;
+#if SOF_USE_HIFI(3, VOLUME) || SOF_USE_HIFI(4, VOLUME)
+	const uint32_t byte_align = audio_stream_get_channels(source) == 6 ?
+		VOLUME_HIFI3_HIFI4_FRAME_BYTE_ALIGN_6CH : SOF_FRAME_BYTE_ALIGN;
+#else
+	const uint32_t byte_align = SOF_FRAME_BYTE_ALIGN;
+#endif
 
 	/*There is no limit for frame number, so both source and sink set it to be 1*/
 	const uint32_t frame_align_req = 1;
 
 	audio_stream_set_align(byte_align, frame_align_req, source);
 	audio_stream_set_align(byte_align, frame_align_req, sink);
-#endif
 }
 
 /**

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -113,6 +113,12 @@ struct sof_ipc_ctrl_value_chan;
 #define VOL_S32_SAMPLES_TO_BYTES(s)	((s) << 2)
 
 /**
+ * \brief Bytes align requirement for 6ch PCM frame on HiFi3 and Hifi4
+ * platforms for volume component.
+ */
+#define VOLUME_HIFI3_HIFI4_FRAME_BYTE_ALIGN_6CH	16
+
+/**
  * \brief volume processing function interface
  */
 typedef void (*vol_scale_func)(struct processing_module *mod, struct input_stream_buffer *source,

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -80,7 +80,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -219,7 +219,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
 
-	/** to ensure the address is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -361,7 +361,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */

--- a/src/audio/volume/volume_hifi4.c
+++ b/src/audio/volume/volume_hifi4.c
@@ -80,7 +80,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -219,7 +219,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	ae_f32x2 *out = (ae_f32x2 *)audio_stream_wrap(sink, (char *)audio_stream_get_wptr(sink)
 						      + bsink->size);
 
-	/** to ensure the address is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -360,7 +360,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	const int inc = sizeof(ae_f32x2);
 	int samples = channels_count * frames;
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -77,7 +77,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -244,7 +244,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct input_strea
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 2);
 
-	/** to ensure the address is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */
@@ -413,7 +413,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct input_stream_bu
 	AE_SETCBEGIN1(cd->peak_vol);
 	AE_SETCEND1(cd->peak_vol  + channels_count * 4);
 
-	/** to ensure the adsress is 8-byte aligned and avoid risk of
+	/* to ensure the address is 8-byte aligned and avoid risk of
 	 * error loading of volume gain while the cd->vol would be set
 	 * as circular buffer
 	 */

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -206,13 +206,21 @@
 // IS_ENABLED() above.
 #  if XCHAL_HAVE_HIFI5
 #    define SOF_MAX_XCHAL_HIFI 5
+#    define SOF_FRAME_BYTE_ALIGN	16
 #  elif XCHAL_HAVE_HIFI4
 #    define SOF_MAX_XCHAL_HIFI 4
+#    define SOF_FRAME_BYTE_ALIGN	8
 #  elif XCHAL_HAVE_HIFI3
 #    define SOF_MAX_XCHAL_HIFI 3
+#    define SOF_FRAME_BYTE_ALIGN	8
 #  else
 #    define SOF_MAX_XCHAL_HIFI NONE
 #  endif
+#endif
+
+/* Keep this last after all platform specific align defaults */
+#ifndef SOF_FRAME_BYTE_ALIGN
+#  define SOF_FRAME_BYTE_ALIGN	4
 #endif
 
 #ifndef __GLIBC_USE

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -775,9 +775,11 @@ if(CONFIG_COMP_VOLUME STREQUAL "m")
 	add_dependencies(app volume)
 elseif(CONFIG_COMP_VOLUME)
 	zephyr_library_sources(
+		${SOF_AUDIO_PATH}/volume/volume_hifi5.c
 		${SOF_AUDIO_PATH}/volume/volume_hifi4.c
 		${SOF_AUDIO_PATH}/volume/volume_hifi3.c
 		${SOF_AUDIO_PATH}/volume/volume_generic.c
+		${SOF_AUDIO_PATH}/volume/volume_hifi5_with_peakvol.c
 		${SOF_AUDIO_PATH}/volume/volume_hifi4_with_peakvol.c
 		${SOF_AUDIO_PATH}/volume/volume_hifi3_with_peakvol.c
 		${SOF_AUDIO_PATH}/volume/volume_generic_with_peakvol.c


### PR DESCRIPTION
Add HiFi5 implementation of volume functions, compared with HiFi3 version, can reduce about 28% cycles.