### PR TITLE
app: remove ptl as integration platform

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -25,8 +25,6 @@ tests:
       - intel_adsp/cavs25  # TGL
       - intel_adsp/ace15_mtpm  # MTL
       - intel_adsp/ace20_lnl
-      - intel_adsp/ace30/ptl
-      - intel_adsp/ace30/ptl/sim
       - imx8qm_mek/mimx8qm6/adsp
       - imx8qxp_mek/mimx8qx6/adsp
       - imx8mp_evk/mimx8ml8/adsp


### PR DESCRIPTION
We are not able to build this platform in CI yet due to missing
toolchain. This causes errors in twister, so remove as integration
platform until we have the toolchain in place.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
