### PR TITLE
[cavs2.5-001] IPC timeout on max98373 boards

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -794,7 +794,9 @@ static int mux_sink_status_count(struct comp_dev *mux, uint32_t status)
 							source_list);
 		struct comp_buffer __sparse_cache *sink_c = buffer_acquire(sink);
 
-		if (sink_c->sink && sink_c->sink->state == status)
+		/* ignore active sink on other pipeline */
+		if (sink_c->sink && sink_c->sink->state == status &&
+		    sink_c->sink->pipeline->pipeline_id == mux->pipeline->pipeline_id)
 			count++;
 		buffer_release(sink_c);
 	}


### PR DESCRIPTION
There is IPC time out after disabling core1. However, we don't have sufficient log on FW side.

```
[   55.979513] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x40070000: GLB_PM_MSG: CORE_ENABLE
[   55.979904] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx succeeded: 0x40070000: GLB_PM_MSG: CORE_ENABLE
[   55.979916] sof-audio-pci-intel-tgl 0000:00:1f.3: Core 1 powered down
[   55.979921] sof-audio-pci-intel-tgl 0000:00:1f.3: widget PIPELINE.1.SSP1.OUT freed
[   55.980386] sof-audio-pci-intel-tgl 0000:00:1f.3: FW Poll Status: reg[0x80]=0x20140000 successful
[   55.980403] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x90050000: GLB_TRACE_MSG: DMA_FREE
[   56.487374] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx timed out for 0x90050000 (msg/reply size: 8/0)
[   56.487382] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump start ]------------
[   56.487426] sof-audio-pci-intel-tgl 0000:00:1f.3: hda irq intsts 0x00000000 intlctl 0xc0000000 rirb 00
[   56.487429] sof-audio-pci-intel-tgl 0000:00:1f.3: dsp irq ppsts 0x00000000 adspis 0x00000000
[   56.487461] sof-audio-pci-intel-tgl 0000:00:1f.3: error: host status 0x00000000 dsp status 0x00000000 mask 0x00000003
[   56.487463] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump end ]------------
[   56.487465] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump start ]------------
[   56.487467] sof-audio-pci-intel-tgl 0000:00:1f.3: IPC timeout
[   56.487468] sof-audio-pci-intel-tgl 0000:00:1f.3: fw_state: SOF_FW_BOOT_COMPLETE (7)
[   56.487491] sof-audio-pci-intel-tgl 0000:00:1f.3: 0x00000005: module: ROM, state: FW_ENTERED, running
[   56.487900] sof-audio-pci-intel-tgl 0000:00:1f.3: unexpected fault 0x00000000 trace 0x00004000
[   56.487902] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump end ]------------
[   56.487905] sof-audio-pci-intel-tgl 0000:00:1f.3: DMA_TRACE_FREE failed with error: -110
[   56.487930] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx: 0x40010000: GLB_PM_MSG: CTX_SAVE
[   56.988418] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx timed out for 0x40010000 (msg/reply size: 76/0)
[   56.988427] sof-audio-pci-intel-tgl 0000:00:1f.3: IPC timeout
[   56.988430] sof-audio-pci-intel-tgl 0000:00:1f.3: ctx_save IPC error: -110, proceeding with suspend
[   56.988501] sof-audio-pci-intel-tgl 0000:00:1f.3: FW Poll Status: reg[0x4]=0x9010f0f successful
[   56.989416] sof-audio-pci-intel-tgl 0000:00:1f.3: FW Poll Status: reg[0x4]=0xf0f successful
[   56.989424] sof-audio-pci-intel-tgl 0000:00:1f.3: DSP core(s) enabled? 0 : core_mask 1
[   56.989540] sof-audio-pci-intel-tgl 0000:00:1f.3: Debug PCIR: 00000000 at  00000044
[   56.989546] sof-audio-pci-intel-tgl 0000:00:1f.3: Debug PCIW: 00000010 at  00000044
[   56.989559] sof-audio-pci-intel-tgl 0000:00:1f.3: Turning i915 HDAC power 0
[   56.989561] sof-audio-pci-intel-tgl 0000:00:1f.3: Current DSP power state: D3
[   56.989562] sof-audio-pci-intel-tgl 0000:00:1f.3: fw_state change: 7 -> 0
```

I checked FW log and finally realized that capture pipeline task on core1 does not exit because the mux_trigger() function failed due to active sink count.

```
[   113559640.904212] (      922524.500000) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x60050000
[   113559915.070868] (         274.166656) c1 idc                ......./intel/cavs/idc.c:58   INFO idc_irq_handler(), IPC_IDCTFC_BUSY
[   113559944.237533] (          29.166666) c1 idc                ......./intel/cavs/idc.c:186  INFO idc_do_cmd()
[   113559971.737532] (          27.499998) c1 pipe         11.52 ....../pipeline-stream.c:270  INFO pipe trigger cmd 0
[   113561679.341631] (        1707.604126) c1 demux        11.48      src/audio/mux/mux.c:811  INFO mux_trigger(), command = 0
[   113563467.414477] (        1788.072876) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x60030000
```

When mux is on capture pipeline, sinks could not be active/paused when processing COMP_TRIGGER_STOP command. However, active sink could be on another pipeline and should be ignored or the pipeline task will not exit and cause DSP panic if the core running the task is disabled later.

```
PCMP ----> smart_amp ----> SSP(A)  # playback ppl
             ^
             |
PCMC <---- demux <----- SSP(B)     # echo reference ppl
```

In this PR, I modify mux_sink_status_count() function to ignore active sink on other pipeline. The log looks normal and IPC time out is gone.

```
[   126341028.625492] (     1416139.000000) c0 ipc                  src/ipc/ipc3/handler.c:1605 INFO ipc: new cmd 0x60050000
[   126341674.771300] (         646.145813) c1 idc                ......./intel/cavs/idc.c:58   INFO idc_irq_handler(), IPC_IDCTFC_BUSY
[   126341702.687965] (          27.916666) c1 idc                ......./intel/cavs/idc.c:186  INFO idc_do_cmd()
[   126341729.667131] (          26.979166) c1 pipe         11.52 ....../pipeline-stream.c:270  INFO pipe trigger cmd 0
[   126343484.302478] (        1754.635376) c1 demux        11.48      src/audio/mux/mux.c:812  INFO mux_trigger(), command = 0
[   126343521.229560] (          36.927082) c1 ssp-dai      1.1   /drivers/intel/ssp/ssp.c:1135 INFO ssp_trigger() cmd 0
[   126343544.250392] (          23.020832) c1 ssp-dai      1.1   /drivers/intel/ssp/ssp.c:1088 INFO ssp_stop(), RX stop
[   126343566.385808] (          22.135416) c1 dw-dma                 src/drivers/dw/dma.c:413  INFO dw_dma_stop(): dma 0 channel 1 stop
[   126343600.187890] (          33.802082) c1 ll-schedule        ./schedule/ll_schedule.c:159  INFO task complete 0xbe200980 pipe-task <f11818eb-e92e-4082-82a3-dc54c604ebb3>
[   126343617.687889] (          17.500000) c1 ll-schedule        ./schedule/ll_schedule.c:162  INFO num_tasks 1 total_num_tasks 3
```
