### PR TITLE
src: mark code as "cold"

### DIFF
--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -33,9 +33,9 @@
 
 LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);
 
-static int src_prepare(struct processing_module *mod,
-		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink **sinks, int num_of_sinks)
+__cold static int src_prepare(struct processing_module *mod,
+			      struct sof_source **sources, int num_of_sources,
+			      struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct src_param *a = &cd->param;

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -44,7 +44,7 @@
 LOG_MODULE_REGISTER(src, CONFIG_SOF_LOG_LEVEL);
 
 /* Calculates buffers to allocate for a SRC mode */
-static int src_buffer_lengths(struct comp_dev *dev, struct comp_data *cd, int nch)
+__cold static int src_buffer_lengths(struct comp_dev *dev, struct comp_data *cd, int nch)
 {
 	const struct src_stage *stage1;
 	const struct src_stage *stage2;
@@ -183,8 +183,8 @@ static int init_stages(const struct src_stage *stage1, const struct src_stage *s
 	return 0;
 }
 
-static int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
-			      int32_t *delay_lines_start)
+__cold static int src_polyphase_init(struct polyphase_src *src, struct src_param *p,
+				     int32_t *delay_lines_start)
 {
 	const struct src_stage *stage1;
 	const struct src_stage *stage2;
@@ -392,7 +392,7 @@ void src_set_alignment(struct sof_source *source, struct sof_sink *sink)
 	sink_set_alignment_constants(sink, byte_align, frame_align_req);
 }
 
-static int src_verify_params(struct processing_module *mod)
+__cold static int src_verify_params(struct processing_module *mod)
 {
 	struct sof_ipc_stream_params *params = mod->stream_params;
 	struct comp_data *cd = module_get_private_data(mod);
@@ -473,9 +473,9 @@ static bool src_get_copy_limits(struct comp_data *cd,
 	return true;
 }
 
-int src_params_general(struct processing_module *mod,
-		       struct sof_source *source,
-		       struct sof_sink *sink)
+__cold int src_params_general(struct processing_module *mod,
+			      struct sof_source *source,
+			      struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -574,7 +574,7 @@ int src_params_general(struct processing_module *mod,
 	return 0;
 }
 
-int src_param_set(struct comp_dev *dev, struct comp_data *cd)
+__cold int src_param_set(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct src_param *a = &cd->param;
 	int fs_in = cd->source_rate;
@@ -593,9 +593,9 @@ int src_param_set(struct comp_dev *dev, struct comp_data *cd)
 	return 0;
 }
 
-int src_allocate_copy_stages(struct comp_dev *dev, struct src_param *prm,
-			     const struct src_stage *stage_src1,
-			     const struct src_stage *stage_src2)
+__cold int src_allocate_copy_stages(struct comp_dev *dev, struct src_param *prm,
+				    const struct src_stage *stage_src1,
+				    const struct src_stage *stage_src2)
 {
 #if CONFIG_FAST_GET
 	struct src_stage *stage_dst;
@@ -666,21 +666,21 @@ int src_process(struct processing_module *mod,
 	return cd->src_func(cd, sources[0], sinks[0]);
 }
 
-int src_set_config(struct processing_module *mod, uint32_t config_id,
-		   enum module_cfg_fragment_position pos, uint32_t data_offset_size,
-		   const uint8_t *fragment, size_t fragment_size, uint8_t *response,
-		   size_t response_size)
+__cold int src_set_config(struct processing_module *mod, uint32_t config_id,
+			  enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+			  const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+			  size_t response_size)
 {
 	return -EINVAL;
 }
 
-int src_get_config(struct processing_module *mod, uint32_t config_id,
-		   uint32_t *data_offset_size, uint8_t *fragment, size_t fragment_size)
+__cold int src_get_config(struct processing_module *mod, uint32_t config_id,
+			  uint32_t *data_offset_size, uint8_t *fragment, size_t fragment_size)
 {
 	return -EINVAL;
 }
 
-int src_reset(struct processing_module *mod)
+__cold int src_reset(struct processing_module *mod)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -76,7 +76,7 @@ int src_stream_pcm_sink_rate_check(struct ipc4_config_src cfg,
  * set up param then verify param. BTW for IPC3 path, the param is sent by
  * host driver.
  */
-int src_set_params(struct processing_module *mod, struct sof_sink *sink)
+__cold int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 {
 	struct sof_ipc_stream_params src_params;
 	struct sof_ipc_stream_params *params = mod->stream_params;
@@ -116,8 +116,8 @@ int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 	return ret;
 }
 
-void src_get_source_sink_params(struct comp_dev *dev, struct sof_source *source,
-				struct sof_sink *sink)
+__cold void src_get_source_sink_params(struct comp_dev *dev, struct sof_source *source,
+				       struct sof_sink *sink)
 {
 	struct processing_module *mod = comp_mod(dev);
 	struct comp_data *cd = module_get_private_data(mod);
@@ -135,9 +135,9 @@ void src_get_source_sink_params(struct comp_dev *dev, struct sof_source *source,
 	sink_set_rate(sink, cd->ipc_config.sink_rate);
 }
 
-int src_prepare_general(struct processing_module *mod,
-			struct sof_source *source,
-			struct sof_sink *sink)
+__cold int src_prepare_general(struct processing_module *mod,
+			       struct sof_source *source,
+			       struct sof_sink *sink)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;


### PR DESCRIPTION
Mark further initialisation, configuration and freeing paths as "cold."