### PR TITLE
ipc3: override type field once comp_driver found

### DIFF
--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -134,7 +134,7 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 		info = container_of(clist, struct comp_driver_info,
 				    list);
 		if (!memcmp(info->drv->uid, comp_ext->uuid,
-			    UUID_SIZE)) {
+			    UUID_SIZE) && comp->type == info->drv->type) {
 			drv = info->drv;
 			break;
 		}


### PR DESCRIPTION
A bad IPC can mismatch UUID and type, causing downstream processes to operate differently than the final component target. This is because get_drv will not reject the mismatch and given we don't know the state of topology we can't start now. Instead we can override the ipc with the proper type.