### PR TITLE
topology2: cavs-nocodec-bt: align Port0/1 configuration with Port2

### DIFF
--- a/tools/topology/topology2/cavs-nocodec-bt.conf
+++ b/tools/topology/topology2/cavs-nocodec-bt.conf
@@ -82,15 +82,58 @@ Object.Dai.SSP [
 		direction	"duplex"
 		name		NoCodec-0
 		default_hw_conf_id	0
-		sample_bits		32
+		sample_bits		16
 		quirks			"lbm_mode"
-		io_clk		$MCLK
+		io_clk			$BT_MCLK
 		Object.Base.hw_config.1 {
-			name	"SSP0"
-			id      0
-			bclk_freq       3072000
-			tdm_slot_width  32
-			# TODO: remove this. Needs alsaptlg change.
+			id		0
+			name		"BT-SCO-WB"
+			mclk_freq	$BT_MCLK
+			bclk_freq	256000
+			bclk_invert     true
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	16000
+			tdm_slots	1
+			tx_slots	1
+			rx_slots	1
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+		Object.Base.hw_config.2 {
+			id		1
+			name		"BT-SCO-NB"
+			mclk_freq	$BT_MCLK
+			bclk_freq	128000
+			bclk_invert     true
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	8000
+			tdm_slots	1
+			tx_slots	1
+			rx_slots	1
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+		Object.Base.hw_config.3 {
+			id		2
+			name		"BT-A2DP"
+			mclk_freq	$BT_MCLK
+			bclk_freq	1536000
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	48000
+			tdm_slots	2
+			tx_slots	3
+			rx_slots	3
 			Object.Base.link_config.1 {
 				clock_source	1
 			}
@@ -102,16 +145,58 @@ Object.Dai.SSP [
 		direction	"duplex"
 		name		NoCodec-1
 		default_hw_conf_id	0
-		sample_bits		32
+		sample_bits		16
 		quirks			"lbm_mode"
-		io_clk		$MCLK
-
+		io_clk			$BT_MCLK
 		Object.Base.hw_config.1 {
-			name	"SSP1"
-			id	0
-			bclk_freq	3072000
-			tdm_slot_width	32
-			# TODO: remove this. Needs alsaptlg change.
+			id		0
+			name		"BT-SCO-WB"
+			mclk_freq	$BT_MCLK
+			bclk_freq	256000
+			bclk_invert     true
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	16000
+			tdm_slots	1
+			tx_slots	1
+			rx_slots	1
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+		Object.Base.hw_config.2 {
+			id		1
+			name		"BT-SCO-NB"
+			mclk_freq	$BT_MCLK
+			bclk_freq	128000
+			bclk_invert     true
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	8000
+			tdm_slots	1
+			tx_slots	1
+			rx_slots	1
+			Object.Base.link_config.1 {
+				clock_source	1
+			}
+		}
+		Object.Base.hw_config.3 {
+			id		2
+			name		"BT-A2DP"
+			mclk_freq	$BT_MCLK
+			bclk_freq	1536000
+			tdm_slot_width	16
+			format		"DSP_A"
+			bclk		"codec_consumer"
+			fsync		"codec_consumer"
+			fsync_freq	48000
+			tdm_slots	2
+			tx_slots	3
+			rx_slots	3
 			Object.Base.link_config.1 {
 				clock_source	1
 			}
@@ -131,7 +216,7 @@ Object.Pipeline {
 			index	2
 			direction	playback
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-0'
+				stream_name	"dai-copier.SSP.NoCodec-0.playback"
 			}
 
 			Object.Widget.dai-copier.1 {
@@ -141,13 +226,49 @@ Object.Pipeline {
 				stream_name "NoCodec-0"
 				node_type $I2S_LINK_OUTPUT_CLASS
 				num_input_pins 1
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				num_input_pins 1
+
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 		{
 			index	4
 			direction	playback
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-1'
+				stream_name	"dai-copier.SSP.NoCodec-1.playback"
 			}
 
 			Object.Widget.dai-copier.1 {
@@ -157,6 +278,42 @@ Object.Pipeline {
 				stream_name "NoCodec-1"
 				node_type $I2S_LINK_OUTPUT_CLASS
 				num_input_pins 1
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				num_input_pins 1
+
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 	]
@@ -165,21 +322,89 @@ Object.Pipeline {
 			{
 			index	1
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-0'
+				stream_name	"dai-copier.SSP.NoCodec-0.playback"
 			}
 			Object.Widget.host-copier.1 {
 				stream_name 'SSP0 Playback'
 				pcm_id 0
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 		{
 			index	3
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-1'
+				stream_name	"dai-copier.SSP.NoCodec-1.playback"
 			}
 			Object.Widget.host-copier.1 {
 				stream_name 'SSP1 Playback'
 				pcm_id 1
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 	]
@@ -189,21 +414,89 @@ Object.Pipeline {
 		{
 			index 	5
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-0'
+				stream_name	"dai-copier.SSP.NoCodec-0.capture"
 			}
 			Object.Widget.host-copier.1 {
 				stream_name 'SSP0 Capture'
 				pcm_id 0
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 		{
 			index 	9
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-1'
+				stream_name	"dai-copier.SSP.NoCodec-1.capture"
 			}
 			Object.Widget.host-copier.1 {
 				stream_name 'SSP1 Capture'
 				pcm_id 1
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
+					{
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
+					}
+				]
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
+					{
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
+					}
+				]
 			}
 		}
 	]
@@ -213,7 +506,7 @@ Object.Pipeline {
 			index		6
 			direction	capture
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-0'
+				stream_name	"dai-copier.SSP.NoCodec-0.capture"
 			}
 
 			Object.Widget.dai-copier."1" {
@@ -223,16 +516,40 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	"NoCodec-0"
 				node_type	$I2S_LINK_INPUT_CLASS
-				Object.Base.input_audio_format [
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				num_input_pins 1
+
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
 					{
-						in_bit_depth		32
-						in_valid_bit_depth	32
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
 					}
 				]
-				Object.Base.output_audio_format [
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
 					{
-						out_bit_depth		32
-						out_valid_bit_depth	32
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
 					}
 				]
 			}
@@ -241,7 +558,7 @@ Object.Pipeline {
 			index		10
 			direction	capture
 			Object.Widget.pipeline.1 {
-				stream_name 'NoCodec-1'
+				stream_name	"dai-copier.SSP.NoCodec-1.capture"
 			}
 
 			Object.Widget.dai-copier."1" {
@@ -251,16 +568,40 @@ Object.Pipeline {
 				copier_type	"SSP"
 				stream_name	"NoCodec-1"
 				node_type	$I2S_LINK_INPUT_CLASS
-				Object.Base.input_audio_format [
+				num_input_audio_formats 3
+				num_output_audio_formats 3
+				num_input_pins 1
+
+				CombineArrays.Object.Base.output_audio_format [
+					# array of 2ch format with range of rates
 					{
-						in_bit_depth		32
-						in_valid_bit_depth	32
+						out_rate [
+							8000
+							16000
+						]
+						out_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						out_bit_depth		[ 16 ]
+						out_valid_bit_depth	[ 16 ]
+						out_channels		[ 2 ]
 					}
 				]
-				Object.Base.output_audio_format [
+				CombineArrays.Object.Base.input_audio_format [
+					# array of 2ch format with range of rates
 					{
-						out_bit_depth		32
-						out_valid_bit_depth	32
+						in_rate [
+							8000
+							16000
+						]
+						in_channels [ 1 ]
+					}
+					# 2ch 16-bit 48k
+					{
+						in_bit_depth		[ 16 ]
+						in_valid_bit_depth	[ 16 ]
+						in_channels		[ 2 ]
 					}
 				]
 			}
@@ -280,13 +621,19 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			direction "playback"
 			name "SSP0 Playback"
-			formats 'S32_LE'
+			formats 'S16_LE'
+			rates '8000,16000,48000'
+			channels_min 1
+			channels_max 2
 		}
 
 		Object.PCM.pcm_caps.2 {
 			direction "capture"
 			name "SSP0 Capture"
-			formats 'S32_LE'
+			formats 'S16_LE'
+			rates '8000,16000,48000'
+			channels_min 1
+			channels_max 2
 		}
 	}
 	{
@@ -300,13 +647,19 @@ Object.PCM.pcm [
 		Object.PCM.pcm_caps.1 {
 			direction "playback"
 			name "SSP1 Playback"
-			formats 'S32_LE'
+			formats 'S16_LE'
+			rates '8000,16000,48000'
+			channels_min 1
+			channels_max 2
 		}
 
 		Object.PCM.pcm_caps.2 {
 			direction "capture"
 			name "SSP1 Capture"
-			formats 'S32_LE'
+			formats 'S16_LE'
+			rates '8000,16000,48000'
+			channels_min 1
+			channels_max 2
 		}
 	}
 ]


### PR DESCRIPTION
Align Port0 and Port1 PCM parameters with Port2, so that all PCMs can be used to test pipelines aligned with Bluetooth profiles.

Continue using the common infrastructure in "bt-generic.conf" for Port2 as these definitions are used by many other topologies. Set up Port0/1 manually in cavs-nocodec-bt.conf and always enable loopback configuration for these ports.