### PR TITLE
rimage: configs: imx95: use SRAM instead of DRAM

### DIFF
--- a/tools/rimage/config/imx95.toml
+++ b/tools/rimage/config/imx95.toml
@@ -4,6 +4,6 @@ version = [1, 0]
 name = "imx95"
 
 [[adsp.mem_zone]]
-type = "DRAM"
+type = "SRAM"
 base = "0x80000000"
 size = "0x100000"


### PR DESCRIPTION
For imx95, the firmware is meant to be put in SRAM instead of the DRAM. Fix this.

When https://lore.kernel.org/linux-arm-kernel/20241216145039.3074-1-laurentiumihalcea111@gmail.com/T/ and
https://lore.kernel.org/imx/20250203171808.4108-10-laurentiumihalcea111@gmail.com/T/ will land, the SOF imx95 driver will expect the firmware to be placed in SRAM instead of DRAM. Make appropriate changes to rimage.