### PR TITLE
Tools: Tplg_parser: Fix handling of tokens found count

### DIFF
--- a/tools/tplg_parser/tokens.c
+++ b/tools/tplg_parser/tokens.c
@@ -136,8 +136,8 @@ int sof_parse_token_sets(void *object, const struct sof_topology_token *tokens,
 
 		array = MOVE_POINTER_BY_BYTES(array, array->size);
 
-		if (found >= count) {
-			total += found;
+		if (found > 0) {
+			total += count;
 			offset += object_size;
 			found = 0;
 		}


### PR DESCRIPTION
This change fixes for testbench support for topologies where widgets have more than one format. Without this change if not all e.g. count = 8 tokens are found but e.g. count = 7 the tokens are applied to the format array but the index (offset) to next format (of num_sets) is not advanced. So the first entry will be written again for all found formats. The found tokens count can be less than 8 if the optional
SOF_TKN_CAVS_AUDIO_FORMAT_INPUT_PIN_INDEX or
SOF_TKN_CAVS_AUDIO_FORMAT_OUTPUT_PIN_INDEX are not set.

As fix the offset should be advanced when one or more of tokens is found from topology. The total is incremented by count for the loop end condition check.