### PR TITLE
[ptl-002] topology2: Add HDA with DMIC, HDMI topologies support for ACE3 archit…

### DIFF
--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -104,6 +104,12 @@ NHLT_BIN=nhlt-sof-ptl-max98357a-rt5682-ssp2-ssp0.bin,DEEPBUFFER_FW_DMA_MS=10,HEA
 SPK_ID=6,SPEAKER_SSP_DAI_INDEX=0,HEADSET_CODEC_NAME=SSP2-Codec,SPEAKER_CODEC_NAME=SSP0-Codec,\
 BT_NAME=SSP1-BT,BT_INDEX=1,BT_ID=7,BT_PCM_NAME=Bluetooth,INCLUDE_ECHO_REF=true,DEEP_BUF_SPK=true"
 
+# Topology for PTL with rt5682 (SSP 0), max98360a (SSP 1), BT (SSP 2) and PDM0, PDM1 enabled
+"cavs-rt5682\;sof-ptl-max98360a-rt5682\;PLATFORM=ptl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,\
+PDM1_MIC_B_ENABLE=1,DMIC0_PCM_ID=99,PREPROCESS_PLUGINS=nhlt,\
+NHLT_BIN=nhlt-sof-ptl-max98360a-rt5682.bin,SPK_ID=6,DEEPBUFFER_FW_DMA_MS=10,INCLUDE_ECHO_REF=true,\
+BT_NAME=SSP2-BT,BT_ID=7,BT_PCM_NAME=Bluetooth,DEEP_BUF_SPK=true"
+
 # CAVS HDA topology with mixer-based efx eq pipelines for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-efx-generic\;HDA_CONFIG=efx,HDA_MIC_ENHANCED_CAPTURE=true,\
 EFX_FIR_PARAMS=passthrough,EFX_IIR_PARAMS=passthrough,EFX_DRC_PARAMS=passthrough,\

--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -25,4 +25,8 @@ SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt722-4ch.bin"
 
+"cavs-sdw\;sof-ptl-rt712-l2-rt1320-l1\;PLATFORM=ptl,SDW_DMIC=1,NUM_SDW_AMP_LINKS=2,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
 )

--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -29,4 +29,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt722-4ch.bin"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+"cavs-sdw\;sof-ptl-rt713-l2-rt1320-l13\;PLATFORM=ptl,SDW_DMIC=1,NUM_SDW_AMP_LINKS=2,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 )

--- a/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-hda-generic.cmake
@@ -67,4 +67,24 @@ EFX_DMIC0_DRC_PARAMS=dmic_default"
 PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace1-4ch.bin,DMIC0_ENHANCED_CAPTURE=true,\
 EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
+
+# Topologies for ACE3 architecture
+# HDMI + DMICs
+"sof-hda-generic\;sof-hda-generic-ace3-idisp-2ch\;PLATFORM=ptl,NUM_DMICS=2,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace3-idisp-2ch.bin"
+
+"sof-hda-generic\;sof-hda-generic-ace3-idisp-4ch\;PLATFORM=ptl,NUM_DMICS=4,\
+PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace3-idisp-4ch.bin"
+
+# HDA + HDMI + DMICs
+"sof-hda-generic\;sof-hda-generic-ace3-2ch\;PLATFORM=ptl,HDA_CONFIG=mix,NUM_DMICS=2,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace3-2ch.bin,\
+DMIC0_ENHANCED_CAPTURE=true,EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,\
+EFX_DMIC0_DRC_PARAMS=dmic_default"
+
+"sof-hda-generic\;sof-hda-generic-ace3-4ch\;PLATFORM=ptl,HDA_CONFIG=mix,NUM_DMICS=4,\
+PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-ace3-4ch.bin,DMIC0_ENHANCED_CAPTURE=true,\
+EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
 )

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -58,6 +58,7 @@ Define {
 IncludeByKey.PLATFORM {
 	"mtl"	"platform/intel/mtl.conf"
 	"lnl"	"platform/intel/lnl.conf"
+	"ptl"	"platform/intel/ptl.conf"
 }
 
 # include HDA config if needed.


### PR DESCRIPTION
…ecture

These entries creates multiple topologies for the HDA codec with 2, 4 DMICs and HDMI for ACE 3 architecture


(cherry picked from commit 0b3ee3a05a96cb0aef2017a77f41e39a149a4748)