### PR TITLE
ipc: remove unnecessary inclusion of dma-trace.h

### DIFF
--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -9,7 +9,6 @@
 #include <sof/lib/dma.h>
 #include <sof/lib/uuid.h>
 #include <sof/platform.h>
-#include <sof/trace/dma-trace.h>
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -35,7 +35,6 @@
 
 #include <rtos/atomic.h>
 #include <rtos/kernel.h>
-#include <sof/trace/dma-trace.h>
 #include <sof/lib_manager.h>
 
 #if CONFIG_SOF_BOOT_TEST


### PR DESCRIPTION
dma-trace.h is only needed to implement the IPC3 sof-logger DMA trace and the definitions are not needed for IPC4 or dma-copy.c implementation.