### PR TITLE
[ported from cavs2.5-001-drop-stable] ssp-related changes

### DIFF
--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -913,6 +913,10 @@ static void ssp_start(struct dai *dai, int direction)
 
 	spin_lock(&dai->lock);
 
+	/* RX fifo must be cleared before start */
+	if (direction == DAI_DIR_CAPTURE)
+		ssp_empty_rx_fifo(dai);
+
 	/* request mclk/bclk */
 	ssp_pre_start(dai);
 

--- a/src/drivers/intel/ssp/ssp.c
+++ b/src/drivers/intel/ssp/ssp.c
@@ -1108,9 +1108,18 @@ static int ssp_probe(struct dai *dai)
 
 static int ssp_remove(struct dai *dai)
 {
+	struct ssp_pdata *ssp = dai_get_drvdata(dai);
+
 	pm_runtime_put_sync(SSP_CLK, dai->index);
 
-	ssp_mclk_disable_unprepare(dai);
+	/*
+	 * dai comp will be freed during HW_FREE stage if dynamic pipeline is
+	 * enabled; need to check the MCLK_AON quirk to see if we need to keep
+	 * MCLK on even when dai comp is going to be freed
+	 */
+	if (!(ssp->params.clks_control & SOF_DAI_INTEL_SSP_CLKCTRL_MCLK_AON))
+		ssp_mclk_disable_unprepare(dai);
+
 	ssp_bclk_disable_unprepare(dai);
 
 	/* Disable SSP power */


### PR DESCRIPTION
Update some ssp-related commits from cavs2.5-001-drop-stable to jsl-005-drop-stable.
(we didn't do cherry-picking from main directly because the code has been diverted by the age. cavs2.5-001-drop-stable is the nearest branch and has been verified as good.