### PR TITLE
Revert "ipc3: override type field once comp_driver found"

### DIFF
--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -134,7 +134,7 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 		info = container_of(clist, struct comp_driver_info,
 				    list);
 		if (!memcmp(info->drv->uid, comp_ext->uuid,
-			    UUID_SIZE) && comp->type == info->drv->type) {
+			    UUID_SIZE)) {
 			drv = info->drv;
 			break;
 		}


### PR DESCRIPTION
This reverts commit b53573a15ca56da680dd646d63f9c192bce314b5. This commit broke cmocka unit tests.