### PR TITLE
 llext: use the new inspection API

### DIFF
--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -97,12 +97,14 @@ struct lib_manager_segment_desc {
 };
 
 struct llext;
+struct llext_buf_loader;
 
 struct lib_manager_module {
 	unsigned int start_idx;	/* Index of the first driver from this module in
 				 * the library-global driver list */
 	const struct sof_man_module_manifest *mod_manifest;
 	struct llext *llext; /* Zephyr loadable extension context */
+	struct llext_buf_loader *ebl; /* Zephyr loadable extension buffer loader */
 	bool mapped;
 	struct lib_manager_segment_desc segment[LIB_MANAGER_N_SEGMENTS];
 };


### PR DESCRIPTION
This PR tries to improve SOF by minimizing its dependency on LLEXT internals. 
Instead of relying on direct field access, the code in `llext_manager.c` is refactored to use a set of new, stable LLEXT APIs that expose the same information. These code changes should have no measurable effects in the rest of SOF.

[LNL test passed](https://sof-ci.01.org/sofpr/PR9831/build10984/devicetest/index.html) as of commit 23478ef20cb4390c7bbfd62a9e19288077794c79.