### PR TITLE
zephyr: add rtos/mutex.h

### DIFF
--- a/zephyr/include/rtos/mutex.h
+++ b/zephyr/include/rtos/mutex.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2024 Intel Corporation.
+//
+
+#ifndef __ZEPHYR_RTOS_MUTEX_H__
+#define __ZEPHYR_RTOS_MUTEX_H__
+
+#include <zephyr/kernel.h> /* k_mutex_*() */
+
+#endif /* __ZEPHYR_RTOS_MUTEX_H__ */


### PR DESCRIPTION
The RTOS layer should provide the same interface for all OS'es. Currently rtos/mutex.h is only defined for XTOS. Add rtos/mutex.h also for Zephyr to allow generic SOF code to use this interface.

Link: https://github.com/thesofproject/sof/issues/9015