### PR TITLE
xtos: move sof/lib/perf_cnt.h to application interface

### DIFF
--- a/src/include/sof/lib/perf_cnt.h
+++ b/src/include/sof/lib/perf_cnt.h
@@ -6,7 +6,7 @@
  */
 
 /**
- * \file xtos/include/sof/lib/perf_cnt.h
+ * \file include/sof/lib/perf_cnt.h
  * \brief Simple performance counters
  * \author Marcin Maka <marcin.maka@linux.intel.com>
  */


### PR DESCRIPTION
The SOF perf_cnt.h provides a simple performance counter interface that is used in SOF to track performance at audio module and pipeline level.

Majority of the implementation is RTOS agnostic, relying on sof_cycle_get_64() to sample platform clock, and timer_get_system() for CPU clock, both defined in rtos/timer.h. There is however some conditional rules for Zephyr to use timing_counter_get() if SOF is built with CONFIG_TIMING_FUNCTIONS=y.

The amount of RTOS variation does not seem to warrant branching the whole perf_cnt.h to RTOS layer. Move perf_cnt.h back to application interface, so the single implementation can be shared.

Link: https://github.com/thesofproject/sof/issues/9015