### PR TITLE
Support a larger range of amp feedback channel counts

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -8,6 +8,7 @@ Define {
 	SDW_AMP_BE_ID 2
 	SDW_AMP_IN_BE_ID 3
 	AMP_FEEDBACK_CH 2
+	AMP_FEEDBACK_CH_PER_LINK 2
 	SDW_AMP_FEEDBACK true
 }
 
@@ -181,6 +182,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 "2"	{
 		Define {
 			AMP_FEEDBACK_CH 4
+			AMP_FEEDBACK_CH_PER_LINK 2
 		}
 
 		Object.Widget {
@@ -353,7 +355,7 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 				name		$SDW_SPK_IN_STREAM
 				default_hw_conf_id	1
 				rate			48000
-				channels		2
+				channels		$AMP_FEEDBACK_CH_PER_LINK
 
 				Object.Base.hw_config.1 {
 					id	1
@@ -386,47 +388,45 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					num_output_audio_formats 1
 					num_output_pins 1
 
-					IncludeByKey.NUM_SDW_AMP_LINKS {
-					"2"	{
-							Object.Base.input_audio_format [
-								{
-									in_channels		4
-									in_bit_depth		32
-									in_valid_bit_depth	$SDW_LINK_VALID_BITS
+					Object.Base.input_audio_format [
+						{
+							in_channels		$AMP_FEEDBACK_CH
+							in_bit_depth		32
+							in_valid_bit_depth	$SDW_LINK_VALID_BITS
+
+							IncludeByKey.AMP_FEEDBACK_CH {
+								"2" {
+									in_ch_cfg	$CHANNEL_CONFIG_STEREO
+									in_ch_map	$CHANNEL_MAP_STEREO
+								}
+								"4" {
 									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									in_ch_map	$CHANNEL_MAP_3_POINT_1
-									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-									in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
 								}
-							]
-							Object.Base.output_audio_format [
-								{
-									out_channels		4
-									out_bit_depth		32
-									out_valid_bit_depth	32
+							}
+
+							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+							in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
+						}
+					]
+					Object.Base.output_audio_format [
+						{
+							out_channels		$AMP_FEEDBACK_CH
+							out_bit_depth		32
+							out_valid_bit_depth	32
+
+							IncludeByKey.AMP_FEEDBACK_CH {
+								"2" {
+									out_ch_cfg	$CHANNEL_CONFIG_STEREO
+									out_ch_map	$CHANNEL_MAP_STEREO
+								}
+								"4" {
 									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									out_ch_map	$CHANNEL_MAP_3_POINT_1
 								}
-							]
+							}
 						}
-					"1"	{
-						# 32-bit 48KHz 2ch
-						Object.Base.input_audio_format [
-							{
-								in_bit_depth            32
-								in_valid_bit_depth      $SDW_LINK_VALID_BITS
-								in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-								in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
-							}
-						]
-						Object.Base.output_audio_format [
-							{
-								out_bit_depth            32
-								out_valid_bit_depth      32
-							}
-						]
-					}
-					}
+					]
 				}
 			]
 			pipeline [

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -371,6 +371,81 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 					Object.Widget.host-copier.1 {
 						stream_name	"amp feedback"
 						pcm_id 3
+
+						IncludeByKey.AMP_FEEDBACK_CH {
+						"6" {
+							num_input_audio_formats 1
+							num_output_audio_formats 3
+							Object.Base.input_audio_format [
+								{
+									in_channels		6
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									in_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_channels		6
+									out_bit_depth		32
+									out_valid_bit_depth	24
+									out_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									out_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+								{
+									out_channels		6
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									out_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+								{
+									out_channels		6
+									out_bit_depth		16
+									out_valid_bit_depth	16
+									out_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									out_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+							]
+						}
+						"8" {
+							num_input_audio_formats 1
+							num_output_audio_formats 3
+							Object.Base.input_audio_format [
+								{
+									in_channels		8
+									in_bit_depth		32
+									in_valid_bit_depth	32
+									in_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									in_ch_map	$CHANNEL_MAP_7_POINT_1
+								}
+							]
+							Object.Base.output_audio_format [
+								{
+									out_channels		8
+									out_bit_depth		32
+									out_valid_bit_depth	24
+									out_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									out_ch_map	$CHANNEL_MAP_7_POINT_1
+								}
+								{
+									out_channels		8
+									out_bit_depth		32
+									out_valid_bit_depth	32
+									out_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									out_ch_map	$CHANNEL_MAP_7_POINT_1
+								}
+								{
+									out_channels		8
+									out_bit_depth		16
+									out_valid_bit_depth	16
+									out_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									out_ch_map	$CHANNEL_MAP_7_POINT_1
+								}
+							]
+						}
+						}
 					}
 				}
 			]
@@ -403,6 +478,14 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 									in_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									in_ch_map	$CHANNEL_MAP_3_POINT_1
 								}
+								"6" {
+									in_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									in_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+								"8" {
+									in_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									in_ch_map	$CHANNEL_MAP_7_POINT_1
+								}
 							}
 
 							in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
@@ -423,6 +506,14 @@ IncludeByKey.SDW_AMP_FEEDBACK {
 								"4" {
 									out_ch_cfg	$CHANNEL_CONFIG_3_POINT_1
 									out_ch_map	$CHANNEL_MAP_3_POINT_1
+								}
+								"6" {
+									out_ch_cfg	$CHANNEL_CONFIG_5_POINT_1
+									out_ch_map	$CHANNEL_MAP_5_POINT_1
+								}
+								"8" {
+									out_ch_cfg	$CHANNEL_CONFIG_7_POINT_1
+									out_ch_map	$CHANNEL_MAP_7_POINT_1
 								}
 							}
 						}


### PR DESCRIPTION
These two patches expand the possible combinations of feedback channel count and number of links.

It has been tested on these combinations:

1 bus, 2 amps, 1 fb channel per amp, total 2 channels
1 bus, 2 amps, 2 fb channel per amp, total 4 channels
1 bus, 4 amps, 1 fb channel per amp, total 4 channels

2 buses, 1 amp per bus, 1 fb channel per amp, total 2 channels
2 buses, 1 amp per bus, 2 fb channel per amp, total 4 channels
2 buses, 1 amp per bus, 4 fb channel per amp, total 8 channels
2 buses, 2 amp per bus, 1 fb channel per amp, total 4 channels
2 buses, 2 amp per bus, 2 fb channel per amp, total 8 channels
2 buses, 3 amp per bus, 1 fb channel per amp, total 6 channels
2 buses, 4 amp per bus, 1 fb channel per amp, total 8 channels