### PR TITLE
zephyr: sof/lib/mm_heap.h added Zephyr version

### DIFF
--- a/xtos/include/sof/lib/mm_heap.h
+++ b/xtos/include/sof/lib/mm_heap.h
@@ -9,6 +9,10 @@
 #ifndef __SOF_LIB_MM_HEAP_H__
 #define __SOF_LIB_MM_HEAP_H__
 
+#ifdef __ZEPHYR__
+#error "Please use zephyr/include/sof/lib/mm_heap.h instead"
+#endif
+
 #include <sof/common.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -312,7 +312,6 @@ if (CONFIG_SOC_MIMX8QM6_ADSP OR CONFIG_SOC_MIMX8QX6_ADSP)
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/imx8/platform.c
 		${SOF_PLATFORM_PATH}/imx8/lib/clk.c
-		${SOF_PLATFORM_PATH}/imx8/lib/memory.c
 	)
 
 	# SOF core infrastructure - runs on top of Zephyr
@@ -339,7 +338,6 @@ if (CONFIG_SOC_MIMX8ML8_ADSP)
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/imx8m/platform.c
 		${SOF_PLATFORM_PATH}/imx8m/lib/clk.c
-		${SOF_PLATFORM_PATH}/imx8m/lib/memory.c
 		${SOF_PLATFORM_PATH}/imx8m/lib/dai.c
 		${SOF_PLATFORM_PATH}/imx8m/lib/dma.c
 	)
@@ -363,7 +361,6 @@ if (CONFIG_SOC_MIMX8UD7_ADSP)
 	zephyr_library_sources(
 		${SOF_PLATFORM_PATH}/imx8ulp/platform.c
 		${SOF_PLATFORM_PATH}/imx8ulp/lib/clk.c
-		${SOF_PLATFORM_PATH}/imx8ulp/lib/memory.c
 	)
 
 	# SOF core infrastructure - runs on top of Zephyr

--- a/zephyr/include/sof/lib/mm_heap.h
+++ b/zephyr/include/sof/lib/mm_heap.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2024 Intel Corporation.
+ */
+
+#ifndef __SOF_LIB_MM_HEAP_H__
+#define __SOF_LIB_MM_HEAP_H__
+
+/* no-op on Zephyr */
+
+#endif /* __SOF_LIB_MM_HEAP_H__ */


### PR DESCRIPTION
Definitions of mm_heap.h interface are not needed in Zephyr builds. To avoid pulling in XTOS definitions when building with CONFIG_SOF_ZEPHYR_STRICT_HEADERS=n, add a no-op version for Zephyr.