### PR TITLE
Debug stream thread info fixe. Should be backported for 2.11

### DIFF
--- a/src/debug/debug_stream/debug_stream_slot.c
+++ b/src/debug/debug_stream/debug_stream_slot.c
@@ -100,8 +100,9 @@ int debug_stream_slot_send_record(struct debug_stream_record *rec)
 static int debug_stream_slot_init(void)
 {
 	struct debug_stream_slot_hdr *hdr = debug_stream_get_slot();
-	size_t hdr_size = offsetof(struct debug_stream_slot_hdr,
-				   section_desc[CONFIG_MP_MAX_NUM_CPUS]);
+	size_t hdr_size = ALIGN_UP(offsetof(struct debug_stream_slot_hdr,
+					    section_desc[CONFIG_MP_MAX_NUM_CPUS]),
+				   CONFIG_DCACHE_LINE_SIZE);
 	size_t section_area_size = ADSP_DW_SLOT_SIZE - hdr_size;
 	size_t section_size = ALIGN_DOWN(section_area_size /
 					 CONFIG_MP_MAX_NUM_CPUS,

--- a/src/debug/debug_stream/debug_stream_slot.c
+++ b/src/debug/debug_stream/debug_stream_slot.c
@@ -141,7 +141,7 @@ static int debug_stream_slot_init(void)
 		buf->next_seqno = 0;
 		buf->w_ptr = 0;
 		k_mutex_init(&cpu_mutex[i].m);
-		/* The core specific mutexes are now .dss which is uncached so the
+		/* The core specific mutexes are now .bss which is uncached so the
 		 * following line is commented out. However, since the mutexes are
 		 * core specific there should be nothing preventing from having them
 		 * in cached memory.

--- a/src/debug/debug_stream/debug_stream_thread_info.c
+++ b/src/debug/debug_stream/debug_stream_thread_info.c
@@ -76,7 +76,7 @@ static uint32_t thread_info_get_cycles(void *tid, k_thread_runtime_stats_t *thre
 	int i;
 
 	if (ud->thread_count >= ARRAY_SIZE(ud->active_threads)) {
-		LOG_WRN("Thread could exceeds tha max threads %u >= %u",
+		LOG_WRN("Thread count exceeds the max threads %u >= %u",
 			ud->thread_count, ARRAY_SIZE(ud->active_threads));
 		return 0;
 	}

--- a/src/include/user/debug_stream_slot.h
+++ b/src/include/user/debug_stream_slot.h
@@ -24,43 +24,36 @@
  * structure that is initialized once at DSP boot time. All elements
  * in bellow example are 32-bit unsigned integers:
  *
- *      --------------------------------------------------  ---
- *      | id = DEBUG_STREAM_IDENTIFIER                   |   |
- *      | total_size = 4096                              | 64 bytes
- *      | num_sections = CONFIG_MP_MAX_NUM_CPUS *        |   |
- *      | <padding>                                      |   |
- *      --------------------------------------------------  ---
- *      | section_descriptor [] = {                      |   |
- *      |   {                                            |   |
- *      |      core_id = 0                               |   |
- *      |      size = 1344                               | 64 bytes
- *      |      offset = 64                               |   |
- *      |   }                                            |   |
- *      | <padding>                                      |   |
- *      --------------------------------------------------  ---
- *      |   {                                            |   |
- *      |      core_id = 1                               |   |
- *      |      size = 1344                               | 64 bytes
- *      |      offset = 1344+64                          |   |
- *      |   }                                            |   |
- *      | <padding>                                      |   |
- *      --------------------------------------------------  ---
- *      |   {                                            |   |
- *      |      core_id = 2                               |   |
- *      |      size = 1344                               | 64 bytes
- *      |      offset = 2*1344+64                        |   |
- *      |   }                                            |   |
- *      | }                                              |   |
- *      | <padding>                                      |   |
- *      --------------------------------------------------  ---
+ *      --------------------------------------------------
+ *      | id = DEBUG_STREAM_IDENTIFIER                   |
+ *      | total_size = 4096                              |
+ *      | num_sections = CONFIG_MP_MAX_NUM_CPUS *        |
+ *      | section_descriptor [] = {                      |
+ *      |   {                                            |
+ *      |      core_id = 0                               |
+ *      |      size = 1344                               |
+ *      |      offset = 64                               |
+ *      |   }                                            |
+ *      |   {                                            |
+ *      |      core_id = 1                               |
+ *      |      size = 1344                               |
+ *      |      offset = 1344+64                          |
+ *      |   }                                            |
+ *      |   {                                            |
+ *      |      core_id = 2                               |
+ *      |      size = 1344                               |
+ *      |      offset = 2*1344+64                        |
+ *      |   }                                            |
+ *      | }                                              |
+ *      | <padding>                                      |
+ *      -------------------------------------------------- n * 64 bytes
  *   * CONFIG_MP_MAX_NUM_CPUS is 3 in this example
  *
  * The header contains generic information like identifier, total
  * size, and number of sections. After the generic fields there is an
- * array of section descriptors. Each array element is cacheline
- * aligned. The array has 'num_sections' number of elements. Each
- * element in the array describes a circular buffer, one for each DSP
- * core.
+ * array of section descriptors. The array has 'num_sections' number
+ * of elements. Each element in the array describes a circular buffer,
+ * one for each DSP core.
  *
  * The remaining memory in the debug window slot is divided between
  * those sections. The buffers are not necessarily of equal size, like
@@ -82,11 +75,12 @@
  * The debug stream writes the records of abstract data to the
  * circular buffer, and updates the w_ptr when the record is
  * completely written. The host side receiver tries to keep up with the
- * w_ptr and keeps track of its read position. The size of the record
- * is written - again - after each record and before the next. This is
- * to allow parsing the stream backwards in an overrun recovery
- * situation. The w_ptr value is updated last, when the record is
- * completely written.
+ * w_ptr and keeps track of its read position.
+ *
+ * The size of the record is written - again - after each record and
+ * before the next. This is to allow parsing the stream backwards in
+ * an overrun recovery situation. The w_ptr value is updated last,
+ * when the record is completely written.
  */
 
 #include <stdint.h>


### PR DESCRIPTION
Couple of loose ends that were left from hasty merging to 2.11.