### PR TITLE
module_adapter: add mixer component for initialization

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -40,8 +40,8 @@ int module_adapter_init_data(struct comp_dev *dev,
 {
 	int ret;
 
-	const unsigned char *data;
-	uint32_t size;
+	const unsigned char *data = NULL;
+	uint32_t size = 0;
 
 	switch (config->type) {
 	case SOF_COMP_VOLUME:
@@ -68,6 +68,8 @@ int module_adapter_init_data(struct comp_dev *dev,
 		data = spec;
 		break;
 	}
+	case SOF_COMP_MIXER:
+		break;
 	case SOF_COMP_EQ_IIR:
 	case SOF_COMP_EQ_FIR:
 	case SOF_COMP_KEYWORD_DETECT:


### PR DESCRIPTION
Add mixer component in module_adapter initialization function otherwise, for IPC3, we get the following error:
"module_adapter_init_data() unsupported comp type 6".

Fixes: 0f4a246df10d ("module_adapter: fix switch case for spec parsing")