### PR TITLE
regions_mm: vmh_free: Prevent null pointer dereference

### DIFF
--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -571,6 +571,10 @@ int vmh_free(struct vmh_heap *heap, void *ptr)
 	for (mem_block_iter = 0, ptr_range_found = false;
 		mem_block_iter < MAX_MEMORY_ALLOCATORS_COUNT;
 		mem_block_iter++) {
+		/* continiue so we do not check mem blocks that do not exist */
+		if (!heap->physical_blocks_allocators[mem_block_iter])
+			continue;
+
 		block_size =
 			1 << heap->physical_blocks_allocators[mem_block_iter]->info.blk_sz_shift;
 


### PR DESCRIPTION
The vmh_free function may have referenced a null pointer if an invalid pointer was passed to it. Before referencing the allocator array item, check if it has been initialized.

Add k_panic() function call in error handling code to help detect potential memory release errors.