### PR TITLE
Audio: Aria: Fix compilation for HiFi5

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -35,6 +35,18 @@ SOF_DEFINE_REG_UUID(aria);
 
 DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_uuid), LOG_LEVEL_INFO);
 
+/**
+ * \brief Aria gain index mapping table
+ */
+const int32_t sof_aria_index_tab[] = {
+		0,    1,    2,    3,
+		4,    5,    6,    7,
+		8,    9,    0,    1,
+		2,    3,    4,    5,
+		6,    7,    8,    9,
+		0,    1,    2,    3
+};
+
 static size_t get_required_emory(size_t chan_cnt, size_t smpl_group_cnt)
 {
 	/* Current implementation is able to apply 1 ms transition */
@@ -84,7 +96,7 @@ static inline void aria_process_data(struct processing_module *mod,
 	size_t sample_size = audio_stream_get_channels(source) * frames;
 
 	if (cd->att) {
-		aria_algo_calc_gain(cd, INDEX_TAB[cd->gain_state + 1], source, frames);
+		aria_algo_calc_gain(cd, sof_aria_index_tab[cd->gain_state + 1], source, frames);
 		cd->aria_get_data(mod, sink, frames);
 	} else {
 		/* bypass processing gets unprocessed data from buffer */

--- a/src/audio/aria/aria.h
+++ b/src/audio/aria/aria.h
@@ -80,8 +80,6 @@ struct aria_data {
 	aria_get_data_func aria_get_data;
 };
 
-extern const uint8_t INDEX_TAB[];
-
 struct ipc4_aria_module_cfg {
 	struct ipc4_base_module_cfg base_cfg;
 	uint32_t attenuation;

--- a/src/audio/aria/aria_generic.c
+++ b/src/audio/aria/aria_generic.c
@@ -6,17 +6,7 @@
 
 #if SOF_USE_HIFI(NONE, ARIA)
 
-/**
- * \brief Aria gain index mapping table
- */
-const uint8_t INDEX_TAB[] = {
-		0,    1,    2,    3,
-		4,    5,    6,    7,
-		8,    9,    0,    1,
-		2,    3,    4,    5,
-		6,    7,    8,    9,
-		0,    1,    2,    3
-};
+extern const int32_t sof_aria_index_tab[];
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 				struct audio_stream *source, int frames)
@@ -54,9 +44,9 @@ static void aria_algo_get_data(struct processing_module *mod,
 	int32_t step, in_sample;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
-	int32_t gain_begin = cd->gains[INDEX_TAB[gain_state_add_2]];
+	int32_t gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2]];
 	/* do linear approximation between points gain_begin and gain_end */
-	int32_t gain_end = cd->gains[INDEX_TAB[gain_state_add_3]];
+	int32_t gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3]];
 	int32_t m, n, i, ch;
 	int32_t samples = frames * audio_stream_get_channels(sink);
 	int32_t *out = audio_stream_get_wptr(sink);
@@ -66,10 +56,10 @@ static void aria_algo_get_data(struct processing_module *mod,
 	const int shift = 31 - cd->att;
 
 	for (i = 1; i < ARIA_MAX_GAIN_STATES - 1; i++) {
-		if (cd->gains[INDEX_TAB[gain_state_add_2 + i]] < gain_begin)
-			gain_begin = cd->gains[INDEX_TAB[gain_state_add_2 + i]];
-		if (cd->gains[INDEX_TAB[gain_state_add_3 + i]] < gain_end)
-			gain_end = cd->gains[INDEX_TAB[gain_state_add_3 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_2 + i]] < gain_begin)
+			gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_3 + i]] < gain_end)
+			gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3 + i]];
 	}
 	step = (gain_end - gain_begin) / frames;
 	gain = gain_begin;
@@ -91,7 +81,7 @@ static void aria_algo_get_data(struct processing_module *mod,
 		in = cir_buf_wrap(in, cd->data_addr, cd->data_end);
 		out = audio_stream_wrap(sink, out);
 	}
-	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
+	cd->gain_state = sof_aria_index_tab[cd->gain_state + 1];
 }
 
 aria_get_data_func aria_algo_get_data_func(struct processing_module *mod)

--- a/src/audio/aria/aria_hifi3.c
+++ b/src/audio/aria/aria_hifi3.c
@@ -8,17 +8,7 @@
 #include <xtensa/config/defs.h>
 #include <xtensa/tie/xt_hifi3.h>
 
-/**
- * \brief Aria gain index mapping table
- */
-const uint8_t INDEX_TAB[] = {
-		0,    1,    2,    3,
-		4,    5,    6,    7,
-		8,    9,    0,    1,
-		2,    3,    4,    5,
-		6,    7,    8,    9,
-		0,    1,    2,    3
-};
+extern const int32_t sof_aria_index_tab[];
 
 inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 				struct audio_stream *source, int frames)
@@ -69,9 +59,9 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
-	int32_t gain_begin = cd->gains[INDEX_TAB[gain_state_add_2]];
+	int32_t gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2]];
 	/* do linear approximation between points gain_begin and gain_end */
-	int32_t gain_end = cd->gains[INDEX_TAB[gain_state_add_3]];
+	int32_t gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3]];
 	size_t samples = frames * audio_stream_get_channels(sink);
 	ae_int32x2 *out = audio_stream_get_wptr(sink);
 	ae_int32x2 *in = (ae_int32x2 *)cd->data_ptr;
@@ -85,10 +75,10 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 	ae_int64 out1;
 
 	for (i = 1; i < ARIA_MAX_GAIN_STATES - 1; i++) {
-		if (cd->gains[INDEX_TAB[gain_state_add_2 + i]] < gain_begin)
-			gain_begin = cd->gains[INDEX_TAB[gain_state_add_2 + i]];
-		if (cd->gains[INDEX_TAB[gain_state_add_3 + i]] < gain_end)
-			gain_end = cd->gains[INDEX_TAB[gain_state_add_3 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_2 + i]] < gain_begin)
+			gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_3 + i]] < gain_end)
+			gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3 + i]];
 	}
 
 	step = (gain_end - gain_begin) / frames;
@@ -115,7 +105,7 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 		in = cir_buf_wrap(in, cd->data_addr, cd->data_end);
 		out = audio_stream_wrap(sink, out);
 	}
-	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
+	cd->gain_state = sof_aria_index_tab[cd->gain_state + 1];
 }
 
 static void aria_algo_get_data_even_channel(struct processing_module *mod,
@@ -127,9 +117,9 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
-	int32_t gain_begin = cd->gains[INDEX_TAB[gain_state_add_2]];
+	int32_t gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2]];
 	/* do linear approximation between points gain_begin and gain_end */
-	int32_t gain_end = cd->gains[INDEX_TAB[gain_state_add_3]];
+	int32_t gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3]];
 	size_t samples = frames * audio_stream_get_channels(sink);
 	ae_int32x2 *out = audio_stream_get_wptr(sink);
 	ae_int32x2 *in = (ae_int32x2 *)cd->data_ptr;
@@ -142,10 +132,10 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 	ae_int64 out1, out2;
 
 	for (i = 1; i < ARIA_MAX_GAIN_STATES - 1; i++) {
-		if (cd->gains[INDEX_TAB[gain_state_add_2 + i]] < gain_begin)
-			gain_begin = cd->gains[INDEX_TAB[gain_state_add_2 + i]];
-		if (cd->gains[INDEX_TAB[gain_state_add_3 + i]] < gain_end)
-			gain_end = cd->gains[INDEX_TAB[gain_state_add_3 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_2 + i]] < gain_begin)
+			gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_3 + i]] < gain_end)
+			gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3 + i]];
 	}
 
 	step = (gain_end - gain_begin) / frames;
@@ -174,7 +164,7 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 		in = cir_buf_wrap(in, cd->data_addr, cd->data_end);
 		out = audio_stream_wrap(sink, out);
 	}
-	cd->gain_state = INDEX_TAB[cd->gain_state + 1];
+	cd->gain_state = sof_aria_index_tab[cd->gain_state + 1];
 }
 
 aria_get_data_func aria_algo_get_data_func(struct processing_module *mod)

--- a/src/audio/aria/aria_hifi5.c
+++ b/src/audio/aria/aria_hifi5.c
@@ -8,17 +8,7 @@
 #include <xtensa/config/defs.h>
 #include <xtensa/tie/xt_hifi5.h>
 
-/**
- * \brief Aria gain index mapping table
- */
-static const int32_t index_tab[] = {
-		0,    1,    2,    3,
-		4,    5,    6,    7,
-		8,    9,    0,    1,
-		2,    3,    4,    5,
-		6,    7,    8,    9,
-		0,    1,    2,    3
-};
+extern const int32_t sof_aria_index_tab[];
 
 /* Setup circular buffer 0 */
 static inline void set_circular_buf0(const void *start, const void *end)
@@ -47,7 +37,7 @@ inline void aria_algo_calc_gain(struct aria_data *cd, size_t gain_idx,
 	int32_t *max_ptr = (int32_t *)&max_data;
 	int32_t max;
 	int samples = frames * audio_stream_get_channels(source);
-	ae_int32x2 *in = audio_stream_get_rptr(source);
+	ae_int32x4 *in = audio_stream_get_rptr(source);
 	int i, n, left;
 
 	while (samples) {
@@ -81,13 +71,13 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 					   int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
-	size_t i, n, ch;
+	size_t i, ch;
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
-	int32_t gain_begin = cd->gains[index_tab[gain_state_add_2]];
+	int32_t gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2]];
 	/* do linear approximation between points gain_begin and gain_end */
-	int32_t gain_end = cd->gains[index_tab[gain_state_add_3]];
+	int32_t gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3]];
 	ae_int32 *out = audio_stream_get_wptr(sink);
 	ae_int32 *in = (ae_int32 *)cd->data_ptr;
 	ae_int32x2 in_sample, out_sample;
@@ -98,10 +88,10 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 	ae_int64 out1;
 
 	for (i = 1; i < ARIA_MAX_GAIN_STATES - 1; i++) {
-		if (cd->gains[index_tab[gain_state_add_2 + i]] < gain_begin)
-			gain_begin = cd->gains[index_tab[gain_state_add_2 + i]];
-		if (cd->gains[index_tab[gain_state_add_3 + i]] < gain_end)
-			gain_end = cd->gains[index_tab[gain_state_add_3 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_2 + i]] < gain_begin)
+			gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_3 + i]] < gain_end)
+			gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3 + i]];
 	}
 
 	step = (gain_end - gain_begin) / frames;
@@ -122,7 +112,7 @@ static void aria_algo_get_data_odd_channel(struct processing_module *mod,
 		gain = AE_ADD32S(gain, step);
 	}
 
-	cd->gain_state = index_tab[cd->gain_state + 1];
+	cd->gain_state = sof_aria_index_tab[cd->gain_state + 1];
 }
 
 static void aria_algo_get_data_even_channel(struct processing_module *mod,
@@ -130,14 +120,13 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 					    int frames)
 {
 	struct aria_data *cd = module_get_private_data(mod);
-	size_t i, m, n, ch;
+	size_t i, ch;
 	ae_int32x2 step;
 	int32_t gain_state_add_2 = cd->gain_state + 2;
 	int32_t gain_state_add_3 = cd->gain_state + 3;
-	int32_t gain_begin = cd->gains[index_tab[gain_state_add_2]];
+	int32_t gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2]];
 	/* do linear approximation between points gain_begin and gain_end */
-	int32_t gain_end = cd->gains[index_tab[gain_state_add_3]];
-	size_t samples = frames * audio_stream_get_channels(sink);
+	int32_t gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3]];
 	ae_int32x2 *out = audio_stream_get_wptr(sink);
 	ae_int32x2 *in = (ae_int32x2 *)cd->data_ptr;
 	ae_int32x2 in_sample, out_sample;
@@ -148,10 +137,10 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 	ae_int64 out1, out2;
 
 	for (i = 1; i < ARIA_MAX_GAIN_STATES - 1; i++) {
-		if (cd->gains[index_tab[gain_state_add_2 + i]] < gain_begin)
-			gain_begin = cd->gains[index_tab[gain_state_add_2 + i]];
-		if (cd->gains[index_tab[gain_state_add_3 + i]] < gain_end)
-			gain_end = cd->gains[index_tab[gain_state_add_3 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_2 + i]] < gain_begin)
+			gain_begin = cd->gains[sof_aria_index_tab[gain_state_add_2 + i]];
+		if (cd->gains[sof_aria_index_tab[gain_state_add_3 + i]] < gain_end)
+			gain_end = cd->gains[sof_aria_index_tab[gain_state_add_3 + i]];
 	}
 
 	step = (gain_end - gain_begin) / frames;
@@ -173,7 +162,7 @@ static void aria_algo_get_data_even_channel(struct processing_module *mod,
 		}
 		gain = AE_ADD32S(gain, step);
 	}
-	cd->gain_state = index_tab[cd->gain_state + 1];
+	cd->gain_state = sof_aria_index_tab[cd->gain_state + 1];
 }
 
 aria_get_data_func aria_algo_get_data_func(struct processing_module *mod)


### PR DESCRIPTION
In aria_hifi5.c

- The needed type for "in" in AE_LA32X2X2_IP() needs to be ae_int32x4. The HiFi5 code was likely developed with an earlier toolchain that used different type.
- Removed unused declared variables, warnings are errors in testbench build.
- Changed index_tab to common sof_aria_index_tab[]

In aria_generic.c, hifi3 changed INDEX_TAB[] to a common sof_aria_index_tab[]. It avoids link error in HiFi5 build where aria.c is missing the INDEX_TAB[].

The sof_aria_index_tab[] is changed from uint8_t to int32_t type to use the same table in every build.