### PR TITLE
west.yml: update Zephyr to 689d1edee1d5

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 494f88070f6bb909389630264e4f89c71072ae53
+      revision: 689d1edee1d57f052b1d4572d67618c0b0e2b8a4
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 191 commits, including following affecting SOF build targets:

 81977f2bff2e drivers: dma: intel_adsp_hda: fix intel_adsp_hda_unused() check
 9fd2e119445e drivers: dma: intel-adsp-hda: Report total_copied bytes on ACE2/3
 dd50ff558537 llext: add dependencies
 c5e305fce6c4 llext: fix flag evaluation for section grouping
 a8db637ead17 llext: export a symbol needed for immediate logging
 fe609dd8e8e1 llext: look for symbols in other LLEXT objects too
 19ccec6a0390 llext: use EXPORT_SYMBOL() universally
 bd09a5c73921 llext: make EXPORT_SYMBOL() universal
 92a7c772d90b llext: remove an unused variable
 4902f189ae00 dts: xtensa: intel_adsp: Set soft-off state as disabled
 b9a4900c3002 drivers: dma: intel_adsp_hda: change L1 exit defaults