### PR TITLE
Pipeline2.0: low hanging fruits - move buffers' common params to struct sof_audio_buffer.

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -217,7 +217,6 @@ static struct comp_buffer *buffer_alloc_struct(void *stream_addr, size_t size, u
 		return NULL;
 	}
 
-	buffer->is_shared = is_shared;
 	buffer->caps = caps;
 
 	audio_buffer_init(&buffer->audio_buffer, BUFFER_TYPE_LEGACY_BUFFER, is_shared,

--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -440,7 +440,7 @@ int buffer_set_params(struct comp_buffer *buffer,
 
 	audio_stream_set_buffer_fmt(&buffer->stream, params->buffer_fmt);
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		buffer->chmap[i] = params->chmap[i];
+		audio_buffer_set_chmap(&buffer->audio_buffer, i, params->chmap[i]);
 
 	audio_buffer_set_hw_params_configured(&buffer->audio_buffer);
 

--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -429,7 +429,7 @@ int buffer_set_params(struct comp_buffer *buffer,
 		return -EINVAL;
 	}
 
-	if (buffer->hw_params_configured && !force_update)
+	if (audio_buffer_hw_params_configured(&buffer->audio_buffer) && !force_update)
 		return 0;
 
 	ret = audio_stream_set_params(&buffer->stream, params);
@@ -442,7 +442,7 @@ int buffer_set_params(struct comp_buffer *buffer,
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		buffer->chmap[i] = params->chmap[i];
 
-	buffer->hw_params_configured = true;
+	audio_buffer_set_hw_params_configured(&buffer->audio_buffer);
 
 	return 0;
 }

--- a/src/audio/buffers/ring_buffer.c
+++ b/src/audio/buffers/ring_buffer.c
@@ -224,7 +224,8 @@ static int ring_buffer_set_ipc_params(struct ring_buffer *ring_buffer,
 				      bool force_update)
 {
 	CORE_CHECK_STRUCT(&ring_buffer->audio_buffer);
-	if (ring_buffer->_hw_params_configured && !force_update)
+
+	if (audio_buffer_hw_params_configured(&ring_buffer->audio_buffer) && !force_update)
 		return 0;
 
 	struct sof_audio_stream_params *audio_stream_params =
@@ -235,7 +236,7 @@ static int ring_buffer_set_ipc_params(struct ring_buffer *ring_buffer,
 	audio_stream_params->channels = params->channels;
 	audio_stream_params->buffer_fmt = params->buffer_fmt;
 
-	ring_buffer->_hw_params_configured = true;
+	audio_buffer_set_hw_params_configured(&ring_buffer->audio_buffer);
 
 	return 0;
 }

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -431,7 +431,8 @@ static int do_conversion_copy(struct comp_dev *dev,
 	int i;
 
 	/* buffer params might be not yet configured by component on another pipeline */
-	if (!src->hw_params_configured || !sink->hw_params_configured)
+	if (!audio_buffer_hw_params_configured(&src->audio_buffer) ||
+	    !audio_buffer_hw_params_configured(&sink->audio_buffer))
 		return 0;
 
 	comp_get_copy_limits(src, sink, processed_data);

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -540,7 +540,8 @@ int copier_dai_params(struct copier_data *cd, struct comp_dev *dev,
 		return ret;
 
 	for (j = 0; j < SOF_IPC_MAX_CHANNELS; j++)
-		cd->dd[dai_index]->dma_buffer->chmap[j] = (cd->chan_map[dai_index] >> j * 4) & 0xf;
+		audio_buffer_set_chmap(&cd->dd[dai_index]->dma_buffer->audio_buffer,
+				       j, (cd->chan_map[dai_index] >> j * 4) & 0xf);
 
 	/* set channel copy func */
 	container_size = audio_stream_sample_bytes(&cd->multi_endpoint_buffer->stream);

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -194,7 +194,7 @@ int create_endpoint_buffer(struct comp_dev *dev,
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		buffer->chmap[i] = (chan_map >> i * 4) & 0xf;
 
-	buffer->hw_params_configured = true;
+	audio_buffer_set_hw_params_configured(&buffer->audio_buffer);
 
 	if (create_multi_endpoint_buffer)
 		cd->multi_endpoint_buffer = buffer;

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -192,7 +192,7 @@ int create_endpoint_buffer(struct comp_dev *dev,
 				    copier_cfg->base.audio_fmt.interleaving_style);
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		buffer->chmap[i] = (chan_map >> i * 4) & 0xf;
+		audio_buffer_set_chmap(&buffer->audio_buffer, i, (chan_map >> i * 4) & 0xf);
 
 	audio_buffer_set_hw_params_configured(&buffer->audio_buffer);
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -426,7 +426,8 @@ dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t fr
 
 	/* copy all channels one by one */
 	for (i = 0; i < audio_stream_get_channels(&dd->dma_buffer->stream); i++) {
-		uint32_t multi_buf_channel = dd->dma_buffer->chmap[i];
+		uint32_t multi_buf_channel = audio_buffer_get_chmap(&dd->dma_buffer->audio_buffer,
+								    i);
 
 		if (dev->direction == SOF_IPC_STREAM_PLAYBACK)
 			dd->channel_copy(&multi_endpoint_buffer->stream, multi_buf_channel,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -302,7 +302,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 			}
 
 			if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE  &&
-			    sink->hw_params_configured) {
+			    audio_buffer_hw_params_configured(&sink->audio_buffer)) {
 				ret = stream_copy_from_no_consume(dd->local_buffer, sink,
 								  converter[j], bytes, dd->chmap);
 			}
@@ -353,7 +353,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 				}
 
 				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
-				    sink->hw_params_configured)
+				    audio_buffer_hw_params_configured(&sink->audio_buffer))
 					ret = stream_copy_from_no_consume(dd->dma_buffer,
 									  sink, converter[j],
 									  bytes, dd->chmap);
@@ -1650,7 +1650,7 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 			sink_dev = sink->sink;
 
 			if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
-			    sink->hw_params_configured) {
+			    audio_buffer_hw_params_configured(&sink->audio_buffer)) {
 				sink_frames =
 					audio_stream_get_free_frames(&sink->stream);
 				frames = MIN(frames, sink_frames);
@@ -1680,7 +1680,7 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 				sink_dev = sink->sink;
 
 				if (sink_dev && sink_dev->state == COMP_STATE_ACTIVE &&
-				    sink->hw_params_configured) {
+				    audio_buffer_hw_params_configured(&sink->audio_buffer)) {
 					sink_frames =
 						audio_stream_get_free_frames(&sink->stream);
 					frames = MIN(frames, sink_frames);

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -751,7 +751,7 @@ static int trigger_handler(struct processing_module *mod, int cmd)
 	/* Ignore and halt propagation if we get a trigger from the
 	 * playback pipeline: not for us. (Never happens on IPC4)
 	 */
-	if (cd->ref_comp_buffer->walking)
+	if (cd->ref_comp_buffer->audio_buffer.walking)
 		return PPL_STATUS_PATH_STOP;
 #endif
 

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -95,7 +95,7 @@ static void set_mux_params(struct processing_module *mod)
 	if (!list_is_empty(&dev->bsink_list)) {
 		sink = comp_dev_get_first_data_consumer(dev);
 
-		if (!sink->hw_params_configured) {
+		if (!audio_buffer_hw_params_configured(&sink->audio_buffer)) {
 			ipc4_update_buffer_format(sink, &cd->md.output_format);
 			params->frame_fmt = audio_stream_get_frm_fmt(&sink->stream);
 		}

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -415,7 +415,7 @@ int pipeline_for_each_comp(struct comp_dev *current,
 		 * across CPUs. See further comment below.
 		 */
 		dcache_writeback_invalidate_region(uncache_to_cache(buffer), sizeof(*buffer));
-		if (buffer->walking)
+		if (buffer->audio_buffer.walking)
 			continue;
 
 		buffer_comp = buffer_get_comp(buffer, dir);
@@ -428,12 +428,12 @@ int pipeline_for_each_comp(struct comp_dev *current,
 		if (buffer_comp &&
 		    (!ctx->skip_incomplete || buffer_comp->pipeline) &&
 		    ctx->comp_func) {
-			buffer->walking = true;
+			buffer->audio_buffer.walking = true;
 
 			err = ctx->comp_func(buffer_comp, buffer,
 					     ctx, dir);
 
-			buffer->walking = false;
+			buffer->audio_buffer.walking = false;
 		}
 
 		if (err < 0 || err == PPL_STATUS_PATH_STOP)

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -121,7 +121,7 @@ static void pipeline_update_buffer_pcm_params(struct comp_buffer *buffer,
 	params->rate = audio_stream_get_rate(&buffer->stream);
 	params->channels = audio_stream_get_channels(&buffer->stream);
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		params->chmap[i] = buffer->chmap[i];
+		params->chmap[i] = audio_buffer_get_chmap(&buffer->audio_buffer, i);
 }
 
 /* fetch hardware stream parameters from DAI  */

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -669,7 +669,7 @@ static void set_selector_params(struct processing_module *mod,
 	 */
 	src_buf = comp_dev_get_first_data_producer(dev);
 
-	if (!src_buf->hw_params_configured)
+	if (!audio_buffer_hw_params_configured(&src_buf->audio_buffer))
 		ipc4_update_buffer_format(src_buf, &mod->priv.cfg.base_cfg.audio_fmt);
 }
 

--- a/src/include/ipc/stream.h
+++ b/src/include/ipc/stream.h
@@ -23,9 +23,6 @@
 /*
  * Stream configuration.
  */
-
-#define SOF_IPC_MAX_CHANNELS			8
-
 /* common sample rates for use in masks */
 #define SOF_RATE_8000		(1 <<  0) /**< 8000Hz  */
 #define SOF_RATE_11025		(1 <<  1) /**< 11025Hz */

--- a/src/include/module/audio/audio_stream.h
+++ b/src/include/module/audio/audio_stream.h
@@ -50,6 +50,8 @@ struct sof_audio_stream_params {
 	bool underrun_permitted; /**< indicates whether underrun is permitted */
 
 	uint32_t buffer_fmt; /**< enum sof_ipc_buffer_format */
+
+	bool hw_params_configured; /**< indicates whether hw params were set */
 };
 
 #endif /* __MODULE_AUDIO_AUDIO_STREAM_H__ */

--- a/src/include/module/audio/audio_stream.h
+++ b/src/include/module/audio/audio_stream.h
@@ -51,6 +51,8 @@ struct sof_audio_stream_params {
 
 	uint32_t buffer_fmt; /**< enum sof_ipc_buffer_format */
 
+	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
+
 	bool hw_params_configured; /**< indicates whether hw params were set */
 };
 

--- a/src/include/module/ipc/stream.h
+++ b/src/include/module/ipc/stream.h
@@ -10,6 +10,8 @@
 #ifndef __MODULE_IPC_STREAM_H__
 #define __MODULE_IPC_STREAM_H__
 
+#define SOF_IPC_MAX_CHANNELS			8
+
 /* stream PCM frame format */
 enum sof_ipc_frame {
 	SOF_IPC_FRAME_S16_LE = 0,

--- a/src/include/sof/audio/audio_buffer.h
+++ b/src/include/sof/audio/audio_buffer.h
@@ -34,6 +34,8 @@ struct sof_audio_buffer {
 	/* type of the buffer BUFFER_TYPE_* */
 	uint32_t buffer_type;
 
+	bool is_shared;   /* buffer structure is shared between 2 cores */
+
 #if CONFIG_PIPELINE_2_0
 	/**
 	 * sink API of an additional buffer
@@ -166,6 +168,11 @@ struct sof_source *audio_buffer_get_source(struct sof_audio_buffer *buffer)
 
 #endif /* CONFIG_PIPELINE_2_0 */
 
+static inline bool audio_buffer_is_shared(struct sof_audio_buffer *buffer)
+{
+	return buffer->is_shared;
+}
+
 /**
  * @brief return a handler to stream params structure
  */
@@ -216,6 +223,7 @@ void audio_buffer_init(struct sof_audio_buffer *buffer, uint32_t buffer_type, bo
 	buffer->buffer_type = buffer_type;
 	buffer->ops = audio_buffer_ops;
 	buffer->audio_stream_params = audio_stream_params;
+	buffer->is_shared = is_shared;
 	source_init(audio_buffer_get_source(buffer), source_ops,
 		    audio_buffer_get_stream_params(buffer));
 	sink_init(audio_buffer_get_sink(buffer), sink_ops,

--- a/src/include/sof/audio/audio_buffer.h
+++ b/src/include/sof/audio/audio_buffer.h
@@ -71,6 +71,12 @@ struct sof_audio_buffer {
 
 	/* virtual methods */
 	const struct audio_buffer_ops *ops;
+
+	/*
+	 * legacy params, needed for pipeline binding/iterating, not for data buffering
+	 * should not be in struct sof_audio_buffer at all, kept for pipeline2.0 transition
+	 */
+	bool walking;		/**< indicates if the buffer is being walked */
 };
 
 #if CONFIG_PIPELINE_2_0

--- a/src/include/sof/audio/audio_buffer.h
+++ b/src/include/sof/audio/audio_buffer.h
@@ -173,6 +173,21 @@ static inline bool audio_buffer_is_shared(struct sof_audio_buffer *buffer)
 	return buffer->is_shared;
 }
 
+static inline bool audio_buffer_hw_params_configured(struct sof_audio_buffer *buffer)
+{
+	return buffer->audio_stream_params->hw_params_configured;
+}
+
+static inline void audio_buffer_set_hw_params_configured(struct sof_audio_buffer *buffer)
+{
+	buffer->audio_stream_params->hw_params_configured = true;
+}
+
+static inline void audio_buffer_reset_params(struct sof_audio_buffer *buffer)
+{
+	buffer->audio_stream_params->hw_params_configured = false;
+}
+
 /**
  * @brief return a handler to stream params structure
  */

--- a/src/include/sof/audio/audio_buffer.h
+++ b/src/include/sof/audio/audio_buffer.h
@@ -194,6 +194,17 @@ static inline void audio_buffer_reset_params(struct sof_audio_buffer *buffer)
 	buffer->audio_stream_params->hw_params_configured = false;
 }
 
+static inline uint16_t audio_buffer_get_chmap(struct sof_audio_buffer *buffer, size_t index)
+{
+	return buffer->audio_stream_params->chmap[index];
+}
+
+static inline void audio_buffer_set_chmap(struct sof_audio_buffer *buffer, size_t index,
+					  uint16_t value)
+{
+	buffer->audio_stream_params->chmap[index] = value;
+}
+
 /**
  * @brief return a handler to stream params structure
  */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -144,8 +144,6 @@ struct comp_buffer {
 
 	/* runtime stream params */
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
-
-	bool walking;		/**< indicates if the buffer is being walked */
 };
 
 /* Only to be used for synchronous same-core notifications! */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -141,9 +141,6 @@ struct comp_buffer {
 	/* lists */
 	struct list_item source_list;	/* list in comp buffers */
 	struct list_item sink_list;	/* list in comp buffers */
-
-	/* runtime stream params */
-	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 };
 
 /* Only to be used for synchronous same-core notifications! */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -145,7 +145,6 @@ struct comp_buffer {
 	/* runtime stream params */
 	uint16_t chmap[SOF_IPC_MAX_CHANNELS];	/**< channel map - SOF_CHMAP_ */
 
-	bool hw_params_configured; /**< indicates whether hw params were set */
 	bool walking;		/**< indicates if the buffer is being walked */
 };
 
@@ -285,7 +284,7 @@ static inline void buffer_init_stream(struct comp_buffer *buffer, size_t size)
 
 static inline void buffer_reset_params(struct comp_buffer *buffer, void *data)
 {
-	buffer->hw_params_configured = false;
+	audio_buffer_reset_params(&buffer->audio_buffer);
 }
 
 #endif /* __SOF_AUDIO_BUFFER_H__ */

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -133,7 +133,6 @@ struct comp_buffer {
 	uint32_t caps;
 	uint32_t core;
 	struct tr_ctx tctx;			/* trace settings */
-	bool is_shared;			/* buffer structure is shared between 2 cores */
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */
@@ -227,7 +226,7 @@ bool buffer_params_match(struct comp_buffer *buffer,
 static inline void buffer_stream_invalidate(struct comp_buffer *buffer, uint32_t bytes)
 {
 #if CONFIG_INCOHERENT
-	if (buffer->is_shared)
+	if (audio_buffer_is_shared(&buffer->audio_buffer))
 		audio_stream_invalidate(&buffer->stream, bytes);
 #endif
 }
@@ -235,7 +234,7 @@ static inline void buffer_stream_invalidate(struct comp_buffer *buffer, uint32_t
 static inline void buffer_stream_writeback(struct comp_buffer *buffer, uint32_t bytes)
 {
 #if CONFIG_INCOHERENT
-	if (buffer->is_shared)
+	if (audio_buffer_is_shared(&buffer->audio_buffer))
 		audio_stream_writeback(&buffer->stream, bytes);
 #endif
 }

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -635,8 +635,8 @@ struct comp_dev {
 };
 
 /**
- * Get a pointer to a first comp_buffer object providing data to the component
- * The procedure will return NULL if there's no data provider
+ * Get a pointer to the first comp_buffer object providing data to the component
+ * The function will return NULL if there's no data provider
  */
 static inline struct comp_buffer *comp_dev_get_first_data_producer(struct comp_dev *component)
 {
@@ -645,8 +645,8 @@ static inline struct comp_buffer *comp_dev_get_first_data_producer(struct comp_d
 }
 
 /**
- * Get a pointer to a next comp_buffer object providing data to the component
- * The procedure will return NULL if there're no more data providers
+ * Get a pointer to the next comp_buffer object providing data to the component
+ * The function will return NULL if there're no more data providers
  */
 static inline struct comp_buffer *comp_dev_get_next_data_producer(struct comp_dev *component,
 								  struct comp_buffer *producer)
@@ -656,8 +656,8 @@ static inline struct comp_buffer *comp_dev_get_next_data_producer(struct comp_de
 }
 
 /**
- * Get a pointer to a first comp_buffer object receiving data from the component
- * The procedure will return NULL if there's no data consumers
+ * Get a pointer to the first comp_buffer object receiving data from the component
+ * The function will return NULL if there's no data consumers
  */
 static inline struct comp_buffer *comp_dev_get_first_data_consumer(struct comp_dev *component)
 {
@@ -666,8 +666,8 @@ static inline struct comp_buffer *comp_dev_get_first_data_consumer(struct comp_d
 }
 
 /**
- * Get a pointer to a next comp_buffer object receiving data from the component
- * The procedure will return NULL if there're no more data consumers
+ * Get a pointer to the next comp_buffer object receiving data from the component
+ * The function will return NULL if there're no more data consumers
  */
 static inline struct comp_buffer *comp_dev_get_next_data_consumer(struct comp_dev *component,
 								  struct comp_buffer *consumer)

--- a/src/include/sof/audio/ring_buffer.h
+++ b/src/include/sof/audio/ring_buffer.h
@@ -110,8 +110,6 @@ struct ring_buffer {
 	uint8_t __sparse_cache *_data_buffer;
 	size_t _write_offset;		/* private: to be modified by data producer using API */
 	size_t _read_offset;		/* private: to be modified by data consumer using API */
-
-	bool _hw_params_configured;
 };
 
 /**

--- a/src/include/sof/audio/ring_buffer.h
+++ b/src/include/sof/audio/ring_buffer.h
@@ -100,18 +100,12 @@
 struct ring_buffer;
 struct sof_audio_stream_params;
 
-/* buffer flags */
-#define RING_BUFFER_MODE_LOCAL 0
-#define RING_BUFFER_MODE_SHARED BIT(1)
-
 /* the ring_buffer structure */
 struct ring_buffer {
 	/* public: read only */
 	struct sof_audio_buffer audio_buffer;
 
 	size_t data_buffer_size;
-
-	uint32_t _flags;		/* RING_BUFFER_MODE_* */
 
 	uint8_t __sparse_cache *_data_buffer;
 	size_t _write_offset;		/* private: to be modified by data producer using API */
@@ -126,13 +120,11 @@ struct ring_buffer {
  *			 ring_buffer's source api
  * @param min_free_space minimum buffer space in queue required by the module using
  *			 ring_buffer's sink api
- *
- * @param flags a combinatin of RING_BUFFER_MODE_* flags determining working mode
- *
+ * @param is_shared indicates if the buffer will be shared between cores
  * @param id a stream ID, accessible later by sink_get_id/source_get_id
  *
  */
-struct ring_buffer *ring_buffer_create(size_t min_available, size_t min_free_space, uint32_t flags,
+struct ring_buffer *ring_buffer_create(size_t min_available, size_t min_free_space, bool is_shared,
 				       uint32_t id);
 
 #endif /* __SOF_RING_BUFFER_H__ */

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -186,9 +186,9 @@ int comp_buffer_connect(struct comp_dev *comp, uint32_t comp_core,
 	if (buffer->core != comp_core) {
 #if CONFIG_INCOHERENT
 		/* buffer must be shared */
-		assert(buffer->is_shared);
+		assert(audio_buffer_is_shared(&buffer->audio_buffer));
 #else
-		buffer->is_shared = true;
+		buffer->audio_buffer.is_shared = true;
 #endif
 		if (!comp->is_shared)
 			comp_make_shared(comp);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -569,8 +569,7 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 
 		ring_buffer = ring_buffer_create(source_get_min_available(source),
 						 sink_get_min_free_space(sink),
-						 buffer->is_shared ?
-						   RING_BUFFER_MODE_SHARED : RING_BUFFER_MODE_LOCAL,
+						 audio_buffer_is_shared(&buffer->audio_buffer),
 						 buf_get_id(buffer));
 		if (!ring_buffer)
 			goto free;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1194,7 +1194,7 @@ void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 	audio_stream_set_buffer_fmt(&buf_c->stream, fmt->interleaving_style);
 
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
-		buf_c->chmap[i] = (fmt->ch_map >> i * 4) & 0xf;
+		audio_buffer_set_chmap(&buf_c->audio_buffer, i, (fmt->ch_map >> i * 4) & 0xf);
 
 	audio_buffer_set_hw_params_configured(&buf_c->audio_buffer);
 }

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1196,7 +1196,7 @@ void ipc4_update_buffer_format(struct comp_buffer *buf_c,
 	for (i = 0; i < SOF_IPC_MAX_CHANNELS; i++)
 		buf_c->chmap[i] = (fmt->ch_map >> i * 4) & 0xf;
 
-	buf_c->hw_params_configured = true;
+	audio_buffer_set_hw_params_configured(&buf_c->audio_buffer);
 }
 
 void ipc4_update_source_format(struct sof_source *source,


### PR DESCRIPTION
This PR moves many of parameters that are common for all buffers to struct sof_audio_buffer

there are 4 left:
```
	struct comp_dev *source;	/* source component */
	struct comp_dev *sink;		/* sink component */

	/* lists */
	struct list_item source_list;	/* list in comp buffers */
	struct list_item sink_list;	/* list in comp buffers */
```
and will be moved to sof_audio_buffer in next PR

