### PR TITLE
ipc4: base_fw: Enable scheduler info retrieval for secondary cores

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -336,11 +336,12 @@ int schedulers_info_get(uint32_t *data_off_size,
 			char *data,
 			uint32_t core_id)
 {
-	/* TODO
-	 * Core id parameter is not yet used. For now we only get scheduler info from current core
-	 * Other cores info can be added by implementing idc request for this data.
-	 * Do this if Schedulers info get ipc has uses for accurate info per core
-	 */
+	/* Check if the requested core_id is valid and within the number of configured cores */
+	if (core_id >= CONFIG_CORE_COUNT)
+		return IPC4_ERROR_INVALID_PARAM;
+
+	if (!cpu_is_me(core_id))
+		return ipc4_process_on_core(core_id, false);
 
 	struct scheduler_props *scheduler_props;
 	/* the internal structs have irregular sizes so we cannot use indexing, and have to
@@ -366,7 +367,7 @@ int schedulers_info_get(uint32_t *data_off_size,
 	scheduler_props = (struct scheduler_props *)(data + *data_off_size);
 	scheduler_get_task_info_dp(scheduler_props, data_off_size);
 #endif
-	return 0;
+	return IPC4_SUCCESS;
 }
 
 static int basefw_pipeline_list_info_get(uint32_t *data_offset, char *data)


### PR DESCRIPTION
This commit addresses the limitation in the schedulers_info_get function where scheduler information could only be retrieved for the primary core. The updated implementation now validates the core_id against the number of configured cores (CONFIG_CORE_COUNT) and initiates an IPC process on the requested core if it is not the current core.

Changes include:
- Adding a check to ensure the core_id is within the valid range.
- Calling ipc4_process_on_core to handle IPC processing on secondary cores.
- Returning appropriate IPC4 error codes based on the result of ipc4_process_on_core.