### PR TITLE
[SKIP SOF-TEST] [stable-v2.2] sync CODEOWNERS with main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta
+*       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta @kv2019i
 
 # Order is important. The last matching pattern has the most precedence.
 # File patterns work mostly like .gitignore. Try to keep this file

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,8 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
+# File patterns work mostly like .gitignore. Try to keep this file
+# simple because it's literally impossible to test.
 
 # include files
 src/include/sof/drivers/dmic.h		@singalsu
@@ -63,7 +65,7 @@ src/debug/gdb/*				@abonislawski
 src/schedule				@abonislawski
 
 # other helpers
-# Mostly overridden by *.(ba)sh below
+# Many files overridden by *.(ba)sh pattern below
 scripts/*				@marc-hb @aborisovich
 
 # tools(old 'soft' repo)
@@ -78,11 +80,19 @@ tools/tune/dcblock/*			@thesofproject/google
 tools/tune/drc/*			@thesofproject/google
 tools/oss-fuzz/*			@thesofproject/google
 
-# build system
-**/CMakeLists.txt			@marc-hb @aborisovich
-# **/Kconfig
-# scripts/cmake/**
-# scripts/kconfig/**
+# CMake
+
+# Include only "top-level" CMakeLists.txt files; the other ones are just
+# dumb list of source files and generate too much noise.
+/CMakeLists.txt			@marc-hb @aborisovich
+/*/CMakeLists.txt			@marc-hb @aborisovich
+/test/cmocka/CMakeLists.txt		@marc-hb @aborisovich
+
+# There's a small enough number of files in tools/ and little
+# churn: keep it simple and take them all.
+# FIXME: some topology CMakeLists.txt files are configuration files
+# in disguise. Move them to actual configuration files.
+/tools/**/CMakeLists.txt		@marc-hb @aborisovich
 
 *.sh					@marc-hb
 *.bash					@marc-hb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@ src/include/sof/drivers/afe*		@yaochunhung
 
 # audio component
 src/audio/src*				@singalsu @abonislawski
-src/audio/chain_dma*			@makarukp
+# src/audio/chain_dma*			TODO
 src/audio/copier/*			@randerwang @abonislawski @pblaszko
 src/audio/eq*				@singalsu
 src/audio/eq_fir*			@singalsu
@@ -68,7 +68,7 @@ src/drivers/mediatek/mt8195/*		@yaochunhung @kuanhsuncheng
 src/math/*				@singalsu
 src/ipc/*				@bardliao @marcinszkudlinski @pblaszko
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
-src/lib/*				@libinyang
+# src/lib/*				TODO
 src/debug/gdb/*				@abonislawski
 src/schedule				@pblaszko @marcinszkudlinski @dbaluta @LaurentiuM1234
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 src/include/sof/drivers/dmic.h		@singalsu
 src/include/ipc/**			@thesofproject/steering-committee
 src/include/ipc/**			@randerwang @marcinszkudlinski @pblaszko
-src/include/ipc4/**			@randerwang @marcinszkudlinski @pblaszko @aborisovich
+src/include/ipc4/**			@randerwang @marcinszkudlinski @pblaszko
 src/include/kernel/**			@thesofproject/steering-committee
 src/include/user/**			@thesofproject/steering-committee
 src/include/sof/debug/gdb/*		@abonislawski
@@ -66,7 +66,7 @@ src/drivers/mediatek/mt8195/*		@yaochunhung @kuanhsuncheng
 
 # other libs
 src/math/*				@singalsu
-src/ipc/*				@bardliao @marcinszkudlinski @pblaszko @aborisovich
+src/ipc/*				@bardliao @marcinszkudlinski @pblaszko
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
 src/debug/gdb/*				@abonislawski
@@ -77,7 +77,7 @@ samples/audio/detect_test.c		@iganakov
 
 # other helpers
 # Many files overridden by *.(ba)sh pattern below
-scripts/*				@marc-hb @aborisovich
+scripts/*				@marc-hb
 
 # tools(old 'soft' repo)
 tools/logger/*				@bkokoszx @akloniex
@@ -104,21 +104,21 @@ installer/**				@marc-hb
 
 # Include only "top-level" CMakeLists.txt files; the other ones are just
 # dumb list of source files and generate too much noise.
-/CMakeLists.txt			@marc-hb @aborisovich
-/*/CMakeLists.txt			@marc-hb @aborisovich
-/test/cmocka/CMakeLists.txt		@marc-hb @aborisovich
+/CMakeLists.txt			@marc-hb
+/*/CMakeLists.txt			@marc-hb
+/test/cmocka/CMakeLists.txt		@marc-hb
 
 # There's a small enough number of files in tools/ and little
 # churn: keep it simple and take them all.
 # FIXME: some topology CMakeLists.txt files are configuration files
 # in disguise. Move them to actual configuration files.
-/tools/**/CMakeLists.txt		@marc-hb @aborisovich
+/tools/**/CMakeLists.txt		@marc-hb
 
 *.sh					@marc-hb
 *.bash					@marc-hb
 *trace.*				@akloniex
 
-/.github/				@dbaluta @cujomalainey @lgirdwood @marc-hb @aborisovich
+/.github/				@dbaluta @cujomalainey @lgirdwood @marc-hb
 
 # You can also use email addresses if you prefer.
 #docs/*  docs@example.com

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,8 @@
 *       @lgirdwood @plbossart @mmaka1 @lbetlej @dbaluta
 
 # Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#
+# File patterns work mostly like .gitignore. Try to keep this file
+# simple because it's literally impossible to test.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # include files

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,13 +29,13 @@ src/audio/eq_iir*			@singalsu
 src/audio/tone.c			@singalsu
 src/audio/kpb.c				@mrajwa
 src/audio/mux/*				@akloniex
-src/audio/dcblock*			@cujomalainey @chiang831 @johnylin76
-src/audio/crossover*			@cujomalainey @chiang831 @johnylin76
+src/audio/dcblock*			@thesofproject/google
+src/audio/crossover*			@thesofproject/google
 src/audio/tdfb*                         @singalsu
-src/audio/drc/*				@johnylin76 @cujomalainey @chiang831
-src/audio/multiband_drc/*		@johnylin76 @cujomalainey @chiang831
+src/audio/drc/*				@thesofproject/google
+src/audio/multiband_drc/*		@thesofproject/google
 src/audio/codec_adapter/*		@cujomalainey @mrajwa @dbaluta
-src/audio/google_hotword_detect.c	@bzhg @cujomalainey @chiang831 @johnylin76
+src/audio/google_hotword_detect.c	@thesofproject/google
 
 # platforms
 src/platform/haswell/*			@randerwang
@@ -73,10 +73,10 @@ tools/testbench/*			@ranj063
 tools/test/audio/*			@singalsu
 tools/ctl/*				@singalsu
 tools/tune/*				@singalsu
-tools/tune/crossover/*			@cujomalainey @johnylin76 @chiang831
-tools/tune/dcblock/*			@cujomalainey @johnylin76 @chiang831
-tools/tune/drc/*			@cujomalainey @johnylin76 @chiang831
-tools/oss-fuzz/*			@cujomalainey
+tools/tune/crossover/*			@thesofproject/google
+tools/tune/dcblock/*			@thesofproject/google
+tools/tune/drc/*			@thesofproject/google
+tools/oss-fuzz/*			@thesofproject/google
 
 # build system
 **/CMakeLists.txt			@marc-hb @aborisovich

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,8 +7,8 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-# File patterns work mostly like .gitignore. Try to keep this file
-# simple because it's literally impossible to test.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # include files
 src/include/sof/drivers/dmic.h		@singalsu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,30 +12,39 @@
 # include files
 src/include/sof/drivers/dmic.h		@singalsu
 src/include/ipc/**			@thesofproject/steering-committee
-src/include/ipc/**			@randerwang @marcinszkudlinski
+src/include/ipc/**			@randerwang @marcinszkudlinski @pblaszko
+src/include/ipc4/**			@randerwang @marcinszkudlinski @pblaszko @aborisovich
 src/include/kernel/**			@thesofproject/steering-committee
 src/include/user/**			@thesofproject/steering-committee
 src/include/sof/debug/gdb/*		@abonislawski
-src/include/sof/audio/kpb.h		@abonislawski
-src/include/sof/audio/mux.h		@akloniex
+src/include/sof/audio/aria/*		@abonislawski
+src/include/sof/audio/kpb.h		@fkwasowi @iganakov
+src/include/sof/audio/mux.h		@fkwasowi
+src/include/sof/audio/up_down_mixer/*	@abonislawski
 src/include/sof/audio/codec_adapter/*	@cujomalainey @abonislawski @dbaluta
+src/include/sof/audio/module_adapter/*	@ranj063 @jxstelter
 src/include/sof/drivers/acp_dai_dma.h	@bhiregoudar @sunilkumardommati
 src/include/sof/drivers/afe*		@yaochunhung
 
 # audio component
-src/audio/src*				@singalsu
+src/audio/src*				@singalsu @abonislawski
+src/audio/chain_dma*			@makarukp
+src/audio/copier/*			@randerwang @abonislawski @pblaszko
 src/audio/eq*				@singalsu
 src/audio/eq_fir*			@singalsu
 src/audio/eq_iir*			@singalsu
 src/audio/tone.c			@singalsu
-src/audio/kpb.c				@abonislawski
-src/audio/mux/*				@akloniex
+src/audio/kpb.c				@fkwasowi @iganakov
+src/audio/mux/*				@fkwasowi
 src/audio/dcblock*			@thesofproject/google
 src/audio/crossover*			@thesofproject/google
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@thesofproject/google
+src/audio/selector/*			@tlissows
+src/audio/up_down_mixer/*		@abonislawski
 src/audio/multiband_drc/*		@thesofproject/google
 src/audio/codec_adapter/*		@cujomalainey @abonislawski @dbaluta
+src/audio/module_adapter/*		@ranj063 @jxstelter
 src/audio/google/*			@thesofproject/google
 
 # platforms
@@ -57,11 +66,14 @@ src/drivers/mediatek/mt8195/*		@yaochunhung @kuanhsuncheng
 
 # other libs
 src/math/*				@singalsu
-src/ipc/*				@bardliao @marcinszkudlinski
+src/ipc/*				@bardliao @marcinszkudlinski @pblaszko @aborisovich
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
 src/debug/gdb/*				@abonislawski
-src/schedule				@abonislawski
+src/schedule				@pblaszko @marcinszkudlinski
+
+# samples
+samples/audio/detect_test.c		@iganakov
 
 # other helpers
 # Many files overridden by *.(ba)sh pattern below
@@ -80,7 +92,10 @@ tools/tune/dcblock/*			@thesofproject/google
 tools/tune/drc/*			@thesofproject/google
 tools/oss-fuzz/*			@thesofproject/google
 
-zephyr/**				@kv2019i @lyakh @iuliana-prodan @dbaluta
+zephyr/**				@kv2019i @lyakh @iuliana-prodan @dbaluta @abonislawski
+zephyr/lib/cpu.c			@tmleman
+zephyr/lib/alloc.c			@dabekjakub
+zephyr/lib/regions_mm.c			@dabekjakub
 
 # installer
 installer/**				@marc-hb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -81,6 +81,8 @@ tools/tune/dcblock/*			@thesofproject/google
 tools/tune/drc/*			@thesofproject/google
 tools/oss-fuzz/*			@thesofproject/google
 
+zephyr/**				@kv2019i @lyakh @iuliana-prodan @dbaluta
+
 # CMake
 
 # Include only "top-level" CMakeLists.txt files; the other ones are just

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,7 +70,7 @@ src/ipc/*				@bardliao @marcinszkudlinski @pblaszko @aborisovich
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
 src/debug/gdb/*				@abonislawski
-src/schedule				@pblaszko @marcinszkudlinski
+src/schedule				@pblaszko @marcinszkudlinski @dbaluta @LaurentiuM1234
 
 # samples
 samples/audio/detect_test.c		@iganakov

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -77,7 +77,7 @@ samples/audio/detect_test.c		@iganakov
 
 # other helpers
 # Many files overridden by *.(ba)sh pattern below
-scripts/*				@marc-hb
+# scripts/*				TODO
 
 # tools(old 'soft' repo)
 tools/logger/*				@bkokoszx @akloniex
@@ -98,27 +98,27 @@ zephyr/lib/alloc.c			@dabekjakub
 zephyr/lib/regions_mm.c			@dabekjakub
 
 # installer
-installer/**				@marc-hb
+# installer/**				TODO
 
 # CMake
 
 # Include only "top-level" CMakeLists.txt files; the other ones are just
 # dumb list of source files and generate too much noise.
-/CMakeLists.txt			@marc-hb
-/*/CMakeLists.txt			@marc-hb
-/test/cmocka/CMakeLists.txt		@marc-hb
+# /CMakeLists.txt			TODO
+#/*/CMakeLists.txt			TODO
+# /test/cmocka/CMakeLists.txt		TODO
 
 # There's a small enough number of files in tools/ and little
 # churn: keep it simple and take them all.
 # FIXME: some topology CMakeLists.txt files are configuration files
 # in disguise. Move them to actual configuration files.
-/tools/**/CMakeLists.txt		@marc-hb
+# /tools/**/CMakeLists.txt		TODO
 
-*.sh					@marc-hb
-*.bash					@marc-hb
+# *.sh					TODO
+# *.bash				TODO
 *trace.*				@akloniex
 
-/.github/				@dbaluta @cujomalainey @lgirdwood @marc-hb
+/.github/				@dbaluta @cujomalainey @lgirdwood
 
 # You can also use email addresses if you prefer.
 #docs/*  docs@example.com

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,6 +83,9 @@ tools/oss-fuzz/*			@thesofproject/google
 
 zephyr/**				@kv2019i @lyakh @iuliana-prodan @dbaluta
 
+# installer
+installer/**				@marc-hb
+
 # CMake
 
 # Include only "top-level" CMakeLists.txt files; the other ones are just

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -70,7 +70,8 @@ scripts/*				@marc-hb @aborisovich
 
 # tools(old 'soft' repo)
 tools/logger/*				@bkokoszx @akloniex
-tools/topology/*			@ranj063
+tools/topology/**			@ranj063
+tools/topology/topology2/**		@ranj063 @jsarha
 tools/testbench/*			@ranj063
 tools/test/audio/*			@singalsu
 tools/ctl/*				@singalsu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,10 +14,10 @@ src/include/ipc/**			@thesofproject/steering-committee
 src/include/ipc/**			@randerwang @marcinszkudlinski
 src/include/kernel/**			@thesofproject/steering-committee
 src/include/user/**			@thesofproject/steering-committee
-src/include/sof/debug/gdb/*		@mrajwa
-src/include/sof/audio/kpb.h		@mrajwa
+src/include/sof/debug/gdb/*		@abonislawski
+src/include/sof/audio/kpb.h		@abonislawski
 src/include/sof/audio/mux.h		@akloniex
-src/include/sof/audio/codec_adapter/*	@cujomalainey @mrajwa @dbaluta
+src/include/sof/audio/codec_adapter/*	@cujomalainey @abonislawski @dbaluta
 src/include/sof/drivers/acp_dai_dma.h	@bhiregoudar @sunilkumardommati
 src/include/sof/drivers/afe*		@yaochunhung
 
@@ -27,20 +27,20 @@ src/audio/eq*				@singalsu
 src/audio/eq_fir*			@singalsu
 src/audio/eq_iir*			@singalsu
 src/audio/tone.c			@singalsu
-src/audio/kpb.c				@mrajwa
+src/audio/kpb.c				@abonislawski
 src/audio/mux/*				@akloniex
 src/audio/dcblock*			@thesofproject/google
 src/audio/crossover*			@thesofproject/google
 src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@thesofproject/google
 src/audio/multiband_drc/*		@thesofproject/google
-src/audio/codec_adapter/*		@cujomalainey @mrajwa @dbaluta
+src/audio/codec_adapter/*		@cujomalainey @abonislawski @dbaluta
 src/audio/google/*			@thesofproject/google
 
 # platforms
 src/platform/haswell/*			@randerwang
 src/platform/suecreek/*			@lyakh
-src/arch/xtensa/debug/gdb/*		@mrajwa
+src/arch/xtensa/debug/gdb/*		@abonislawski
 src/platform/imx8/**			@dbaluta
 src/platform/amd/**			@bhiregoudar @sunilkumardommati
 src/platform/mt8195/**		@yaochunhung @kuanhsuncheng
@@ -59,8 +59,8 @@ src/math/*				@singalsu
 src/ipc/*				@bardliao @marcinszkudlinski
 src/drivers/intel/cavs/sue-ipc.c	@lyakh
 src/lib/*				@libinyang
-src/debug/gdb/*				@mrajwa
-src/schedule				@mrajwa
+src/debug/gdb/*				@abonislawski
+src/schedule				@abonislawski
 
 # other helpers
 # Mostly overridden by *.(ba)sh below

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@ src/audio/tdfb*                         @singalsu
 src/audio/drc/*				@thesofproject/google
 src/audio/multiband_drc/*		@thesofproject/google
 src/audio/codec_adapter/*		@cujomalainey @mrajwa @dbaluta
-src/audio/google_hotword_detect.c	@thesofproject/google
+src/audio/google/*			@thesofproject/google
 
 # platforms
 src/platform/haswell/*			@randerwang


### PR DESCRIPTION
People typically don't git branch like software does. It may actually happen in some projects but not in SOF AFAIK so let's stop spamming people who left - especially myself :-)

This makes the CODEOWNERS file almost identical to the one in the main branch, see below.

This means a few patterns that don't match anything in this branch are getting added - who cares.

This was performed with the usual "brute force" forklift method...
```
git rev-list  origin/main ^HEAD -- CODEOWNERS | tac | git cherry-pick -x --stdin
```

... + skipping platform removals and fixing a couple git conflicts.

----------

`git diff origin/main -- CODEOWNERS`

```diff
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,8 @@ src/audio/module_adapter/*            @ranj063 @jxstelter
 src/audio/google/*                     @thesofproject/google

 # platforms
+src/platform/haswell/*                 @randerwang
+src/platform/suecreek/*                        @lyakh
 src/arch/xtensa/debug/gdb/*            @abonislawski
 src/platform/imx8/**                   @dbaluta
 src/platform/amd/**                    @bhiregoudar @sunilkumardommati
@@ -55,6 +57,8 @@ src/platform/mt8195/**                @yaochunhung @kuanhsuncheng

 # drivers
 src/drivers/intel/dmic.c               @singalsu
+src/drivers/intel/cavs/sue-iomux.c     @lyakh
+src/drivers/intel/haswell/*            @randerwang
 src/drivers/imx/**                     @dbaluta
 src/drivers/dw/*                       @lyakh
 src/drivers/amd/*                      @bhiregoudar @sunilkumardommati
@@ -63,6 +67,7 @@ src/drivers/mediatek/mt8195/*         @yaochunhung @kuanhsuncheng
 # other libs
 src/math/*                             @singalsu
 src/ipc/*                              @bardliao @marcinszkudlinski @pblaszko
+src/drivers/intel/cavs/sue-ipc.c       @lyakh
 # src/lib/*                            TODO
 src/debug/gdb/*                                @abonislawski
 src/schedule                           @pblaszko @marcinszkudlinski @dbaluta @LaurentiuM1234
```
