### PR TITLE
platform: intel: drop PLATFORM_DEFAULT_DELAY from platform.h

### DIFF
--- a/src/platform/ace30/include/platform/platform.h
+++ b/src/platform/ace30/include/platform/platform.h
@@ -34,9 +34,6 @@
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	(HOST_PAGE_SIZE * 2)
 
-/* DSP default delay in cycles */
-#define PLATFORM_DEFAULT_DELAY	12
-
 #endif /* __PLATFORM_PLATFORM_H__ */
 
 #else

--- a/src/platform/lunarlake/include/platform/platform.h
+++ b/src/platform/lunarlake/include/platform/platform.h
@@ -34,9 +34,6 @@
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	(HOST_PAGE_SIZE * 2)
 
-/* DSP default delay in cycles */
-#define PLATFORM_DEFAULT_DELAY	12
-
 #endif /* __PLATFORM_PLATFORM_H__ */
 
 #else

--- a/src/platform/meteorlake/include/platform/platform.h
+++ b/src/platform/meteorlake/include/platform/platform.h
@@ -34,9 +34,6 @@
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	(HOST_PAGE_SIZE * 2)
 
-/* DSP default delay in cycles */
-#define PLATFORM_DEFAULT_DELAY	12
-
 #endif /* __PLATFORM_PLATFORM_H__ */
 
 #else

--- a/src/platform/tigerlake/include/platform/platform.h
+++ b/src/platform/tigerlake/include/platform/platform.h
@@ -41,9 +41,6 @@ struct timer;
 /* local buffer size of DMA tracing */
 #define DMA_TRACE_LOCAL_SIZE	(HOST_PAGE_SIZE * 2)
 
-/* DSP default delay in cycles */
-#define PLATFORM_DEFAULT_DELAY	12
-
 extern intptr_t _module_init_start;
 extern intptr_t _module_init_end;
 


### PR DESCRIPTION
PLATFORM_DEFAULT_DELAY is not needed in Zephyr builds, so it can be dropped from platform.h for all Intel platforms.