### PR TITLE
zephyr: add Zephyr version of sof/init.h

### DIFF
--- a/zephyr/include/sof/init.h
+++ b/zephyr/include/sof/init.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2016,2024 Intel Corporation.
+ */
+
+#ifndef __SOF_INIT_H__
+#define __SOF_INIT_H__
+
+/* main firmware entry point - argc and argv not currently used */
+#ifndef CONFIG_ARCH_POSIX
+int main(int argc, char *argv[]);
+#endif
+
+#if CONFIG_MULTICORE
+
+struct sof;
+
+int secondary_core_init(struct sof *sof);
+
+#endif /* CONFIG_MULTICORE */
+
+#endif /* __SOF_INIT_H__ */


### PR DESCRIPTION
Add Zephyr version of sof/init.h. This is used define main entry points to the SOF application. The arch_init() entry point is not needed on Zephyr.

Link: https://github.com/thesofproject/sof/issues/9015