### PR TITLE
zephyr: enable HIFI_SHARING if DP scheduler is enabled with HIFI

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -49,6 +49,7 @@ config ZEPHYR_DP_SCHEDULER
 	depends on ZEPHYR_SOF_MODULE
 	depends on ACE
 	depends on PIPELINE_2_0
+	imply XTENSA_HIFI_SHARING if XTENSA_HIFI
 	help
 	  Enable Data Processing preemptive scheduler based on
 	  Zephyr preemptive threads.


### PR DESCRIPTION
If data processing (DP) scheduler is enabled on Xtensa HiFi platforms, CONFIG_HIFI_SHARING should be enabled as well. Otherwise modules running via DP scheduler cannot use HiFi extensions (as the HiFi register state is not saved and restored on context switches).