### PR TITLE
zephyr: alloc: virtual_heap_free: Panic on deallocations errors

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -257,8 +257,10 @@ static void virtual_heap_free(void *ptr)
 	ptr = (__sparse_force void *)sys_cache_cached_ptr_get(ptr);
 
 	ret = vmh_free(heap, ptr);
-	if (ret)
+	if (ret) {
 		tr_err(&zephyr_tr, "Unable to free %p! %d", ptr, ret);
+		k_panic();
+	}
 }
 
 static const struct vmh_heap_config static_hp_buffers = {


### PR DESCRIPTION
Add k_panic() function call in error handling code to help detect potential memory release errors.

The vmh_free function returns an error if:
1. heap belongs to another core,
2. given pointer to be freed is invalid (doesn't belong to the allocator),
3. there is an error in the code determining the size of the block to be freed
4. memory unmapping fails.

Log entry is easy to miss, stopping the firmware at this point will draw attention to a critical problem related to memory allocation. Otherwise, it will have a slowly progressing memory leak.

If we decide this is a desirable change, we can merge it after https://github.com/thesofproject/sof/pull/9776 and https://github.com/thesofproject/sof/pull/9777 have been merged.