### PR TITLE
iadk: Define pass buffer size and return error code from entry point function

### DIFF
--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -118,17 +118,15 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 } /* namespace system */
 } /* namespace intel_adsp */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 /* The create_instance_f is a function call type known in IADK module. The module entry_point
  * points to this type of function which starts module creation.
  */
 typedef int (*create_instance_f)(uint32_t module_id, uint32_t instance_id, uint32_t core_id,
 				 void *mod_cfg, void *parent_ppl, void **mod_ptr);
 
-void* system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
-			 uint32_t core_id, uint32_t log_handle, void* mod_cfg)
+int system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+		       uint32_t core_id, uint32_t log_handle, void* mod_cfg,
+		       void **adapter)
 {
 	uint32_t ret;
 	SystemAgent system_agent(module_id, instance_id, core_id, log_handle);
@@ -137,12 +135,10 @@ void* system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t inst
 	create_instance_f ci = (create_instance_f)(entry_point);
 	ret = ci(module_id, instance_id, core_id, mod_cfg, NULL, &system_agent_p);
 
-	return system_agent_p;
+	IadkModuleAdapter* module_adapter = reinterpret_cast<IadkModuleAdapter*>(system_agent_p);
+	*adapter = module_adapter;
+	return ret;
 }
-
-#ifdef __cplusplus
-}
-#endif
 
 extern "C" void __cxa_pure_virtual()  __attribute__((weak));
 

--- a/src/include/sof/audio/module_adapter/iadk/api_version.h
+++ b/src/include/sof/audio/module_adapter/iadk/api_version.h
@@ -19,4 +19,10 @@
 #define IADK_MODULE_API_CURRENT_VERSION	MODULE_API_VERSION_ENCODE(IADK_MODULE_API_MAJOR_VERSION, \
 	IADK_MODULE_API_MIDDLE_VERSION, IADK_MODULE_API_MINOR_VERSION)
 
+/* Defines the size of the space reserved within ModuleHandle for SOF to store its private data.
+ * This size comes from the IADK header files and must match the IADK API version.
+ * Please do not modify this value!
+ */
+#define IADK_MODULE_PASS_BUFFER_SIZE		320
+
 #endif /* __MODULE_ADAPTER_IADK_API_VERSION_H__ */

--- a/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
+++ b/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
@@ -15,6 +15,8 @@
 #include <module_initial_settings.h>
 #include <adsp_stddef.h>
 #include <system_error.h>
+#include <sof/common.h>
+#include <api_version.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,6 +113,8 @@ namespace dsp_fw
 
 		intel_adsp::ProcessingModuleInterface &processing_module_;
 	};
+
+STATIC_ASSERT(sizeof(IadkModuleAdapter) <= IADK_MODULE_PASS_BUFFER_SIZE, IadkModuleAdapter_too_big);
 
 } /* namespace dsp_fw */
 

--- a/src/include/sof/audio/module_adapter/iadk/system_agent.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_agent.h
@@ -107,8 +107,8 @@ extern "C" {
  * method (the variant with 7 parameters) via a parameter that initially contained the address to
  * the agent system. The system_agent_start function returns it in the variable adapter.
  */
-void *system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
-			 uint32_t core_id, uint32_t log_handle, void *mod_cfg);
+int system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+		       uint32_t core_id, uint32_t log_handle, void *mod_cfg, void **adapter);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add a definition specifying the size of space reserved in module memory for module handle and a iadk adapter.

Add a brief description of the iadk module loading sequence.

Change the definition of the system_agent_start function so that it returns the error code returned by the module's entry point functions. Return the created IadkModuleAdapter object via a parameter.