### PR TITLE
Platform: Library: Move mailbox_sw_reg_read64() from posix mailbox.h

### DIFF
--- a/posix/include/sof/lib/mailbox.h
+++ b/posix/include/sof/lib/mailbox.h
@@ -72,10 +72,6 @@ void mailbox_dspbox_read(void *dest, size_t dest_size,
 #define mailbox_hostbox_write(_offset, _src, _bytes) \
 	memcpy((char *)ipc->comp_data + _offset, _src, _bytes)
 
-static inline uint64_t mailbox_sw_reg_read64(uint32_t offset)
-{
-	return 0;
-}
 #else
 
 static inline

--- a/src/platform/library/include/platform/lib/mailbox.h
+++ b/src/platform/library/include/platform/lib/mailbox.h
@@ -59,6 +59,11 @@ static inline uint32_t mailbox_sw_reg_read(size_t offset)
 	return 0;
 }
 
+static inline uint64_t mailbox_sw_reg_read64(size_t offset)
+{
+	return 0;
+}
+
 #endif /* __PLATFORM_LIB_MAILBOX_H__ */
 
 #else


### PR DESCRIPTION
Without this change testbench IPC4 build fails with copier with implicit definition of the function. The mailbox_sw_reg_read64() function should be there in the same platform library mailbox.h header as the 32 bit version of similar function. The header mailbox.h for all Intel platforms is organized similarly.

The argument type is changed to size_t from uint32_t to follow other similar functions.