### PR TITLE
fuzzer: add ubsan support

### DIFF
--- a/app/configs/fuzz_ubsan.conf
+++ b/app/configs/fuzz_ubsan.conf
@@ -1,0 +1,1 @@
+CONFIG_UBSAN=y

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -120,6 +120,7 @@ main()
 
   case $SANITIZER in
       address) conf_files_list+=";configs/fuzz_asan.conf";;
+      undefined) conf_files_list+=";configs/fuzz_ubsan.conf";;
       *) echo "Unknown fuzzer type"; print_help; exit 1;;
   esac
 


### PR DESCRIPTION
This PR adds support for undefined fuzzing in SOF.

This is blocked by 2 PRs. One to oss-fuzz to add undefined to the supported manifest. The second is https://github.com/zephyrproject-rtos/zephyr/pull/77963 which blocks the fuzzer currently.