### PR TITLE
audio: selector: fix init pointers

### DIFF
--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -180,7 +180,7 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 
 	comp_set_drvdata(dev, cd);
 
-	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
+	ret = memcpy_s(&cd->config, sizeof(cd->config), &ipc_process->data, bs);
 	if (ret) {
 		rfree(cd);
 		rfree(dev);


### PR DESCRIPTION
Selector has been broken since its last init migration as the memcpy passes in the first byte of data rather than the pointer to the data.

Fixes: 141efbd7b0 ("ipc4: convert selector to use the new module interface")
Fixes: oss-fuzz:59343