### PR TITLE
ipc: move all init parsing to components/modules

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -217,6 +217,25 @@ error:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *dai_new_shim(const struct comp_driver *drv,
+				     const struct comp_ipc_config *config,
+				     const void *spec)
+{
+	const struct sof_ipc_comp_dai *comp = spec;
+	struct ipc_config_dai dai;
+
+	if (IPC_TAIL_IS_SIZE_INVALID(*comp))
+		return NULL;
+
+	dai.dai_index = comp->dai_index;
+	dai.direction = comp->direction;
+	dai.type      = comp->type;
+
+	return dai_new(drv, config, &dai);
+}
+#endif
+
 void dai_common_free(struct dai_data *dd)
 {
 	if (dd->group)
@@ -1109,7 +1128,7 @@ static const struct comp_driver comp_dai = {
 	.uid	= SOF_RT_UUID(dai_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
-		.create				= dai_new,
+		.create				= IPC3_SHIM(dai_new),
 		.free				= dai_free,
 		.params				= dai_params,
 		.dai_get_hw_params		= dai_comp_get_hw_params,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -577,6 +577,25 @@ e_data:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *dai_new_shim(const struct comp_driver *drv,
+				     const struct comp_ipc_config *config,
+				     const void *spec)
+{
+	const struct sof_ipc_comp_dai *comp = spec;
+	struct ipc_config_dai dai;
+
+	if (IPC_TAIL_IS_SIZE_INVALID(*comp))
+		return NULL;
+
+	dai.dai_index = comp->dai_index;
+	dai.direction = comp->direction;
+	dai.type      = comp->type;
+
+	return dai_new(drv, config, &dai);
+}
+#endif
+
 void dai_common_free(struct dai_data *dd)
 {
 #ifdef CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS
@@ -1919,7 +1938,7 @@ static const struct comp_driver comp_dai = {
 	.uid	= SOF_RT_UUID(dai_uuid),
 	.tctx	= &dai_comp_tr,
 	.ops	= {
-		.create				= dai_new,
+		.create				= IPC3_SHIM(dai_new),
 		.free				= dai_free,
 		.params				= dai_params,
 		.dai_get_hw_params		= dai_comp_get_hw_params,

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -444,7 +444,7 @@ static int ctc_process(struct processing_module *mod,
 	return 0;
 }
 
-static struct module_interface google_ctc_audio_processing_interface = {
+static const struct module_interface google_ctc_audio_processing_interface = {
 	.init  = ctc_init,
 	.free = ctc_free,
 	.process_audio_stream = ctc_process,

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -838,7 +838,7 @@ static int mod_process(struct processing_module *mod, struct sof_source **source
 	return 0;
 }
 
-static struct module_interface google_rtc_audio_processing_interface = {
+static const struct module_interface google_rtc_audio_processing_interface = {
 	.init  = google_rtc_audio_processing_init,
 	.free = google_rtc_audio_processing_free,
 	.process = mod_process,

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -599,6 +599,25 @@ e_data:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *host_new_shim(const struct comp_driver *drv,
+				      const struct comp_ipc_config *config,
+				      const void *spec)
+{
+	const struct sof_ipc_comp_host *comp = spec;
+	struct ipc_config_host host;
+
+	if (IPC_TAIL_IS_SIZE_INVALID(*comp))
+		return NULL;
+
+	host.direction   = comp->direction;
+	host.no_irq      = comp->no_irq;
+	host.dmac_config = comp->dmac_config;
+
+	return host_new(drv, config, &host);
+}
+#endif
+
 void host_common_free(struct host_data *hd)
 {
 	dma_put(hd->dma);
@@ -1004,7 +1023,7 @@ static const struct comp_driver comp_host = {
 	.uid	= SOF_RT_UUID(host_uuid),
 	.tctx	= &host_tr,
 	.ops	= {
-		.create				= host_new,
+		.create				= IPC3_SHIM(host_new),
 		.free				= host_free,
 		.params				= host_params,
 		.reset				= host_reset,

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -676,6 +676,22 @@ e_data:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *host_new_shim(const struct comp_driver *drv,
+				      const struct comp_ipc_config *config,
+				      const void *spec)
+{
+	const struct sof_ipc_comp_host *comp = spec;
+	struct ipc_config_host host;
+
+	host.direction = comp->direction;
+	host.no_irq = comp->no_irq;
+	host.dmac_config = comp->dmac_config;
+
+	return host_new(drv, config, &host);
+}
+#endif
+
 void host_common_free(struct host_data *hd)
 {
 	dma_put(hd->dma);
@@ -1150,7 +1166,7 @@ static const struct comp_driver comp_host = {
 	.uid	= SOF_RT_UUID(host_uuid),
 	.tctx	= &host_tr,
 	.ops	= {
-		.create				= host_new,
+		.create				= IPC3_SHIM(host_new),
 		.free				= host_free,
 		.params				= host_params,
 		.reset				= host_reset,

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -525,6 +525,20 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 	return dev;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *kpb_new_shim(const struct comp_driver *drv,
+				     const struct comp_ipc_config *config,
+				     const void *spec)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return kpb_new(drv, config, &proc);
+}
+#endif
+
 /**
  * \brief Allocate history buffer.
  * \param[in] kpb - KPB component data pointer.
@@ -2591,7 +2605,7 @@ static const struct comp_driver comp_kpb = {
 	.uid = SOF_RT_UUID(KPB_UUID),
 	.tctx = &kpb_tr,
 	.ops = {
-		.create		= kpb_new,
+		.create		= IPC3_SHIM(kpb_new),
 		.free		= kpb_free,
 		.trigger	= kpb_trigger,
 		.copy		= kpb_copy,

--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -38,73 +38,8 @@ int module_adapter_init_data(struct comp_dev *dev,
 			     const struct comp_ipc_config *config,
 			     const void *spec)
 {
-	int ret;
-
-	const unsigned char *data = NULL;
-	uint32_t size = 0;
-
-	switch (config->type) {
-	case SOF_COMP_VOLUME:
-	{
-		const struct ipc_config_volume *ipc_volume = spec;
-
-		size = sizeof(*ipc_volume);
-		data = spec;
-		break;
-	}
-	case SOF_COMP_SRC:
-	{
-		const struct ipc_config_src *ipc_src = spec;
-
-		size = sizeof(*ipc_src);
-		data = spec;
-		break;
-	}
-	case SOF_COMP_ASRC:
-	{
-		const struct ipc_config_asrc *ipc_asrc = spec;
-
-		size = sizeof(*ipc_asrc);
-		data = spec;
-		break;
-	}
-	case SOF_COMP_MIXER:
-		break;
-	case SOF_COMP_EQ_IIR:
-	case SOF_COMP_EQ_FIR:
-	case SOF_COMP_KEYWORD_DETECT:
-	case SOF_COMP_KPB:
-	case SOF_COMP_SELECTOR:
-	case SOF_COMP_DEMUX:
-	case SOF_COMP_MUX:
-	case SOF_COMP_DCBLOCK:
-	case SOF_COMP_SMART_AMP:
-	case SOF_COMP_MODULE_ADAPTER:
-	case SOF_COMP_FILEREAD:
-	case SOF_COMP_FILEWRITE:
-	case SOF_COMP_NONE:
-	{
-		const struct ipc_config_process *ipc_module_adapter = spec;
-
-		size = ipc_module_adapter->size;
-		data = ipc_module_adapter->data;
-		break;
-	}
-	default:
-		comp_err(dev, "module_adapter_init_data() unsupported comp type %d", config->type);
-		return -EINVAL;
-	}
-
-	/* Copy initial config */
-	if (size) {
-		ret = module_load_config(dev, data, size);
-		if (ret < 0) {
-			comp_err(dev, "module_adapter_init_data() error %d: config loading has failed.",
-				 ret);
-			return ret;
-		}
-		dst->init_data = dst->data;
-	}
+	// Downstream shim will copy and alloc the correct data
+	dst->init_data = dst->data;
 
 	return 0;
 }

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -181,6 +181,20 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 	return dev;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *selector_new_shim(const struct comp_driver *drv,
+					  const struct comp_ipc_config *config,
+					  const void *spec)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return selector_new(drv, config, &proc);
+}
+#endif
+
 /**
  * \brief Frees selector component.
  * \param[in,out] dev Selector base component device.

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -264,6 +264,20 @@ error:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *smart_amp_new_shim(const struct comp_driver *drv,
+					   const struct comp_ipc_config *config,
+					   const void *spec)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return smart_amp_new(drv, config, &proc);
+}
+#endif
+
 static int smart_amp_set_config(struct comp_dev *dev,
 				struct sof_ipc_ctrl_data *cdata)
 {
@@ -813,7 +827,7 @@ static const struct comp_driver comp_smart_amp = {
 	.uid = SOF_RT_UUID(UUID_SYM),
 	.tctx = &smart_amp_comp_tr,
 	.ops = {
-		.create = smart_amp_new,
+		.create = IPC3_SHIM(smart_amp_new),
 		.free = smart_amp_free,
 		.params = smart_amp_params,
 		.prepare = smart_amp_prepare,

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -706,12 +706,37 @@ static int tone_reset(struct comp_dev *dev)
 	return 0;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *tone_new_shim(const struct comp_driver *drv,
+				      const struct comp_ipc_config *config,
+				      const void *spec)
+{
+	const struct sof_ipc_comp_tone *comp = spec;
+	struct ipc_config_tone tone;
+
+	if (IPC_TAIL_IS_SIZE_INVALID(*comp))
+		return NULL;
+
+	tone.ampl_mult = comp->ampl_mult;
+	tone.amplitude = comp->amplitude;
+	tone.freq_mult = comp->freq_mult;
+	tone.frequency = comp->frequency;
+	tone.length = comp->length;
+	tone.period = comp->period;
+	tone.ramp_step = comp->ramp_step;
+	tone.repeats = comp->repeats;
+	tone.sample_rate = comp->sample_rate;
+
+	return tone_new(drv, config, &tone);
+}
+#endif
+
 static const struct comp_driver comp_tone = {
 	.type = SOF_COMP_TONE,
 	.uid = SOF_RT_UUID(tone_uuid),
 	.tctx = &tone_tr,
 	.ops = {
-		.create = tone_new,
+		.create = IPC3_SHIM(tone_new),
 		.free = tone_free,
 		.params = tone_params,
 #if CONFIG_IPC_MAJOR_3

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -247,6 +247,13 @@ enum {
 
 /** @}*/
 
+/** \brief Helper macro for IPC3 init shims */
+#ifdef CONFIG_IPC_MAJOR_3
+  #define IPC3_SHIM(init) init##_shim
+#else
+  #define IPC3_SHIM(init) init
+#endif
+
 /** \brief Type of endpoint this component is connected to in a pipeline */
 enum comp_endpoint_type {
 	COMP_ENDPOINT_HOST,	/**< Connected to host dma */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -254,6 +254,23 @@ enum {
   #define IPC3_SHIM(init) init
 #endif
 
+/** \brief Helper to convert sof_ipc_comp_process to ipc_config_process in components */
+static inline int comp_sof_process_to_ipc_process(const struct sof_ipc_comp_process *comp,
+						  struct ipc_config_process *proc)
+{
+	if (comp->comp.hdr.size < sizeof(*comp) ||
+	    comp->comp.hdr.size + comp->size > SOF_IPC_MSG_MAX_SIZE)
+		return -EBADMSG;
+	proc->type = comp->type;
+	proc->size = comp->size;
+#if CONFIG_LIBRARY || UNIT_TEST
+	proc->data = comp->data + comp->comp.ext_data_length;
+#else
+	proc->data = comp->data;
+#endif
+	return 0;
+}
+
 /** \brief Type of endpoint this component is connected to in a pipeline */
 enum comp_endpoint_type {
 	COMP_ENDPOINT_HOST,	/**< Connected to host dma */

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -780,6 +780,20 @@ static void test_keyword_free(struct comp_dev *dev)
 	rfree(dev);
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *test_keyword_new_shim(const struct comp_driver *drv,
+					      const struct comp_ipc_config *config,
+					      const void *spec)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return test_keyword_new(drv, config, &proc)
+}
+#endif
+
 static int test_keyword_verify_params(struct comp_dev *dev,
 				      struct sof_ipc_stream_params *params)
 {
@@ -1066,7 +1080,7 @@ static const struct comp_driver comp_keyword = {
 	.uid	= SOF_RT_UUID(keyword_uuid),
 	.tctx	= &keyword_tr,
 	.ops	= {
-		.create			= test_keyword_new,
+		.create			= IPC3_SHIM(test_keyword_new),
 		.free			= test_keyword_free,
 		.params			= test_keyword_params,
 #if CONFIG_IPC_MAJOR_4

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -92,6 +92,20 @@ fail:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *smart_amp_new_shim(const struct comp_driver *drv,
+					   const struct comp_ipc_config *config,
+					   const void *spec)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return smart_amp_new(drv, config, &proc);
+}
+#endif
+
 static void smart_amp_set_params(struct comp_dev *dev,
 				 struct sof_ipc_stream_params *params)
 {
@@ -534,7 +548,7 @@ static const struct comp_driver comp_smart_amp = {
 	.uid = SOF_RT_UUID(smart_amp_test_uuid),
 	.tctx = &smart_amp_test_comp_tr,
 	.ops = {
-		.create			= smart_amp_new,
+		.create			= IPC3_SHIM(smart_amp_new),
 		.free			= smart_amp_free,
 		.params			= smart_amp_params,
 		.prepare		= smart_amp_prepare,

--- a/test/cmocka/src/audio/mixer/comp_mock.c
+++ b/test/cmocka/src/audio/mixer/comp_mock.c
@@ -22,9 +22,8 @@ static struct comp_dev *mock_comp_new(const struct comp_driver *drv,
 				      const struct comp_ipc_config *config,
 				      const void *spec)
 {
-	struct comp_dev *dev = calloc(1, sizeof(struct comp_dev));
+	struct comp_dev *dev = comp_alloc(drv, sizeof(*dev));
 
-	dev->drv = drv;
 	return dev;
 }
 

--- a/tools/plugin/modules/shm.c
+++ b/tools/plugin/modules/shm.c
@@ -137,18 +137,32 @@ error:
 	return NULL;
 }
 
+#if CONFIG_IPC_MAJOR_3
+static struct comp_dev *shm_new_shim(const struct comp_driver *drv,
+				     const struct comp_ipc_config *config,
+				     const void *spec, int direction)
+{
+	struct ipc_config_process proc;
+
+	if (comp_sof_process_to_ipc_process(spec, &proc) < 0)
+		return NULL;
+
+	return shm_new(drv, config, &proc);
+}
+#endif
+
 static struct comp_dev *shmwrite_new(const struct comp_driver *drv,
 				     const struct comp_ipc_config *config,
 				     const void *spec)
 {
-	return shm_new(drv, config, spec, SOF_IPC_STREAM_PLAYBACK);
+	return IPC3_SHIM(shm_new)(drv, config, spec, SOF_IPC_STREAM_PLAYBACK);
 }
 
 static struct comp_dev *shmread_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config,
 				    const void *spec)
 {
-	return shm_new(drv, config, spec, SOF_IPC_STREAM_CAPTURE);
+	return IPC3_SHIM(shm_new)(drv, config, spec, SOF_IPC_STREAM_CAPTURE);
 }
 
 /**


### PR DESCRIPTION
A bad IPC can mismatch UUID and type, causing downstream processes to operate differently than the matched component target. ~~This is because get_drv will not reject the mismatch. This enforces the topology matches the UUID and type.~~ This change moves all type casting down to the final module so it cannot confuse intermediate processes.

Exempted modules/components from shims
- Probe
  - instantiation only supported in IPC4
- ALSA
  - Does not parse `spec` in IPC3
- Google Hotword Detect
  - Does not parse `spec` 
- Chain DMA
  - IPC4 specific 