### PR TITLE
topology1: remove mute led from SoundWire capture

### DIFF
--- a/tools/topology/topology1/sof/pipe-highpass-switch-capture.m4
+++ b/tools/topology/topology1/sof/pipe-highpass-switch-capture.m4
@@ -38,7 +38,7 @@ C_CONTROLMIXER(Master Capture Switch, PIPELINE_ID,
 	,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)),
-	"1", "1")
+	"0", "0")
 #
 # Volume Configuration
 #

--- a/tools/topology/topology1/sof/pipe-volume-switch-capture.m4
+++ b/tools/topology/topology1/sof/pipe-volume-switch-capture.m4
@@ -32,7 +32,7 @@ C_CONTROLMIXER(Master Capture Switch, PIPELINE_ID,
 	,
 	Channel register and shift for Front Left/Right,
 	LIST(`	', KCONTROL_CHANNEL(FL, 2, 0), KCONTROL_CHANNEL(FR, 2, 1)),
-	"1", "1")
+	"0", "0")
 
 #
 # Volume Configuration


### PR DESCRIPTION
We should only use mute led on the PCH dmic.
pipe-highpass-switch-capture.m4 and pipe-volume-switch-capture are only used by SoundWire and nocodec pipelines. It will not impact the existing products.