### PR TITLE
rtos: add Zephyr implementation of sof/lib/memory.h

### DIFF
--- a/zephyr/include/sof/lib/memory.h
+++ b/zephyr/include/sof/lib/memory.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2024 Intel Corporation.
+ */
+
+#ifndef __SOF_LIB_MEMORY_H__
+#define __SOF_LIB_MEMORY_H__
+
+#include <platform/lib/memory.h>
+
+#endif /* __SOF_LIB_MEMORY_H__ */


### PR DESCRIPTION
Implement sof/lib/memory.h for Zephyr build and do not rely on the xtos version for Zephyr builds.

Link: https://github.com/thesofproject/sof/issues/9015