### PR TITLE
ext_manifest: include probe information by CONFIG_PROBE

### DIFF
--- a/src/init/ext_manifest.c
+++ b/src/init/ext_manifest.c
@@ -60,6 +60,7 @@ const struct ext_man_cc_version ext_man_cc_ver
 	},
 };
 
+#if CONFIG_PROBE
 const struct ext_man_probe_support ext_man_probe
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {
 	.hdr.type = EXT_MAN_ELEM_PROBE_INFO,
@@ -69,12 +70,11 @@ const struct ext_man_probe_support ext_man_probe
 		.ext_hdr.hdr.size = sizeof(struct sof_ipc_probe_support),
 		.ext_hdr.hdr.cmd = SOF_IPC_FW_READY,
 		.ext_hdr.type = SOF_IPC_EXT_PROBE_INFO,
-#if CONFIG_PROBE
 		.probe_points_max = CONFIG_PROBE_POINTS_MAX,
 		.injection_dmas_max = CONFIG_PROBE_DMA_MAX
-#endif
 	},
 };
+#endif
 
 const struct ext_man_dbg_abi ext_man_dbg_info
 	__aligned(EXT_MAN_ALIGN) __section(".fw_metadata") = {


### PR DESCRIPTION
Put probe information into manifest by CONFIG_PROBE=y would be better.

This change could help to avoid annoying kernel log from SOF loader ("unknown sof_ext_man header type 3 size 0x30") if CONFIG_PROBE=n on most SOF machines.