### PR TITLE
[TEST ONLY] test redundant .bss removal

### DIFF
--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -195,10 +195,14 @@ cd_fail:
 	return ret;
 }
 
+/* test .bss */
+static unsigned int config_count;
+
 static int drc_free(struct processing_module *mod)
 {
 	struct drc_comp_data *cd = module_get_private_data(mod);
 
+	comp_info(mod->dev, "configured %u times", config_count);
 	comp_data_blob_handler_free(cd->model_handler);
 	rfree(cd);
 	return 0;
@@ -212,6 +216,7 @@ static int drc_set_config(struct processing_module *mod, uint32_t param_id,
 	struct drc_comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 
+	config_count++;
 	comp_dbg(dev, "drc_set_config()");
 
 #if CONFIG_IPC_MAJOR_4

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -144,7 +144,8 @@ static int llext_manager_load_module(uint32_t module_id, const struct sof_man_mo
 			/* .bss directly in front of writable data and properly aligned, prepend */
 			va_base_data = bss_addr;
 			data_size += bss_size;
-		} else if ((uintptr_t)bss_addr == (uintptr_t)va_base_data + data_size) {
+		} else if ((uintptr_t)bss_addr == (uintptr_t)va_base_data +
+			   ALIGN_UP(data_size, 4)) {
 			/* .bss directly behind writable data, append */
 			data_size += bss_size;
 		} else {

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 155f3f3ba688dac3e1113ada3f9cfa894612f951
+      revision: pull/80931/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Verify that removing redundant .bss in Zephyr LLEXT doesn't break SOF LLEXT .bss.