### PR TITLE
[RFC] treewide: zephyr: add sof_ prefix to dma_get/put() and struct dma

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -59,13 +59,13 @@ struct chain_dma_data {
 #endif
 
 	/* local host DMA config */
-	struct dma *dma_host;
+	struct sof_dma *dma_host;
 	struct dma_chan_data *chan_host;
 	struct dma_config z_config_host;
 	struct dma_block_config dma_block_cfg_host;
 
 	/* local link DMA config */
-	struct dma *dma_link;
+	struct sof_dma *dma_link;
 	struct dma_chan_data *chan_link;
 	struct dma_config z_config_link;
 	struct dma_block_config dma_block_cfg_link;
@@ -392,9 +392,9 @@ static void chain_release(struct comp_dev *dev)
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
 
 	dma_release_channel(cd->chan_host->dma->z_dev, cd->chan_host->index);
-	dma_put(cd->dma_host);
+	sof_dma_put(cd->dma_host);
 	dma_release_channel(cd->chan_link->dma->z_dev, cd->chan_link->index);
-	dma_put(cd->dma_link);
+	sof_dma_put(cd->dma_link);
 
 	if (cd->dma_buffer) {
 		buffer_free(cd->dma_buffer);
@@ -538,7 +538,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	dir = (cd->stream_direction == SOF_IPC_STREAM_PLAYBACK) ?
 		SOF_DMA_DIR_HMEM_TO_LMEM : SOF_DMA_DIR_LMEM_TO_HMEM;
 
-	cd->dma_host = dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
+	cd->dma_host = sof_dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
 	if (!cd->dma_host) {
 		comp_err(dev, "chain_task_init(): dma_get() returned NULL");
 		return -EINVAL;
@@ -547,9 +547,9 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	dir = (cd->stream_direction == SOF_IPC_STREAM_PLAYBACK) ?
 		SOF_DMA_DIR_MEM_TO_DEV : SOF_DMA_DIR_DEV_TO_MEM;
 
-	cd->dma_link = dma_get(dir, SOF_DMA_CAP_HDA, SOF_DMA_DEV_HDA, SOF_DMA_ACCESS_SHARED);
+	cd->dma_link = sof_dma_get(dir, SOF_DMA_CAP_HDA, SOF_DMA_DEV_HDA, SOF_DMA_ACCESS_SHARED);
 	if (!cd->dma_link) {
-		dma_put(cd->dma_host);
+		sof_dma_put(cd->dma_host);
 		comp_err(dev, "chain_task_init(): dma_get() returned NULL");
 		return -EINVAL;
 	}
@@ -610,8 +610,8 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 
 	return 0;
 error:
-	dma_put(cd->dma_host);
-	dma_put(cd->dma_link);
+	sof_dma_put(cd->dma_host);
+	sof_dma_put(cd->dma_link);
 	return ret;
 }
 

--- a/src/audio/copier/host_copier.h
+++ b/src/audio/copier/host_copier.h
@@ -48,7 +48,11 @@ struct hc_buf {
  */
 struct host_data {
 	/* local DMA config */
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	struct sof_dma *dma;
+#else
 	struct dma *dma;
+#endif
 	struct dma_chan_data *chan;
 	struct dma_sg_config config;
 #ifdef __ZEPHYR__

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -479,7 +479,7 @@ int dai_common_new(struct dai_data *dd, struct comp_dev *dev,
 	dir = dai_cfg->direction == SOF_IPC_STREAM_PLAYBACK ?
 		SOF_DMA_DIR_MEM_TO_DEV : SOF_DMA_DIR_DEV_TO_MEM;
 
-	dd->dma = dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, SOF_DMA_ACCESS_SHARED);
+	dd->dma = sof_dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, SOF_DMA_ACCESS_SHARED);
 	if (!dd->dma) {
 		dai_put(dd->dai);
 		comp_err(dev, "dma_get() failed to get shared access to DMA.");
@@ -591,7 +591,7 @@ void dai_common_free(struct dai_data *dd)
 		dd->chan->dev_data = NULL;
 	}
 
-	dma_put(dd->dma);
+	sof_dma_put(dd->dma);
 
 	dai_release_llp_slot(dd);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -614,7 +614,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 	dir = hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK ?
 		SOF_DMA_DIR_HMEM_TO_LMEM : SOF_DMA_DIR_LMEM_TO_HMEM;
 
-	hd->dma = dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
+	hd->dma = sof_dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
 	if (!hd->dma) {
 		comp_err(dev, "dma_get() returned NULL");
 		return -ENODEV;
@@ -630,7 +630,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
 	if (!hd->msg) {
 		comp_err(dev, "ipc_msg_init failed");
-		dma_put(hd->dma);
+		sof_dma_put(hd->dma);
 		return -ENOMEM;
 	}
 	hd->chan = NULL;
@@ -678,7 +678,7 @@ e_data:
 
 void host_common_free(struct host_data *hd)
 {
-	dma_put(hd->dma);
+	sof_dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
 	dma_sg_free(&hd->config.elem_array);

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -207,8 +207,13 @@ int platform_ipc_init(struct ipc *ipc)
 					     PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->dh_buffer.page_table)
 		bzero(iipc->dh_buffer.page_table, PLATFORM_PAGE_TABLE_SIZE);
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	iipc->dh_buffer.dmac = sof_dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
+					   SOF_DMA_ACCESS_SHARED);
+#else
 	iipc->dh_buffer.dmac = dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
 				       SOF_DMA_ACCESS_SHARED);
+#endif
 	if (!iipc->dh_buffer.dmac) {
 		tr_err(&ipc_tr, "Unable to find DMA for host page table");
 		sof_panic(SOF_IPC_PANIC_IPC);

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -120,7 +120,11 @@ void ipc_free(struct ipc *ipc);
  */
 struct ipc_data_host_buffer {
 	/* DMA */
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	struct sof_dma *dmac;
+#else
 	struct dma *dmac;
+#endif
 	uint8_t *page_table;
 };
 

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -125,7 +125,7 @@ struct dai_data {
 	struct comp_buffer *local_buffer;
 	struct dai_ts_cfg ts_config;
 	struct dai *dai;
-	struct dma *dma;
+	struct sof_dma *dma;
 	struct dai_group *group;		/* NULL if no group assigned */
 	int xrun;				/* true if we are doing xrun recovery */
 

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -85,7 +85,7 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 /*
  * Copy the audio buffer page tables from the host to the DSP max of 4K.
  */
-static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
+static int ipc_get_page_descriptors(struct sof_dma *dmac, uint8_t *page_table,
 				    struct sof_ipc_host_buffer *ring)
 {
 	struct dma_config cfg;

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -28,14 +28,14 @@ SOF_DEFINE_REG_UUID(dma);
 DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-static int dma_init(struct dma *dma);
+static int dma_init(struct sof_dma *dma);
 
-struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
+struct sof_dma *sof_dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
 	const struct dma_info *info = dma_info_get();
 	int users, ret = 0;
 	int min_users = INT32_MAX;
-	struct dma *d = NULL, *dmin = NULL;
+	struct sof_dma *d = NULL, *dmin = NULL;
 	k_spinlock_key_t key;
 
 	if (!info->num_dmas) {
@@ -123,7 +123,7 @@ out:
 	return !ret ? dmin : NULL;
 }
 
-void dma_put(struct dma *dma)
+void sof_dma_put(struct sof_dma *dma)
 {
 	k_spinlock_key_t key;
 
@@ -138,7 +138,7 @@ void dma_put(struct dma *dma)
 	k_spin_unlock(&dma->lock, key);
 }
 
-static int dma_init(struct dma *dma)
+static int dma_init(struct sof_dma *dma)
 {
 	struct dma_chan_data *chan;
 	int i;
@@ -162,6 +162,8 @@ static int dma_init(struct dma *dma)
 
 	return 0;
 }
+EXPORT_SYMBOL(sof_dma_get);
+EXPORT_SYMBOL(sof_dma_put);
 #else
 struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
@@ -278,9 +280,9 @@ void dma_put(struct dma *dma)
 		dma, dma->sref);
 	k_spin_unlock(&dma->lock, key);
 }
-#endif
 EXPORT_SYMBOL(dma_get);
 EXPORT_SYMBOL(dma_put);
+#endif
 
 int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 		 enum mem_zone zone,

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -51,7 +51,7 @@ SOF_DEFINE_REG_UUID(lib_manager);
 DECLARE_TR_CTX(lib_manager_tr, SOF_UUID(lib_manager_uuid), LOG_LEVEL_INFO);
 
 struct lib_manager_dma_ext {
-	struct dma *dma;
+	struct sof_dma *dma;
 	struct dma_chan_data *chan;
 	uintptr_t dma_addr;		/**< buffer start pointer */
 	uint32_t addr_align;
@@ -746,8 +746,8 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 	/* Initialize dma_ext with zeros */
 	memset(dma_ext, 0, sizeof(struct lib_manager_dma_ext));
 	/* request DMA in the dir HMEM->LMEM */
-	dma_ext->dma = dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
-			       SOF_DMA_ACCESS_EXCLUSIVE);
+	dma_ext->dma = sof_dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
+				   SOF_DMA_ACCESS_EXCLUSIVE);
 	if (!dma_ext->dma) {
 		tr_err(&lib_manager_tr,
 		       "lib_manager_dma_init(): dma_ext->dma = NULL");
@@ -774,7 +774,7 @@ static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t 
 		if (dma_ext->dma->z_dev)
 			dma_release_channel(dma_ext->dma->z_dev, dma_id);
 
-		dma_put(dma_ext->dma);
+		sof_dma_put(dma_ext->dma);
 	}
 	return 0;
 }

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -42,7 +42,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = cache_to_uncache_init((struct dma *)dma),
+	.dma_array = cache_to_uncache_init((void *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/posix/dma.c
+++ b/src/platform/posix/dma.c
@@ -176,7 +176,7 @@ DEVICE_DEFINE(pzdma2, "pzdma2", pzdma_init, NULL, &pzdma2_data, &pzdma2_cfg,
 DEVICE_DEFINE(pzdma3, "pzdma3", pzdma_init, NULL, &pzdma3_data, &pzdma3_cfg,
 	      POST_KERNEL, 0, &pzdma_api);
 
-struct dma posix_sof_dma[4];
+struct sof_dma posix_sof_dma[4];
 
 const struct dma_info posix_sof_dma_info = {
 	.dma_array = posix_sof_dma,
@@ -194,7 +194,7 @@ void posix_dma_init(struct sof *sof)
 	};
 
 	for (int i = 0; i < ARRAY_SIZE(posix_sof_dma); i++) {
-		posix_sof_dma[i] = (struct dma) {};
+		posix_sof_dma[i] = (struct sof_dma) {};
 		posix_sof_dma[i].plat_data.dir = 0xffffffff;
 		posix_sof_dma[i].plat_data.caps = 0xffffffff;
 		posix_sof_dma[i].plat_data.devs = 0xffffffff;

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -198,8 +198,8 @@ static int probe_dma_init(struct probe_dma_ext *dma, uint32_t direction)
 	channel = ((union ipc4_connector_node_id)dma->stream_tag).f.v_index;
 
 	/* request DMA in the dir LMEM->HMEM with shared access */
-	dma->dc.dmac = dma_get(direction, 0, SOF_DMA_DEV_HOST,
-			       SOF_DMA_ACCESS_SHARED);
+	dma->dc.dmac = sof_dma_get(direction, 0, SOF_DMA_DEV_HOST,
+				   SOF_DMA_ACCESS_SHARED);
 	if (!dma->dc.dmac) {
 		tr_err(&pr_tr, "probe_dma_init(): dma->dc.dmac = NULL");
 		return -ENODEV;
@@ -267,10 +267,11 @@ static int probe_dma_deinit(struct probe_dma_ext *dma)
 	}
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
 	dma_release_channel(dma->dc.dmac->z_dev, dma->dc.chan->index);
+	sof_dma_put(dma->dc.dmac);
 #else
 	dma_channel_put_legacy(dma->dc.chan);
-#endif
 	dma_put(dma->dc.dmac);
+#endif
 
 	rfree((void *)dma->dmapb.addr);
 	dma->dmapb.addr = 0;

--- a/zephyr/include/sof/lib/dma-legacy.h
+++ b/zephyr/include/sof/lib/dma-legacy.h
@@ -27,6 +27,21 @@
 #define DMA_CHAN_INVALID	SOF_DMA_CHAN_INVALID
 #define DMA_CORE_INVALID	SOF_DMA_CORE_INVALID
 
+/* Compatibility for drivers using legacy DMA dma_get/put() */
+struct dma {
+	struct dma_plat_data plat_data;
+	struct k_spinlock lock;	/**< locking mechanism */
+	int sref;		/**< simple ref counter, guarded by lock */
+	const struct dma_ops *ops;
+	atomic_t num_channels_busy; /* number of busy channels */
+	struct dma_chan_data *chan; /* channels array */
+	const struct device *z_dev; /* Zephyr driver */
+	void *priv_data;
+};
+
+struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+void dma_put(struct dma *dma);
+
 enum dma_cb_status {
 	DMA_CB_STATUS_RELOAD = 0,
 	DMA_CB_STATUS_END,

--- a/zephyr/include/sof/lib/dma.h
+++ b/zephyr/include/sof/lib/dma.h
@@ -121,7 +121,7 @@ enum sof_dma_cb_status {
 /* Attributes have been ported to Zephyr. This condition is necessary until full support of
  * CONFIG_SOF_ZEPHYR_STRICT_HEADERS.
  */
-struct dma;
+struct sof_dma;
 
 /**
  *  \brief Element of SG list (as array item).
@@ -193,7 +193,7 @@ struct dma_plat_data {
 	uint32_t period_count;
 };
 
-struct dma {
+struct sof_dma {
 	struct dma_plat_data plat_data;
 	struct k_spinlock lock;	/**< locking mechanism */
 	int sref;		/**< simple ref counter, guarded by lock */
@@ -204,8 +204,20 @@ struct dma {
 	void *priv_data;
 };
 
+/*
+ * Note: typedef use like this is generally avoided in SOF,
+ *       but this is an exceptional case to handle SOF platforms
+ *       that can be built with both Zephyr and XTOS drivers (like imx8).
+ *       Once no users left, this can be removed.
+ */
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+typedef struct sof_dma sof_dma;
+#else
+typedef struct dma sof_dma;
+#endif
+
 struct dma_chan_data {
-	struct dma *dma;
+	sof_dma *dma;
 
 	uint32_t status;
 	uint32_t direction;
@@ -223,14 +235,14 @@ struct dma_chan_data {
 };
 
 struct dma_info {
-	struct dma *dma_array;
+	sof_dma *dma_array;
 	size_t num_dmas;
 };
 
 /* generic DMA DSP <-> Host copier */
 struct dma_copy {
 	struct dma_chan_data *chan;
-	struct dma *dmac;
+	struct sof_dma *dmac;
 };
 
 struct audio_stream;
@@ -253,14 +265,14 @@ int dmac_init(struct sof *sof);
  * For exclusive access, ret DMAC with no channels draining.
  * For shared access, ret DMAC with the least number of channels draining.
  */
-struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+struct sof_dma *sof_dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 /**
  * \brief API to release a platform DMAC.
  *
  * @param[in] dma DMAC to relese.
  */
-void dma_put(struct dma *dma);
+void sof_dma_put(struct sof_dma *dma);
 
 #ifndef CONFIG_ZEPHYR_NATIVE_DRIVERS
 #include "dma-legacy.h"

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -20,7 +20,7 @@
 #define DW_DMA_BUFFER_PERIOD_COUNT	0x4
 #define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
-SHARED_DATA struct dma dma[] = {
+SHARED_DATA sof_dma dma[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {


### PR DESCRIPTION
Add "sof_" namespace to dma_get()/put() in the Zephyr native drivers builds. The main "struct dma" is also renamed, so this touches quite many places in code.

Link: https://github.com/thesofproject/sof/issues/9561