### PR TITLE
[stable-v2.11] Tools: Topology2: SDW: Use for PCH DMIC IIR type with +20 dB gain

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -79,6 +79,7 @@ Define {
 	SDW_JACK_CAPTURE_CH 2
 	ADD_BT  false
 	SDW_LINK_VALID_BITS	24
+        DMIC0_DAI_EQIIR "highpass_40hz_20db"
 }
 
 # override defaults with platform-specific config


### PR DESCRIPTION
The existing default is high-pass 40 Hz with 0 dB gain. This change amplifies captured sound from DMIC by 20 dB. The same amplifying IIR type is used in hda-generic.

The change is for now, but not the final solution. After we have UCM2 control for capture processing in SOF we can shift applying more gain to the DRC component that will provide more robustness with silent and loud environments.