### PR TITLE
Lib: Add to dai-legacy.h "struct dai" new member "type"

### DIFF
--- a/src/include/sof/lib/dai-legacy.h
+++ b/src/include/sof/lib/dai-legacy.h
@@ -217,6 +217,7 @@ struct dai_data {
 
 struct dai {
 	uint32_t index;		/**< index */
+	uint32_t type;		/**< added for dai-zephyr.h compatibility */
 	struct k_spinlock lock;	/**< locking mechanism */
 	int sref;		/**< simple ref counter, guarded by lock */
 	struct dai_plat_data plat_data;


### PR DESCRIPTION
The IPC4 testbench build fails without this change in copier_gain.c switch case to check for dd->dai->type for DMIC. Testbench is using the legacy header to avoid to include zephyr drivers headers with a lot more
dependencies.