### PR TITLE
Zephyr preproc.h implementation (OPTION B)

### DIFF
--- a/posix/include/sof/compiler_attributes.h
+++ b/posix/include/sof/compiler_attributes.h
@@ -23,6 +23,10 @@
 #define __unused __attribute__((unused))
 #endif
 
+#ifndef __maybe_unused
+#define __maybe_unused __attribute__((unused))
+#endif
+
 #endif
 
 #ifndef __aligned

--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -239,7 +239,7 @@ static int module_adapter_ctrl_get_set_data(struct comp_dev *dev, struct sof_ipc
 					    bool set)
 {
 	int ret;
-	struct processing_module *mod = comp_mod(dev);
+	struct processing_module __maybe_unused *mod = comp_mod(dev);
 
 	comp_dbg(dev, "module_adapter_ctrl_set_data() start, state %d, cmd %d",
 		 mod->priv.state, cdata->cmd);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -283,9 +283,9 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	};
 
 #if !UNIT_TEST && !CONFIG_LIBRARY
-	int freq = clock_get_freq(cpu_get_id());
+	int __maybe_unused freq = clock_get_freq(cpu_get_id());
 #else
-	int freq = 0;
+	int __maybe_unused freq = 0;
 #endif
 	int ret;
 

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -203,7 +203,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 			void *spec_config)
 {
-	struct sof_ipc_dai_config *config = spec_config;
+	struct sof_ipc_dai_config __maybe_unused *config = spec_config;
 	bool comp_on_core[CONFIG_CORE_COUNT] = { false };
 	struct sof_ipc_reply reply;
 	struct ipc_comp_dev *icd;

--- a/src/trace/Kconfig
+++ b/src/trace/Kconfig
@@ -6,9 +6,12 @@ menu "Trace"
 
 config TRACE
 	bool "Trace"
+	default n if ZEPHYR_SOF_MODULE
 	default y
 	help
-	  Enabling traces. All traces (normal and error) are sent by dma.
+	  Enable SOF DMA based traces compatible with the sof-logger tool.
+	  With Zephyr, RTOS side events are not seen in the SOF trace, so native
+	  Zephyr logging (CONFIG_ZEPHYR_LOG) is recommended instead.
 
 config TRACEV
 	bool "Trace verbose"

--- a/xtos/include/sof/compiler_attributes.h
+++ b/xtos/include/sof/compiler_attributes.h
@@ -19,6 +19,10 @@
 #define __unused __attribute__((unused))
 #endif
 
+#ifndef __maybe_unused
+#define __maybe_unused __attribute__((unused))
+#endif
+
 #ifndef __aligned
 #define __aligned(x) __attribute__((__aligned__(x)))
 #endif

--- a/zephyr/include/sof/trace/preproc.h
+++ b/zephyr/include/sof/trace/preproc.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2024 Intel Corporation.
+ */
+
+#ifndef __SOF_TRACE_PREPROC_H__
+#define __SOF_TRACE_PREPROC_H__
+
+#ifdef CONFIG_TRACE
+#error "SOF dma-trace (CONFIG_TRACE) not supported in Zephyr builds. \
+	Please use CONFIG_ZEPHYR_LOG instead."
+#endif
+
+#ifndef CONFIG_ZEPHYR_LOG
+
+/*
+ * Unlike the XTOS version of this macro, this does not silence all
+ * compiler warnings about unused variables.
+ */
+#define SOF_TRACE_UNUSED(arg1, ...) ((void)arg1)
+
+#endif /* CONFIG_ZEPHYR_LOG */
+
+#endif /* __SOF_TRACE_PREPROC_H__ */


### PR DESCRIPTION
Alternative to pull request https://github.com/thesofproject/sof/pull/9598 and follow-up to discussion in https://github.com/thesofproject/sof/pull/9598#issuecomment-2425917932 .

This takes the decision to not support dma-trace (sof-logger) in Zephyr builds. and this allows to drop preproc.h family of preprocessor macro infra. In current CI, one IMX target is built with CONFIG_TRACE=n and CONFIG_ZEPHYR_LOG=n, and will hit build errors without the patches in this set to add maybe_unused attribute and a simple definition of SOF_TRACE_UNUSED().

Motivation for this work is #9015 and clean separate of XTOS and Zephyr headers.