### PR TITLE
posix: align mailboxes

### DIFF
--- a/src/platform/posix/include/platform/lib/memory.h
+++ b/src/platform/posix/include/platform/lib/memory.h
@@ -11,19 +11,19 @@
 #define uncache_to_cache(addr) (addr)
 #define cache_to_uncache(addr) (addr)
 
-extern uint8_t posix_hostbox[];
+extern uint32_t posix_hostbox[];
 #define MAILBOX_HOSTBOX_SIZE 1024
 #define MAILBOX_HOSTBOX_BASE (&posix_hostbox[0])
 
-extern uint8_t posix_dspbox[];
+extern uint32_t posix_dspbox[];
 #define MAILBOX_DSPBOX_SIZE 4096
 #define MAILBOX_DSPBOX_BASE (&posix_dspbox[0])
 
-extern uint8_t posix_stream[];
+extern uint32_t posix_stream[];
 #define MAILBOX_STREAM_SIZE 4096
 #define MAILBOX_STREAM_BASE (&posix_stream[0])
 
-extern uint8_t posix_trace[];
+extern uint32_t posix_trace[];
 #define MAILBOX_TRACE_BASE (&posix_trace[0])
 #define MAILBOX_TRACE_SIZE 4096
 

--- a/src/platform/posix/posix.c
+++ b/src/platform/posix/posix.c
@@ -9,10 +9,10 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/lib/agent.h>
 
-uint8_t posix_hostbox[MAILBOX_HOSTBOX_SIZE];
-uint8_t posix_dspbox[MAILBOX_DSPBOX_SIZE];
-uint8_t posix_stream[MAILBOX_STREAM_SIZE];
-uint8_t posix_trace[MAILBOX_TRACE_SIZE];
+uint32_t posix_hostbox[MAILBOX_HOSTBOX_SIZE / sizeof(uint32_t)];
+uint32_t posix_dspbox[MAILBOX_DSPBOX_SIZE / sizeof(uint32_t)];
+uint32_t posix_stream[MAILBOX_STREAM_SIZE / sizeof(uint32_t)];
+uint32_t posix_trace[MAILBOX_TRACE_SIZE / sizeof(uint32_t)];
 
 /* This seems like a vestige.  Existing Zephyr platforms are emitting
  * these markers in their linker scripts, and wrapper.c code iterates


### PR DESCRIPTION
Using unaligned mailboxes with UBSAN causes fuzzing failures with aligned data structures