### PR TITLE
Update waves codec integration for Zephyr production builds

### DIFF
--- a/src/drivers/mediatek/mt8196/intc.c
+++ b/src/drivers/mediatek/mt8196/intc.c
@@ -52,11 +52,10 @@ void intc_init(void)
 
 void intc_irq_unmask(enum IRQn_Type irq)
 {
-	uint32_t word, group;
+	uint32_t word;
 
 	if (irq < IRQ_MAX_CHANNEL && intc_desc.irqs[irq].group < INTC_GRP_NUM) {
 		word = INTC_WORD(irq);
-		group = intc_desc.irqs[irq].group;
 		io_reg_update_bits(INTC_IRQ_EN(word), INTC_BIT(irq), INTC_BIT(irq));
 	} else {
 		tr_err(&intc_tr, "Invalid INTC interrupt %d", irq);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1141,17 +1141,21 @@ elseif(CONFIG_DTS_CODEC)
 	endif()
 endif()
 
-if(CONFIG_WAVES_CODEC STREQUAL "m")
-	add_subdirectory(${SOF_AUDIO_PATH}/module_adapter/module/waves/llext
-			 ${PROJECT_BINARY_DIR}/waves_llext)
-	add_dependencies(app waves)
-elseif(CONFIG_WAVES_CODEC)
-	zephyr_library_sources(
-		${SOF_AUDIO_PATH}/module_adapter/module/waves/waves.c
-	)
-	zephyr_library_sources_ifdef(CONFIG_WAVES_CODEC_STUB
-		${SOF_AUDIO_PATH}/module_adapter/module/waves/maxx_stub.c
-	)
+if(CONFIG_WAVES_CODEC)
+	set(WAVES_DIR ${SOF_AUDIO_PATH}/module_adapter/module/waves)
+	if(CONFIG_WAVES_CODEC STREQUAL "m")
+		add_subdirectory(${WAVES_DIR}/llext ${PROJECT_BINARY_DIR}/waves_llext)
+		add_dependencies(app waves)
+	else()
+		zephyr_library_sources(${WAVES_DIR}/waves.c)
+		if(CONFIG_WAVES_CODEC_STUB)
+			zephyr_library_sources_ifdef(CONFIG_WAVES_CODEC_STUB
+						     ${WAVES_DIR}/maxx_stub.c)
+		else()
+			zephyr_library_import(waves_codec
+				${sof_top_dir}/third_party/lib/libMaxxChrome.a)
+		endif()
+	endif()
 endif()
 
 if(CONFIG_PROBE STREQUAL "m")


### PR DESCRIPTION
This wasn't including the needed third party library.  Also rework it a little to make the cmake a little less of a mess.  Not sure I actually improved things, but I tried.

Also one trivial warning fixup I stumbled on with a variant xt-clang.