### PR TITLE
testbench: dont build testbench, tools and topologies in the source directory

### DIFF
--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -34,6 +34,8 @@ permissions:
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
+    env:
+      SOF_WORKSPACE=$HOME:/work/sof/sof
 
     steps:
       - name: Checkout SOF repository (PR source)

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ tools/test/audio/zeros_in.raw
 
 __pycache__
 
-build*/
 
 # Eclipse project metadata
 .settings

--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -98,7 +98,7 @@ main()
                 CMAKE_ONLY BUILD_ALL
         SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
         SOF_REPO=$(dirname "$SCRIPT_DIR")
-        : "${BUILD_TOOLS_DIR:=$SOF_REPO/tools/build_tools}"
+        : "${BUILD_TOOLS_DIR:=$SOF_REPO/../build-tools-tplg}"
         : "${NO_PROCESSORS:=$(nproc)}"
         BUILD_ALL=false
 

--- a/scripts/sof-testbench-build-profile.sh
+++ b/scripts/sof-testbench-build-profile.sh
@@ -9,6 +9,7 @@ usage() {
     echo "  -h shows this text"
     echo "  -p <platform> sets platform for scripts/rebuild-testbench.sh"
     echo
+    echo "This script must be run from the sof firmware toplevel or workspace directory"
 }
 
 MODULES_S32_44K_48K="asrc src"
@@ -16,13 +17,26 @@ MODULES_S32="dcblock drc drc_multiband dolby-dax eqfir eqiir gain level_multipli
 	     sound_dose stft_process_1536_240_ template_comp tdfb"
 MODULES_S24="aria"
 
-if [ -z "${SOF_WORKSPACE}" ]; then
-    echo "Error: environment variable SOF_WORKSPACE need to be set to top level sof directory"
+# This script can be executed from the sof firmware toplevel or workspace directory
+# First check for the worksapce environment variable
+if [ -z "$SOF_WORKSPACE" ]; then
+    # Environment variable is empty or unset so use default
+    BASE_DIR="$HOME/work/sof"
+else
+    # Environment variable exists and has a value
+    BASE_DIR="$SOF_WORKSPACE"
+fi
+cd "$BASE_DIR"
+
+# check we are in the workspace directory
+if [ ! -d "sof" ]; then
+    echo "Error: can't find SOF firmware directory. Please check your installation."
     exit 1
 fi
 
+#set default values
 PLATFORM=none
-PDIR=$SOF_WORKSPACE/sof/tools/testbench/profile
+PDIR=$PWD/sof/tools/testbench/profile
 
 while getopts "hp:d:" opt; do
     case "${opt}" in
@@ -45,7 +59,7 @@ done
 shift $((OPTIND-1))
 
 # Build
-SCRIPTS=$SOF_WORKSPACE/sof/scripts
+SCRIPTS=$PWD/sof/scripts
 mkdir -p "$PDIR"
 "$SCRIPTS"/rebuild-testbench.sh -p "$PLATFORM"
 HELPER="$SCRIPTS"/sof-testbench-helper.sh

--- a/scripts/sof-testbench-build-profile.sh
+++ b/scripts/sof-testbench-build-profile.sh
@@ -36,7 +36,7 @@ fi
 
 #set default values
 PLATFORM=none
-PDIR=$PWD/sof/tools/testbench/profile
+PDIR=$PWD/testbench/profile
 
 while getopts "hp:d:" opt; do
     case "${opt}" in

--- a/scripts/sof-testbench-helper.sh
+++ b/scripts/sof-testbench-helper.sh
@@ -30,10 +30,22 @@ usage() {
     echo "Example: check component eqiir with valgrind"
     echo "$0 -v -m eqiir"
     echo
+    echo This script must be run from the sof firmware toplevel or workspace directory
 }
 
-if [ -z "${SOF_WORKSPACE}" ]; then
-    echo "Error: environment variable SOF_WORKSPACE need to be set to top level sof directory"
+# First check for the workspace environment variable
+if [ -z "$SOF_WORKSPACE" ]; then
+    # Environment variable is empty or unset so use default
+    BASE_DIR="$HOME/work/sof"
+else
+    # Environment variable exists and has a value
+    BASE_DIR="$SOF_WORKSPACE"
+fi
+cd "$BASE_DIR"
+
+# check we are in the workspace directory
+if [ ! -d "sof" ]; then
+    echo "Error: can't find SOF firmware directory. Please check your installation."
     exit 1
 fi
 
@@ -122,13 +134,13 @@ else
     sox --encoding signed-integer "$CLIP" -L -r "$RATE_IN" -c "$CHANNELS_IN" -b "$BITS" "$INFILE1"
 fi
 
-TB4="$SOF_WORKSPACE/sof/tools/testbench/build_testbench/install/bin/sof-testbench4"
-XTB4="$SOF_WORKSPACE/sof/tools/testbench/build_xt_testbench/sof-testbench4"
-XTB4_SETUP="$SOF_WORKSPACE/sof/tools/testbench/build_xt_testbench/xtrun_env.sh"
+TB4="$PWD/sof/tools/testbench/build_testbench/install/bin/sof-testbench4"
+XTB4="$PWD/sof/tools/testbench/build_xt_testbench/sof-testbench4"
+XTB4_SETUP="$PWD/sof/tools/testbench/build_xt_testbench/xtrun_env.sh"
 if [ -z "$TPLG0" ]; then
-    TPLG="$SOF_WORKSPACE/sof/tools/build_tools/topology/topology2/development/sof-hda-benchmark-${MODULE}${BITS}.tplg"
+    TPLG="$PWD/sof/tools/build_tools/topology/topology2/development/sof-hda-benchmark-${MODULE}${BITS}.tplg"
 else
-    TPLG="$SOF_WORKSPACE/sof/tools/build_tools/topology/topology2/$TPLG0"
+    TPLG="$PWD/sof/tools/build_tools/topology/topology2/$TPLG0"
 fi
 FMT="S${BITS}_LE"
 OPTS="-r $RATE_IN -R $RATE_OUT -c $CHANNELS_IN -c $CHANNELS_OUT -b $FMT -p $PIPELINES -t $TPLG -i $INFILE1 -o $OUTFILE1"

--- a/scripts/sof-testbench-helper.sh
+++ b/scripts/sof-testbench-helper.sh
@@ -84,7 +84,7 @@ while getopts "b:c:hi:km:n:o:p:r:R:t:vx" opt; do
         i)
 	    CLIP=${OPTARG}
 	    ;;
-	k)
+        k)
 	    KEEP_TMP=true
 	    ;;
         m)
@@ -112,7 +112,7 @@ while getopts "b:c:hi:km:n:o:p:r:R:t:vx" opt; do
         v)
 	    VALGRIND=valgrind
 	    ;;
-	x)
+        x)
 	    XTRUN=true
 	    ;;
         *)

--- a/scripts/sof-testbench-helper.sh
+++ b/scripts/sof-testbench-helper.sh
@@ -10,10 +10,9 @@ usage() {
     echo "  -c <channels>, default 2"
     echo "  -h shows this text"
     echo "  -i <input wav>, default /usr/share/sounds/alsa/Front_Center.wav"
-    echo "  -k keep temporary files in /tmp"
+    echo "  -k keep temporary files in data directory"
     echo "  -m <module>, default gain"
     echo "  -n <pipelines>, default 1,2"
-    echo "  -o <output wav>, default none"
     echo "  -p <profiling result text>, use with -x, default none"
     echo "  -r <rate>, input rate, default 48000"
     echo "  -R <rate>, output rate, default 48000"
@@ -49,7 +48,6 @@ if [ ! -d "sof" ]; then
     exit 1
 fi
 
-OUTWAV=
 CLIP=/usr/share/sounds/alsa/Front_Center.wav
 MODULE=gain
 BITS=32
@@ -58,10 +56,6 @@ RATE_OUT=48000
 CHANNELS_IN=2
 CHANNELS_OUT=2
 PIPELINES="1,2"
-INFILE1=$(mktemp --tmpdir=/tmp in-XXXX.raw)
-OUTFILE1=$(mktemp --tmpdir=/tmp out-XXXX.raw)
-TRACEFILE=$(mktemp --tmpdir=/tmp trace-XXXX.txt)
-PROFILEOUT=$(mktemp --tmpdir=/tmp profile-XXXX.out)
 KEEP_TMP=false
 XTRUN=false
 PROFILE=false
@@ -122,6 +116,19 @@ while getopts "b:c:hi:km:n:o:p:r:R:t:vx" opt; do
     esac
 done
 shift $((OPTIND-1))
+
+# Get the current date and time in a specific format (YYYYMMDD_HHMMSS)
+timestamp=$(date +"%Y%m%d_%H%M%S")
+
+# Combine the prefix and timestamp to create the filename
+INFILE1="$PWD/testbench_data/in-${MODULE}-${timestamp}.raw"
+OUTFILE1="$PWD/testbench_data/out-${MODULE}-${timestamp}.raw"
+TRACEFILE="$PWD/testbench_data/trace-${MODULE}-${timestamp}.txt"
+PROFILEOUT="$PWD/testbench_data/profile-${MODULE}-${timestamp}.out"
+OUTWAV="$PWD/testbench_data/outwav-${MODULE}-${timestamp}.wav"
+
+# make the data directory if it doesn't exist
+mkdir -p $PWD/testbench_data
 
 echo Converting clip "$CLIP" to raw input
 if [[ "$BITS" == "24" ]]; then
@@ -184,16 +191,17 @@ else
     fi
 fi
 
-if [ -n "$OUTWAV" ]; then
-    echo Converting raw output to "$OUTWAV"
-    if [[ "$BITS" == "24" ]]; then
-	sox --encoding signed-integer -L -r "$RATE_OUT" -c "$CHANNELS_OUT" -b 32 "$OUTFILE1" "$OUTWAV" vol 256
-    else
-	sox --encoding signed-integer -L -r "$RATE_OUT" -c "$CHANNELS_OUT" -b "$BITS" "$OUTFILE1" "$OUTWAV"
-    fi
-fi
-
+# Generate the outwav if we are keeping our data files for inspection.
 if [[ "$KEEP_TMP" == false ]]; then
     echo Deleting temporary files
     rm -f "$INFILE1" "$OUTFILE1" "$TRACEFILE" "$PROFILEOUT"
+else
+    echo Converting raw output to "$OUTWAV"
+    if [[ "$BITS" == "24" ]]; then
+        sox --encoding signed-integer -L -r "$RATE_OUT" -c "$CHANNELS_OUT" -b 32 \
+            "$OUTFILE1" "$OUTWAV" vol 256
+    else
+        sox --encoding signed-integer -L -r "$RATE_OUT" -c "$CHANNELS_OUT" -b "$BITS" \
+            "$OUTFILE1" "$OUTWAV"
+    fi
 fi

--- a/scripts/sof-testbench-helper.sh
+++ b/scripts/sof-testbench-helper.sh
@@ -133,14 +133,14 @@ if [[ "$BITS" == "24" ]]; then
 else
     sox --encoding signed-integer "$CLIP" -L -r "$RATE_IN" -c "$CHANNELS_IN" -b "$BITS" "$INFILE1"
 fi
-
-TB4="$PWD/sof/tools/testbench/build_testbench/install/bin/sof-testbench4"
-XTB4="$PWD/sof/tools/testbench/build_xt_testbench/sof-testbench4"
-XTB4_SETUP="$PWD/sof/tools/testbench/build_xt_testbench/xtrun_env.sh"
+TOOLSDIR="$PWD/build_tools/testbench"
+TB4="$PWD/build-testbench/install/bin/sof-testbench4"
+XTB4="$PWD/build-xt-testbench/sof-testbench4"
+XTB4_SETUP="$PWD/build-xt-testbench/xtrun_env.sh"
 if [ -z "$TPLG0" ]; then
-    TPLG="$PWD/sof/tools/build_tools/topology/topology2/development/sof-hda-benchmark-${MODULE}${BITS}.tplg"
+    TPLG="$PWD/build_tools/topology/topology2/development/sof-hda-benchmark-${MODULE}${BITS}.tplg"
 else
-    TPLG="$PWD/sof/tools/build_tools/topology/topology2/$TPLG0"
+    TPLG="$PWD/build_tools/topology/topology2/$TPLG0"
 fi
 FMT="S${BITS}_LE"
 OPTS="-r $RATE_IN -R $RATE_OUT -c $CHANNELS_IN -c $CHANNELS_OUT -b $FMT -p $PIPELINES -t $TPLG -i $INFILE1 -o $OUTFILE1"

--- a/tools/test/audio/comp_run.sh
+++ b/tools/test/audio/comp_run.sh
@@ -132,13 +132,13 @@ run_testbench ()
 parse_args "$@"
 
 # Path to topologies
-TPLG_DIR=../../build_tools/test/topology
+TPLG_DIR=../../../../build_tools/test/topology
 
 # Testbench path and executable
 if [[ -z $XTRUN ]]; then
-    PATH_TESTBENCH=../../testbench/build_testbench/install/bin/$TESTBENCH
+    PATH_TESTBENCH=../../../../build_testbench/install/bin/$TESTBENCH
 else
-    BUILD_DIR=../../testbench/build_xt_testbench
+    BUILD_DIR=../../../../build_xt_testbench
     PATH_TESTBENCH="$BUILD_DIR"/$TESTBENCH
     source "$BUILD_DIR"/xtrun_env.sh
     XTRUN_CMD=$XTENSA_PATH/$XTRUN
@@ -168,7 +168,7 @@ PIPELINES=
     [[ $DIRECTION == "playback" ]] && PIPELINES="-p 1,2"
     [[ $DIRECTION == "capture" ]] && PIPELINES="-p 3,4"
     TPLGFN=sof-hda-benchmark-${COMP}${BITS_IN}.tplg
-    TPLG_DIR="../../build_tools/topology/topology2/development"
+    TPLG_DIR="../../../../build_tools/topology/topology2/development"
     TPLG_BUILD_TIP="Please run scripts/build-tools.sh"
 }
 


### PR DESCRIPTION
Currently all topologies, testbench and some tools are built within the FW source directory unlike FW which has separate binary destination directories outside of the main FW source directory.

This series moves all tools, testbench and topologies binaries to outside the source directory to the parent SOF "workspace" directory alongside the FW build output directories.