### PR TITLE
Tools: Testbench: Fix ibs/obs calculation

### DIFF
--- a/tools/testbench/include/testbench/utils.h
+++ b/tools/testbench/include/testbench/utils.h
@@ -137,7 +137,7 @@ struct testbench_prm {
 	struct tplg_pcm_info *pcm_info;
 	struct tb_config config[TB_MAX_CONFIG_COUNT];
 	int num_configs;
-	size_t period_size;
+	int period_frames;
 	struct tb_glb_state glb_ctx;
 #endif
 };

--- a/tools/testbench/topology_ipc4.c
+++ b/tools/testbench/topology_ipc4.c
@@ -272,6 +272,7 @@ int tb_match_audio_format(struct testbench_prm *tp, struct tplg_comp_info *comp_
 	struct ipc4_base_module_cfg *base_cfg = &comp_info->basecfg;
 	struct sof_ipc4_pin_format *fmt;
 	int config_valid_bits;
+	int sample_bytes;
 	int i;
 
 	switch (config->format) {
@@ -326,8 +327,9 @@ out:
 		(fmt->audio_fmt.fmt_cfg & MASK(15, 8)) >> 8;
 	base_cfg->audio_fmt.s_type =
 		(fmt->audio_fmt.fmt_cfg & MASK(23, 16)) >> 16;
-	base_cfg->ibs = tp->period_size * 2;
-	base_cfg->obs = tp->period_size * 2;
+	sample_bytes = fmt->audio_fmt.bit_depth >> 3;
+	base_cfg->ibs = 2 * tp->period_frames * base_cfg->audio_fmt.channels_count * sample_bytes;
+	base_cfg->obs = base_cfg->ibs;
 
 	return 0;
 }

--- a/tools/testbench/utils_ipc4.c
+++ b/tools/testbench/utils_ipc4.c
@@ -125,7 +125,7 @@ int tb_setup(struct sof *sof, struct testbench_prm *tp)
 	tp->config[0].rate = tp->fs_in;
 	tp->config[0].channels = tp->channels_in;
 	tp->config[0].format = tp->frame_fmt;
-	tp->period_size = 2 * krate;
+	tp->period_frames = krate;
 
 	/* TODO: Need to set this later for larger topologies with multiple PCMs. The
 	 * pipelines are determined based on just the PCM ID for the device that we


### PR DESCRIPTION
The previous ibs and obs calculate was wrong but it appeared to work since not many components use it. The issue was seen with Aria. Since the ibs depends on audio frame format and number of frames in period, the testbench parameter period_size is changed to period_frames to calculate ibs and obs in component setup.

This fix is a workaround until parsing ibs/obs from topology is done to testbench.