### PR TITLE
west.yml: update zephyr to 42701fdb272

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 54435e000afa08fa05ce4417abd615e2fe6788d4
+      revision: 42701fdb27298d20b4040cea5cde375b72c27cfc
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 380 commits.

Changes include:

6d0c23be314 soc: intel_adsp: add support for .cold* sections
09cdc1f4b8c soc: intel_adsp: add a "cold" module manifest
de4003c07be soc: intel_adsp: check module address before copying to SRAM
020985b38b4 dts: xtensa: nxp_imx8m: Add SAI3 and SDMA3 node
e94c86f3951 drivers: dma: Add initial support for NXP SDMA
b0416f51b64 drivers: ssp: start with xtal clock on ssp ver >= 2.0