### PR TITLE
ipc4: remove unused code

### DIFF
--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -754,27 +754,6 @@ int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	return IPC4_SUCCESS;
 }
 
-/* dma index may be for playback or capture. Current hw supports PLATFORM_MAX_DMA_CHAN playback
- * channels and the rest are for capture. This function converts DMA ID to DMA channel.
- */
-static inline int process_dma_index(uint32_t dma_id, uint32_t *dir, uint32_t *chan)
-{
-	if (dma_id > DAI_NUM_HDA_OUT + DAI_NUM_HDA_IN) {
-		tr_err(&ipc_tr, "dma id %d is out of range", dma_id);
-		return IPC4_INVALID_NODE_ID;
-	}
-
-	if (dma_id >= PLATFORM_MAX_DMA_CHAN) {
-		*dir = SOF_IPC_STREAM_CAPTURE;
-		*chan = dma_id - PLATFORM_MAX_DMA_CHAN;
-	} else {
-		*dir = SOF_IPC_STREAM_PLAYBACK;
-		*chan = dma_id;
-	}
-
-	return IPC4_SUCCESS;
-}
-
 #if CONFIG_COMP_CHAIN_DMA
 int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma)
 {


### PR DESCRIPTION
Removes unused process_dma_index() from src/ipc/ipc4/helper.c.

In addition to being unused, that func also requires all IPC4 platforms to define PLATFORM_MAX_DMA_CHAN. On some platforms that unused func is the only place such define is used. Removing the unused func allows to skip defining of PLATFORM_MAX_DMA_CHAN on platforms where it is not needed.