### PR TITLE
Tools: Topology2: Swap gain and eqiir in DMIC capture

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -23,7 +23,7 @@
 <mixout-gain-dai-copier-playback.conf>
 <mixout-gain-smart-amp-dai-copier-playback.conf>
 <dai-copier-gain-module-copier-capture.conf>
-<dai-copier-eqiir-gain-module-copier-capture.conf>
+<dai-copier-gain-eqiir-module-copier-capture.conf>
 <gain-module-copier.conf>
 <gain-capture.conf>
 <gain-copier-capture.conf>

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -22,7 +22,7 @@
 <mixout-gain-ctc-dai-copier-playback.conf>
 <deepbuffer-playback.conf>
 <dai-copier-be.conf>
-<dai-copier-eqiir-gain-module-copier-capture.conf>
+<dai-copier-gain-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <gain-module-copier.conf>
 <google-rtc-aec-capture.conf>

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -14,7 +14,7 @@
 <host-copier-gain-mixin-playback.conf>
 <mixout-gain-alh-dai-copier-playback.conf>
 <mixout-gain-eqiir-eqfir-drc-alh-dai-copier-playback.conf>
-<dai-copier-eqiir-gain-module-copier-capture.conf>
+<dai-copier-gain-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <gain-copier-capture.conf>
 <deepbuffer-playback.conf>

--- a/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-eqiir-module-copier-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/dai-copier-gain-eqiir-module-copier-capture.conf
@@ -1,12 +1,12 @@
 #
-# BE capture pipeline: dai-copier-eqiir-gain-module-copier-capture
+# BE capture pipeline: dai-copier-gain-eqiir-module-copier-capture
 #
 # All attributes defined herein are namespaced
-# by alsatplg to "Object.Pipeline.dai-copier-eqiir-gain-module-copier-capture.N.attribute_name"
+# by alsatplg to "Object.Pipeline.dai-copier-gain-eqiir-module-copier-capture.N.attribute_name"
 #
-# Usage: dai-copier-eqiir-gain-module-copier-capture pipeline object can be instantiated as:
+# Usage: dai-copier-gain-eqiir-module-copier-capture pipeline object can be instantiated as:
 #
-# Object.Pipeline.dai-copier-eqiir-gain-module-copier-capture."N" {
+# Object.Pipeline.dai-copier-gain-eqiir-module-copier-capture."N" {
 # 	period		1000
 # 	time_domain	"timer"
 # }
@@ -21,7 +21,7 @@
 <include/components/eqiir.conf>
 <include/components/pipeline.conf>
 
-Class.Pipeline."dai-copier-eqiir-gain-module-copier-capture" {
+Class.Pipeline."dai-copier-gain-eqiir-module-copier-capture" {
 
 	<include/pipelines/pipeline-common.conf>
 
@@ -35,7 +35,7 @@ Class.Pipeline."dai-copier-eqiir-gain-module-copier-capture" {
 		]
 
 		#
-		# dai-copier-eqiir-gain-module-copier-capture objects instantiated
+		# dai-copier-gain-eqiir-module-copier-capture objects instantiated
 		# within the same alsaconf node must have unique pipeline_id
 		# attribute
 		#
@@ -185,12 +185,12 @@ Class.Pipeline."dai-copier-eqiir-gain-module-copier-capture" {
 
 	Object.Base {
 		route.1 {
-			source	gain.$index.1
+			source	eqiir.$index.1
 			sink	module-copier.$index.2
 		}
 		route.2 {
-			source	eqiir.$index.1
-			sink	gain.$index.1
+			source	gain.$index.1
+			sink	eqiir.$index.1
 		}
 	}
 

--- a/tools/topology/topology2/platform/intel/dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/dmic-generic.conf
@@ -2,7 +2,6 @@ Define {
        DMIC0_PCM_NAME	"DMIC Raw"
 }
 
-
 # If DMIC0_PCM_CHANNELS is zero, copy it from NUM_DMICS. This
 # allows by setting both NUM_DMICS and DMIC0_PCM_CHANNELS to
 # have a different channels count in DAI and host.
@@ -152,7 +151,7 @@ IncludeByKey.PASSTHROUGH {
 			}
 		]
 
-		Object.Pipeline.dai-copier-eqiir-gain-module-copier-capture [
+		Object.Pipeline.dai-copier-gain-eqiir-module-copier-capture [
 			{
 				index		$DMIC0_DAI_PIPELINE_ID
 				core_id		$DMIC_CORE_ID
@@ -552,7 +551,7 @@ IncludeByKey.PASSTHROUGH {
 				Object.Base.route [
 					{
 						source $DMIC0_DAI_COPIER
-						sink eqiir.$DMIC0_DAI_PIPELINE_ID.1
+						sink gain.$DMIC0_DAI_PIPELINE_ID.1
 					}
 					{
 						source $DMIC0_DAI_PIPELINE_SRC
@@ -572,7 +571,7 @@ IncludeByKey.PASSTHROUGH {
 				Object.Base.route [
 					{
 						source $DMIC0_DAI_COPIER
-						sink eqiir.$DMIC0_DAI_PIPELINE_ID.1
+						sink gain.$DMIC0_DAI_PIPELINE_ID.1
 					}
 					{
 						source $DMIC0_DAI_PIPELINE_SRC

--- a/tools/topology/topology2/platform/intel/dmic1-mfcc.conf
+++ b/tools/topology/topology2/platform/intel/dmic1-mfcc.conf
@@ -60,7 +60,7 @@ Object.Pipeline.host-gateway-capture [
 	}
 ]
 
-Object.Pipeline.dai-copier-eqiir-gain-module-copier-capture [
+Object.Pipeline.dai-copier-gain-eqiir-module-copier-capture [
 	{
 		index		$DMIC1_DAI_PIPELINE_ID
 		core_id		$DMIC_CORE_ID
@@ -382,7 +382,7 @@ Object.Widget.mfcc.1 {
 Object.Base.route [
 	{
 		source "dai-copier.DMIC.$DMIC1_NAME.capture"
-		sink "eqiir.$DMIC1_DAI_PIPELINE_ID.1"
+		sink "gain.$DMIC1_DAI_PIPELINE_ID.1"
 	}
 	{
 		source module-copier.$DMIC1_DAI_PIPELINE_ID.2

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -21,7 +21,7 @@
 <mixout-gain-efx-mbdrc-dai-copier-playback.conf>
 <mixout-gain-host-copier-capture.conf>
 <dai-copier-eqiir-module-copier-capture.conf>
-<dai-copier-eqiir-gain-module-copier-capture.conf>
+<dai-copier-gain-eqiir-module-copier-capture.conf>
 <gain-capture.conf>
 <deepbuffer-playback.conf>
 <io-gateway.conf>


### PR DESCRIPTION
This patch swaps the order of IIR and gain components in capture pipeline. In IPC4 systems the gain component can only attenuate the signal, largest gain is 0 dB (pass-through). The IIR component can be set up to amplify the signal by e.g. +20 dB that is currently default in many topologies. The gain can possibly distort the signal in loud environment.

With current "dai-copier -> eqiir -> gain -> module-copier" topology the user configurable gain (ALSA mixer control) can't prevent clipping of audio signal in IIR. While with swapped order "dai-copier -> gain -> eqiir -> module-copier" using attenuation in gain component can be used to prevent audio signal clipping in IIR. It would be useful in capturing audio in a very loud environment.

Since the pipeline is 32-bits there is no practical loss of audio quality even if there would be first attenuation and then gain. Plus normally the gain control for Dmic0 is set to maximum.