### PR TITLE
llext: fix multi-core use cases

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -464,8 +464,8 @@ static void lib_manager_update_sof_ctx(void *base_addr, uint32_t lib_id)
 {
 	struct ext_library *_ext_lib = ext_lib_get();
 	/* Never freed, will panic if fails */
-	struct lib_manager_mod_ctx *ctx = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
-						  sizeof(*ctx));
+	struct lib_manager_mod_ctx *ctx = rzalloc(SOF_MEM_ZONE_SYS, SOF_MEM_FLAG_COHERENT,
+						  SOF_MEM_CAPS_RAM, sizeof(*ctx));
 
 	ctx->base_addr = base_addr;
 

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -343,8 +343,8 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 		size_t offset = (uintptr_t)mod_manifest - imr_rodata;
 
 		/* ctx->mod_manifest points to an array of module manifests */
-		ctx->mod_manifest = (const struct sof_man_module_manifest *)(va_rodata_base +
-									     offset);
+		ctx->mod_manifest = sys_cache_uncached_ptr_get((__sparse_force void __sparse_cache *)
+							       (va_rodata_base + offset));
 	}
 
 	return ctx->mod_manifest[entry_index].module.entry_point;


### PR DESCRIPTION
MOD_INIT_INSTANCE IPCs can be processed on different cores, different cores can use the same modules. Make shared data uncached.