### PR TITLE
scripts: gen-uuid-reg.py: Generate string identifier for toml files

### DIFF
--- a/scripts/gen-uuid-reg.py
+++ b/scripts/gen-uuid-reg.py
@@ -31,6 +31,9 @@ def emit_uuid_rec(uu, sym):
     uuidinit = "{ " + ", ".join(wrecs) + ", { " + ", ".join(byts) + " } }"
     out_recs.append(f"#define _UUIDREG_{sym} {uuidinit}")
 
+    uuidstr = uu[:23] + '-' + uu[23:]
+    out_recs.append(f'#define UUIDREG_STR_{sym.upper()} "{uuidstr}"')
+
 def main():
     with open(sys.argv[1]) as f:
         for line in f.readlines():


### PR DESCRIPTION
Extend the script that generates the `uuid-registry.h` file to also generate definitions containing the uuid as a string. These definitions (UUIDREG_STR_...) can be used in toml files, allowing get values from the uuid-registry.

After merge, `uuid-registry.h` will contain following entries:
```C
#define _UUIDREG_dcblock { 0xb809efaf, 0x5681, 0x42b1, { 0x9e, 0xd6, 0x04, 0xbb, 0x01, 0x2d, 0xd3, 0x84 } }
#define UUIDREG_STR_DCBLOCK "b809efaf-5681-42b1-9ed6-04bb012dd384"
```

For example, following toml file fragment:
```
	[[module.entry]]
	name = "DCBLOCK"
	uuid = "B809EFAF-5681-42B1-9ED6-04BB012DD384"
```
will be possible to change to:
```
	[[module.entry]]
	name = "DCBLOCK"
	uuid = UUIDREG_STR_DCBLOCK
```

Require update `sign.py` on Zephyrs side: https://github.com/zephyrproject-rtos/zephyr/pull/84615