### PR TITLE
topology2: intel: fix default BT clock for ACE1.5 and newer

### DIFF
--- a/tools/topology/topology2/platform/intel/bt-generic.conf
+++ b/tools/topology/topology2/platform/intel/bt-generic.conf
@@ -66,7 +66,7 @@ Object.Pipeline {
 		{
 			index		$BT_PB_HOST_PIPELINE_ID
 			Object.Widget.pipeline.1 {
-		                stream_name "dai-copier.SSP.$BT_NAME.playback"
+				stream_name "dai-copier.SSP.$BT_NAME.playback"
 			}
 			Object.Widget.host-copier.1 {
 				stream_name $BT_PB_PCM_CAPS

--- a/tools/topology/topology2/platform/intel/bt-ssp-config.conf
+++ b/tools/topology/topology2/platform/intel/bt-ssp-config.conf
@@ -21,6 +21,8 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			# link_config ignored for <ACE1.5, must be compatible
+			# with BT_MCLK
 			Object.Base.link_config.1 {
 				clock_source	1
 			}
@@ -39,6 +41,8 @@ Object.Dai.SSP [
 			tdm_slots	1
 			tx_slots	1
 			rx_slots	1
+			# link_config ignored for <ACE1.5, must be compatible
+			# with BT_MCLK
 			Object.Base.link_config.1 {
 				clock_source	1
 			}
@@ -56,6 +60,8 @@ Object.Dai.SSP [
 			tdm_slots	2
 			tx_slots	3
 			rx_slots	0
+			# link_config ignored for <ACE1.5, must be compatible
+			# with BT_MCLK
 			Object.Base.link_config.1 {
 				clock_source	1
 			}

--- a/tools/topology/topology2/platform/intel/lnl.conf
+++ b/tools/topology/topology2/platform/intel/lnl.conf
@@ -3,4 +3,7 @@ Define {
 	DMIC_DRIVER_VERSION		4
 	SSP_BLOB_VERSION		0x105
 	NUM_HDMIS			3
+
+	# matches with clock_source=1 (Audio Cardinal Clock)
+	BT_MCLK			24576000
 }

--- a/tools/topology/topology2/platform/intel/mtl.conf
+++ b/tools/topology/topology2/platform/intel/mtl.conf
@@ -3,4 +3,7 @@ Define {
 	DMIC_DRIVER_VERSION		3
 	SSP_BLOB_VERSION		0x105
 	NUM_HDMIS			3
+
+	# matches with clock_source=1 (Audio Cardinal Clock)
+	BT_MCLK			24576000
 }

--- a/tools/topology/topology2/platform/intel/ptl.conf
+++ b/tools/topology/topology2/platform/intel/ptl.conf
@@ -3,4 +3,7 @@ Define {
 	DMIC_DRIVER_VERSION		5
 	SSP_BLOB_VERSION		0x300
 	NUM_HDMIS			3
+
+	# matches with clock_source=1 (Audio Cardinal Clock)
+	BT_MCLK			24576000
 }


### PR DESCRIPTION
Fix a bug in clock definitions for BT offload configurations. The BT_MCLK and link_control.clock_source definitions must match and this has not been the case for all ACE1.5+ scenarios.

The practical impacts are limited as this does not impact the common HFP NB/WB configuration, as the DSP is not the clock provider in these cases.

Impacts can be seen on ACE1.5+ with A2DP offload and BT HFP LBM test mode. Result is incorrect playback/capture speed.
