### PR TITLE
[stable-v2.2] Missing topologies commits from jsl 005

### DIFF
--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -218,7 +218,6 @@ set(TPLGS
 	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DPLATFORM=jsl-rt1015"
 	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
 	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DPLATFORM=jsl-dedede"
-	"sof-jsl-rt5682\;sof-jsl-cs42l42-mx98360a\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-rt5682\;-DHEADPHONE=rt5682\;-DPLATFORM=icl\;-DNO_AMP"
 
 	## DRC/EQ topologies

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -220,6 +220,7 @@ set(TPLGS
 	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-cs42l42-mx98360a\;-DHEADPHONE=cs42l42\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-rt5682\;-DHEADPHONE=rt5682\;-DPLATFORM=icl\;-DNO_AMP"
+	"sof-jsl-rt5682\;sof-jsl-rt5650\;-DHEADPHONE=rt5650\;-DPLATFORM=jsl-rt1015"
 
 	## DRC/EQ topologies
 	"sof-tgl-max98357a-rt5682\;sof-adl-max98357a-rt5682-drceq\;-DCODEC=MAX98357A\;-DFMT=s16le\;-DPLATFORM=adl\;-DLINUX_MACHINE_DRIVER=sof_rt5682\;-DAMP_SSP=2\;-DDYNAMIC=1\;-DDRC_EQ"

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -215,9 +215,10 @@ set(TPLGS
 	"sof-jsl-da7219\;sof-jsl-da7219\;-DPLATFORM=jsl"
 	"sof-jsl-da7219\;sof-jsl-da7219-mx98360a\;-DPLATFORM=jsl-dedede"
 	"sof-smart-amplifier-nocodec\;sof-smart-amplifier-nocodec"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DPLATFORM=jsl-rt1015"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
-	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DPLATFORM=jsl-dedede"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-rt1015"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-rt1015-xperi\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-rt1015\;-DINCLUDE_IIR_EQ=1"
+	"sof-jsl-rt5682\;sof-jsl-rt5682-mx98360a\;-DHEADPHONE=rt5682\;-DPLATFORM=jsl-dedede"
+	"sof-jsl-rt5682\;sof-jsl-cs42l42-mx98360a\;-DHEADPHONE=cs42l42\;-DPLATFORM=jsl-dedede"
 	"sof-jsl-rt5682\;sof-jsl-rt5682\;-DHEADPHONE=rt5682\;-DPLATFORM=icl\;-DNO_AMP"
 
 	## DRC/EQ topologies

--- a/tools/topology/topology1/platform/intel/jsl-rt1015.m4
+++ b/tools/topology/topology1/platform/intel/jsl-rt1015.m4
@@ -10,9 +10,18 @@ define(`SPK_NAME', `SSP1-Codec')
 undefine(`SPK_DATA_FORMAT')
 define(`SPK_DATA_FORMAT', `s24le')
 
+ifelse(HEADPHONE, `rt5650', `
+define(`SET_SSP_CONFIG',
+				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+						SSP_CLOCK(bclk, 3072000, codec_slave),
+						SSP_CLOCK(fsync, 48000, codec_slave),
+						SSP_TDM(2, 32, 3, 3),
+						SSP_CONFIG_DATA(SSP, 1, 24, 0, 0, 0, SSP_CC_MCLK_AON))')
+', `
 define(`SET_SSP_CONFIG',
 				`SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 						SSP_CLOCK(bclk, 3072000, codec_slave),
 						SSP_CLOCK(fsync, 48000, codec_slave),
 						SSP_TDM(2, 32, 3, 3),
 						SSP_CONFIG_DATA(SSP, 1, 24))')
+')

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -182,7 +182,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+		SSP_CONFIG_DATA(SSP, 0, 24)))
 
 ifdef(`NO_AMP',`',`
 # SSP 1 (ID: 6)

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -1,5 +1,8 @@
 #
-# Topology for JasperLake with rt5682 codec + DMIC + 3 HDMI + Speaker amp
+# Topology for JasperLake with rt5682 or cs42l42 codec +
+#                              DMIC +
+#                              3 HDMI +
+#                              speaker amp
 #
 
 # Include topology builder
@@ -25,7 +28,7 @@ DEBUG_START
 #
 ifdef(`NO_AMP',`',`
 # PCM0 ----> volume -----> SSP1  (Speaker - ALC1015)')
-# PCM1 <---> volume <----> SSP0  (Headset - ALC5682)
+`# PCM1 <---> volume <----> SSP0  (Headset - 'HEADPHONE`)'
 # PCM2 ----> volume -----> iDisp1
 # PCM3 ----> volume -----> iDisp2
 # PCM4 ----> volume -----> iDisp3
@@ -176,6 +179,7 @@ dnl SSP_CONFIG(format, mclk, bclk, fsync, tdm, ssp_config_data)
 dnl SSP_CLOCK(clock, freq, codec_master, polarity)
 dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
 
+ifelse(HEADPHONE, `rt5682', `
 # SSP 0 (ID: 0) ALC5682
 DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
@@ -183,6 +187,15 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 0, 24)))
+', HEADPHONE, `cs42l42', `
+# SSP 0 (ID: 0) CS42L42
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
+		SSP_CLOCK(bclk, 2400000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 25, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+', )
 
 ifdef(`NO_AMP',`',`
 # SSP 1 (ID: 6)

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -195,6 +195,14 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
 		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_BCLK_ES)))
+', HEADPHONE, `rt5650', `
+# SSP 0 (ID: 0) ALC5650-I2S1
+DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3072000, codec_slave),
+		SSP_CLOCK(fsync, 48000, codec_slave),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_MCLK_AON)))
 ', )
 
 ifdef(`NO_AMP',`',`

--- a/tools/topology/topology1/sof-jsl-rt5682.m4
+++ b/tools/topology/topology1/sof-jsl-rt5682.m4
@@ -186,7 +186,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 24)))
+		SSP_CONFIG_DATA(SSP, 0, 24, 0, 0, 0, SSP_CC_MCLK_AON)))
 ', HEADPHONE, `cs42l42', `
 # SSP 0 (ID: 0) CS42L42
 DAI_CONFIG(SSP, 0, 0, SSP0-Codec,


### PR DESCRIPTION
After topology1 was removed from main branch, some topology changes to JSL boards only commits to jsl-005-drop-stable. In this PR we cherry-pick those commits to stable-v2.2 branch.

This PR impacts following topology files:
1. sof-jsl-rt5650.tplg
=> new topology
2. sof-jsl-rt5682.tplg
4. sof-jsl-rt5682-max98360a.tplg
5. sof-jsl-rt5682-rt1015.tplg
6. sof-jsl-rt5682.-rt1015.tplg
=> ALC5682's SOF_TKN_INTEL_SSP_CLKS_CONTROL token value changes from SSP_CC_BCLK_ES to SSP_CC_MCLK_AON since BCLK_ES flag is for CS42L42 and MCLK_AON is for ALC5682.