### PR TITLE
Audio: Module adapter: Fix in IPC4 invalid blob pass to init()

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -48,7 +48,7 @@ int module_adapter_init_data(struct comp_dev *dev,
 		return -EINVAL;
 
 	dst->base_cfg = cfg->base_cfg;
-	dst->size = cfgsz;
+	dst->size = cfgsz - sizeof(cfg->base_cfg);
 
 	if (cfgsz >= sizeof(*cfg)) {
 		int n_in = cfg->base_cfg_ext.nb_input_pins;

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -186,10 +186,12 @@ int src_init(struct processing_module *mod)
 	struct module_config *cfg = &md->cfg;
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = NULL;
+	const size_t cfg_size_expect = sizeof(cd->ipc_config) -
+		sizeof(struct ipc4_base_module_cfg);
 
 	comp_dbg(dev, "src_init()");
 
-	if (!cfg->init_data || cfg->size != sizeof(cd->ipc_config)) {
+	if (!cfg->init_data || cfg->size != cfg_size_expect) {
 		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
 			 cfg->size);
 		return -EINVAL;


### PR DESCRIPTION
The cfg->size is the size of ipc4_base_module_cfg. The cfg->data is NULL but when such is encountered the comp_init_data_blob() allocates a zero bytes of size.

Such blob is illegal and e.g. IIR will fail if not another blob is received by prepare(). DC block operates,
but applies a rather high cut-off frequency that results to silent audio for e.g. lower voice frequencies. What happens with such illegal blob is component specific.

The expected operation for most components is pass-through when a configuration blob is not set. This change should ensure that the component is not initialized with incorrect bytes control data if such is not passed with topology.