### PR TITLE
audio: kpb: fix potential NULL pointer dereference in device list reset

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2405,11 +2405,11 @@ static void devicelist_reset(struct device_list *devlist, bool remove_items)
 {
 	/* clear items */
 	if (remove_items) {
-		for (int i = 0; i < DEVICE_LIST_SIZE; i++)
+		for (int i = 0; i < devlist->count; i++)
 			*devlist->devs[i] = NULL;
 	}
 	/* zero the pointers */
-	for (int i = 0; i < DEVICE_LIST_SIZE; i++)
+	for (int i = 0; i < devlist->count; i++)
 		devlist->devs[i] = NULL;
 
 	devlist->count = 0;


### PR DESCRIPTION
This patch addresses a potential NULL pointer dereference issue in the `devicelist_reset` function within the Key Phrase Buffer (KPB) component. The issue was exposed by a recent change in Zephyr's MMU mapping for Intel ADSP ACE30, which now catches NULL pointer accesses.

The `devicelist_reset` function previously iterated over the entire `DEVICE_LIST_SIZE` when clearing items and zeroing pointers, which could lead to dereferencing NULL pointers. The fix involves iterating only up to `devlist->count` to ensure that only valid pointers are accessed.

This change prevents potential NULL pointer dereference and ensures the stability of the KPB component.