### PR TITLE
[stable-v2.12] Tools: Topology2: Fix DMIC TDFB blob in sof-lnl-cs42l43-l0-2ch

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -63,7 +63,7 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-lnl-cs42l43-l0-2ch.bin,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
 HDMI1_ID=5,HDMI2_ID=6,HDMI3_ID=7,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
+EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
 
 "cavs-sdw\;sof-lnl-cs42l43-l0-cs35l56-l3\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\


### PR DESCRIPTION
The 2ch DMIC TDFB blob should be "line2_generic_pm10deg". The blob for 4ch pass-through does not work correctly with a 2ch stream. Note: Another option for pass-through is "line2_pass". But I'm assuming here that the same blob as used for other 2ch systems should be suitable.

Fixes: f4cd55c2e879e7f822cb793bd65449fa1da36b04
       ("topology2: Add support for cs42l43 SKU with two host DMICs")

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
(cherry picked from commit 7650d0ac21f2a51e7dfb63b785142e7bb5a0921a)