### PR TITLE
LLEXT: libraries with multiple modules

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -475,7 +475,7 @@ static const struct module_interface demux_interface = {
 DECLARE_MODULE_ADAPTER(demux_interface, demux_uuid, demux_tr);
 SOF_MODULE_INIT(demux, sys_comp_module_demux_interface_init);
 
-#if CONFIG_COMP_VOLUME_MODULE
+#if CONFIG_COMP_MUX_MODULE
 /* modular: llext dynamic link */
 
 #include <module/module/api_ver.h>
@@ -486,13 +486,21 @@ SOF_MODULE_INIT(demux, sys_comp_module_demux_interface_init);
 		0xE2, 0xA2, 0xF4, 0x2E, 0x30, 0x69
 SOF_LLEXT_MOD_ENTRY(mux, &mux_interface);
 
-#define UUID_DEMUX 0x68, 0x68, 0xB2, 0xC4, 0x30, 0x14, 0x0E, 0x47, 0x89, 0xA0, \
-		0x15, 0xD1, 0xC7, 0x7F, 0x85, 0x1A
-SOF_LLEXT_MOD_ENTRY(demux, &demux_interface);
+/*
+ * The demux entry is removed because mtl.toml doesn't have an entry
+ * for it. Once that is fixed, the manifest line below can be
+ * re-activated:
+ * #define UUID_DEMUX 0x68, 0x68, 0xB2, 0xC4, 0x30, 0x14, 0x0E, 0x47, 0x89, 0xA0, \
+ *		0x15, 0xD1, 0xC7, 0x7F, 0x85, 0x1A
+ * SOF_LLEXT_MOD_ENTRY(demux, &demux_interface);
+ */
 
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
 	SOF_LLEXT_MODULE_MANIFEST("MUX", mux_llext_entry, 1, UUID_MUX, 15),
-	SOF_LLEXT_MODULE_MANIFEST("DEMUX", demux_llext_entry, 1, UUID_DEMUX, 15),
+	/*
+	 * See comment above for a demux deactivation reason
+	 * SOF_LLEXT_MODULE_MANIFEST("DEMUX", demux_llext_entry, 1, UUID_DEMUX, 15),
+	 */
 };
 
 SOF_LLEXT_BUILDINFO;

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -95,10 +95,16 @@ struct lib_manager_segment_desc {
 	size_t size;
 };
 
-struct lib_manager_mod_ctx {
-	void *base_addr;
+struct lib_manager_module {
+	unsigned int start_idx;
 	const struct sof_man_module_manifest *mod_manifest;
 	struct lib_manager_segment_desc segment[LIB_MANAGER_N_SEGMENTS];
+};
+
+struct lib_manager_mod_ctx {
+	void *base_addr;
+	unsigned int n_mod;
+	struct lib_manager_module *mod;
 };
 
 struct ext_library {

--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -316,26 +316,26 @@ uintptr_t llext_manager_allocate_module(struct processing_module *proc,
 {
 	uint32_t module_id = IPC4_MOD_ID(ipc_config->id);
 	struct sof_man_fw_desc *desc = (struct sof_man_fw_desc *)lib_manager_get_library_manifest(module_id);
-	struct sof_man_module *mod_array;
-	int ret;
-	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
 	struct lib_manager_mod_ctx *ctx = lib_manager_get_mod_ctx(module_id);
-	const struct sof_module_api_build_info *buildinfo;
-	const struct sof_man_module_manifest *mod_manifest;
-	size_t mod_size = desc->header.preload_page_count * PAGE_SZ - FILE_TEXT_OFFSET_V1_8;
-	uintptr_t dram_base = (uintptr_t)desc - SOF_MAN_ELF_TEXT_OFFSET;
-	struct llext_buf_loader ebl = LLEXT_BUF_LOADER((uint8_t *)dram_base + FILE_TEXT_OFFSET_V1_8,
-						       mod_size);
-	struct module_data *md = &proc->priv;
-
-	tr_dbg(&lib_manager_tr, "mod_id: %#x", ipc_config->id);
 
 	if (!ctx || !desc) {
 		tr_err(&lib_manager_tr, "failed to get module descriptor");
 		return 0;
 	}
 
-	mod_array = (struct sof_man_module *)((char *)desc + SOF_MAN_MODULE_OFFSET(0));
+	struct sof_man_module *mod_array = (struct sof_man_module *)((char *)desc +
+								     SOF_MAN_MODULE_OFFSET(0));
+	size_t mod_size = desc->header.preload_page_count * PAGE_SZ - FILE_TEXT_OFFSET_V1_8;
+	uintptr_t dram_base = (uintptr_t)desc - SOF_MAN_ELF_TEXT_OFFSET;
+	struct llext_buf_loader ebl = LLEXT_BUF_LOADER((uint8_t *)dram_base + FILE_TEXT_OFFSET_V1_8,
+						       mod_size);
+	uint32_t entry_index = LIB_MANAGER_GET_MODULE_INDEX(module_id);
+	const struct sof_man_module_manifest *mod_manifest;
+	const struct sof_module_api_build_info *buildinfo;
+	struct module_data *md = &proc->priv;
+	int ret;
+
+	tr_dbg(&lib_manager_tr, "mod_id: %#x", ipc_config->id);
 
 	if (!ctx->mod)
 		llext_manager_mod_init(ctx, desc, mod_array);

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -519,6 +519,9 @@ static int man_module_create_reloc(struct image *image, struct manifest_module *
 				/* Found a TOML manifest, matching ELF */
 				if (i)
 					(*man_module)++;
+				/* Use manifest created using toml files as template */
+				**man_module = image->adsp->modules->mod_man[j];
+				/* Use .manifest to update individual fields */
 				man_get_section_manifest(image, sof_mod, *man_module);
 				man_module_fill_reloc(module, *man_module);
 				break;
@@ -648,10 +651,12 @@ static int man_create_modules(struct image *image, struct sof_man_fw_desc *desc,
 		if (image->reloc) {
 			err = man_module_create_reloc(image, module, &man_module);
 		} else {
-			/* Some platforms dont have modules configuration in toml file */
+			/* Some platforms don't have modules configuration in toml file */
 			if (image->adsp->modules) {
+				/* Use manifest created using toml files as template */
 				assert(i < image->adsp->modules->mod_man_count);
-				memcpy(man_module, &image->adsp->modules->mod_man[i], sizeof(*man_module));
+				memcpy(man_module, &image->adsp->modules->mod_man[i],
+				       sizeof(*man_module));
 			}
 
 			err = man_module_create(image, module, man_module);

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -457,22 +457,11 @@ out:
 	return 0;
 }
 
-static int man_module_create_reloc(struct image *image, struct manifest_module *module,
-				   struct sof_man_module *man_module)
+static void man_module_fill_reloc(const struct manifest_module *module,
+				  struct sof_man_module *man_module)
 {
-	/* create module and segments */
-	int err;
-
-	image->image_end = 0;
-
-	err = man_get_module_manifest(image, module, man_module);
-	if (err < 0)
-		return err;
-
 	/* stack size ??? convert sizes to PAGES */
 	man_module->instance_bss_size = 1;
-
-	module_print_zones(&module->file);
 
 	/* main module */
 	/* text section is first */
@@ -491,6 +480,23 @@ static int man_module_create_reloc(struct image *image, struct manifest_module *
 	man_module->segment[SOF_MAN_SEGMENT_BSS].file_offset = 0;
 	man_module->segment[SOF_MAN_SEGMENT_BSS].v_base_addr = 0;
 	man_module->segment[SOF_MAN_SEGMENT_BSS].flags.r.length = 0;
+}
+
+static int man_module_create_reloc(struct image *image, struct manifest_module *module,
+				   struct sof_man_module *man_module)
+{
+	/* create module and segments */
+	int err;
+
+	image->image_end = 0;
+
+	err = man_get_module_manifest(image, module, man_module);
+	if (err < 0)
+		return err;
+
+	module_print_zones(&module->file);
+
+	man_module_fill_reloc(module, man_module);
 
 	fprintf(stdout, "\tNo\tAddress\t\tSize\t\tFile\tType\n");
 


### PR DESCRIPTION
Add support for libraries with multiple modules. This handles loading of libraries. Creation will be added later, isn't too complex, needs minor additions to cmake and Python.