### PR TITLE
smex and trace sections cleanup

### DIFF
--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -393,7 +393,7 @@ struct tr_ctx {
 	uint32_t level;				/**< Default log level */
 };
 
-#if defined(UNIT_TEST)
+#if defined(UNIT_TEST) || !defined(CONFIG_TRACE)
 #define TRACE_CONTEXT_SECTION
 #else
 #define TRACE_CONTEXT_SECTION __section(".trace_ctx")

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -167,29 +167,8 @@ unsigned int _xtos_ints_off(unsigned int mask)
 	return 0;
 }
 
-/* Zephyr redefines log_message() and mtrace_printf() which leaves
- * totally empty the .static_log_entries ELF sections for the
- * sof-logger. This makes smex fail. Define at least one such section to
- * fix the build when sof-logger is not used.
- */
-static inline const void *smex_placeholder_f(void)
-{
-	_DECLARE_LOG_ENTRY(LOG_LEVEL_DEBUG,
-			   "placeholder so .static_log.X are not all empty",
-			   _TRACE_INV_CLASS, 0);
-
-	return &log_entry;
-}
-
-/* Need to actually use the function and export something otherwise the
- * compiler optimizes everything away.
- */
-const void *_smex_placeholder;
-
 int task_main_start(struct sof *sof)
 {
-	_smex_placeholder = smex_placeholder_f();
-
 	/* init default audio components */
 	sys_comp_init(sof);
 


### PR DESCRIPTION
This series removes the need to add ".trace_ctx" and ".static_log_entries" linker sections for Zephyr platforms not using trace.