### PR TITLE
scripts: vscode: add support for building SOF from vscode tasks

### DIFF
--- a/scripts/vscode-task.sh
+++ b/scripts/vscode-task.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2025 Intel Corporation. All rights reserved.
+
+# Simple helper script for vscode task support.
+# Current vscode tasks have difficulty executing multiple commands.
+
+# setup environment
+source ~/zephyrproject/.venv/bin/activate
+
+# vscode workspace root is the parent directory of sof
+# we need to cd into sof to run the zephyr build script
+cd sof
+
+# run the zephyr script
+./scripts/xtensa-build-zephyr.py "$@"
+
+# cleanup
+deactivate


### PR DESCRIPTION
vscode tasks can execute multiple commands easily so wrap the necessary commands to use the SOF convenience script with a small script that enables the python virtual environment.