### PR TITLE
ipc: move delayed IPC sending to the primary core

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -170,6 +170,11 @@ out:
 	k_spin_unlock(&ipc->lock, key);
 }
 
+#ifdef __ZEPHYR__
+static struct k_work_q ipc_send_wq;
+static K_THREAD_STACK_DEFINE(ipc_send_wq_stack, CONFIG_STACK_SIZE_IPC_TX);
+#endif
+
 static void schedule_ipc_worker(void)
 {
 	/*
@@ -179,7 +184,7 @@ static void schedule_ipc_worker(void)
 #ifdef __ZEPHYR__
 	struct ipc *ipc = ipc_get();
 
-	k_work_schedule(&ipc->z_delayed_work, K_USEC(IPC_PERIOD_USEC));
+	k_work_schedule_for_queue(&ipc_send_wq, &ipc->z_delayed_work, K_USEC(IPC_PERIOD_USEC));
 #endif
 }
 
@@ -305,6 +310,20 @@ int ipc_init(struct sof *sof)
 #endif
 
 #ifdef __ZEPHYR__
+	struct k_thread *thread = &ipc_send_wq.thread;
+
+	k_work_queue_start(&ipc_send_wq,
+		       ipc_send_wq_stack,
+		       K_THREAD_STACK_SIZEOF(ipc_send_wq_stack),
+		       1, NULL);
+
+	k_thread_suspend(thread);
+
+	k_thread_cpu_pin(thread, PLATFORM_PRIMARY_CORE_ID);
+	k_thread_name_set(thread, "ipc_send_wq");
+
+	k_thread_resume(thread);
+
 	k_work_init_delayable(&sof->ipc->z_delayed_work, ipc_work_handler);
 #endif
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -96,4 +96,10 @@ config STACK_SIZE_EDF
 	help
 	  EDF scheduler work-queue thread stack size. Keep a power of 2.
 
+config STACK_SIZE_IPC_TX
+	int "IPC sender stack size"
+	default 2048
+	help
+	  IPC sender work-queue thread stack size. Keep a power of 2.
+
 endif

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -89,4 +89,11 @@ config VIRTUAL_HEAP
 	help
 	  Enabling this option will use the virtual memory heap allocator to allocate buffers.
 	  It is based on a set of buffers whose size is predetermined.
+
+config STACK_SIZE_EDF
+	int "EDF scheduler stack size"
+	default 8192
+	help
+	  EDF scheduler work-queue thread stack size. Keep a power of 2.
+
 endif

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -14,7 +14,7 @@
 #include <zephyr/sys_clock.h>
 
 static struct k_work_q edf_workq;
-static K_THREAD_STACK_DEFINE(edf_workq_stack, 8192);
+static K_THREAD_STACK_DEFINE(edf_workq_stack, CONFIG_STACK_SIZE_EDF);
 
 /*
  * since only IPC is using the EDF scheduler - we schedule the work in the


### PR DESCRIPTION
Low level IPC processing should be confined to the primary core. Move delayed IPC sending to a dedicated work queue with core 0 affinity.

Fixes: #8165