### PR TITLE
llext: remove third-party modules from SOF lib

### DIFF
--- a/src/audio/codec/dts/llext/CMakeLists.txt
+++ b/src/audio/codec/dts/llext/CMakeLists.txt
@@ -5,7 +5,6 @@ if(CONFIG_DTS_CODEC_STUB)
 sof_llext_build("dts"
 	SOURCES ../dts.c
 		../dts_stub.c
-	LIB openmodules
 )
 target_include_directories(dts_llext_lib PRIVATE
 	"../../../../../third_party/include"

--- a/src/audio/google/llext_ctc/CMakeLists.txt
+++ b/src/audio/google/llext_ctc/CMakeLists.txt
@@ -6,7 +6,6 @@ sof_llext_build("google_ctc_audio_processing"
 	SOURCES ../google_ctc_audio_processing.c
 		../google_ctc_audio_processing_ipc4.c
 		../google_ctc_audio_processing_mock.c
-	LIB openmodules
 )
 target_include_directories(google_ctc_audio_processing_llext_lib PRIVATE
 	"${sof_top_dir}/third_party/include"

--- a/src/audio/google/llext_rtc/CMakeLists.txt
+++ b/src/audio/google/llext_rtc/CMakeLists.txt
@@ -2,7 +2,6 @@ if(CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK)
 sof_llext_build("google_rtc_audio_processing"
 	SOURCES ../google_rtc_audio_processing.c
 		../google_rtc_audio_processing_mock.c
-	LIB openmodules
 )
 target_include_directories(google_rtc_audio_processing_llext_lib PRIVATE
 	"${sof_top_dir}/third_party/include"

--- a/src/audio/igo_nr/llext/CMakeLists.txt
+++ b/src/audio/igo_nr/llext/CMakeLists.txt
@@ -5,7 +5,6 @@ if(CONFIG_DTS_CODEC_STUB)
 sof_llext_build("igo_nr"
 	SOURCES ../igo_nr.c
 		../igo_nr_stub.c
-	LIB openmodules
 )
 target_include_directories(igo_nr_llext_lib PRIVATE
 	"../../../../third_party/include"

--- a/src/audio/rtnr/llext/CMakeLists.txt
+++ b/src/audio/rtnr/llext/CMakeLists.txt
@@ -5,7 +5,6 @@ if(CONFIG_COMP_RTNR_STUB)
 sof_llext_build("rtnr"
 	SOURCES ../rtnr.c
 		../rtnr_stub.c
-	LIB openmodules
 )
 else()
 message(FATAL_ERROR "Add library linking support in src/audio/rtnr/llext/CMakeFiles.txt")


### PR DESCRIPTION
Third-party modules should be built individually
or in a separate vendor lib