### PR TITLE
audio: remove unnecessary inclusion of lib/memory.h

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -12,7 +12,6 @@
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -13,7 +13,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/numbers.h>
 #include <sof/trace/trace.h>

--- a/src/audio/asrc/asrc_ipc3.c
+++ b/src/audio/asrc/asrc_ipc3.c
@@ -6,7 +6,6 @@
 #include <sof/audio/ipc-config.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
 #include <sof/common.h>

--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -6,7 +6,6 @@
 #include <sof/audio/ipc-config.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/trace/trace.h>
 #include <sof/common.h>

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -4,7 +4,7 @@
 //
 
 #include <sof/audio/component.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/ut.h>
 #include <sof/tlv.h>
 #include <ipc4/base_fw.h>

--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -15,7 +15,6 @@
 #include <rtos/interrupt.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/list.h>
 #include <rtos/spinlock.h>

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -12,7 +12,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/list.h>
 #include <rtos/sof.h>
 #include <rtos/string.h>

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -18,7 +18,6 @@
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/string.h>

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -5,7 +5,6 @@
 #include <sof/audio/component_ext.h>
 #include <sof/trace/trace.h>
 #include <sof/lib/uuid.h>
-#include <sof/lib/memory.h>
 #include <sof/ut.h>
 #include <rtos/init.h>
 #include "copier.h"

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -17,7 +17,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/iir_df2t.h>
 #include <sof/list.h>

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -19,7 +19,7 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -19,7 +19,7 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/lib/dma.h>

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -16,7 +16,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -12,7 +12,6 @@
 #include <sof/audio/ipc-config.h>
 #include <sof/audio/pipeline.h>
 #include <sof/ipc/msg.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/numbers.h>
 #include <sof/trace/trace.h>

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -17,7 +17,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/fir_config.h>

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -19,7 +19,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>

--- a/src/audio/eq_iir/eq_iir_generic.c
+++ b/src/audio/eq_iir/eq_iir_generic.c
@@ -19,7 +19,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/iir_df1.h>

--- a/src/audio/eq_iir/eq_iir_ipc3.c
+++ b/src/audio/eq_iir/eq_iir_ipc3.c
@@ -19,7 +19,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/iir_df1.h>

--- a/src/audio/eq_iir/eq_iir_ipc4.c
+++ b/src/audio/eq_iir/eq_iir_ipc4.c
@@ -19,7 +19,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/iir_df1.h>

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -15,7 +15,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/notifier.h>
 #include <rtos/wait.h>
 #include <sof/lib/uuid.h>

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -20,7 +20,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <rtos/wait.h>

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -17,7 +17,7 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -17,7 +17,7 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -14,7 +14,6 @@
 #include <rtos/panic.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -26,7 +26,7 @@
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -15,7 +15,6 @@
 #include <sof/common.h>
 #include <rtos/panic.h>
 #include <sof/ipc/msg.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -16,7 +16,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -14,7 +14,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -10,7 +10,6 @@
 #include <sof/audio/ipc-config.h>
 #include <sof/audio/pipeline.h>
 #include <sof/ipc/msg.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/numbers.h>
 #include <module/crossover/crossover_common.h>

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -13,7 +13,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -8,7 +8,6 @@
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
 #include <sof/audio/pipeline.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/compiler_attributes.h>
 #include <sof/list.h>

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -17,7 +17,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -22,7 +22,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/string.h>

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -20,7 +20,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -20,7 +20,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -20,7 +20,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -16,7 +16,6 @@
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/pipeline.h>
 #include <sof/ipc/msg.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/math/fir_generic.h>
 #include <sof/math/fir_hifi2ep.h>

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -16,7 +16,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
+#include <sof/lib/memory.h> /* for SHARED_DATA */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -14,7 +14,6 @@
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -27,7 +27,6 @@
 #include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -17,7 +17,6 @@
 #include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -17,7 +17,6 @@
 #include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -15,7 +15,6 @@
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
 #include <sof/lib/cpu.h>
-#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -15,7 +15,6 @@
 
 #include <sof/audio/component.h>
 #include <sof/ut.h>
-#include <sof/lib/memory.h>
 #include <sof/audio/sink_api.h>
 #include <sof/audio/source_api.h>
 #include "module_interface.h"

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -10,7 +10,6 @@
 
 #include <sof/lib/cpu.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <rtos/task.h>
 #include <rtos/sof.h>

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -16,7 +16,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h>
 #include <rtos/wait.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>


### PR DESCRIPTION
Remove unnecessary incluce statements for lib/memory.h in large number of files in audio. Some are pure bad copy and paste, while in some cases the module has in the past used SHARED_DATA macro, but this has been since been removed. The SHARED_DATA use might be removed later, so add a comment to files where lib/memory.h is only included for this one macro.