### PR TITLE
library_manager: llext: don't try to copy .bss

### DIFF
--- a/src/library_manager/llext_manager.c
+++ b/src/library_manager/llext_manager.c
@@ -98,10 +98,12 @@ static int llext_manager_load_data_from_storage(const struct llext *ext,
 		/* found a section within the region */
 		size_t offset = shdr->sh_offset - init_offset;
 
-		ret = memcpy_s((__sparse_force void *)shdr->sh_addr, size - offset,
-			       load_base + offset, shdr->sh_size);
-		if (ret < 0)
-			return ret;
+		if (shdr->sh_type != SHT_NOBITS) {
+			ret = memcpy_s((__sparse_force void *)shdr->sh_addr, size - offset,
+				       load_base + offset, shdr->sh_size);
+			if (ret < 0)
+				return ret;
+		}
 	}
 
 	/*


### PR DESCRIPTION
When copying LLEXT modules from DRAM to SRAM we allocate and copy .data and .bss together because they have the same access flags, but .bss doesn't have to be copied, this can in fact generate an error because it isn't present in the ELF image. Only copy valid sections.