### PR TITLE
buffer: init channels to 2

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -218,6 +218,8 @@ static struct comp_buffer *buffer_alloc_struct(void *stream_addr, size_t size, u
 	}
 
 	buffer->caps = caps;
+	/* Force channels to 2 for init to prevent bad call to clz in buffer_init_stream */
+	buffer->stream.runtime_stream_params.channels = 2;
 
 	audio_buffer_init(&buffer->audio_buffer, BUFFER_TYPE_LEGACY_BUFFER, is_shared,
 			  &comp_buffer_source_ops, &comp_buffer_sink_ops, &audio_buffer_ops,


### PR DESCRIPTION
On initialization we use rzalloc which 0s out all fields. We later call audio_stream_recalc_align which uses the frame_bytes to align the buffer. This is problematic as clz() is passed the size of the frame size which is 0 since channel is 0 and passing 0 to clz is undefined behaviour.