### PR TITLE
[stable-v2.2] platform: tigerlake: increase ALH group count

### DIFF
--- a/src/platform/tigerlake/include/platform/lib/dai.h
+++ b/src/platform/tigerlake/include/platform/lib/dai.h
@@ -40,10 +40,10 @@
 /* ALH */
 
 /** \brief Number of ALH bi-directional links */
-#define DAI_NUM_ALH_BI_DIR_LINKS	16
+#define DAI_NUM_ALH_BI_DIR_LINKS	24
 
 /** \brief Number of contiguous ALH bi-dir links */
-#define DAI_NUM_ALH_BI_DIR_LINKS_GROUP	4
+#define DAI_NUM_ALH_BI_DIR_LINKS_GROUP	6
 
 #endif /* __PLATFORM_LIB_DAI_H__ */
 


### PR DESCRIPTION
The PCM bidirectional FIFO count is 6 for Tigerlake hardware.

Link: https://github.com/thesofproject/sof/issues/9571