### PR TITLE
west.yml: update zephyr to 1d40a7ee3415 (Dec 5th)

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: e59289d899990781f5ab1de3cd94cc876061a5f2
+      revision: 1d40a7ee3415d8bb6a3772c41ce580bc8a8c2db4
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 084 commits.

Changes include:

caece8dd54cd drivers: dai: Place API into iterable section
c2f02533a6ad drivers: dma: intel_adsp_hda: change L1_EXIT defaults
b4fb833eb9cc soc/mediatek/adsp: Source timer rate from DTS
09495c9e4807 soc/mediatek: Ruffify python scripts
fe5c11db0538 boards/mediatek: Add mt8196_adsp
e35de00f86c3 soc/mtk_adsp: Update gen_img.py address space rules
3c0269f4f697 soc/mtk_adsp: Add missing z_prep_c() prototype
4b3874b9ea42 boards/mediated: Add twister.yaml
cc43e3a52738 soc/mediatek: Add missing snippets sections
2b8d54281507 boards/mtk_adsp: Add a doc page
5364783ba181 soc: boards: Add Mediatek MT8186 and MT8188 audio DSPs
cdd4cbcc676c soc/mtk_adsp: Remove "msg" API
48a84911acf6 soc/mtk_adsp: Add default console hook
22de29e76875 soc: intel_adsp/ace: put syscall helpers in vector code section