### PR TITLE
west.yml: update Zephyr to 155f3f3ba688

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 99e6280d7e22552de9a94992b626acdcbde00fee
+      revision: 155f3f3ba688dac3e1113ada3f9cfa894612f951
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Includes the following changes potentially relevant to SOF:

155f3f3ba688 west_commands: sign: add imx95 to target list
01754956de29 boards: nxp: imx95_evk: add rimage support for m7 ddr variant
848907c0f81d soc: imx: imx95: enable cache management for M7
f3e870dfa5d4 boards: nxp: imx95_evk: add edma and sai nodes


Needed for https://github.com/thesofproject/sof/pull/9512.