### PR TITLE
topology2: rename sof-arl-rt722-l0-rt1320-l2

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -106,7 +106,7 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
-"cavs-sdw\;sof-arl-rt722-l0-rt1320-l2\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+"cavs-sdw\;sof-arl-rt722-l0_rt1320-l2\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 


### PR DESCRIPTION
The file name defined in the Linux kernel is
sof-arl-rt722-l0_rt1320-l2.tplg.

The kernel code is [.sof_tplg_filename = "sof-arl-rt722-l0_rt1320-l2.tplg",](https://github.com/thesofproject/linux/blob/topic/sof-dev/sound/soc/intel/common/soc-acpi-intel-arl-match.c#L449)