### PR TITLE
Clean up dma-trace.h and dma-trace.c dependencies

### DIFF
--- a/src/ipc/CMakeLists.txt
+++ b/src/ipc/CMakeLists.txt
@@ -15,9 +15,8 @@ add_local_sources(sof
 is_zephyr(it_is)
 if(it_is) ###  Zephyr ###
 
-zephyr_library_sources(
-	dma-copy.c
-)
+# dma-copy only used for dma-trace
+zephyr_library_sources_ifdef(CONFIG_TRACE dma-copy.c)
 
 if (CONFIG_SOC_SERIES_INTEL_CAVS_V25 OR CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	zephyr_library_sources(

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -34,7 +34,9 @@
 #include <sof/platform.h>
 #include <rtos/string.h>
 #include <rtos/string_macro.h>
+#if CONFIG_TRACE
 #include <sof/trace/dma-trace.h>
+#endif
 #include <sof/trace/trace.h>
 #include <ipc/control.h>
 #include <ipc/dai.h>

--- a/src/platform/imx8ulp/platform.c
+++ b/src/platform/imx8ulp/platform.c
@@ -25,7 +25,9 @@
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <rtos/sof.h>
+#if CONFIG_TRACE
 #include <sof/trace/dma-trace.h>
+#endif
 #include <ipc/dai.h>
 #include <ipc/header.h>
 #include <ipc/info.h>


### PR DESCRIPTION
As part of RTOS header cleanups, I've noted a few incorrect dependencies between common code and DMA trace. This series has a few small fixes to add proper ifdef guards to code only needed for DMA trace (like dma-copy).