### PR TITLE
Audio: Fix Xtensa HiFi5 build for audio processing components

### DIFF
--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -10,7 +10,7 @@
 
 #include "dcblock.h"
 
-#if SOF_USE_HIFI(4, DCBLOCK)
+#if SOF_USE_MIN_HIFI(4, DCBLOCK)
 
 #include <xtensa/tie/xt_hifi4.h>
 LOG_MODULE_DECLARE(dcblock, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/drc/drc_hifi4.c
+++ b/src/audio/drc/drc_hifi4.c
@@ -15,7 +15,7 @@
 #include "drc_algorithm.h"
 #include "drc_math.h"
 
-#if SOF_USE_HIFI(4, DRC)
+#if SOF_USE_MIN_HIFI(4, DRC)
 
 #include <xtensa/tie/xt_hifi4.h>
 

--- a/src/audio/drc/drc_math.h
+++ b/src/audio/drc/drc_math.h
@@ -18,7 +18,7 @@
 /* Unmark this define to use cordic arc sine implementation. */
 /* #define DRC_USE_CORDIC_ASIN */
 
-#if SOF_USE_HIFI(4, DRC) || SOF_USE_HIFI(3, DRC)
+#if SOF_USE_MIN_HIFI(3, DRC)
 
 #include <xtensa/tie/xt_hifi3.h>
 

--- a/src/audio/drc/drc_math_hifi3.c
+++ b/src/audio/drc/drc_math_hifi3.c
@@ -8,7 +8,7 @@
 #include <sof/common.h>
 #include "drc_math.h"
 
-#if SOF_USE_HIFI(4, DRC) || SOF_USE_HIFI(3, DRC)
+#if SOF_USE_MIN_HIFI(3, DRC)
 
 #include <xtensa/tie/xt_hifi3.h>
 

--- a/src/audio/eq_fir/eq_fir.h
+++ b/src/audio/eq_fir/eq_fir.h
@@ -20,7 +20,7 @@
 #if SOF_USE_HIFI(2, FILTER)
 #include <sof/math/fir_hifi2ep.h>
 #endif
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 #include <sof/math/fir_hifi3.h>
 #endif
 #include <user/fir.h>
@@ -77,7 +77,7 @@ int eq_fir_params(struct processing_module *mod);
  * set_fir_func.
  */
 
-#if SOF_USE_HIFI(2, FILTER) || SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(2, FILTER)
 #if CONFIG_FORMAT_S16LE
 static inline void set_s16_fir(struct comp_data *cd)
 {

--- a/src/audio/eq_fir/eq_fir_hifi3.c
+++ b/src/audio/eq_fir/eq_fir_hifi3.c
@@ -7,7 +7,7 @@
 #include <sof/math/fir_config.h>
 #include <sof/common.h>
 
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/math/fir_hifi3.h>

--- a/src/audio/tdfb/tdfb_comp.h
+++ b/src/audio/tdfb/tdfb_comp.h
@@ -20,7 +20,7 @@
 /* TDFB and EQFIR depend on math FIR.
  * so align TDFB, math FIR, and EQFIR use same selection.
  */
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 #define TDFB_HIFI3	1
 #elif SOF_USE_HIFI(2, FILTER)
 #define TDFB_HIFI2	1

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -187,6 +187,17 @@
 #define SOF_USE_HIFI(level, component) (SOF_CONFIG_HIFI(level, component) || \
 	(SOF_CONFIG_HIFI(MAX, component) && level == SOF_MAX_XCHAL_HIFI))
 
+/* True if:
+ *  (1) EITHER this particular level was manually forced in Kconfig,
+ *  (2) OR:  - this component defaulted to "MAX"
+ *           - AND this level is less or equal to max available in the XC HAL.
+ *
+ * Use e.g. for highest optimization level source file, e.g. SOF_USE_MIN_HIFI(4, component)
+ * for HiFi4 code version that can be built with HiFi4 or HiFi5 tool chain.
+ */
+#define SOF_USE_MIN_HIFI(minlevel, component) (SOF_CONFIG_HIFI(minlevel, component) || \
+	(SOF_CONFIG_HIFI(MAX, component) && minlevel <= SOF_MAX_XCHAL_HIFI))
+
 #ifndef __XCC__ // Cadence toolchains: either xt-xcc or xt-clang.
 #  define SOF_MAX_XCHAL_HIFI NONE
 #else

--- a/src/include/sof/math/fir_hifi3.h
+++ b/src/include/sof/math/fir_hifi3.h
@@ -11,7 +11,7 @@
 #include <sof/math/fir_config.h>
 #include <sof/common.h>
 
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/buffer.h>

--- a/src/math/fir_hifi3.c
+++ b/src/math/fir_hifi3.c
@@ -7,7 +7,7 @@
 #include <sof/math/fir_config.h>
 #include <sof/common.h>
 
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 
 #include <sof/audio/buffer.h>
 #include <sof/math/fir_hifi3.h>

--- a/src/math/iir_df1_hifi3.c
+++ b/src/math/iir_df1_hifi3.c
@@ -14,7 +14,7 @@
 
 #include <rtos/symbol.h>
 
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 
 /*
  * Direct form I second order filter block (biquad)

--- a/src/math/iir_df2t_hifi3.c
+++ b/src/math/iir_df2t_hifi3.c
@@ -13,7 +13,7 @@
 #include <sof/math/iir_df2t.h>
 #include <user/eq.h>
 
-#if SOF_USE_HIFI(3, FILTER) || SOF_USE_HIFI(4, FILTER)
+#if SOF_USE_MIN_HIFI(3, FILTER)
 
 #include <xtensa/tie/xt_hifi3.h>
 


### PR DESCRIPTION
This patch avoids build error when testbench is built with a Xtensa HiFi5 tool chain. The changes select for HiFi5 the best option of available HiFi4 or HiFi3 code options. No HiFi5 specific optimizations are done.

The updated components those got build issues are: DCblock, DRC, FIR, TDFB, and IIR.