### PR TITLE
audio: chain_dma: update build time dependencies

### DIFF
--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -52,6 +52,7 @@ config COMP_CHAIN_DMA
 	  bool "Chain DMA component"
 	  default n
 	  depends on IPC_MAJOR_4
+	  depends on DMA_INTEL_ADSP_HDA
 	  help
 	    Chain DMA support in hardware
 


### PR DESCRIPTION
Add explicit dependency to CONFIG_DMA_INTEL_ADSP_HDA as the current chain DMA uses HDA definitions in its implementation.