### PR TITLE
llext: export symbols, needed for aria

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -420,6 +420,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
 
 #endif
 EXPORT_SYMBOL(audio_stream_copy);
+EXPORT_SYMBOL(cir_buf_copy);
 
 void audio_stream_copy_from_linear(const void *linear_source, int ioffset,
 				   struct audio_stream *sink, int ooffset,

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -183,4 +183,10 @@ EXPORT_SYMBOL(__udivdi3);
 
 int64_t __divdi3(int64_t a, int64_t b);
 EXPORT_SYMBOL(__divdi3);
+
+long __ashldi3(long a, int b);
+EXPORT_SYMBOL(__ashldi3);
+
+long __lshrdi3(long a, int b);
+EXPORT_SYMBOL(__lshrdi3);
 #endif


### PR DESCRIPTION
Aria needs additional exported symbols from SOF.