### PR TITLE
config: enable RTC_AEC module for LNL and PTL platforms

### DIFF
--- a/app/boards/intel_adsp_ace20_lnl.conf
+++ b/app/boards/intel_adsp_ace20_lnl.conf
@@ -23,6 +23,12 @@ CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32=y
 CONFIG_PIPELINE_2_0=y
 CONFIG_SAMPLE_KEYPHRASE=y
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=y
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_AMS=y
 CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL=n

--- a/app/boards/intel_adsp_ace30_ptl.conf
+++ b/app/boards/intel_adsp_ace30_ptl.conf
@@ -26,6 +26,12 @@ CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32=y
 CONFIG_PCM_CONVERTER_FORMAT_U8=y
 CONFIG_PIPELINE_2_0=y
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=y
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL=n
 CONFIG_PROBE=y


### PR DESCRIPTION
This patch enables the Google Real Time Communication Audio Processing (RTC_AEC) module for the LNL (Lunar Lake) and PTL (Panther Lake) platforms. The RTC_AEC module is essential for performing echo-cancelling and other real-time audio processing tasks.

Changes include:
- Enabling CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING and CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK in the intel_adsp_ace20_lnl.conf configuration file.
- Enabling CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING and CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK in the intel_adsp_ace30_ptl.conf configuration file.

This change ensures that the RTC_AEC module is included in the firmware builds for these platforms, allowing for proper testing and functionality of real-time audio processing features.