### PR TITLE
.github/zephyr: switch to python 3.10 on windows

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -305,7 +305,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: West install
         run: pip3 install west
@@ -329,7 +329,7 @@ jobs:
         uses: actions/setup-python@v5
         id: cache-python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: workspace/zephyr/scripts/requirements.txt
 


### PR DESCRIPTION
Zephyr commit b3b8360f3993 ("west: runners: Add `west rtt` command with pyocd implementation") adds some functionality to the west commands making use of the pipe ("|") operator for function return type hinting. As per PEP 604 [1], this operator can be used for writing union types starting from python 3.10. Since the SOF windows builds use python 3.8 this leads to the CI failing.

To fix this, switch to using python 3.10. This is not a problem for Linux CI jobs as they already use python 3.10.

The following is a snippet of a failed windows CI job regarding this:

File "D:\a\sof\sof\workspace\zephyr\scripts/west_commands\runners\core.py", line 780, in ZephyrBinaryRunner

    def get_rtt_address(self) -> int | None:

    TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'

[1]: https://peps.python.org/pep-0604/