### PR TITLE
README.md: update Discord channel instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 ### Status
 [![Daily Actions](https://github.com/thesofproject/sof/actions/workflows/daily-tests.yml/badge.svg)](https://github.com/thesofproject/sof/actions/workflows/daily-tests.yml)
 
+### Community
+
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/thesofproject/community)
 
-[#sof channel on discord.com](https://discord.com/channels/720317445772017664/930855494472589362)
+Additional community support is available via the `#sof` channel in the Zephyr Project Discord server. See the [Resources section of the @zephyrproject-rtos GitHub organization README](https://github.com/zephyrproject-rtos#resources) for Discord access information.
 
 ### Documentation
 


### PR DESCRIPTION
Replace the direct #sof Discord channel link with a reference to the
Zephyr project's documentation for accessing their server, where the
channel is hosted.

The previous link only worked for users already in the Zephyr Discord
server, potentially confusing new visitors looking to join the channel.

Pointing to Zephyr's community docs provides the necessary context and
instructions for getting an invite to access the #sof channel.

Since the channel is part of Zephyr’s Discord server, directing readers
to their official documentation ensures the instructions remain accurate
while sparing this project from duplicating details.

Fixes GitHub issue #7161.