### PR TITLE
Tools: Topology2: Enable DMIC capture pre-processing for hda-generic

### DIFF
--- a/tools/topology/topology2/cavs-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-mixin-mixout-hda.conf
@@ -1,3 +1,5 @@
+<include/components/tdfb.conf>
+
 Define {
 	ANALOG_PLAYBACK_PCM		'Analog Playback'
 	ANALOG_CAPTURE_PCM		'Analog Capture'

--- a/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
@@ -10,9 +10,13 @@ list(APPEND TPLGS
 # HDA topology with mixer-based pipelines for HDA and
 # passthrough pipelines for HDMI and
 # 2 or 4 DMIC, no NHLT blob included in topology
-"sof-hda-generic\;sof-hda-generic-2ch\;HDA_CONFIG=mix,NUM_DMICS=2"
+"sof-hda-generic\;sof-hda-generic-2ch\;HDA_CONFIG=mix,NUM_DMICS=2,\
+DMIC0_ENHANCED_CAPTURE=true,EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,\
+EFX_DMIC0_DRC_PARAMS=dmic_default"
+
 "sof-hda-generic\;sof-hda-generic-4ch\;HDA_CONFIG=mix,NUM_DMICS=4,\
-PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1"
+PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ENHANCED_CAPTURE=true,\
+EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
 
 # HDA topology with mixer-based pipelines for HDA and
 # passthrough pipelines for HDMI and
@@ -23,15 +27,24 @@ PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1"
 
 # Topologies for CAVS2.5 architecture
 "sof-hda-generic\;sof-hda-generic-cavs25-2ch\;HDA_CONFIG=mix,NUM_DMICS=2,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-2ch.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-2ch.bin,\
+DMIC0_ENHANCED_CAPTURE=true,EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,\
+EFX_DMIC0_DRC_PARAMS=dmic_default"
+
 "sof-hda-generic\;sof-hda-generic-cavs25-4ch\;HDA_CONFIG=mix,NUM_DMICS=4,\
 PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-4ch.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-4ch.bin,\
+DMIC0_ENHANCED_CAPTURE=true,\
+EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
 
 # Topologies for ACE1 and ACE2 architectures
 "sof-hda-generic\;sof-hda-generic-ace1-2ch\;PLATFORM=mtl,HDA_CONFIG=mix,NUM_DMICS=2,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace1-2ch.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace1-2ch.bin,\
+DMIC0_ENHANCED_CAPTURE=true,EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,\
+EFX_DMIC0_DRC_PARAMS=dmic_default"
+
 "sof-hda-generic\;sof-hda-generic-ace1-4ch\;PLATFORM=mtl,HDA_CONFIG=mix,NUM_DMICS=4,\
 PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace1-4ch.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace1-4ch.bin,DMIC0_ENHANCED_CAPTURE=true,\
+EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
 )


### PR DESCRIPTION
This patch adds to DMIC0 capture TDFB beamformer and DRC for dynamic range control. The impacted topology names are:

- sof-hda-generic-2ch.tplg
- sof-hda-generic-4ch.tplg
- sof-hda-generic-cavs25-2ch.tplg
- sof-hda-generic-cavs25-4ch.tplg
- sof-hda-generic-ace1-2ch.tplg
- sof-hda-generic-ace2-2ch.tplg

The DMIC0 capture pipelines before this patch was:

DAI-copier -> IIR -> gain -> module copier -> host-copier

After:

DAI-copier -> IIR -> gain -> module copier ->
TDFB -> DRC -> host-copier

The beamformer is set for 2ch topologies to a narrow user direction stereo image enhance with about 3 dB signal-to-noise ratio improvement with blob "line2_generic_pm10deg.conf". In 4ch topologies the beamformer is set to pass-through due to large variations in notebook array geometries. The processing need to be enabled per product by UCM2. The beamformer control switch is by default off.

The DRC is set with blob "dmic_default.conf" to produce up to 10 dB boost in capture level. It helps to make DMIC capture louder in normal silent conditions while it prevents clipping of samples in loud conditions. The DRC control switch is by default off.

The added controls (seen with "amixer -c0 controls") are:

- Dmic0 Capture DRC bytes
- Dmic0 Capture DRC switch
- Dmic0 Capture TDFB angle set enum
- Dmic0 Capture TDFB beam switch
- Dmic0 Capture TDFB bytes