### PR TITLE
xtensa/config/core.h: provide UINT32_C() not just for __ZEPHYR__

### DIFF
--- a/src/arch/xtensa/include/xtensa/config/core.h
+++ b/src/arch/xtensa/include/xtensa/config/core.h
@@ -36,22 +36,16 @@
 #ifndef XTENSA_CONFIG_CORE_H
 #define XTENSA_CONFIG_CORE_H
 
-/*
- * This define is used by the new 2023 xt-clang toolchain and, while there are a few definitions
- * (identical to this one) in various implementations such as newlib, none of them is in use when
- * building SOF with Zephyr and XtensaTools.
+/* xt-clang uses UINT32_C() without import it. This affects both Zephyr and XTOS.
+ * See #9413 for the longer story.
  */
-
-#if defined(__ZEPHYR__)
-
-#ifndef __UINT32_C
-#define __UINT32_C(x) x ## U
-#endif
-
-#ifndef UINT32_C
-#define UINT32_C(x) __UINT32_C(x)
-#endif
-
+#if defined(_ASMLANGUAGE) || defined(__ASSEMBLER__)
+#  ifndef UINT32_C
+#    define UINT32_C(x) x
+#  endif
+#else
+   /* UINT32_C(x) x ## U */
+#  include <stdint.h>
 #endif
 
 /*  CONFIGURATION INDEPENDENT DEFINITIONS:  */


### PR DESCRIPTION
xt-clang uses UINT32_C() without importing it.  Commit ef38a0c2654e ("arch: xtensa: core.h: Add define for UINT32_C") added it but only for `__ZEPHYR__`, add it unconditionally.

Provide an alternative, assembly-compatible definition apparently needed by XTOS ACP 7.0 compiled with xt-clang.

For C code, simply include <stdint.h>

Longer and convoluted story in #9413.