### PR TITLE
audio: move more code to DRAM

### DIFF
--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -58,9 +58,11 @@ struct ipc4_modules_info {
 
 LOG_MODULE_REGISTER(basefw_intel, CONFIG_SOF_LOG_LEVEL);
 
-int basefw_vendor_fw_config(uint32_t *data_offset, char *data)
+__cold int basefw_vendor_fw_config(uint32_t *data_offset, char *data)
 {
 	struct sof_tlv *tuple = (struct sof_tlv *)data;
+
+	assert_can_be_cold();
 
 	tlv_value_uint32_set(tuple, IPC4_SLOW_CLOCK_FREQ_HZ_FW_CFG, IPC4_ALH_CAVS_1_8);
 
@@ -76,10 +78,12 @@ int basefw_vendor_fw_config(uint32_t *data_offset, char *data)
 	return 0;
 }
 
-int basefw_vendor_hw_config(uint32_t *data_offset, char *data)
+__cold int basefw_vendor_hw_config(uint32_t *data_offset, char *data)
 {
 	struct sof_tlv *tuple = (struct sof_tlv *)data;
 	uint32_t value;
+
+	assert_can_be_cold();
 
 	tlv_value_uint32_set(tuple, IPC4_HP_EBB_COUNT_HW_CFG, PLATFORM_HPSRAM_EBB_COUNT);
 
@@ -122,18 +126,23 @@ int basefw_vendor_hw_config(uint32_t *data_offset, char *data)
 	return 0;
 }
 
-struct sof_man_fw_desc *basefw_vendor_get_manifest(void)
+__cold struct sof_man_fw_desc *basefw_vendor_get_manifest(void)
 {
+	assert_can_be_cold();
+
 	return (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
 }
 
-int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
+__cold int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
 {
-	struct ipc4_modules_info *const module_info = (struct ipc4_modules_info *)data;
+	assert_can_be_cold();
+
 	struct sof_man_fw_desc *desc = basefw_vendor_get_manifest();
 
 	if (!desc)
 		return IPC4_ERROR_INVALID_PARAM;
+
+	struct ipc4_modules_info *const module_info = (struct ipc4_modules_info *)data;
 
 	module_info->modules_count = desc->header.num_module_entries;
 
@@ -153,7 +162,7 @@ int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
  * low power mode sram. This function retures memory size in page
  * , memory bank power and usage status of each sram to host driver
  */
-static int basefw_mem_state_info(uint32_t *data_offset, char *data)
+__cold static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 {
 	struct sof_tlv *tuple = (struct sof_tlv *)data;
 	struct ipc4_sram_state_info info;
@@ -162,6 +171,8 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	uint32_t size;
 	uint16_t *ptr;
 	int i;
+
+	assert_can_be_cold();
 
 	/* set hpsram */
 	info.free_phys_mem_pages = SRAM_BANK_SIZE * PLATFORM_HPSRAM_EBB_COUNT / HOST_PAGE_SIZE;
@@ -220,8 +231,10 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	return IPC4_SUCCESS;
 }
 
-static uint32_t basefw_get_ext_system_time(uint32_t *data_offset, char *data)
+__cold static uint32_t basefw_get_ext_system_time(uint32_t *data_offset, char *data)
 {
+	assert_can_be_cold();
+
 #if CONFIG_ACE_V1X_ART_COUNTER && CONFIG_ACE_V1X_RTC_COUNTER
 	struct ipc4_ext_system_time *ext_system_time = (struct ipc4_ext_system_time *)(data);
 	struct ipc4_ext_system_time ext_system_time_data = {0};
@@ -278,13 +291,12 @@ static uint32_t basefw_get_ext_system_time(uint32_t *data_offset, char *data)
 #endif
 }
 
-int basefw_vendor_get_large_config(struct comp_dev *dev,
-				   uint32_t param_id,
-				   bool first_block,
-				   bool last_block,
-				   uint32_t *data_offset,
-				   char *data)
+__cold int basefw_vendor_get_large_config(struct comp_dev *dev, uint32_t param_id,
+					  bool first_block, bool last_block,
+					  uint32_t *data_offset, char *data)
 {
+	assert_can_be_cold();
+
 	/* We can use extended param id for both extended and standard param id */
 	union ipc4_extended_param_id extended_param_id;
 
@@ -312,8 +324,10 @@ int basefw_vendor_get_large_config(struct comp_dev *dev,
 	return ret;
 }
 
-static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
+__cold static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
 {
+	assert_can_be_cold();
+
 #if defined(CONFIG_SOC_SERIES_INTEL_ADSP_ACE)
 	const uint32_t force = tlv->value[0];
 
@@ -331,12 +345,12 @@ static int fw_config_set_force_l1_exit(const struct sof_tlv *tlv)
 #endif
 }
 
-static int basefw_set_fw_config(bool first_block,
-				bool last_block,
-				uint32_t data_offset,
-				const char *data)
+__cold static int basefw_set_fw_config(bool first_block, bool last_block,
+				       uint32_t data_offset, const char *data)
 {
 	const struct sof_tlv *tlv = (const struct sof_tlv *)data;
+
+	assert_can_be_cold();
 
 	switch (tlv->type) {
 	case IPC4_DMI_FORCE_L1_EXIT:
@@ -380,13 +394,12 @@ static int basefw_mic_priv_state_changed(bool first_block,
 #endif
 }
 
-int basefw_vendor_set_large_config(struct comp_dev *dev,
-				   uint32_t param_id,
-				   bool first_block,
-				   bool last_block,
-				   uint32_t data_offset,
-				   const char *data)
+__cold int basefw_vendor_set_large_config(struct comp_dev *dev, uint32_t param_id,
+					  bool first_block, bool last_block,
+					  uint32_t data_offset, const char *data)
 {
+	assert_can_be_cold();
+
 	switch (param_id) {
 	case IPC4_FW_CONFIG:
 		return basefw_set_fw_config(first_block, last_block, data_offset, data);
@@ -401,11 +414,13 @@ int basefw_vendor_set_large_config(struct comp_dev *dev,
 	return IPC4_UNKNOWN_MESSAGE_TYPE;
 }
 
-int basefw_vendor_dma_control(uint32_t node_id, const char *config_data, size_t data_size)
+__cold int basefw_vendor_dma_control(uint32_t node_id, const char *config_data, size_t data_size)
 {
 	union ipc4_connector_node_id node = (union ipc4_connector_node_id)node_id;
 	int ret, result;
 	enum dai_type type;
+
+	assert_can_be_cold();
 
 	tr_info(&basefw_comp_tr, "node_id 0x%x, config_data 0x%x, data_size %u",
 		node_id, (uint32_t)config_data, data_size);

--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -124,11 +124,7 @@ int basefw_vendor_hw_config(uint32_t *data_offset, char *data)
 
 struct sof_man_fw_desc *basefw_vendor_get_manifest(void)
 {
-	struct sof_man_fw_desc *desc;
-
-	desc = (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
-
-	return desc;
+	return (struct sof_man_fw_desc *)IMR_BOOT_LDR_MANIFEST_BASE;
 }
 
 int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
@@ -137,7 +133,7 @@ int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
 	struct sof_man_fw_desc *desc = basefw_vendor_get_manifest();
 
 	if (!desc)
-		return -EINVAL;
+		return IPC4_ERROR_INVALID_PARAM;
 
 	module_info->modules_count = desc->header.num_module_entries;
 
@@ -150,7 +146,7 @@ int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
 
 	*data_offset = sizeof(*module_info) +
 				module_info->modules_count * sizeof(module_info->modules[0]);
-	return 0;
+	return IPC4_SUCCESS;
 }
 
 /* There are two types of sram memory : high power mode sram and
@@ -221,7 +217,7 @@ static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	*data_offset = (int)((char *)tuple - data);
 
 	rfree(tuple_data);
-	return 0;
+	return IPC4_SUCCESS;
 }
 
 static uint32_t basefw_get_ext_system_time(uint32_t *data_offset, char *data)
@@ -277,8 +273,9 @@ static uint32_t basefw_get_ext_system_time(uint32_t *data_offset, char *data)
 	*data_offset = sizeof(struct ipc4_ext_system_time);
 
 	return IPC4_SUCCESS;
-#endif
+#else
 	return IPC4_UNAVAILABLE;
+#endif
 }
 
 int basefw_vendor_get_large_config(struct comp_dev *dev,
@@ -293,7 +290,7 @@ int basefw_vendor_get_large_config(struct comp_dev *dev,
 
 	extended_param_id.full = param_id;
 
-	uint32_t ret = -EINVAL;
+	uint32_t ret = IPC4_ERROR_INVALID_PARAM;
 
 	switch (extended_param_id.part.parameter_type) {
 	case IPC4_MEMORY_STATE_INFO_GET:
@@ -303,7 +300,7 @@ int basefw_vendor_get_large_config(struct comp_dev *dev,
 		if (ret == IPC4_UNAVAILABLE) {
 			tr_warn(&basefw_comp_tr,
 				"returning success for get host EXTENDED_SYSTEM_TIME without handling it");
-			return 0;
+			return IPC4_SUCCESS;
 		} else {
 			return ret;
 		}

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -4,6 +4,7 @@
 //
 // Author: Baofeng Tian <baofeng.tian@intel.com>
 
+#include <sof/lib/memory.h>
 #include <sof/trace/trace.h>
 #include <sof/audio/component_ext.h>
 #include <ipc/dai.h>
@@ -155,19 +156,21 @@ static int copier_alh_assign_dai_index(struct comp_dev *dev,
 	return 0;
 }
 
-static int copier_dai_init(struct comp_dev *dev,
-			   struct comp_ipc_config *config,
-			   const struct ipc4_copier_module_cfg *copier,
-			   struct pipeline *pipeline,
-			   struct ipc_config_dai *dai,
-			   enum ipc4_gateway_type type,
-			   int index, int dai_count)
+__cold static int copier_dai_init(struct comp_dev *dev,
+				  struct comp_ipc_config *config,
+				  const struct ipc4_copier_module_cfg *copier,
+				  struct pipeline *pipeline,
+				  struct ipc_config_dai *dai,
+				  enum ipc4_gateway_type type,
+				  int index, int dai_count)
 {
 	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
 	uint32_t chmap;
 	struct dai_data *dd;
 	int ret;
+
+	assert_can_be_cold();
 
 	if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
 		enum sof_ipc_frame out_frame_fmt, out_valid_fmt;
@@ -254,9 +257,9 @@ free_dd:
  * ssp, dmic or alh. Sof dai component can support this case so copier
  * reuses dai component to support non-host gateway.
  */
-int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
-		      const struct ipc4_copier_module_cfg *copier,
-		      struct pipeline *pipeline)
+__cold int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
+			     const struct ipc4_copier_module_cfg *copier,
+			     struct pipeline *pipeline)
 {
 	struct processing_module *mod = comp_mod(dev);
 	struct comp_ipc_config *config = &dev->ipc_config;
@@ -265,6 +268,8 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	struct ipc_config_dai dai;
 	int dai_count;
 	int i, ret;
+
+	assert_can_be_cold();
 
 	config->type = SOF_COMP_DAI;
 
@@ -370,8 +375,10 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	return 0;
 }
 
-void copier_dai_free(struct copier_data *cd)
+__cold void copier_dai_free(struct copier_data *cd)
 {
+	assert_can_be_cold();
+
 	for (int i = 0; i < cd->endpoint_num; i++) {
 		dai_common_free(cd->dd[i]);
 		rfree(cd->dd[i]->gain_data);

--- a/src/audio/copier/copier_gain.c
+++ b/src/audio/copier/copier_gain.c
@@ -4,6 +4,7 @@
 //
 // Author: Ievgen Ganakov <ievgen.ganakov@intel.com>
 
+#include <sof/lib/memory.h>
 #include <sof/trace/trace.h>
 #include <ipc4/base-config.h>
 #include <sof/audio/component_ext.h>
@@ -15,10 +16,8 @@
 
 LOG_MODULE_DECLARE(copier, CONFIG_SOF_LOG_LEVEL);
 
-int copier_gain_set_params(struct comp_dev *dev,
-			   struct copier_gain_params *gain_params,
-			   uint32_t fade_period,
-			   enum sof_ipc_dai_type dai_type)
+__cold int copier_gain_set_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
+				  uint32_t fade_period, enum sof_ipc_dai_type dai_type)
 {
 	struct processing_module *mod = comp_mod(dev);
 	struct copier_data *cd = module_get_private_data(mod);
@@ -26,6 +25,8 @@ int copier_gain_set_params(struct comp_dev *dev,
 	uint32_t sampling_freq = ipc4_cfg->audio_fmt.sampling_frequency;
 	uint32_t frames = sampling_freq / dev->pipeline->period;
 	int ret;
+
+	assert_can_be_cold();
 
 	/* Set basic gain parameters */
 	copier_gain_set_basic_params(dev, gain_params, ipc4_cfg);

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -6,6 +6,7 @@
 
 #include <ipc4/base-config.h>
 #include <sof/audio/component_ext.h>
+#include <sof/lib/memory.h>
 #include <module/module/base.h>
 #include <sof/common.h>
 #include <ipc/dai.h>
@@ -60,9 +61,11 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	}
 }
 
-void copier_gain_set_basic_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
-				  struct ipc4_base_module_cfg *ipc4_cfg)
+__cold void copier_gain_set_basic_params(struct comp_dev *dev,
+					 struct copier_gain_params *gain_params,
+					 struct ipc4_base_module_cfg *ipc4_cfg)
 {
+	assert_can_be_cold();
 
 	gain_params->channels_count = ipc4_cfg->audio_fmt.channels_count;
 
@@ -70,11 +73,13 @@ void copier_gain_set_basic_params(struct comp_dev *dev, struct copier_gain_param
 		gain_params->gain_coeffs[i] = UNITY_GAIN_GENERIC;
 }
 
-int copier_gain_set_fade_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
-				struct ipc4_base_module_cfg *ipc4_cfg,
-				uint32_t fade_period, uint32_t frames)
+__cold int copier_gain_set_fade_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
+				       struct ipc4_base_module_cfg *ipc4_cfg,
+				       uint32_t fade_period, uint32_t frames)
 {
 	uint16_t step_i64_to_i16;
+
+	assert_can_be_cold();
 
 	if (fade_period == GAIN_DEFAULT_FADE_PERIOD) {
 		/* Set fade transition delay to default value*/
@@ -347,9 +352,9 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 	}
 }
 
-int create_multi_endpoint_buffer(struct comp_dev *dev,
-				 struct copier_data *cd,
-				 const struct ipc4_copier_module_cfg *copier_cfg)
+__cold int create_multi_endpoint_buffer(struct comp_dev *dev,
+					struct copier_data *cd,
+					const struct ipc4_copier_module_cfg *copier_cfg)
 {
 	struct comp_ipc_config *config = &dev->ipc_config;
 	enum sof_ipc_frame in_frame_fmt, out_frame_fmt;
@@ -360,6 +365,8 @@ int create_multi_endpoint_buffer(struct comp_dev *dev,
 	uint32_t buf_size;
 	uint32_t chan_map;
 	int i;
+
+	assert_can_be_cold();
 
 	audio_stream_fmt_conversion(copier_cfg->base.audio_fmt.depth,
 				    copier_cfg->base.audio_fmt.valid_bit_depth,
@@ -442,9 +449,11 @@ int create_multi_endpoint_buffer(struct comp_dev *dev,
 	return 0;
 }
 
-enum sof_ipc_stream_direction
+__cold enum sof_ipc_stream_direction
 	get_gateway_direction(enum ipc4_connector_node_id_type node_id_type)
 {
+	assert_can_be_cold();
+
 	/* WARNING: simple "% 2" formula that was used before does not work for all
 	 * interfaces: at least it does not work for IPC gateway. But it may also
 	 * does not work for other not yet supported interfaces. And so additional

--- a/src/audio/copier/copier_hifi.c
+++ b/src/audio/copier/copier_hifi.c
@@ -13,6 +13,7 @@
 #include <sof/audio/format.h>
 #include <sof/audio/pipeline.h>
 #include <sof/audio/component.h>
+#include <sof/lib/memory.h>
 #include <module/module/base.h>
 #include <stddef.h>
 #include <errno.h>
@@ -75,9 +76,11 @@ int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,
 	}
 }
 
-void copier_gain_set_basic_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
-				  struct ipc4_base_module_cfg *ipc4_cfg)
+__cold void copier_gain_set_basic_params(struct comp_dev *dev,
+					 struct copier_gain_params *gain_params,
+					 struct ipc4_base_module_cfg *ipc4_cfg)
 {
+	assert_can_be_cold();
 
 	/* Set default gain coefficients */
 	for (int i = 0; i < ARRAY_SIZE(gain_params->gain_coeffs); ++i)
@@ -90,13 +93,15 @@ void copier_gain_set_basic_params(struct comp_dev *dev, struct copier_gain_param
 	gain_params->channels_count = ipc4_cfg->audio_fmt.channels_count;
 }
 
-int copier_gain_set_fade_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
-				struct ipc4_base_module_cfg *ipc4_cfg,
-				uint32_t fade_period, uint32_t frames)
+__cold int copier_gain_set_fade_params(struct comp_dev *dev, struct copier_gain_params *gain_params,
+				       struct ipc4_base_module_cfg *ipc4_cfg,
+				       uint32_t fade_period, uint32_t frames)
 {
 	uint16_t init_gain[MAX_GAIN_COEFFS_CNT];
 	uint16_t step_i64_to_i16;
 	ae_f16 step_f16;
+
+	assert_can_be_cold();
 
 	/* For backward compatibility add a case with default fade transition.
 	 * Backward compatibility is referring to clock_on_delay in DMIC blob.

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -4,6 +4,7 @@
 
 #include <sof/audio/component_ext.h>
 #include <sof/trace/trace.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/ut.h>
 #include <rtos/init.h>
@@ -206,14 +207,17 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	}
 }
 
-int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
-			 const struct ipc4_copier_module_cfg *copier, struct pipeline *pipeline)
+__cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
+				const struct ipc4_copier_module_cfg *copier,
+				struct pipeline *pipeline)
 {
 	struct comp_ipc_config *config = &dev->ipc_config;
 	struct ipcgtw_data *ipcgtw_data;
 	const struct ipc4_copier_gateway_cfg *gtw_cfg;
 	const struct ipc4_ipc_gateway_config_blob *blob;
 	int ret;
+
+	assert_can_be_cold();
 
 	gtw_cfg = &copier->gtw_cfg;
 	if (!gtw_cfg->config_length) {
@@ -273,8 +277,10 @@ e_ipcgtw:
 	return ret;
 }
 
-void copier_ipcgtw_free(struct copier_data *cd)
+__cold void copier_ipcgtw_free(struct copier_data *cd)
 {
+	assert_can_be_cold();
+
 	list_item_del(&cd->ipcgtw_data->item);
 	rfree(cd->ipcgtw_data);
 }

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -76,8 +76,10 @@ static void dai_atomic_trigger(void *arg, enum notify_id type, void *data)
 }
 
 /* Assign DAI to a group */
-int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
+__cold int dai_assign_group(struct dai_data *dd, struct comp_dev *dev, uint32_t group_id)
 {
+	assert_can_be_cold();
+
 	if (dd->group) {
 		if (dd->group->group_id != group_id) {
 			comp_err(dev, "DAI already in group %d, requested %d",
@@ -135,14 +137,16 @@ static int dai_trigger_op(struct dai *dai, int cmd, int direction)
 }
 
 /* called from src/ipc/ipc3/handler.c and src/ipc/ipc4/dai.c */
-int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
-		   const void *spec_config)
+__cold int dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
+			  const void *spec_config)
 {
 	const struct device *dev = dai->dev;
 	const struct sof_ipc_dai_config *sof_cfg = spec_config;
 	struct dai_config cfg;
 	const void *cfg_params;
 	bool is_blob;
+
+	assert_can_be_cold();
 
 	cfg.dai_index = common_config->dai_index;
 	is_blob = common_config->is_config_blob;
@@ -467,10 +471,12 @@ dai_dma_multi_endpoint_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t fr
 	return dma_status;
 }
 
-int dai_common_new(struct dai_data *dd, struct comp_dev *dev,
-		   const struct ipc_config_dai *dai_cfg)
+__cold int dai_common_new(struct dai_data *dd, struct comp_dev *dev,
+			  const struct ipc_config_dai *dai_cfg)
 {
 	uint32_t dir;
+
+	assert_can_be_cold();
 
 	dd->dai = dai_get(dai_cfg->type, dai_cfg->dai_index, DAI_CREAT);
 	if (!dd->dai) {
@@ -542,14 +548,16 @@ int dai_common_new(struct dai_data *dd, struct comp_dev *dev,
 	return 0;
 }
 
-static struct comp_dev *dai_new(const struct comp_driver *drv,
-				const struct comp_ipc_config *config,
-				const void *spec)
+__cold static struct comp_dev *dai_new(const struct comp_driver *drv,
+				       const struct comp_ipc_config *config,
+				       const void *spec)
 {
 	struct comp_dev *dev;
 	const struct ipc_config_dai *dai_cfg = spec;
 	struct dai_data *dd;
 	int ret;
+
+	assert_can_be_cold();
 
 	comp_cl_dbg(&comp_dai, "dai_new()");
 
@@ -582,8 +590,10 @@ e_data:
 	return NULL;
 }
 
-void dai_common_free(struct dai_data *dd)
+__cold void dai_common_free(struct dai_data *dd)
 {
+	assert_can_be_cold();
+
 #ifdef CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS
 	io_perf_monitor_release_slot(dd->io_perf_bytes_count);
 #endif
@@ -605,9 +615,11 @@ void dai_common_free(struct dai_data *dd)
 	rfree(dd->dai_spec_config);
 }
 
-static void dai_free(struct comp_dev *dev)
+__cold static void dai_free(struct comp_dev *dev)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+
+	assert_can_be_cold();
 
 	if (dd->group)
 		notifier_unregister(dev, dd->group, NOTIFIER_ID_DAI_TRIGGER);
@@ -619,7 +631,7 @@ static void dai_free(struct comp_dev *dev)
 }
 
 int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
-			     struct sof_ipc_stream_params *params, int dir)
+				    struct sof_ipc_stream_params *params, int dir)
 {
 	struct dai_config cfg;
 	int ret;
@@ -645,11 +657,13 @@ int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 	return ret;
 }
 
-static int dai_comp_get_hw_params(struct comp_dev *dev,
-				  struct sof_ipc_stream_params *params,
-				  int dir)
+__cold static int dai_comp_get_hw_params(struct comp_dev *dev,
+					 struct sof_ipc_stream_params *params,
+					 int dir)
 {
 	struct dai_data *dd = comp_get_drvdata(dev);
+
+	assert_can_be_cold();
 
 	return dai_common_get_hw_params(dd, dev, params, dir);
 }
@@ -1901,10 +1915,12 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 }
 
 #ifdef CONFIG_IPC_MAJOR_4
-int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
+__cold int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
 {
 	struct ipc4_module_bind_unbind *bu;
 	int buf_id;
+
+	assert_can_be_cold();
 
 	bu = (struct ipc4_module_bind_unbind *)data;
 	buf_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -504,8 +504,9 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 	return ret;
 }
 
-static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32_t buffer_count,
-			      uint32_t buffer_bytes, uint32_t direction)
+static int create_local_elems(struct host_data *hd, struct comp_dev *dev,
+			      uint32_t buffer_count, uint32_t buffer_bytes,
+			      uint32_t direction)
 {
 	struct dma_sg_elem_array *elem_array;
 	uint32_t dir;
@@ -604,10 +605,12 @@ static int host_trigger(struct comp_dev *dev, int cmd)
 	return host_common_trigger(hd, dev, cmd);
 }
 
-int host_common_new(struct host_data *hd, struct comp_dev *dev,
-		    const struct ipc_config_host *ipc_host, uint32_t config_id)
+__cold int host_common_new(struct host_data *hd, struct comp_dev *dev,
+			   const struct ipc_config_host *ipc_host, uint32_t config_id)
 {
 	uint32_t dir;
+
+	assert_can_be_cold();
 
 	hd->ipc_host = *ipc_host;
 	/* request HDA DMA with shared access privilege */
@@ -639,14 +642,16 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 	return 0;
 }
 
-static struct comp_dev *host_new(const struct comp_driver *drv,
-				 const struct comp_ipc_config *config,
-				 const void *spec)
+__cold static struct comp_dev *host_new(const struct comp_driver *drv,
+					const struct comp_ipc_config *config,
+					const void *spec)
 {
 	struct comp_dev *dev;
 	struct host_data *hd;
 	const struct ipc_config_host *ipc_host = spec;
 	int ret;
+
+	assert_can_be_cold();
 
 	comp_cl_dbg(&comp_host, "host_new()");
 
@@ -676,17 +681,21 @@ e_data:
 	return NULL;
 }
 
-void host_common_free(struct host_data *hd)
+__cold void host_common_free(struct host_data *hd)
 {
+	assert_can_be_cold();
+
 	sof_dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
 	dma_sg_free(&hd->config.elem_array);
 }
 
-static void host_free(struct comp_dev *dev)
+__cold static void host_free(struct comp_dev *dev)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+
+	assert_can_be_cold();
 
 	comp_dbg(dev, "host_free()");
 	host_common_free(hd);
@@ -1092,10 +1101,12 @@ static int host_copy(struct comp_dev *dev)
 	return host_common_copy(hd, dev, host_dma_cb);
 }
 
-static int host_get_attribute(struct comp_dev *dev, uint32_t type,
-			      void *value)
+__cold static int host_get_attribute(struct comp_dev *dev, uint32_t type,
+				     void *value)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+
+	assert_can_be_cold();
 
 	switch (type) {
 	case COMP_ATTR_COPY_TYPE:
@@ -1111,10 +1122,12 @@ static int host_get_attribute(struct comp_dev *dev, uint32_t type,
 	return 0;
 }
 
-static int host_set_attribute(struct comp_dev *dev, uint32_t type,
-			      void *value)
+__cold static int host_set_attribute(struct comp_dev *dev, uint32_t type,
+				     void *value)
 {
 	struct host_data *hd = comp_get_drvdata(dev);
+
+	assert_can_be_cold();
 
 	switch (type) {
 	case COMP_ATTR_COPY_TYPE:

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -293,6 +293,7 @@ struct comp_ops {
 	 * comp_set_drvdata() and later retrieved by comp_get_drvdata().
 	 *
 	 * All parameters should be initialized to their default values.
+	 * Usually can be __cold.
 	 */
 	struct comp_dev *(*create)(const struct comp_driver *drv,
 				   const struct comp_ipc_config *ipc_config,
@@ -304,6 +305,7 @@ struct comp_ops {
 	 *
 	 * All data structures previously allocated on the run-time heap
 	 * must be freed by the implementation of <code>free()</code>.
+	 * Usually can be __cold.
 	 */
 	void (*free)(struct comp_dev *dev);
 
@@ -315,6 +317,7 @@ struct comp_ops {
 	 * Infrastructure calls comp_verify_params() if this handler is not
 	 * defined, therefore it should be left NULL if no extra steps are
 	 * required.
+	 * Usually shouldn't be __cold.
 	 */
 	int (*params)(struct comp_dev *dev,
 		      struct sof_ipc_stream_params *params);
@@ -327,6 +330,7 @@ struct comp_ops {
 	 * @param dir Stream direction (see enum sof_ipc_stream_direction).
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually can be __cold.
 	 */
 	int (*dai_get_hw_params)(struct comp_dev *dev,
 				 struct sof_ipc_stream_params *params, int dir);
@@ -337,6 +341,7 @@ struct comp_ops {
 	 * @param dai_config DAI configuration.
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually can be __cold.
 	 */
 	int (*dai_config)(struct dai_data *dd, struct comp_dev *dev,
 			  struct ipc_config_dai *dai_config, const void *dai_spec_config);
@@ -358,6 +363,8 @@ struct comp_ops {
 	 * Trigger, atomic - used to start/stop/pause stream operations.
 	 * @param dev Component device.
 	 * @param cmd Command, one of COMP_TRIGGER_...
+	 *
+	 * Usually shouldn't be __cold.
 	 */
 	int (*trigger)(struct comp_dev *dev, int cmd);
 
@@ -367,6 +374,7 @@ struct comp_ops {
 	 *
 	 * Prepare should be used to get the component ready for starting
 	 * processing after it's hw_params are known or after an XRUN.
+	 * Usually shouldn't be __cold.
 	 */
 	int (*prepare)(struct comp_dev *dev);
 
@@ -376,6 +384,7 @@ struct comp_ops {
 	 *
 	 * Resets the component state and any hw_params to default component
 	 * state. Should also free any resources acquired during hw_params.
+	 * Usually shouldn't be __cold.
 	 */
 	int (*reset)(struct comp_dev *dev);
 
@@ -383,6 +392,8 @@ struct comp_ops {
 	 * Copy and process stream data from source to sink buffers.
 	 * @param dev Component device.
 	 * @return Number of copied frames.
+	 *
+	 * Usually shouldn't be __cold.
 	 */
 	int (*copy)(struct comp_dev *dev);
 
@@ -390,6 +401,8 @@ struct comp_ops {
 	 * Retrieves component rendering position.
 	 * @param dev Component device.
 	 * @param posn Receives reported position.
+	 *
+	 * Usually shouldn't be __cold.
 	 */
 	int (*position)(struct comp_dev *dev,
 		struct sof_ipc_stream_posn *posn);
@@ -400,6 +413,8 @@ struct comp_ops {
 	 * @param type Attribute type.
 	 * @param value Attribute value.
 	 * @return 0 if succeeded, error code otherwise.
+	 *
+	 * Usually can be __cold.
 	 */
 	int (*get_attribute)(struct comp_dev *dev, uint32_t type,
 			     void *value);
@@ -410,6 +425,8 @@ struct comp_ops {
 	 * @param type Attribute type.
 	 * @param value Attribute value.
 	 * @return 0 if succeeded, error code otherwise.
+	 *
+	 * Usually can be __cold.
 	 */
 	int (*set_attribute)(struct comp_dev *dev, uint32_t type,
 			     void *value);
@@ -419,6 +436,7 @@ struct comp_ops {
 	 * @param dev Component device.
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually can be __cold.
 	 */
 	int (*dai_ts_config)(struct comp_dev *dev);
 
@@ -427,6 +445,7 @@ struct comp_ops {
 	 * @param dev Component device.
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually can be __cold.
 	 */
 	int (*dai_ts_start)(struct comp_dev *dev);
 
@@ -435,6 +454,7 @@ struct comp_ops {
 	 * @param dev Component device.
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually can be __cold.
 	 */
 	int (*dai_ts_stop)(struct comp_dev *dev);
 
@@ -444,6 +464,7 @@ struct comp_ops {
 	 * @param tsd Receives timestamp data.
 	 *
 	 * Mandatory for components that allocate DAI.
+	 * Usually shouldn't be __cold.
 	 */
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
 	int (*dai_ts_get)(struct comp_dev *dev, struct dai_ts_data *tsd);
@@ -456,6 +477,8 @@ struct comp_ops {
 	 * Bind, atomic - used to notify component of bind event.
 	 * @param dev Component device.
 	 * @param data Bind info
+	 *
+	 * Usually can be __cold.
 	 */
 	int (*bind)(struct comp_dev *dev, void *data);
 
@@ -463,6 +486,8 @@ struct comp_ops {
 	 * Unbind, atomic - used to notify component of unbind event.
 	 * @param dev Component device.
 	 * @param data unBind info
+	 *
+	 * Usually can be __cold.
 	 */
 	int (*unbind)(struct comp_dev *dev, void *data);
 
@@ -478,6 +503,7 @@ struct comp_ops {
 	 *
 	 * Callee fills up *data with config data and save the config
 	 * size in *data_offset for host to reconstruct the config
+	 * Usually can be __cold.
 	 */
 	int (*get_large_config)(struct comp_dev *dev, uint32_t param_id,
 				bool first_block,
@@ -498,6 +524,7 @@ struct comp_ops {
 	 * Host divides large block into small blocks and sends them
 	 * to fw. The data_offset indicates the offset in the large
 	 * block data.
+	 * Usually can be __cold.
 	 */
 	int (*set_large_config)(struct comp_dev *dev, uint32_t param_id,
 				bool first_block,
@@ -511,6 +538,8 @@ struct comp_ops {
 	 * @param stream_no Index of input/output stream
 	 * @param input Selects between input (true) or output (false) stream direction
 	 * @return total data processed if succeeded, 0 otherwise.
+	 *
+	 * Usually shouldn't be __cold.
 	 */
 	uint64_t (*get_total_data_processed)(struct comp_dev *dev, uint32_t stream_no, bool input);
 };

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -12,6 +12,7 @@
 #include <rtos/idc.h>
 #include <rtos/alloc.h>
 #include <sof/lib/dai.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/platform.h>
 #include <rtos/sof.h>
@@ -331,12 +332,14 @@ static int dai_init_llp_info(struct dai_data *dd, struct comp_dev *dev)
 	return 0;
 }
 
-int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai *common_config,
-	       const void *spec_config)
+__cold int dai_config(struct dai_data *dd, struct comp_dev *dev,
+		      struct ipc_config_dai *common_config, const void *spec_config)
 {
 	const struct ipc4_copier_module_cfg *copier_cfg = spec_config;
 	int size;
 	int ret;
+
+	assert_can_be_cold();
 
 	/* ignore if message not for this DAI id/type */
 	if (dd->ipc_config.dai_index != common_config->dai_index ||

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -34,9 +34,11 @@ struct dai_group_list {
 
 static struct dai_group_list *groups[CONFIG_CORE_COUNT];
 
-static struct dai_group_list *dai_group_list_get(int core_id)
+__cold static struct dai_group_list *dai_group_list_get(int core_id)
 {
 	struct dai_group_list *group_list = groups[core_id];
+
+	assert_can_be_cold();
 
 	if (!group_list) {
 		group_list = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
@@ -49,11 +51,13 @@ static struct dai_group_list *dai_group_list_get(int core_id)
 	return group_list;
 }
 
-static struct dai_group *dai_group_find(uint32_t group_id)
+__cold static struct dai_group *dai_group_find(uint32_t group_id)
 {
 	struct list_item *dai_groups;
 	struct list_item *group_item;
 	struct dai_group *group = NULL;
+
+	assert_can_be_cold();
 
 	dai_groups = &dai_group_list_get(cpu_get_id())->list;
 
@@ -69,10 +73,12 @@ static struct dai_group *dai_group_find(uint32_t group_id)
 	return group;
 }
 
-static struct dai_group *dai_group_alloc()
+__cold static struct dai_group *dai_group_alloc(void)
 {
 	struct list_item *dai_groups = &dai_group_list_get(cpu_get_id())->list;
 	struct dai_group *group;
+
+	assert_can_be_cold();
 
 	group = rzalloc(SOF_MEM_ZONE_SYS, 0, SOF_MEM_CAPS_RAM,
 			sizeof(*group));
@@ -82,9 +88,11 @@ static struct dai_group *dai_group_alloc()
 	return group;
 }
 
-struct dai_group *dai_group_get(uint32_t group_id, uint32_t flags)
+__cold struct dai_group *dai_group_get(uint32_t group_id, uint32_t flags)
 {
 	struct dai_group *group;
+
+	assert_can_be_cold();
 
 	if (!group_id) {
 		tr_err(&dai_tr, "dai_group_get(): invalid group_id %u",
@@ -117,8 +125,10 @@ struct dai_group *dai_group_get(uint32_t group_id, uint32_t flags)
 	return group;
 }
 
-void dai_group_put(struct dai_group *group)
+__cold void dai_group_put(struct dai_group *group)
 {
+	assert_can_be_cold();
+
 	group->num_dais--;
 
 	/* Mark as unused if there are no more DAIs in this group */


### PR DESCRIPTION
DAI, host and copier code is always hard linked into the base firmware image, never as loadable modules. Move a large part of non-performance critical code to DRAM