### PR TITLE
DRAM: `fast_get()` cache-handling improvements

### DIFF
--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -10,6 +10,7 @@
 
 #include <sof/lib/fast-get.h>
 #include <rtos/alloc.h>
+#include <rtos/cache.h>
 #include <rtos/spinlock.h>
 #include <rtos/symbol.h>
 #include <ipc/topology.h>
@@ -113,6 +114,11 @@ const void *fast_get(const void *dram_ptr, size_t size)
 
 		ret = entry->sram_ptr;
 		entry->refcount++;
+		/*
+		 * The data is constant, so it's safe to use cached access to
+		 * it, but initially we have to invalidate cached
+		 */
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)ret, size);
 		goto out;
 	}
 

--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -159,10 +159,10 @@ void fast_put(const void *sram_ptr)
 		goto out;
 	}
 	entry->refcount--;
-	if (entry->refcount > 0)
-		goto out;
-	rfree(entry->sram_ptr);
-	memset(entry, 0, sizeof(*entry));
+	if (!entry->refcount) {
+		rfree(entry->sram_ptr);
+		memset(entry, 0, sizeof(*entry));
+	}
 out:
 	tr_dbg(fast_get, "put %p, DRAM %p size %u refcnt %u", sram_ptr, entry ? entry->dram_ptr : 0,
 	       entry ? entry->size : 0, entry ? entry->refcount : 0);


### PR DESCRIPTION
Use uncached aliases for potentially shared objects, synchronise cache properly when sharing cached access