### PR TITLE
rtos: add Zephyr implementation of sof/lib/dai.h

### DIFF
--- a/xtos/include/sof/lib/dai.h
+++ b/xtos/include/sof/lib/dai.h
@@ -13,13 +13,13 @@
   * \author Keyon Jie <yang.jie@linux.intel.com>
   */
 
+#ifdef __ZEPHYR__
+#error "Please use zephyr/include/sof/lib/dai.h instead"
+#endif
+
 #ifndef __SOF_LIB_DAI_H__
 #define __SOF_LIB_DAI_H__
 
-#ifdef CONFIG_ZEPHYR_NATIVE_DRIVERS
-#include <sof/lib/dai-zephyr.h>
-#else
 #include <sof/lib/dai-legacy.h>
-#endif
 
 #endif /* __SOF_LIB_DAI_H__ */

--- a/zephyr/include/sof/lib/dai.h
+++ b/zephyr/include/sof/lib/dai.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2024 Intel Corporation.
+ */
+
+#ifndef __SOF_LIB_DAI_H__
+#define __SOF_LIB_DAI_H__
+
+/* no-op on Zephyr */
+
+#ifdef CONFIG_ZEPHYR_NATIVE_DRIVERS
+#include <sof/lib/dai-zephyr.h>
+#else
+#include <sof/lib/dai-legacy.h>
+#endif
+
+#endif /* __SOF_LIB_MEMORY_H__ */


### PR DESCRIPTION
Implement sof/lib/dai.h for Zephyr build and do not rely o the xtos version for Zephyr builds. Add a warning to catch invalid build configurations.

Link: https://github.com/thesofproject/sof/issues/9015