### PR TITLE
rimage: config: add ptl to generic platform toml

### DIFF
--- a/tools/rimage/config/platform.toml
+++ b/tools/rimage/config/platform.toml
@@ -2,4 +2,6 @@
 #include "platform-mtl.toml"
 #elif CONFIG_LUNARLAKE
 #include "platform-lnl.toml"
+#elif CONFIG_PANTHERLAKE
+#include "platform-ptl.toml"
 #endif


### PR DESCRIPTION
This is required to build single PTL loadable module