### PR TITLE
topology2: add rt713 and rt1318 support on LNL machine

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -18,6 +18,12 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+"cavs-sdw\;sof-lnl-rt713-l0-rt1318-l1-2ch\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,\
+SDW_SPK_STREAM=SDW1-Playback,SDW_AMP_FEEDBACK=false,\
+NUM_DMICS=2,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-lnl-rt713-l0-rt1318-l1-2ch.bin,\
+HDMI1_ID=6,HDMI2_ID=7,HDMI3_ID=8"
+
 # No SDW Jack. SDW DMIC+SPK
 "cavs-sdw\;sof-lnl-rt1318-l12-rt714-l0\;PLATFORM=lnl,SDW_JACK=false,SDW_DMIC=1,\
 NUM_SDW_AMP_LINKS=2,SDW_DMIC_STREAM=SDW0-Capture"


### PR DESCRIPTION
SDW link0: rt713
SDW link1: rt1318
And 2ch PCH-attached DMICs.