### PR TITLE
scripts: build-tools: Add support to build tplg1/tplg2 individually

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -16,13 +16,15 @@ Attention: the list of selected shortcuts below is _not_ exhaustive. To
 build _everything_ don't select any particular target; this will build
 CMake's default target "ALL".
 
-usage: $0 [-c|-f|-h|-l|-p|-t|-T]
+usage: $0 [-c|-f|-h|-l|-p|-t|-T|-X|-Y]
        -h Display help
 
        -c Rebuild ctl/
        -l Rebuild logger/
        -p Rebuild probes/
        -T Rebuild topology/ (not topology/development/! Use ALL)
+       -X Rebuild topology1 only
+       -Y Rebuild topology2 only
        -t Rebuild test/topology/ (or tools/test/topology/tplg-build.sh directly)
 
        -C No build, only CMake re-configuration. Shows CMake targets.
@@ -63,6 +65,9 @@ Build commands for respective tools:
         logger:     ninja -C "$BUILD_TOOLS_DIR" sof-logger
         probes:     ninja -C "$BUILD_TOOLS_DIR" sof-probes
         topologies: ninja -C "$BUILD_TOOLS_DIR" topologies
+        topologies1: ninja -C "$BUILD_TOOLS_DIR" topologies1
+        topologies2: ninja -C "$BUILD_TOOLS_DIR" topologies2
+
         test tplgs: ninja -C "$BUILD_TOOLS_DIR" tests
                (or ./tools/test/topology/tplg-build.sh directly)
 
@@ -88,8 +93,8 @@ EOF
 main()
 {
         local DO_BUILD_ctl DO_BUILD_logger DO_BUILD_probes \
-                DO_BUILD_tests DO_BUILD_topologies SCRIPT_DIR SOF_REPO CMAKE_ONLY \
-                BUILD_ALL
+                DO_BUILD_tests DO_BUILD_topologies1 DO_BUILD_topologies2 SCRIPT_DIR SOF_REPO \
+                CMAKE_ONLY BUILD_ALL
         SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
         SOF_REPO=$(dirname "$SCRIPT_DIR")
         : "${BUILD_TOOLS_DIR:=$SOF_REPO/tools/build_tools}"
@@ -104,7 +109,8 @@ main()
         DO_BUILD_logger=false
         DO_BUILD_probes=false
         DO_BUILD_tests=false
-        DO_BUILD_topologies=false
+        DO_BUILD_topologies1=false
+        DO_BUILD_topologies2=false
         CMAKE_ONLY=false
 
         # better safe than sorry
@@ -112,13 +118,15 @@ main()
 
         # eval is a sometimes necessary evil
         # shellcheck disable=SC2034
-        while getopts "cfhlptTC" OPTION; do
+        while getopts "cfhlptTCXY" OPTION; do
                 case "$OPTION" in
                 c) DO_BUILD_ctl=true ;;
                 l) DO_BUILD_logger=true ;;
                 p) DO_BUILD_probes=true ;;
                 t) DO_BUILD_tests=true ;;
-                T) DO_BUILD_topologies=true ;;
+                T) DO_BUILD_topologies1=true ; DO_BUILD_topologies2=true ;;
+                X) DO_BUILD_topologies1=true ;;
+                Y) DO_BUILD_topologies2=true ;;
                 C) CMAKE_ONLY=true ;;
                 h) print_usage; exit 1;;
                 *) print_usage; exit 1;;
@@ -147,7 +155,7 @@ main()
         fi
 
         # Keep 'topologies' first because it's the noisiest.
-        for util in topologies tests; do
+        for util in topologies1 topologies2 tests; do
                 if eval '$DO_BUILD_'$util; then
                         make_tool $util
                 fi


### PR DESCRIPTION
NXP platforms do not support tplg2 and we don't want to build them every time.

So introduce new options to ./scripts/build-tools.sh so that it can build tplg1 and tplg2 separately.

- ./scripts/build-tools.sh -X, will only build topology1
- ./scripts/build-tools.sh -Y, will only build topology2

Target:
- ./scripts/build-tools.sh -T, remains unchanged and will build both topology1 and topolog2.