### PR TITLE
zephyr: move to strict headers builds for all targets

### DIFF
--- a/smex/CMakeLists.txt
+++ b/smex/CMakeLists.txt
@@ -32,8 +32,6 @@ target_include_directories(smex PRIVATE
 )
 
 # TODO: smex should not need RTOS headers: FIX.
-if (NOT CONFIG_SOF_ZEPHYR_STRICT_HEADERS)
 target_include_directories(smex PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/xtos/include"
 )
-endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -158,15 +158,7 @@ target_include_directories(SOF INTERFACE ${RIMAGE_TOP}/src/include)
 target_include_directories(SOF INTERFACE ${SOF_SRC_PATH}/include)
 target_include_directories(SOF INTERFACE ${SOF_SRC_PATH}/arch/${ARCH}/include)
 target_include_directories(SOF INTERFACE ${sof_top_dir}/third_party/include)
-
-# TODO: Zephyr should not need xtos headers: FIX.
-if (CONFIG_SOF_ZEPHYR_STRICT_HEADERS)
-	target_include_directories(SOF INTERFACE ${sof_top_dir}/zephyr/include)
-else()
-	# include Zephyr before xtos to flag up any errors in SOF
-	target_include_directories(SOF INTERFACE ${sof_top_dir}/zephyr/include)
-	target_include_directories(SOF INTERFACE ${sof_top_dir}/${PLATFORM_HEADERS}/include)
-endif()
+target_include_directories(SOF INTERFACE ${sof_top_dir}/zephyr/include)
 
 # SOF module init
 zephyr_library_named(modules_sof)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -18,16 +18,6 @@ config ZEPHYR_NATIVE_DRIVERS
 	  dai-zephyr
 	  will be used instead of legacy xtos version.
 
-config SOF_ZEPHYR_STRICT_HEADERS
-	bool "Experimental: Force build with Zephyr RTOS headers only"
-	default n
-	help
-	  This is a transitional option that allows developers to test builds
-	  only using the Zephyr RTOS headers. This will eventually become the
-	  default header configuration when native Zephyr is ready and this menu
-	  choice will be removed.
-	  If unsure, say n.
-
 config DMA_DOMAIN
 	bool "Enable the usage of DMA domain."
 	default y if IMX8M


### PR DESCRIPTION
Remove CONFIG_SOF_ZEPHYR_STRICT_HEADERS and make strict headers mode the only supported way to build SOF with Zephyr. This means SOF Zephyr builds do not use any headers from sof/xtos/include anymore.

This change simplifies the SOF build as full RTOS adaptation is in sof/zephyr/include for Zephyr builds.

Link: https://github.com/thesofproject/sof/issues/9015