### PR TITLE
topology2: sdw-amp-generic: Fix missing channel config for amp feedback

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -413,16 +413,22 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 						# 32-bit 48KHz 2ch
 						Object.Base.input_audio_format [
 							{
+								in_channels		2
 								in_bit_depth            32
 								in_valid_bit_depth      $SDW_LINK_VALID_BITS
+								in_ch_cfg		$CHANNEL_CONFIG_STEREO
+								in_ch_map		$CHANNEL_MAP_STEREO
 								in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 								in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 							}
 						]
 						Object.Base.output_audio_format [
 							{
+								out_channels		2
 								out_bit_depth            32
 								out_valid_bit_depth      32
+								out_ch_cfg		$CHANNEL_CONFIG_STEREO
+								out_ch_map		$CHANNEL_MAP_STEREO
 							}
 						]
 					}


### PR DESCRIPTION
Provide channel count and map for the amp feedback alh-copier when NUM_SDW_AMP_LINKS=1.

This fixes audio corruption that produced a "metallic" sound to the captured audio and dropped samples.

The case for NUM_SDW_AMP_LINKS=2 specified in_channels, in_ch_config, in_ch_map, out_channels, out_ch_config and out_ch_map. But these were missing from the case for NUM_SDW_AMP_LINKS=1.