### PR TITLE
.github/zephyr: switch to HWMv2 naming of imx93_evk

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           cd workspace && ./sof/zephyr/docker-run.sh /bin/sh -c \
              'ln -s  /opt/toolchains/zephyr-sdk-*  ~/;
-              west build --board mimx93_evk_a55 sof/app              \
+              west build --board imx93_evk/mimx9352/a55 sof/app      \
               -- -DEXTRA_CFLAGS=-Werror -DEXTRA_CXXFLAGS=-Werror     \
               -DEXTRA_AFLAGS=-Werror'
 

--- a/app/boards/imx93_evk_mimx9352_a55.overlay
+++ b/app/boards/imx93_evk_mimx9352_a55.overlay
@@ -9,7 +9,7 @@
 	/* Inmate memory, reserved through "mem=1248MB" boot argument,
 	 * starts at 0xce000000.
 	 */
-	sram0: memory@ce000000 {
+	dram: memory@ce000000 {
 		reg = <0xce000000 DT_SIZE_M(1)>;
 	};
 


### PR DESCRIPTION
As of Zephyr commit 93d60ecdb01("boards: Remove all deprecated HWMv1 board aliases") HWMv1 naming is no longer allowed. As such, change to HWMv2 naming for the imx93_evk board.

Fixes #9716.