### PR TITLE
tools: mtrace-reader.py: Add option to mark chunk starts in output

### DIFF
--- a/tools/mtrace/mtrace-reader.py
+++ b/tools/mtrace/mtrace-reader.py
@@ -13,9 +13,18 @@
 import struct
 import os
 import sys
+import argparse
 
 READ_BUFFER = 16384
 MTRACE_FILE = "/sys/kernel/debug/sof/mtrace/core0"
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-m', '--mark-chunks',
+                    action='store_true')
+
+args = parser.parse_args()
+
+chunk_idx = 0
 
 fd = os.open(MTRACE_FILE, os.O_RDONLY)
 while fd >= 0:
@@ -35,4 +44,10 @@ while fd >= 0:
     data_len = header[0]
     data = read_bytes[4:4+data_len]
 
-    os.write(sys.stdout.fileno(), data)
+    if (args.mark_chunks):
+        chunk_msg = "\n--- Chunk #{} start (size: {}) ---\n" .format(chunk_idx, data_len)
+        sys.stdout.write(chunk_msg)
+
+    sys.stdout.buffer.write(data)
+    sys.stdout.flush()
+    chunk_idx += 1


### PR DESCRIPTION
Sometimes it can help to see how the chunks arrive from firmware when comparing logs with the kernel for example.

The --mark-chunks flag will add a marker for each new chunk that is printed with a running number and the size of the given chunk, for example:

--- Chunk #604 start (size: 652) ---
[    0.000000] <inf> init: print_version_banner: FW ABI 0x301d001 DBG ABI 0x5003000 tags SOF:v2.5-stable-branch-2772-g76e650e56598-dirty zephyr:v3.7.0-2127-ge7c84756087f src hash 0x4ff3fd64 (ref hash 0x4ff3fd64)
*** Booting Zephyr OS build v3.7.0-2127-ge7c84756087f ***
[    0.000000] <inf> main: sof_app_main: SOF on intel_adsp
[    0.000000] <inf> main: sof_app_main: SOF initialized
[    0.000000] <inf> ipc: ipc_cmd: rx   : 0x44000000|0x31400008
[11896.403666] <inf> ipc: ipc_cmd: tx-reply     : 0x64000000|0x31400008
[11896.404076] <inf> ipc: ipc_cmd: rx   : 0x44000000|0x3060004c
[11896.404093] <inf> ipc: ipc_cmd: tx-reply     : 0x64000000|0x3060004c
--- Chunk #605 start (size: 196) ---

[11896.969658] <inf> ipc: ipc_cmd: rx   : 0x11000005|0x0
[11896.969671] <inf> pipe: pipeline_new: pipeline new pipe_id 0 priority 0
[11896.969685] <inf> ipc: ipc_cmd: tx-reply     : 0xb1000000|0x0

--- Chunk #606 start (size: 2236) ---