### PR TITLE
Tools: Testbench: Fix IPC4 PGA controls load

### DIFF
--- a/tools/testbench/topology_ipc4.c
+++ b/tools/testbench/topology_ipc4.c
@@ -905,7 +905,7 @@ int tb_new_pga(struct testbench_prm *tp)
 
 	/* skip kcontrols for now */
 	ret = tplg_create_controls(ctx, ctx->widget->num_kcontrols, tplg_ctl,
-				   ctx->hdr->payload_size, &volume);
+				   ctx->hdr->payload_size, comp_info);
 	if (ret < 0) {
 		fprintf(stderr, "error: loading controls\n");
 		goto out;


### PR DESCRIPTION
This mistake causes the module id and instance number number to be garbage, so the control can't be set up later in widget setup. The issue fixes the valgrind step fail with new proposed IPC4 version of scripts/host-testbench.sh.