### PR TITLE
debug: debug_stream: Access debug slot directly using cavstool.py

### DIFF
--- a/app/debug_stream_overlay.conf
+++ b/app/debug_stream_overlay.conf
@@ -1,0 +1,20 @@
+# Enable debug-stream protocol
+CONFIG_SOF_DEBUG_STREAM_SLOT=y
+# Add thread_info-client for debug stream
+CONFIG_SOF_DEBUG_STREAM_THREAD_INFO=y
+# Zephyr option for storing human readable thread names
+CONFIG_THREAD_NAME=y
+
+# Debug window slot configuration 1
+# The CONFIG_SOF_TELEMETRY uses slot 2, but with performance and IO-performance
+# it extends beyond slot 3.
+CONFIG_MEMORY_WIN_2_SIZE=16384
+CONFIG_SOF_TELEMETRY_PERFORMANCE_MEASUREMENTS=n
+CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS=n
+
+# If we turn telemetry off all together, we can use slot 2. Slot 1 is used by mtrace
+#CONFIG_SOF_DEBUG_STREAM_SLOT_NUMBER=2
+#CONFIG_SOF_TELEMETRY=n
+#CONFIG_SOF_TELEMETRY_PERFORMANCE_MEASUREMENTS=n
+#CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS=n
+

--- a/src/debug/debug_stream/debug_stream_slot.c
+++ b/src/debug/debug_stream/debug_stream_slot.c
@@ -109,7 +109,7 @@ static int debug_stream_slot_init(void)
 	size_t offset = hdr_size;
 	int i;
 
-	LOG_INF("%u sections of %u bytes, hdr %u, secton area %u\n",
+	LOG_INF("%u sections of %u bytes, hdr %u, section area %u\n",
 		CONFIG_MP_MAX_NUM_CPUS, section_size, hdr_size,
 		section_area_size);
 


### PR DESCRIPTION
Access debug slot directly using cavstool.py, by specifying the debug slot number where the debug_stream data is transferred.

Adds one command line parameter for selecting the debug slot directly, adds an alternative mainloop for polling the slot through cavstool.py direct access, and relaxes some often occurring warning print. The warning prints happen when the FW boots and the cavstool code wakes up before the init code has initialized the slot.

NOTE:
This code depends from this PR: https://github.com/zephyrproject-rtos/zephyr/pull/78753 . However, since the import line is in the function that is only called if the --direct-access-slot flag is present, the old code will still work without cavstool.py, but that would in turn need this PR: https://github.com/thesofproject/linux/pull/5154