### PR TITLE
Lib: Add to dai-legacy.h struct copier_gain_params for testbench

### DIFF
--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -10,7 +10,6 @@
 #include <sof/common.h>
 #include <ipc/dai.h>
 #include "copier.h"
-#include <sof/lib/dai-zephyr.h>
 
 LOG_MODULE_DECLARE(copier, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -210,6 +210,9 @@ struct dai_data {
 
 	/* llp slot info in memory windows */
 	struct llp_slot_info slot_info;
+
+	/* Copier gain params */
+	struct copier_gain_params *gain_data;
 };
 
 struct dai {


### PR DESCRIPTION
Two patches for copier to prevent IPC4 testbench build fail. Copier is part of SOF lib build that is linked to testbench executable. File component is a minimal implementation of a copier and uses copier headers.