### PR TITLE
ipc: do not build dma-copy.c if native Zephyr DMA drivers used

### DIFF
--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -15,9 +15,12 @@ add_local_sources(sof
 is_zephyr(it_is)
 if(it_is) ###  Zephyr ###
 
-zephyr_library_sources(
-	dma-copy.c
-)
+if (NOT CONFIG_ZEPHYR_NATIVE_DRIVERS)
+	# XTOS DMA drivers used in Zephyr build
+	zephyr_library_sources(
+		dma-copy.c
+	)
+endif()
 
 if (CONFIG_SOC_SERIES_INTEL_CAVS_V25 OR CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	zephyr_library_sources(


### PR DESCRIPTION
The dma-copy.c only supports the XTOS DMA driver interface (dma_copy_legacy()), so no need to include it in SOF Zephyr builds if native Zephyr DMA drivers are in use.