### PR TITLE
west.yml: update Zephyr to c50777a84311 (Zephyr Nov 11 update)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 155f3f3ba688dac3e1113ada3f9cfa894612f951
+      revision: c50777a8431157bd4ab3a2c2e2a37e8151ae07da
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Includes the following changes potentially relevant to SOF:

ac162b041abf intel_adsp: set exec for simulator targets
475878428c11 soc: intel_adsp: tools: cavstool.py: add RPL and ADL-N support
7ad012d3bbd1 soc: intel_adsp: tools: sort cAVS2.5 PCI DIDs in cavstool.py
2c79024b2f71 soc: intel_adsp: tools: cavstool.py: add PCI DIDs for Intel Arrow Lake
8795a17fa210 soc: intel_adsp: tools: reword cavstool.py startup log message
52bd2ff9a6ca soc: intel_adsp: tools: continue cavstool.py legacy cleanup
cdd563500292 nxp: imx8m: adsp: enable the irqstr interrupt controller
18419b618f20 llext: xtensa: fix relocations with multiple SLOT0_OP
d3aa1709631b drivers: dai: sai: support pm runtime operations
52efa3bb9b8a soc: intel_adsp: tools: fix ace15 ROM status check in cavstool.py
256ab0c9191c ace: mm: tlb: Check tlb translation enabled before flushing cache
0e9b9b0cf304 ace: mm: tlb: Ignore unmappig error in driver initalization
e8d28bfdfd15 drivers: dai: sai: disable IRQs when not needed
48b98a9284c3 drivers: dma: dma_nxp_edma: disable IRQs when not needed
c7be48aae42b drivers: intc: irqstr: manage dispatchers dynamically
d274cabf839c drivers: intc: irqstr: add reference count for IRQs
b43e7387db4d tests: mem_map: no exec test for intel_adsp/ace30/ptl
3d65839dbc58 tests: rename intel_adsp_ace30.conf to intel_adsp_ace30_ptl.conf
32f9ecacc429 soc: intel_adsp: tools: cavstool.py: Add debug_slot_offset_by_type()
80e629cd974a soc: intel_adsp: tools: cavstool.py: Add debug_slot_offset()
9563960bde37 soc: intel_adsp: tools: cavstool: Fix fw_is_alive() and wait_fw_entered()
91495812bdb5 soc: intel_adsp: tools: cavstool.py: Make map_regs() shareable
c2126cb90686 soc: intel_adsp: tools: cavstool.py: argsparse code to separate function