### PR TITLE
[SKIP SOF-TEST] github: free some disc space

### DIFF
--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -17,6 +17,11 @@ jobs:
         platform: [mtl, lnl]
 
     steps:
+      - name: free space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
       - name: git clone sof
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -25,6 +25,11 @@ jobs:
         platform: [tgl, mtl, lnl]
 
     steps:
+      - name: free space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
       - name: git clone sparse analyzer
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -138,6 +138,11 @@ jobs:
           filter: 'tree:0'
           path: ./workspace/sof
 
+      - name: free space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
       - name: west clones
 
         run: pip3 install west && cd workspace/sof/ && west init -l &&


### PR DESCRIPTION
We're getting GitHub workflow failures like:

docker: failed to register layer: write /usr/lib/x86_64-linux-gnu/libz3.so.4: no space left on device.

e.g. in
https://github.com/thesofproject/sof/actions/runs/12651056289/job/35250849879?pr=9702 This patch frees some space before running tests.