### PR TITLE
chain_dma: fix compilation error

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -659,7 +659,7 @@ static struct comp_dev *chain_task_create(const struct comp_driver *drv,
 		goto error_cd;
 
 #if CONFIG_XRUN_NOTIFICATIONS_ENABLE
-	cd->msg_xrun = ipc_msg_init(header.dat,
+	cd->msg_xrun = ipc_msg_init(cdma->primary.dat,
 				    sizeof(struct ipc4_resource_event_data_notification));
 	if (!cd->msg_xrun)
 		goto error_cd;

--- a/src/include/ipc4/notification.h
+++ b/src/include/ipc4/notification.h
@@ -255,3 +255,7 @@ struct ipc4_resource_event_data_notification {
 	/* Detailed event data */
 	union ipc4_resource_event_data event_data;
 } __packed __aligned(8);
+
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
+void xrun_notif_msg_init(struct ipc_msg *msg_xrun, uint32_t resource_id, uint32_t event_type);
+#endif

--- a/src/ipc/ipc4/notification.c
+++ b/src/ipc/ipc4/notification.c
@@ -8,6 +8,7 @@
 #include <sof/common.h>
 #include <stdbool.h>
 #include <ipc4/notification.h>
+#include <sof/ipc/msg.h>
 
 #if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 void xrun_notif_msg_init(struct ipc_msg *msg_xrun, uint32_t resource_id, uint32_t event_type)


### PR DESCRIPTION
Fixes compilation error when CONFIG_XRUN_NOTIFICATIONS_ENABLE is enabled.