### PR TITLE
topology2: cavs-nocodec-bt: add Intel PTL support

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -63,6 +63,7 @@ IncludeByKey.PLATFORM {
 	"adl"	"platform/intel/tgl.conf"
 	"mtl"	"platform/intel/mtl.conf"
 	"lnl"	"platform/intel/lnl.conf"
+	"ptl"	"platform/intel/ptl.conf"
 }
 
 # include DMIC config if needed.

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -280,6 +280,13 @@ PLATFORM=mtl"
 "cavs-nocodec-bt\;sof-nocodec-bt-mtl-lbm\;BT_LOOPBACK_MODE=true,PLATFORM=mtl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-mtl-lbm.bin"
 
+# BT offload for ptl
+"cavs-nocodec-bt\;sof-nocodec-bt-ptl\;PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-ptl.bin,\
+PLATFORM=ptl"
+# BT offload loopback test topology (lbm) for ptl
+"cavs-nocodec-bt\;sof-nocodec-bt-ptl-lbm\;BT_LOOPBACK_MODE=true,PLATFORM=ptl,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-ptl-lbm.bin"
+
 # CAVS HDA topology for benchmarking performance
 # Copier - peak volume - mixin - mixout - aria - peak volume - mixin - mixout - copier
 "sof-hda-generic\;sof-hda-benchmark-generic\;HDA_CONFIG=benchmark,BENCH_CONFIG=benchmark,BENCH_ARIA_PARAMS=param_1"


### PR DESCRIPTION
Add rules to create sof-nocodec-bt-ptl.tplg and
sof-nocodec-bt-ptl-lbm.tplg.