### PR TITLE
tools: topology1: imx8mp: Switch to time domain timer

### DIFF
--- a/tools/topology/topology1/sof-imx8mp-btsco-dual-8ch.m4
+++ b/tools/topology/topology1/sof-imx8mp-btsco-dual-8ch.m4
@@ -79,7 +79,7 @@ dnl     deadline, priority, core)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, 2, sai2-bt-sco-pcm-wb,
 	PIPELINE_SOURCE_1, 2, s16le,
-	DEADLINE, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	DEADLINE, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI SAI2 using 2 periods
 DAI_ADD(sof/pipe-dai-capture.m4,
@@ -91,7 +91,7 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 DAI_ADD(sof/pipe-dai-playback.m4,
 	3, SAI, 3, sai3-bt-sco-pcm-wb,
 	PIPELINE_SOURCE_3, 2, s16le,
-	DEADLINE, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	DEADLINE, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 # capture DAI SAI3 using 2 periods
 DAI_ADD(sof/pipe-dai-capture.m4,

--- a/tools/topology/topology1/sof-imx8mp-compr-pcm-cap-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8mp-compr-pcm-cap-wm8960.m4
@@ -75,7 +75,7 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-capture.m4,
 	1, SAI, 3, sai3-wm8960-hifi,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 
 # PCM Low Latency, id 0

--- a/tools/topology/topology1/sof-imx8mp-compr-pcm-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8mp-compr-pcm-wm8960.m4
@@ -75,7 +75,7 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, 3, sai3-wm8960-hifi,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 
 # PCM Low Latency, id 0

--- a/tools/topology/topology1/sof-imx8mp-compr-wm8960.m4
+++ b/tools/topology/topology1/sof-imx8mp-compr-wm8960.m4
@@ -91,7 +91,7 @@ dnl     period, priority, core, time_domain)
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SAI, 3, DAI_BE_NAME,
 	PIPELINE_SOURCE_1, 2, s32le,
-	1000, 0, 0, SCHEDULE_TIME_DOMAIN_DMA)
+	1000, 0, 0, SCHEDULE_TIME_DOMAIN_TIMER)
 
 
 # PCM Low Latency, id 0


### PR DESCRIPTION
After commit eac3c4470a13 ("imx8mp: Switch to native drivers and timer domain") we no longer use DMA domain for scheduling.

Fix topologies to use time domain timer.