### PR TITLE
treewide: zephyr: add sof_ prefix to dma_get/put()

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -392,9 +392,9 @@ static void chain_release(struct comp_dev *dev)
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
 
 	dma_release_channel(cd->chan_host->dma->z_dev, cd->chan_host->index);
-	dma_put(cd->dma_host);
+	sof_dma_put(cd->dma_host);
 	dma_release_channel(cd->chan_link->dma->z_dev, cd->chan_link->index);
-	dma_put(cd->dma_link);
+	sof_dma_put(cd->dma_link);
 
 	if (cd->dma_buffer) {
 		buffer_free(cd->dma_buffer);
@@ -538,7 +538,7 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	dir = (cd->stream_direction == SOF_IPC_STREAM_PLAYBACK) ?
 		SOF_DMA_DIR_HMEM_TO_LMEM : SOF_DMA_DIR_LMEM_TO_HMEM;
 
-	cd->dma_host = dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
+	cd->dma_host = sof_dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
 	if (!cd->dma_host) {
 		comp_err(dev, "chain_task_init(): dma_get() returned NULL");
 		return -EINVAL;
@@ -547,9 +547,9 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 	dir = (cd->stream_direction == SOF_IPC_STREAM_PLAYBACK) ?
 		SOF_DMA_DIR_MEM_TO_DEV : SOF_DMA_DIR_DEV_TO_MEM;
 
-	cd->dma_link = dma_get(dir, SOF_DMA_CAP_HDA, SOF_DMA_DEV_HDA, SOF_DMA_ACCESS_SHARED);
+	cd->dma_link = sof_dma_get(dir, SOF_DMA_CAP_HDA, SOF_DMA_DEV_HDA, SOF_DMA_ACCESS_SHARED);
 	if (!cd->dma_link) {
-		dma_put(cd->dma_host);
+		sof_dma_put(cd->dma_host);
 		comp_err(dev, "chain_task_init(): dma_get() returned NULL");
 		return -EINVAL;
 	}
@@ -610,8 +610,8 @@ static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uint8_t li
 
 	return 0;
 error:
-	dma_put(cd->dma_host);
-	dma_put(cd->dma_link);
+	sof_dma_put(cd->dma_host);
+	sof_dma_put(cd->dma_link);
 	return ret;
 }
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -479,7 +479,7 @@ int dai_common_new(struct dai_data *dd, struct comp_dev *dev,
 	dir = dai_cfg->direction == SOF_IPC_STREAM_PLAYBACK ?
 		SOF_DMA_DIR_MEM_TO_DEV : SOF_DMA_DIR_DEV_TO_MEM;
 
-	dd->dma = dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, SOF_DMA_ACCESS_SHARED);
+	dd->dma = sof_dma_get(dir, dd->dai->dma_caps, dd->dai->dma_dev, SOF_DMA_ACCESS_SHARED);
 	if (!dd->dma) {
 		dai_put(dd->dai);
 		comp_err(dev, "dma_get() failed to get shared access to DMA.");
@@ -591,7 +591,7 @@ void dai_common_free(struct dai_data *dd)
 		dd->chan->dev_data = NULL;
 	}
 
-	dma_put(dd->dma);
+	sof_dma_put(dd->dma);
 
 	dai_release_llp_slot(dd);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -614,7 +614,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 	dir = hd->ipc_host.direction == SOF_IPC_STREAM_PLAYBACK ?
 		SOF_DMA_DIR_HMEM_TO_LMEM : SOF_DMA_DIR_LMEM_TO_HMEM;
 
-	hd->dma = dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
+	hd->dma = sof_dma_get(dir, 0, SOF_DMA_DEV_HOST, SOF_DMA_ACCESS_SHARED);
 	if (!hd->dma) {
 		comp_err(dev, "dma_get() returned NULL");
 		return -ENODEV;
@@ -630,7 +630,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, sizeof(hd->posn));
 	if (!hd->msg) {
 		comp_err(dev, "ipc_msg_init failed");
-		dma_put(hd->dma);
+		sof_dma_put(hd->dma);
 		return -ENOMEM;
 	}
 	hd->chan = NULL;
@@ -678,7 +678,7 @@ e_data:
 
 void host_common_free(struct host_data *hd)
 {
-	dma_put(hd->dma);
+	sof_dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
 	dma_sg_free(&hd->config.elem_array);

--- a/src/drivers/imx/ipc.c
+++ b/src/drivers/imx/ipc.c
@@ -207,8 +207,13 @@ int platform_ipc_init(struct ipc *ipc)
 					     PLATFORM_PAGE_TABLE_SIZE);
 	if (iipc->dh_buffer.page_table)
 		bzero(iipc->dh_buffer.page_table, PLATFORM_PAGE_TABLE_SIZE);
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	iipc->dh_buffer.dmac = sof_dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
+					   SOF_DMA_ACCESS_SHARED);
+#else
 	iipc->dh_buffer.dmac = dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
 				       SOF_DMA_ACCESS_SHARED);
+#endif
 	if (!iipc->dh_buffer.dmac) {
 		tr_err(&ipc_tr, "Unable to find DMA for host page table");
 		sof_panic(SOF_IPC_PANIC_IPC);

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -30,7 +30,7 @@ DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
 static int dma_init(struct dma *dma);
 
-struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
+struct dma *sof_dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
 	const struct dma_info *info = dma_info_get();
 	int users, ret = 0;
@@ -123,7 +123,7 @@ out:
 	return !ret ? dmin : NULL;
 }
 
-void dma_put(struct dma *dma)
+void sof_dma_put(struct dma *dma)
 {
 	k_spinlock_key_t key;
 
@@ -162,6 +162,8 @@ static int dma_init(struct dma *dma)
 
 	return 0;
 }
+EXPORT_SYMBOL(sof_dma_get);
+EXPORT_SYMBOL(sof_dma_put);
 #else
 struct dma *dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
@@ -278,9 +280,9 @@ void dma_put(struct dma *dma)
 		dma, dma->sref);
 	k_spin_unlock(&dma->lock, key);
 }
-#endif
 EXPORT_SYMBOL(dma_get);
 EXPORT_SYMBOL(dma_put);
+#endif
 
 int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 		 enum mem_zone zone,

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -746,8 +746,8 @@ static int lib_manager_dma_init(struct lib_manager_dma_ext *dma_ext, uint32_t dm
 	/* Initialize dma_ext with zeros */
 	memset(dma_ext, 0, sizeof(struct lib_manager_dma_ext));
 	/* request DMA in the dir HMEM->LMEM */
-	dma_ext->dma = dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
-			       SOF_DMA_ACCESS_EXCLUSIVE);
+	dma_ext->dma = sof_dma_get(SOF_DMA_DIR_HMEM_TO_LMEM, 0, SOF_DMA_DEV_HOST,
+				   SOF_DMA_ACCESS_EXCLUSIVE);
 	if (!dma_ext->dma) {
 		tr_err(&lib_manager_tr,
 		       "lib_manager_dma_init(): dma_ext->dma = NULL");
@@ -774,7 +774,7 @@ static int lib_manager_dma_deinit(struct lib_manager_dma_ext *dma_ext, uint32_t 
 		if (dma_ext->dma->z_dev)
 			dma_release_channel(dma_ext->dma->z_dev, dma_id);
 
-		dma_put(dma_ext->dma);
+		sof_dma_put(dma_ext->dma);
 	}
 	return 0;
 }

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -198,8 +198,8 @@ static int probe_dma_init(struct probe_dma_ext *dma, uint32_t direction)
 	channel = ((union ipc4_connector_node_id)dma->stream_tag).f.v_index;
 
 	/* request DMA in the dir LMEM->HMEM with shared access */
-	dma->dc.dmac = dma_get(direction, 0, SOF_DMA_DEV_HOST,
-			       SOF_DMA_ACCESS_SHARED);
+	dma->dc.dmac = sof_dma_get(direction, 0, SOF_DMA_DEV_HOST,
+				   SOF_DMA_ACCESS_SHARED);
 	if (!dma->dc.dmac) {
 		tr_err(&pr_tr, "probe_dma_init(): dma->dc.dmac = NULL");
 		return -ENODEV;
@@ -267,10 +267,11 @@ static int probe_dma_deinit(struct probe_dma_ext *dma)
 	}
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
 	dma_release_channel(dma->dc.dmac->z_dev, dma->dc.chan->index);
+	sof_dma_put(dma->dc.dmac);
 #else
 	dma_channel_put_legacy(dma->dc.chan);
-#endif
 	dma_put(dma->dc.dmac);
+#endif
 
 	rfree((void *)dma->dmapb.addr);
 	dma->dmapb.addr = 0;

--- a/zephyr/include/sof/lib/dma-legacy.h
+++ b/zephyr/include/sof/lib/dma-legacy.h
@@ -27,6 +27,9 @@
 #define DMA_CHAN_INVALID	SOF_DMA_CHAN_INVALID
 #define DMA_CORE_INVALID	SOF_DMA_CORE_INVALID
 
+struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+void dma_put(struct dma *dma);
+
 enum dma_cb_status {
 	DMA_CB_STATUS_RELOAD = 0,
 	DMA_CB_STATUS_END,

--- a/zephyr/include/sof/lib/dma.h
+++ b/zephyr/include/sof/lib/dma.h
@@ -253,14 +253,14 @@ int dmac_init(struct sof *sof);
  * For exclusive access, ret DMAC with no channels draining.
  * For shared access, ret DMAC with the least number of channels draining.
  */
-struct dma *dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+struct dma *sof_dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 /**
  * \brief API to release a platform DMAC.
  *
  * @param[in] dma DMAC to relese.
  */
-void dma_put(struct dma *dma);
+void sof_dma_put(struct dma *dma);
 
 #ifndef CONFIG_ZEPHYR_NATIVE_DRIVERS
 #include "dma-legacy.h"


### PR DESCRIPTION
Add "sof_" namespace to dma_get()/put() calls in and modify all uses of the interface for builds with native Zephyr drivers.

Keep the old name for XTOS builds. This reduces the amount of code that needs to be touched, and in XTOS code, there is no confusion with the namespaces as all dma_foo() calls are to SOF DMA layer.

Link: https://github.com/thesofproject/sof/issues/9561