### PR TITLE
Add missing header includes to init.c and IPC3 handler

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -34,7 +34,7 @@
 #include <ipc/trace.h>
 #if CONFIG_IPC_MAJOR_4
 #include <ipc4/fw_reg.h>
-#include <platform/lib/mailbox.h>
+#include <sof/lib/mailbox.h>
 #endif
 #ifdef CONFIG_ZEPHYR_LOG
 #include <zephyr/logging/log_ctrl.h>

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -8,6 +8,7 @@
 
 #include <rtos/bit.h>
 #include <rtos/string.h>
+#include <sof/lib/memory.h> /* PLATFORM_DCACHE_ALIGN */
 #include <sof/trace/trace.h>
 #include <user/trace.h>
 


### PR DESCRIPTION
Small series to fix header dependencies. Unrecovered while cleaning up RTOS headers and noticed these files won't compile unless e.g. trace.h pulls a bunch of common headers.