### PR TITLE
ipc4: mixin: Improve HiFi3 mix with gain impl

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -21,8 +21,8 @@ static void mix_s16(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixe
 	ae_int16x4 out_sample;
 	ae_int16x4 *in;
 	ae_int16x4 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	ae_int16 *dst = (ae_int16 *)sink->ptr + start_sample;
@@ -108,8 +108,8 @@ static void mix_s16_gain(struct cir_buf_ptr *sink, int32_t start_sample, int32_t
 	ae_int16x4 out_sample;
 	ae_int16x4 *in;
 	ae_int16x4 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	ae_int16 *dst = (ae_int16 *)sink->ptr + start_sample;
@@ -224,8 +224,8 @@ static void mix_s24(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixe
 	ae_int32x2 out_sample;
 	ae_int32x2 *in;
 	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->ptr + start_sample;
@@ -313,8 +313,8 @@ static void mix_s24_gain(struct cir_buf_ptr *sink, int32_t start_sample, int32_t
 	ae_int32x2 out_sample;
 	ae_int32x2 *in;
 	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->ptr + start_sample;
@@ -431,8 +431,8 @@ static void mix_s32(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixe
 	ae_int32x2 out_sample;
 	ae_int32x2 *in;
 	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->ptr + start_sample;
@@ -512,8 +512,8 @@ static void mix_s32_gain(struct cir_buf_ptr *sink, int32_t start_sample, int32_t
 	ae_int32x2 out_sample;
 	ae_int32x2 *in;
 	ae_int32x2 *out;
-	ae_valign inu = AE_ZALIGN64();
-	ae_valign outu1 = AE_ZALIGN64();
+	ae_valign inu;
+	ae_valign outu1;
 	ae_valign outu2 = AE_ZALIGN64();
 	/* cir_buf_wrap() is required and is done below in a loop */
 	int32_t *dst = (int32_t *)sink->ptr + start_sample;


### PR DESCRIPTION
Simpler and faster implementation of HiFi3 mix with gain functions. The previous version works fine. This is just an improvement to make the code faster and more straightforward.