### PR TITLE
Pipeline2.0: step3, make all components using API instead of direct access to bsink_list and bsource_list

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -181,7 +181,7 @@ static int aria_prepare(struct processing_module *mod,
 	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	aria_set_stream_params(source, mod);
 
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sink = comp_dev_get_first_data_consumer(dev);
 	aria_set_stream_params(sink, mod);
 
 	if (audio_stream_get_valid_fmt(&source->stream) != SOF_IPC_FRAME_S24_4LE ||

--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -178,7 +178,7 @@ static int aria_prepare(struct processing_module *mod,
 
 	comp_info(dev, "aria_prepare()");
 
-	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 	aria_set_stream_params(source, mod);
 
 	sink = comp_dev_get_first_data_consumer(dev);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -398,8 +398,7 @@ static int asrc_params(struct processing_module *mod)
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* update the source/sink buffer formats. Sink rate will be modified below */
 	asrc_update_buffer_format(sourceb, cd);
@@ -452,7 +451,7 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 	if (cd->mode == ASRC_OM_PUSH) {
 		/* In push mode check if sink component is DAI */
 		do {
-			sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+			sinkb = comp_dev_get_first_data_consumer(dev);
 
 			dev = sinkb->sink;
 
@@ -547,8 +546,7 @@ static int asrc_prepare(struct processing_module *mod,
 	/* SRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list,
 				  struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list,
-				struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format and period bytes */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
@@ -798,8 +796,7 @@ static int asrc_process(struct processing_module *mod,
 	/* asrc component needs 1 source and 1 sink buffer */
 	source = list_first_item(&dev->bsource_list, struct comp_buffer,
 				 sink_list);
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-			       source_list);
+	sink = comp_dev_get_first_data_consumer(dev);
 
 	frames_src = audio_stream_get_avail_frames(source_s);
 	frames_snk = audio_stream_get_free_frames(sink_s);

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -396,8 +396,7 @@ static int asrc_params(struct processing_module *mod)
 		return -EINVAL;
 	}
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* update the source/sink buffer formats. Sink rate will be modified below */
@@ -469,7 +468,7 @@ static int asrc_dai_find(struct comp_dev *dev, struct comp_data *cd)
 	} else {
 		/* In pull mode check if source component is DAI */
 		do {
-			sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+			sourceb = comp_dev_get_first_data_producer(dev);
 
 			dev = sourceb->source;
 
@@ -544,8 +543,7 @@ static int asrc_prepare(struct processing_module *mod,
 		return ret;
 
 	/* SRC component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list,
-				  struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format and period bytes */
@@ -794,8 +792,7 @@ static int asrc_process(struct processing_module *mod,
 		return ret;
 
 	/* asrc component needs 1 source and 1 sink buffer */
-	source = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 	sink = comp_dev_get_first_data_consumer(dev);
 
 	frames_src = audio_stream_get_avail_frames(source_s);

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -76,8 +76,7 @@ static int dts_effect_convert_sof_interface_result(struct comp_dev *dev,
 static int dts_effect_populate_buffer_configuration(struct comp_dev *dev,
 	DtsSofInterfaceBufferConfiguration *buffer_config)
 {
-	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
-						     sink_list);
+	struct comp_buffer *source = comp_dev_get_first_data_producer(dev);
 	const struct audio_stream *stream;
 	DtsSofInterfaceBufferLayout buffer_layout;
 	DtsSofInterfaceBufferFormat buffer_format;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -455,15 +455,13 @@ static int copier_copy_to_sinks(struct copier_data *cd, struct comp_dev *dev,
 				struct comp_buffer *src_c,
 				struct comp_copy_limits *processed_data)
 {
-	struct list_item *sink_list;
 	struct comp_buffer *sink;
 	int ret = 0;
 
 	/* module copy, one source to multiple sink buffers */
-	list_for_item(sink_list, &dev->bsink_list) {
+	comp_dev_for_each_consumer(dev, sink) {
 		struct comp_dev *sink_dev;
 
-		sink = container_of(sink_list, struct comp_buffer, source_list);
 		sink_dev = sink->sink;
 		processed_data->sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {
@@ -1066,14 +1064,14 @@ static int copier_bind(struct processing_module *mod, void *data)
 	const uint32_t src_queue_id = bu->extension.r.src_queue;
 	struct copier_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct list_item *list;
 
 	if (dev->ipc_config.id != src_id)
 		return 0; /* Another component is a data producer */
 
 	/* update sink format */
-	list_for_item(list, &dev->bsink_list) {
-		struct comp_buffer *buffer = container_of(list, struct comp_buffer, source_list);
+	struct comp_buffer *buffer;
+
+	comp_dev_for_each_consumer(dev, buffer) {
 		uint32_t id = IPC4_SRC_QUEUE_ID(buf_get_id(buffer));
 
 		if (src_queue_id == id) {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -388,7 +388,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			return -EINVAL;
 		}
 
-		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
+		buffer = comp_dev_get_first_data_producer(dai_copier);
 		pipe_reg.stream_start_offset = posn.dai_posn +
 			latency * audio_stream_period_bytes(&buffer->stream, dev->frames);
 		pipe_reg.stream_end_offset = 0;
@@ -412,7 +412,7 @@ static int copier_comp_trigger(struct comp_dev *dev, int cmd)
 			return -EINVAL;
 		}
 
-		buffer = list_first_item(&dai_copier->bsource_list, struct comp_buffer, sink_list);
+		buffer = comp_dev_get_first_data_producer(dai_copier);
 		pipe_reg.stream_start_offset += latency *
 			audio_stream_period_bytes(&buffer->stream, dev->frames);
 		mailbox_sw_regs_write(cd->pipeline_reg_offset, &pipe_reg.stream_start_offset,
@@ -561,7 +561,7 @@ static int copier_multi_endpoint_dai_copy(struct copier_data *cd, struct comp_de
 		return -EINVAL;
 	}
 
-	src = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	src = comp_dev_get_first_data_producer(dev);
 
 	/* gateway(s) on output */
 	ret = do_conversion_copy(dev, cd, src, cd->multi_endpoint_buffer, &processed_data);

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -62,7 +62,6 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 			  struct sof_ipc_stream_params *params)
 {
 	struct comp_buffer *sink;
-	struct list_item *sink_list;
 
 	memset(params, 0, sizeof(*params));
 	params->direction = cd->direction;
@@ -80,11 +79,8 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 	params->no_stream_position = 1;
 
 	/* update each sink format */
-	list_for_item(sink_list, &dev->bsink_list) {
+	comp_dev_for_each_consumer(dev, sink) {
 		int j;
-
-		sink = container_of(sink_list, struct comp_buffer, source_list);
-
 		j = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
 
 		ipc4_update_buffer_format(sink, &cd->out_fmt[j]);

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -82,7 +82,7 @@ static inline struct comp_buffer *get_buffer(struct comp_dev *dev)
 
 	if (list_is_empty(&dev->bsource_list))
 		return NULL;
-	return list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	return comp_dev_get_first_data_producer(dev);
 }
 
 int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -75,7 +75,7 @@ static inline struct comp_buffer *get_buffer(struct comp_dev *dev)
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		if (list_is_empty(&dev->bsink_list))
 			return NULL;
-		return list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+		return comp_dev_get_first_data_consumer(dev);
 	}
 
 	assert(dev->direction == SOF_IPC_STREAM_CAPTURE);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -536,7 +536,7 @@ static int crossover_prepare(struct processing_module *mod,
 
 	/* Crossover has a variable number of sinks */
 	mod->max_sinks = SOF_CROSSOVER_MAX_STREAMS;
-	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 
 	/* Get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&source->stream);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -100,15 +100,13 @@ static int crossover_assign_sinks(struct processing_module *mod,
 	struct sof_crossover_config *config = cd->config;
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct list_item *sink_list;
 	int num_sinks = 0;
 	int i;
 	int j = 0;
 
-	list_for_item(sink_list, &dev->bsink_list) {
+	comp_dev_for_each_consumer(dev, sink) {
 		unsigned int sink_id, state;
 
-		sink = container_of(sink_list, struct comp_buffer, source_list);
 		sink_id = crossover_get_sink_id(cd, buffer_pipeline_id(sink), j);
 		state = sink->sink->state;
 		if (state != dev->state) {
@@ -529,7 +527,6 @@ static int crossover_prepare(struct processing_module *mod,
 	struct comp_data *cd =  module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *source, *sink;
-	struct list_item *sink_list;
 	int channels;
 	int ret = 0;
 
@@ -546,8 +543,7 @@ static int crossover_prepare(struct processing_module *mod,
 	channels = audio_stream_get_channels(&source->stream);
 
 	/* Validate frame format and buffer size of sinks */
-	list_for_item(sink_list, &dev->bsink_list) {
-		sink = container_of(sink_list, struct comp_buffer, source_list);
+	comp_dev_for_each_consumer(dev, sink) {
 		if (cd->source_format != audio_stream_get_frm_fmt(&sink->stream)) {
 			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different.",
 				 cd->source_format, audio_stream_get_frm_fmt(&sink->stream));

--- a/src/audio/crossover/crossover_ipc3.c
+++ b/src/audio/crossover/crossover_ipc3.c
@@ -37,15 +37,13 @@ int crossover_check_sink_assign(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink;
-	struct list_item *sink_list;
 	int num_assigned_sinks = 0;
 	uint8_t assigned_sinks[SOF_CROSSOVER_MAX_STREAMS] = {0};
 	int i;
 
-	list_for_item(sink_list, &dev->bsink_list) {
+	comp_dev_for_each_consumer(dev, sink) {
 		unsigned int pipeline_id;
 
-		sink = container_of(sink_list, struct comp_buffer, source_list);
 		pipeline_id = buffer_pipeline_id(sink);
 
 		i = crossover_get_stream_index(mod, config, pipeline_id);

--- a/src/audio/crossover/crossover_ipc4.c
+++ b/src/audio/crossover/crossover_ipc4.c
@@ -118,7 +118,7 @@ void crossover_params(struct processing_module *mod)
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	comp_dev_for_each_consumer(dev, sinkb) {

--- a/src/audio/crossover/crossover_ipc4.c
+++ b/src/audio/crossover/crossover_ipc4.c
@@ -111,7 +111,6 @@ void crossover_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct comp_buffer *sinkb, *sourceb;
-	struct list_item *sink_list;
 	struct comp_dev *dev = mod->dev;
 
 	comp_dbg(dev, "crossover_params()");
@@ -122,8 +121,7 @@ void crossover_params(struct processing_module *mod)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	list_for_item(sink_list, &dev->bsink_list) {
-		sinkb = container_of(sink_list, struct comp_buffer, source_list);
+	comp_dev_for_each_consumer(dev, sinkb) {
 		ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 	}
 }

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -493,9 +493,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 	}
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		dd->local_buffer = list_first_item(&dev->bsource_list,
-						   struct comp_buffer,
-						   sink_list);
+		dd->local_buffer = comp_dev_get_first_data_producer(dev);
 	else
 		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -497,9 +497,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 						   struct comp_buffer,
 						   sink_list);
 	else
-		dd->local_buffer = list_first_item(&dev->bsink_list,
-						   struct comp_buffer,
-						   source_list);
+		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 
 	/* check if already configured */
 	if (dev->state == COMP_STATE_PREPARE) {

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -855,8 +855,7 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 		dd->local_buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
 						   sink_list);
 	else
-		dd->local_buffer = list_first_item(&dev->bsink_list, struct comp_buffer,
-						   source_list);
+		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 
 	/* check if already configured */
 	if (dev->state == COMP_STATE_PREPARE) {
@@ -1528,9 +1527,7 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 						   struct comp_buffer,
 						   sink_list);
 	else
-		dd->local_buffer = list_first_item(&dev->bsink_list,
-						   struct comp_buffer,
-						   source_list);
+		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 
 	local_fmt = audio_stream_get_frm_fmt(&dd->local_buffer->stream);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -269,17 +269,15 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 #if CONFIG_IPC_MAJOR_4
-		struct list_item *sink_list;
 		/*
 		 * copy from local buffer to all sinks that are not gateway buffers
 		 * using the right PCM converter function.
 		 */
-		list_for_item(sink_list, &dev->bsink_list) {
-			struct comp_dev *sink_dev;
-			struct comp_buffer *sink;
-			int j;
+		struct comp_buffer *sink;
 
-			sink = container_of(sink_list, struct comp_buffer, source_list);
+		comp_dev_for_each_consumer(dev, sink) {
+			struct comp_dev *sink_dev;
+			int j;
 
 			if (sink == dd->dma_buffer)
 				continue;
@@ -319,19 +317,17 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 		ret = stream_copy_from_no_consume(dd->dma_buffer, dd->local_buffer,
 						  dd->process, bytes, dd->chmap);
 #if CONFIG_IPC_MAJOR_4
-		struct list_item *sink_list;
 		/* Skip in case of endpoint DAI devices created by the copier */
 		if (converter) {
 			/*
 			 * copy from DMA buffer to all sink buffers using the right PCM converter
 			 * function
 			 */
-			list_for_item(sink_list, &dev->bsink_list) {
-				struct comp_dev *sink_dev;
-				struct comp_buffer *sink;
-				int j;
+			struct comp_buffer *sink;
 
-				sink = container_of(sink_list, struct comp_buffer, source_list);
+			comp_dev_for_each_consumer(dev, sink) {
+				struct comp_dev *sink_dev;
+				int j;
 
 				/* this has been handled above already */
 				if (sink == dd->local_buffer)
@@ -1592,17 +1588,16 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 		sink_frames = free_bytes / audio_stream_frame_bytes(&dd->dma_buffer->stream);
 		frames = MIN(src_frames, sink_frames);
 
-		struct list_item *sink_list;
 		/*
 		 * In the case of playback DAI's with multiple sink buffers, compute the
 		 * minimum number of frames based on the DMA avail_bytes and the free
 		 * samples in all active sink buffers.
 		 */
-		list_for_item(sink_list, &dev->bsink_list) {
-			struct comp_dev *sink_dev;
-			struct comp_buffer *sink;
+		struct comp_buffer *sink;
 
-			sink = container_of(sink_list, struct comp_buffer, source_list);
+		comp_dev_for_each_consumer(dev, sink) {
+			struct comp_dev *sink_dev;
+
 			sink_dev = sink->sink;
 
 			if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
@@ -1613,8 +1608,6 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 			}
 		}
 	} else {
-		struct list_item *sink_list;
-
 		src_frames = avail_bytes / audio_stream_frame_bytes(&dd->dma_buffer->stream);
 
 		/*
@@ -1630,11 +1623,11 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 			 * minimum number of samples based on the DMA avail_bytes and the free
 			 * samples in all active sink buffers.
 			 */
-			list_for_item(sink_list, &dev->bsink_list) {
-				struct comp_dev *sink_dev;
-				struct comp_buffer *sink;
+			struct comp_buffer *sink;
 
-				sink = container_of(sink_list, struct comp_buffer, source_list);
+			comp_dev_for_each_consumer(dev, sink) {
+				struct comp_dev *sink_dev;
+
 				sink_dev = sink->sink;
 
 				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -848,8 +848,7 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 	comp_dbg(dev, "dai_set_dma_buffer()");
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		dd->local_buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
-						   sink_list);
+		dd->local_buffer = comp_dev_get_first_data_producer(dev);
 	else
 		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 
@@ -1519,9 +1518,7 @@ static void set_new_local_buffer(struct dai_data *dd, struct comp_dev *dev)
 	uint32_t local_fmt;
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		dd->local_buffer = list_first_item(&dev->bsource_list,
-						   struct comp_buffer,
-						   sink_list);
+		dd->local_buffer = comp_dev_get_first_data_producer(dev);
 	else
 		dd->local_buffer = comp_dev_get_first_data_consumer(dev);
 

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -200,7 +200,7 @@ static int dcblock_prepare(struct processing_module *mod,
 
 	/* DC Filter component will only ever have one source and sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -199,7 +199,7 @@ static int dcblock_prepare(struct processing_module *mod,
 	dcblock_params(mod);
 
 	/* DC Filter component will only ever have one source and sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */

--- a/src/audio/dcblock/dcblock_ipc4.c
+++ b/src/audio/dcblock/dcblock_ipc4.c
@@ -61,7 +61,7 @@ void dcblock_params(struct processing_module *mod)
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);

--- a/src/audio/dcblock/dcblock_ipc4.c
+++ b/src/audio/dcblock/dcblock_ipc4.c
@@ -64,7 +64,7 @@ void dcblock_params(struct processing_module *mod)
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -303,7 +303,7 @@ static void drc_params(struct processing_module *mod)
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
@@ -330,7 +330,7 @@ static int drc_prepare(struct processing_module *mod,
 
 	/* DRC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -306,7 +306,7 @@ static void drc_params(struct processing_module *mod)
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
@@ -329,7 +329,7 @@ static int drc_prepare(struct processing_module *mod,
 #endif
 
 	/* DRC component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -424,7 +424,7 @@ static int eq_fir_prepare(struct processing_module *mod,
 	}
 
 	/* EQ component will only ever have 1 source and 1 sink buffer. */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	eq_fir_set_alignment(&sourceb->stream, &sinkb->stream);
 	channels = audio_stream_get_channels(&sinkb->stream);

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -425,7 +425,7 @@ static int eq_fir_prepare(struct processing_module *mod,
 
 	/* EQ component will only ever have 1 source and 1 sink buffer. */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	eq_fir_set_alignment(&sourceb->stream, &sinkb->stream);
 	channels = audio_stream_get_channels(&sinkb->stream);
 	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/eq_fir/eq_fir_ipc4.c
+++ b/src/audio/eq_fir/eq_fir_ipc4.c
@@ -62,7 +62,7 @@ int eq_fir_params(struct processing_module *mod)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	return 0;

--- a/src/audio/eq_fir/eq_fir_ipc4.c
+++ b/src/audio/eq_fir/eq_fir_ipc4.c
@@ -59,7 +59,7 @@ int eq_fir_params(struct processing_module *mod)
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sinkb = comp_dev_get_first_data_consumer(dev);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -193,7 +193,7 @@ static int eq_iir_prepare(struct processing_module *mod,
 		return ret;
 
 	/* EQ component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	eq_iir_set_alignment(&sourceb->stream, &sinkb->stream);
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -194,7 +194,7 @@ static int eq_iir_prepare(struct processing_module *mod,
 
 	/* EQ component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	eq_iir_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	/* get source and sink data format */

--- a/src/audio/eq_iir/eq_iir_ipc3.c
+++ b/src/audio/eq_iir/eq_iir_ipc3.c
@@ -274,8 +274,7 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 	comp_dbg(dev, "eq_iir_verify_params()");
 
 	/* EQ component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* we check whether we can support frame_fmt conversion (whether we have

--- a/src/audio/eq_iir/eq_iir_ipc3.c
+++ b/src/audio/eq_iir/eq_iir_ipc3.c
@@ -276,8 +276,7 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 	/* EQ component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* we check whether we can support frame_fmt conversion (whether we have
 	 * such conversion function) due to source and sink buffer frame_fmt's.

--- a/src/audio/eq_iir/eq_iir_ipc4.c
+++ b/src/audio/eq_iir/eq_iir_ipc4.c
@@ -125,7 +125,7 @@ static int eq_iir_params(struct processing_module *mod)
 		comp_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;
 
 	component_set_nearest_period_frames(dev, comp_params.rate);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ret = buffer_set_params(sinkb, &comp_params, true);
 	return ret;
 }

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -355,7 +355,7 @@ static int ctc_prepare(struct processing_module *mod,
 
 	comp_info(mod->dev, "ctc_prepare()");
 
-	source = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 	switch (audio_stream_get_frm_fmt(&source->stream)) {
 #if CONFIG_FORMAT_S16LE
 	case SOF_IPC_FRAME_S16_LE:

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -170,8 +170,7 @@ static int ghd_params(struct comp_dev *dev,
 	}
 
 	/* This detector component will only ever have 1 source */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	if (audio_stream_get_channels(sourceb->stream) != 1) {
 		comp_err(dev, "ghd_params(): Only single-channel supported");
@@ -391,8 +390,7 @@ static int ghd_copy(struct comp_dev *dev)
 	}
 
 	/* keyword components will only ever have 1 source */
-	source = list_first_item(&dev->bsource_list,
-				 struct comp_buffer, sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 	stream = &sourceb->stream;
 
 	bytes = audio_stream_get_avail_bytes(stream);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -633,10 +633,9 @@ static int google_rtc_audio_processing_prepare(struct processing_module *mod,
 	/* Don't need the ref buffer on IPC4 as pipelines are always
 	 * activated in tandem; also the API is deprecated
 	 */
-	cd->ref_comp_buffer = list_first_item(&dev->bsource_list,
-					      struct comp_buffer, sink_list);
+	cd->ref_comp_buffer = comp_dev_get_first_data_producer(dev);
 	if (cd->aec_reference_source == 1)
-		cd->ref_comp_buffer = list_next_item(cd->ref_comp_buffer, sink_list);
+		cd->ref_comp_buffer = comp_dev_get_next_data_producer(dev, cd->ref_comp_buffer);
 #endif
 
 #ifdef CONFIG_IPC_MAJOR_4

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -712,9 +712,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	}
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
-		hd->local_buffer = list_first_item(&dev->bsink_list,
-						   struct comp_buffer,
-						   source_list);
+		hd->local_buffer = comp_dev_get_first_data_consumer(dev);
 	else
 		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -714,9 +714,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 		hd->local_buffer = comp_dev_get_first_data_consumer(dev);
 	else
-		hd->local_buffer = list_first_item(&dev->bsource_list,
-						   struct comp_buffer,
-						   sink_list);
+		hd->local_buffer = comp_dev_get_first_data_producer(dev);
 
 	period_bytes = dev->frames *
 		audio_stream_frame_bytes(&hd->local_buffer->stream);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -795,9 +795,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	if (params->direction == SOF_IPC_STREAM_PLAYBACK)
 		hd->local_buffer = comp_dev_get_first_data_consumer(dev);
 	else
-		hd->local_buffer = list_first_item(&dev->bsource_list,
-						   struct comp_buffer,
-						   sink_list);
+		hd->local_buffer = comp_dev_get_first_data_producer(dev);
 
 	period_bytes = dev->frames * get_frame_bytes(params->frame_fmt, params->channels);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -793,9 +793,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	}
 
 	if (params->direction == SOF_IPC_STREAM_PLAYBACK)
-		hd->local_buffer = list_first_item(&dev->bsink_list,
-						   struct comp_buffer,
-						   source_list);
+		hd->local_buffer = comp_dev_get_first_data_consumer(dev);
 	else
 		hd->local_buffer = list_first_item(&dev->bsource_list,
 						   struct comp_buffer,

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1182,8 +1182,7 @@ static int kpb_copy(struct comp_dev *dev)
 	}
 
 	/* Get source and sink buffers */
-	source = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 
 	/* Validate source */
 	if (!audio_stream_get_rptr(&source->stream)) {

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -193,7 +193,7 @@ static int mfcc_prepare(struct processing_module *mod,
 
 	/* MFCC component will only ever have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */
 	source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -192,7 +192,7 @@ static int mfcc_prepare(struct processing_module *mod,
 	comp_info(dev, "mfcc_prepare()");
 
 	/* MFCC component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format */

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -216,8 +216,7 @@ static int mixer_prepare(struct processing_module *mod,
 	struct comp_buffer *sink;
 	struct list_item *blist;
 
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-			       source_list);
+	sink = comp_dev_get_first_data_consumer(dev);
 	md->mix_func = mixer_get_processing_function(dev, sink);
 	mixer_set_frame_alignment(&sink->stream);
 

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -215,8 +215,7 @@ static int waves_effect_allocate(struct processing_module *mod)
 /* checks if sink/source parameters fit MaxxEffect */
 static int waves_effect_check(struct comp_dev *dev)
 {
-	struct comp_buffer *sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-						    source_list);
+	struct comp_buffer *sink = comp_dev_get_first_data_consumer(dev);
 	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
 						     sink_list);
 	const struct audio_stream *src_fmt = &source->stream;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -216,8 +216,7 @@ static int waves_effect_allocate(struct processing_module *mod)
 static int waves_effect_check(struct comp_dev *dev)
 {
 	struct comp_buffer *sink = comp_dev_get_first_data_consumer(dev);
-	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
-						     sink_list);
+	struct comp_buffer *source = comp_dev_get_first_data_producer(dev);
 	const struct audio_stream *src_fmt = &source->stream;
 	const struct audio_stream *snk_fmt = &sink->stream;
 
@@ -283,8 +282,7 @@ static int waves_effect_check(struct comp_dev *dev)
 static int waves_effect_init(struct processing_module *mod)
 {
 	struct comp_dev *dev = mod->dev;
-	struct comp_buffer *source = list_first_item(&dev->bsource_list, struct comp_buffer,
-						     sink_list);
+	struct comp_buffer *source = comp_dev_get_first_data_producer(dev);
 	struct module_data *codec = &mod->priv;
 	struct waves_codec_data *waves_codec = codec->private;
 	const struct audio_stream *src_fmt = &source->stream;

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -364,7 +364,7 @@ static int multiband_drc_prepare(struct processing_module *mod,
 		return ret;
 
 	/* DRC component will only ever have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	/* get source data format */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/multiband_drc/multiband_drc_ipc4.c
+++ b/src/audio/multiband_drc/multiband_drc_ipc4.c
@@ -98,7 +98,7 @@ int multiband_drc_params(struct processing_module *mod)
 		comp_params.chmap[i] = (mod->priv.cfg.base_cfg.audio_fmt.ch_map >> i * 4) & 0xf;
 
 	component_set_nearest_period_frames(dev, comp_params.rate);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ret = buffer_set_params(sinkb, &comp_params, true);
 
 	return ret;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -233,7 +233,6 @@ static int demux_process(struct processing_module *mod,
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
-	struct list_item *clist;
 	struct comp_buffer *sink;
 	struct audio_stream *sinks_stream[MUX_MAX_STREAMS] = { NULL };
 	struct mux_look_up *look_ups[MUX_MAX_STREAMS] = { NULL };
@@ -245,8 +244,7 @@ static int demux_process(struct processing_module *mod,
 	comp_dbg(dev, "demux_process()");
 
 	/* align sink streams with their respective configurations */
-	list_for_item(clist, &dev->bsink_list) {
-		sink = container_of(clist, struct comp_buffer, source_list);
+	comp_dev_for_each_consumer(dev, sink) {
 		if (sink->sink->state == dev->state) {
 			i = get_stream_index(dev, cd, buffer_pipeline_id(sink));
 			/* return if index wrong */

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -527,8 +527,7 @@ mux_func mux_get_processing_function(struct processing_module *mod)
 	if (list_is_empty(&dev->bsink_list))
 		return NULL;
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
 		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sinkb->stream);

--- a/src/audio/mux/mux_generic.c
+++ b/src/audio/mux/mux_generic.c
@@ -549,8 +549,7 @@ demux_func demux_get_processing_function(struct processing_module *mod)
 	if (list_is_empty(&dev->bsource_list))
 		return NULL;
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	for (i = 0; i < ARRAY_SIZE(mux_func_map); i++) {
 		enum sof_ipc_frame fmt = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -74,7 +74,6 @@ static void set_mux_params(struct processing_module *mod)
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	struct comp_buffer *sink, *source;
-	struct list_item *source_list;
 	int j;
 
 	params->direction = dev->direction;
@@ -106,9 +105,7 @@ static void set_mux_params(struct processing_module *mod)
 	if (!list_is_empty(&dev->bsource_list)) {
 		struct ipc4_audio_format *audio_fmt;
 
-		list_for_item(source_list, &dev->bsource_list)
-		{
-			source = container_of(source_list, struct comp_buffer, sink_list);
+		comp_dev_for_each_producer(dev, source) {
 			j = buf_get_id(source);
 			cd->config.streams[j].pipeline_id = buffer_pipeline_id(source);
 			if (j == BASE_CFG_QUEUED_ID)

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -94,7 +94,7 @@ static void set_mux_params(struct processing_module *mod)
 
 	/* update sink format */
 	if (!list_is_empty(&dev->bsink_list)) {
-		sink = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+		sink = comp_dev_get_first_data_consumer(dev);
 
 		if (!sink->hw_params_configured) {
 			ipc4_update_buffer_format(sink, &cd->md.output_format);

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -781,7 +781,7 @@ static void rtnr_params(struct processing_module *mod)
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sinkb = comp_dev_get_first_data_consumer(dev);
@@ -817,7 +817,7 @@ static int rtnr_prepare(struct processing_module *mod,
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
 	cd->sink_stream.frame_fmt = audio_stream_get_frm_fmt(&sinkb->stream);
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ret = rtnr_check_params(mod, &sourceb->stream, &sinkb->stream);
 	if (ret)
 		goto err;

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -784,7 +784,7 @@ static void rtnr_params(struct processing_module *mod)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 #endif
@@ -814,7 +814,7 @@ static int rtnr_prepare(struct processing_module *mod,
 	/* Initialize RTNR */
 
 	/* Get sink data format */
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	cd->sink_format = audio_stream_get_frm_fmt(&sinkb->stream);
 	cd->sink_stream.frame_fmt = audio_stream_get_frm_fmt(&sinkb->stream);
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -62,8 +62,7 @@ static int selector_verify_params(struct comp_dev *dev,
 
 	comp_dbg(dev, "selector_verify_params()");
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* check whether params->channels (received from driver) are equal to
 	 * cd->config.in_channels_count (PLAYBACK) or
@@ -73,8 +72,7 @@ static int selector_verify_params(struct comp_dev *dev,
 	 */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		/* fetch sink buffer for playback */
-		buffer = list_first_item(&dev->bsink_list, struct comp_buffer,
-					 source_list);
+		buffer = comp_dev_get_first_data_consumer(dev);
 		if (cd->config.in_channels_count &&
 		    cd->config.in_channels_count != params->channels) {
 			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
@@ -387,8 +385,7 @@ static int selector_copy(struct comp_dev *dev)
 	/* selector component will have 1 source and 1 sink buffer */
 	source = list_first_item(&dev->bsource_list, struct comp_buffer,
 				 sink_list);
-	sink = list_first_item(&dev->bsink_list, struct comp_buffer,
-			       source_list);
+	sink = comp_dev_get_first_data_consumer(dev);
 
 	if (!audio_stream_get_avail(&source->stream))
 		return PPL_STATUS_PATH_STOP;
@@ -436,8 +433,7 @@ static int selector_prepare(struct comp_dev *dev)
 	/* selector component will have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format and period bytes */
 	cd->source_format = audio_stream_get_frm_fmt(&sourceb->stream);
@@ -715,7 +711,7 @@ static int selector_verify_params(struct processing_module *mod,
 	/* apply input/output channels count according to stream direction */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		params->channels = out_channels;
-		buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+		buffer = comp_dev_get_first_data_consumer(dev);
 	} else {
 		params->channels = in_channels;
 		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
@@ -723,7 +719,7 @@ static int selector_verify_params(struct processing_module *mod,
 	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
 	/* set component period frames */
-	buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	buffer = comp_dev_get_first_data_consumer(dev);
 	component_set_nearest_period_frames(dev, audio_stream_get_rate(&buffer->stream));
 
 	return 0;
@@ -844,7 +840,7 @@ static int selector_prepare(struct processing_module *mod,
 
 	/* selector component will have 1 source and 1 sink buffer */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	audio_stream_set_align(4, 1, &sourceb->stream);
 	audio_stream_set_align(4, 1, &sinkb->stream);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -644,7 +644,6 @@ static void set_selector_params(struct processing_module *mod,
 	const struct sof_selector_ipc4_config *sel_cfg = &cd->sel_ipc4_cfg;
 	const struct ipc4_audio_format *out_fmt = NULL;
 	struct comp_buffer *src_buf;
-	struct list_item *sink_list;
 	int i;
 
 	if (cd->sel_ipc4_cfg.init_payload_fmt == IPC4_SEL_INIT_PAYLOAD_BASE_WITH_EXT)
@@ -664,10 +663,9 @@ static void set_selector_params(struct processing_module *mod,
 		params->chmap[i] = (out_fmt->ch_map >> i * 4) & 0xf;
 
 	/* update each sink format */
-	list_for_item(sink_list, &dev->bsink_list) {
-		struct comp_buffer *sink_buf =
-			container_of(sink_list, struct comp_buffer, source_list);
+	struct comp_buffer *sink_buf;
 
+	comp_dev_for_each_consumer(dev, sink_buf) {
 		ipc4_update_buffer_format(sink_buf, out_fmt);
 		audio_stream_set_channels(&sink_buf->stream, params->channels);
 		audio_stream_set_rate(&sink_buf->stream, params->rate);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -90,8 +90,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		params->channels = out_channels;
 	} else {
 		/* fetch source buffer for capture */
-		buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
-					 sink_list);
+		buffer = comp_dev_get_first_data_producer(dev);
 		if (cd->config.out_channels_count &&
 		    cd->config.out_channels_count != params->channels) {
 			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
@@ -353,8 +352,7 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 
 	comp_dbg(dev, "selector_trigger()");
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	ret = comp_set_state(dev, cmd);
 
@@ -383,8 +381,7 @@ static int selector_copy(struct comp_dev *dev)
 	comp_dbg(dev, "selector_copy()");
 
 	/* selector component will have 1 source and 1 sink buffer */
-	source = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 	sink = comp_dev_get_first_data_consumer(dev);
 
 	if (!audio_stream_get_avail(&source->stream))
@@ -431,8 +428,7 @@ static int selector_prepare(struct comp_dev *dev)
 		return PPL_STATUS_PATH_STOP;
 
 	/* selector component will have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	/* get source data format and period bytes */
@@ -677,7 +673,7 @@ static void set_selector_params(struct processing_module *mod,
 	 * for a short time when the second pipeline already started
 	 * and the first one is not ready yet along with sink buffers params
 	 */
-	src_buf = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	src_buf = comp_dev_get_first_data_producer(dev);
 
 	if (!src_buf->hw_params_configured)
 		ipc4_update_buffer_format(src_buf, &mod->priv.cfg.base_cfg.audio_fmt);
@@ -712,7 +708,7 @@ static int selector_verify_params(struct processing_module *mod,
 		buffer = comp_dev_get_first_data_consumer(dev);
 	} else {
 		params->channels = in_channels;
-		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+		buffer = comp_dev_get_first_data_producer(dev);
 	}
 	buffer_set_params(buffer, params, BUFFER_UPDATE_FORCE);
 
@@ -837,7 +833,7 @@ static int selector_prepare(struct processing_module *mod,
 		return PPL_STATUS_PATH_STOP;
 
 	/* selector component will have 1 source and 1 sink buffer */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	audio_stream_set_align(4, 1, &sourceb->stream);

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -731,7 +731,6 @@ static int smart_amp_resolve_mod_fmt(struct comp_dev *dev, uint32_t least_req_de
 static int smart_amp_prepare(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
-	struct list_item *blist;
 	uint16_t ff_src_fmt, fb_src_fmt, resolved_mod_fmt;
 	uint32_t least_req_depth;
 	uint32_t rate;
@@ -744,10 +743,9 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		return ret;
 
 	/* searching for stream and feedback source buffers */
-	list_for_item(blist, &dev->bsource_list) {
-		struct comp_buffer *source_buffer = container_of(blist, struct comp_buffer,
-								 sink_list);
+	struct comp_buffer *source_buffer;
 
+	comp_dev_for_each_producer(dev, source_buffer) {
 		if (source_buffer->source->ipc_config.type == SOF_COMP_DEMUX)
 			sad->feedback_buf = source_buffer;
 		else

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -755,8 +755,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	}
 
 	/* sink buffer */
-	sad->sink_buf = list_first_item(&dev->bsink_list, struct comp_buffer,
-					source_list);
+	sad->sink_buf = comp_dev_get_first_data_consumer(dev);
 
 	/* get frame format and channels param of stream and feedback source */
 	ff_src_fmt = audio_stream_get_frm_fmt(&sad->source_buf->stream);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -739,7 +739,7 @@ static int tdfb_prepare(struct processing_module *mod,
 	}
 
 	/* Find source and sink buffers */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	tdfb_set_alignment(&sourceb->stream, &sinkb->stream);
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -740,7 +740,7 @@ static int tdfb_prepare(struct processing_module *mod,
 
 	/* Find source and sink buffers */
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	tdfb_set_alignment(&sourceb->stream, &sinkb->stream);
 
 	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);

--- a/src/audio/tdfb/tdfb_ipc4.c
+++ b/src/audio/tdfb/tdfb_ipc4.c
@@ -201,7 +201,7 @@ int tdfb_params(struct processing_module *mod)
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.input_pins[0].audio_fmt);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.output_pins[0].audio_fmt);
 	return 0;
 }

--- a/src/audio/tdfb/tdfb_ipc4.c
+++ b/src/audio/tdfb/tdfb_ipc4.c
@@ -198,7 +198,7 @@ int tdfb_params(struct processing_module *mod)
 
 	ipc4_base_module_cfg_to_stream_params(&mod->priv.cfg.base_cfg, params);
 	component_set_nearest_period_frames(dev, params->rate);
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.input_pins[0].audio_fmt);
 
 	sinkb = comp_dev_get_first_data_consumer(dev);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -431,8 +431,7 @@ static int tone_params(struct comp_dev *dev,
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
 				  sink_list);
 
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer,
-				source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 
 	comp_info(dev, "tone_params(), config->frame_fmt = %u",
 		  dev->ipc_config.frame_fmt);

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -428,8 +428,7 @@ static int tone_params(struct comp_dev *dev,
 	struct comp_data *cd = comp_get_drvdata(dev);
 	struct comp_buffer *sourceb, *sinkb;
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	sinkb = comp_dev_get_first_data_consumer(dev);
 
@@ -673,8 +672,7 @@ static int tone_prepare(struct comp_dev *dev)
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		return PPL_STATUS_PATH_STOP;
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	cd->channels = audio_stream_get_channels(&sourceb->stream);
 	comp_info(dev, "tone_prepare(), cd->channels = %u, cd->rate = %u",

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -689,8 +689,7 @@ static int volume_prepare(struct processing_module *mod,
 
 	/* volume component will only ever have 1 sink and source buffer */
 	sinkb = comp_dev_get_first_data_consumer(dev);
-	sourceb = list_first_item(&dev->bsource_list,
-				  struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 
 	volume_set_alignment(&sourceb->stream, &sinkb->stream);
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -688,8 +688,7 @@ static int volume_prepare(struct processing_module *mod,
 	ret = volume_peak_prepare(cd, mod);
 
 	/* volume component will only ever have 1 sink and source buffer */
-	sinkb = list_first_item(&dev->bsink_list,
-				struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	sourceb = list_first_item(&dev->bsource_list,
 				  struct comp_buffer, sink_list);
 

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -42,8 +42,7 @@ void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_o
 		bufferb = list_first_item(&dev->bsource_list,
 					  struct comp_buffer, sink_list);
 	else
-		bufferb = list_first_item(&dev->bsink_list,
-					  struct comp_buffer, source_list);
+		bufferb = comp_dev_get_first_data_consumer(dev);
 
 	cd->scale_vol = vol_get_processing_function(dev, bufferb, cd);
 }

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -39,8 +39,7 @@ void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_o
 	struct comp_buffer *bufferb;
 
 	if (source_or_sink)
-		bufferb = list_first_item(&dev->bsource_list,
-					  struct comp_buffer, sink_list);
+		bufferb = comp_dev_get_first_data_producer(dev);
 	else
 		bufferb = comp_dev_get_first_data_consumer(dev);
 

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -413,7 +413,7 @@ static int volume_params(struct processing_module *mod)
 	component_set_nearest_period_frames(dev, params->rate);
 
 	/* volume component will only ever have 1 sink buffer */
-	sinkb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -416,7 +416,7 @@ static int volume_params(struct processing_module *mod)
 	sinkb = comp_dev_get_first_data_consumer(dev);
 	ipc4_update_buffer_format(sinkb, &mod->priv.cfg.base_cfg.audio_fmt);
 
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	ipc4_update_buffer_format(sourceb, &mod->priv.cfg.base_cfg.audio_fmt);
 
 	return 0;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -634,6 +634,64 @@ struct comp_dev {
 #endif
 };
 
+/**
+ * Get a pointer to a first comp_buffer object providing data to the component
+ * The procedure will return NULL if there's no data provider
+ */
+static inline struct comp_buffer *comp_dev_get_first_data_producer(struct comp_dev *component)
+{
+	return list_is_empty(&component->bsource_list) ? NULL :
+	       list_first_item(&component->bsource_list, struct comp_buffer, sink_list);
+}
+
+/**
+ * Get a pointer to a next comp_buffer object providing data to the component
+ * The procedure will return NULL if there're no more data providers
+ */
+static inline struct comp_buffer *comp_dev_get_next_data_producer(struct comp_dev *component,
+								  struct comp_buffer *producer)
+{
+	return producer->sink_list.next == &component->bsource_list ? NULL :
+	       list_item(producer->sink_list.next, struct comp_buffer, sink_list);
+}
+
+/**
+ * Get a pointer to a first comp_buffer object receiving data from the component
+ * The procedure will return NULL if there's no data consumers
+ */
+static inline struct comp_buffer *comp_dev_get_first_data_consumer(struct comp_dev *component)
+{
+	return list_is_empty(&component->bsink_list) ? NULL :
+	       list_first_item(&component->bsink_list, struct comp_buffer, source_list);
+}
+
+/**
+ * Get a pointer to a next comp_buffer object receiving data from the component
+ * The procedure will return NULL if there're no more data consumers
+ */
+static inline struct comp_buffer *comp_dev_get_next_data_consumer(struct comp_dev *component,
+								  struct comp_buffer *consumer)
+{
+	return consumer->source_list.next == &component->bsink_list ? NULL :
+			list_item(consumer->source_list.next, struct comp_buffer, source_list);
+}
+
+/*
+ * a macro for easy iteration through component's list of producers
+ */
+#define comp_dev_for_each_producer(_dev, _producer)			\
+	for (_producer = comp_dev_get_first_data_producer(_dev);	\
+	     _producer != NULL;						\
+	     _producer = comp_dev_get_next_data_producer(_dev, _producer))
+
+/*
+ * a macro for easy iteration through component's list of consumers
+ */
+#define comp_dev_for_each_consumer(_dev, _consumer)			\
+	for (_consumer = comp_dev_get_first_data_consumer(_dev);	\
+	     _consumer != NULL;						\
+	     _consumer = comp_dev_get_next_data_consumer(_dev, _consumer))
+
 /** @}*/
 
 /* Common helper function used internally by the component implementations

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1061,7 +1061,7 @@ static bool probe_purpose_needs_ext_dma(uint32_t purpose)
 static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point_id_t probe_point)
 {
 	struct comp_buffer *buf;
-	struct list_item *sink_list, *source_list;
+	struct list_item *source_list;
 	unsigned int queue_id;
 
 	switch (probe_point.fields.type) {
@@ -1075,8 +1075,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 		}
 		break;
 	case PROBE_TYPE_OUTPUT:
-		list_for_item(sink_list, &dev->cd->bsink_list) {
-			buf = container_of(sink_list, struct comp_buffer, source_list);
+		comp_dev_for_each_consumer(dev->cd, buf) {
 			queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(buf));
 
 			if (queue_id == probe_point.fields.index)

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1061,13 +1061,11 @@ static bool probe_purpose_needs_ext_dma(uint32_t purpose)
 static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point_id_t probe_point)
 {
 	struct comp_buffer *buf;
-	struct list_item *source_list;
 	unsigned int queue_id;
 
 	switch (probe_point.fields.type) {
 	case PROBE_TYPE_INPUT:
-		list_for_item(source_list, &dev->cd->bsource_list) {
-			buf = container_of(source_list, struct comp_buffer, sink_list);
+		comp_dev_for_each_producer(dev->cd, buf) {
 			queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(buf));
 
 			if (queue_id == probe_point.fields.index)

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -818,8 +818,7 @@ static int test_keyword_params(struct comp_dev *dev,
 	cd->sample_valid_bytes = params->sample_valid_bytes;
 
 	/* keyword components will only ever have 1 source */
-	sourceb = list_first_item(&dev->bsource_list, struct comp_buffer,
-				  sink_list);
+	sourceb = comp_dev_get_first_data_producer(dev);
 	channels = audio_stream_get_channels(&sourceb->stream);
 	frame_fmt = audio_stream_get_frm_fmt(&sourceb->stream);
 	rate = audio_stream_get_rate(&sourceb->stream);
@@ -895,8 +894,7 @@ static int test_keyword_copy(struct comp_dev *dev)
 	comp_dbg(dev, "test_keyword_copy()");
 
 	/* keyword components will only ever have 1 source */
-	source = list_first_item(&dev->bsource_list,
-				 struct comp_buffer, sink_list);
+	source = comp_dev_get_first_data_producer(dev);
 
 	if (!audio_stream_get_avail(&source->stream))
 		return PPL_STATUS_PATH_STOP;

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -487,7 +487,6 @@ static int smart_amp_prepare(struct comp_dev *dev)
 {
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
 	struct comp_buffer *source_buffer;
-	struct list_item *blist;
 	int ret;
 
 	comp_info(dev, "smart_amp_prepare()");
@@ -500,10 +499,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 		return PPL_STATUS_PATH_STOP;
 
 	/* searching for stream and feedback source buffers */
-	list_for_item(blist, &dev->bsource_list) {
-		source_buffer = container_of(blist, struct comp_buffer,
-					     sink_list);
-
+	comp_dev_for_each_producer(dev, source_buffer) {
 		/* FIXME: how often can this loop be run? */
 		if (source_buffer->source->ipc_config.type == SOF_COMP_DEMUX)
 			sad->feedback_buf = source_buffer;

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -511,8 +511,7 @@ static int smart_amp_prepare(struct comp_dev *dev)
 			sad->source_buf = source_buffer;
 	}
 
-	sad->sink_buf = list_first_item(&dev->bsink_list, struct comp_buffer,
-					source_list);
+	sad->sink_buf = comp_dev_get_first_data_consumer(dev);
 
 	sad->out_channels = audio_stream_get_channels(&sad->sink_buf->stream);
 

--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -211,7 +211,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);
@@ -277,7 +277,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);
@@ -343,7 +343,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);

--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -246,7 +246,7 @@ static void verify_sink_s16(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 1;
 	for (i = 0; i < samples; i++) {
@@ -312,7 +312,7 @@ static void verify_sink_s24(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 2;
 	for (i = 0; i < samples; i++) {
@@ -378,7 +378,7 @@ static void verify_sink_s32(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 2;
 	for (i = 0; i < samples; i++) {

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -210,7 +210,7 @@ static void fill_source_s16(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);
@@ -273,7 +273,7 @@ static void fill_source_s24(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);
@@ -336,7 +336,7 @@ static void fill_source_s32(struct test_data *td, int frames_max)
 	int i;
 	int samples_processed = 0;
 
-	sb = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+	sb = comp_dev_get_first_data_producer(dev);
 	ss = &sb->stream;
 	frames = MIN(audio_stream_get_free_frames(ss), frames_max);
 	samples = frames * audio_stream_get_channels(ss);

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -245,7 +245,7 @@ static void verify_sink_s16(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 1;
 	for (i = 0; i < samples; i++) {
@@ -308,7 +308,7 @@ static void verify_sink_s24(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 2;
 	for (i = 0; i < samples; i++) {
@@ -371,7 +371,7 @@ static void verify_sink_s32(struct test_data *td)
 	int samples;
 	int i;
 
-	sb = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	sb = comp_dev_get_first_data_consumer(dev);
 	ss = &sb->stream;
 	samples = mod->output_buffers[0].size >> 2;
 	for (i = 0; i < samples; i++) {

--- a/tools/plugin/modules/alsa.c
+++ b/tools/plugin/modules/alsa.c
@@ -428,7 +428,7 @@ static int arecord_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 	memcpy(&cd->params, params, sizeof(*params));
 
 	/* file component sink/source buffer period count */
-	buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	buffer = comp_dev_get_first_data_consumer(dev);
 	buffer_reset_pos(buffer, NULL);
 
 	comp_dbg(dev, "prepare done ret = %d", ret);
@@ -529,7 +529,7 @@ static int arecord_copy(struct comp_dev *dev)
 	}
 
 	/* file component sink buffer */
-	buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+	buffer = comp_dev_get_first_data_consumer(dev);
 	sink = &buffer->stream;
 	pos = sink->w_ptr;
 

--- a/tools/plugin/modules/alsa.c
+++ b/tools/plugin/modules/alsa.c
@@ -460,8 +460,7 @@ static int aplay_params(struct comp_dev *dev, struct sof_ipc_stream_params *para
 	memcpy(&cd->params, params, sizeof(*params));
 
 	/* file component sink/source buffer period count */
-	buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	buffer = comp_dev_get_first_data_producer(dev);
 	buffer_reset_pos(buffer, NULL);
 
 	comp_dbg(dev, "prepare done ret = %d", ret);
@@ -587,8 +586,7 @@ static int aplay_copy(struct comp_dev *dev)
 	}
 
 	/* file component source buffer */
-	buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	buffer = comp_dev_get_first_data_producer(dev);
 	source = &buffer->stream;
 	pos = source->r_ptr;
 	avail = audio_stream_get_avail_frames(source);

--- a/tools/plugin/modules/shm.c
+++ b/tools/plugin/modules/shm.c
@@ -306,8 +306,7 @@ static int shmwrite_copy(struct comp_dev *dev)
 	void *src;
 
 	/* local SOF sink buffer */
-	buffer = list_first_item(&dev->bsink_list, struct comp_buffer,
-				 source_list);
+	buffer = comp_dev_get_first_data_consumer(dev);
 	sink = &buffer->stream;
 	wptr = sink->w_ptr;
 

--- a/tools/plugin/modules/shm.c
+++ b/tools/plugin/modules/shm.c
@@ -247,8 +247,7 @@ static int shmread_copy(struct comp_dev *dev)
 	void *dest;
 
 	/* local SOF source buffer */
-	buffer = list_first_item(&dev->bsource_list, struct comp_buffer,
-				 sink_list);
+	buffer = comp_dev_get_first_data_producer(dev);
 	source = &buffer->stream;
 	rptr = source->r_ptr;
 

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -695,7 +695,7 @@ static int file_process(struct processing_module *mod,
 		break;
 	case FILE_WRITE:
 		/* write PCM samples into file */
-		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+		buffer = comp_dev_get_first_data_producer(dev);
 		source = &buffer->stream;
 		frames = audio_stream_get_avail_frames(source);
 		frames = MIN(frames, cd->max_frames);
@@ -738,7 +738,7 @@ static int file_prepare(struct processing_module *mod,
 		buffer = comp_dev_get_first_data_consumer(dev);
 		break;
 	case FILE_WRITE:
-		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);
+		buffer = comp_dev_get_first_data_producer(dev);
 		break;
 	default:
 		/* TODO: duplex mode */

--- a/tools/testbench/file.c
+++ b/tools/testbench/file.c
@@ -686,7 +686,7 @@ static int file_process(struct processing_module *mod,
 	switch (cd->fs.mode) {
 	case FILE_READ:
 		/* read PCM samples from file */
-		buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+		buffer = comp_dev_get_first_data_consumer(dev);
 		sink = &buffer->stream;
 		frames = audio_stream_get_free_frames(sink);
 		frames = MIN(frames, cd->max_frames);
@@ -735,7 +735,7 @@ static int file_prepare(struct processing_module *mod,
 	cd->max_frames = dev->frames;
 	switch (cd->fs.mode) {
 	case FILE_READ:
-		buffer = list_first_item(&dev->bsink_list, struct comp_buffer, source_list);
+		buffer = comp_dev_get_first_data_consumer(dev);
 		break;
 	case FILE_WRITE:
 		buffer = list_first_item(&dev->bsource_list, struct comp_buffer, sink_list);


### PR DESCRIPTION
As described here: 

https://github.com/thesofproject/sof-docs/pull/497
(compiled version: https://marcinszkudlinski.github.io/sof-docs/PAGES/architectures/firmware/sof-common/pipeline_2_0/pipeline2_0_discussion.html)

All buffers in the system must implement 3 types of API:
 - sink API (described before - exposed to a module producing data)
 - source API (described before - exposed to a module consuming data)
 - audio_buffer API (exposed to pipeline code, not to the modules)

Conversion of all modules to use sink/src is a complex task, so this PR is an intermediate step, unblocking future changes in pipeline code.
The change from this PR will make possible modification way the comp_buffer list is stored and maintained in the pipeline, making the implentation more flexible. The target is to make the pipeline code independent of comp_buffer before all modules are converted to sink/src API

the change should be 100% transparent 
