### PR TITLE
kpb: KPB fixes

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1850,9 +1850,15 @@ static enum task_state kpb_draining_task(void *arg)
 out:
 	draining_time_end = sof_cycle_get_64();
 
-	/* Reset host-sink copy mode back to its pre-draining value */
-	comp_set_attribute(comp_buffer_get_sink_component(kpb->host_sink), COMP_ATTR_COPY_TYPE,
-			   &kpb->draining_task_data.copy_type);
+	/* Reset host-sink copy mode back to its pre-draining value.
+	 * kpb->host_sink is NULL after a reset or unbind.
+	 */
+	if (kpb->host_sink)
+		comp_set_attribute(comp_buffer_get_sink_component(kpb->host_sink),
+				   COMP_ATTR_COPY_TYPE,
+				   &kpb->draining_task_data.copy_type);
+	else
+		comp_cl_err(&comp_kpb, "Failed to restore host copy mode!");
 
 	draining_time_ms = k_cyc_to_ms_near64(draining_time_end - draining_time_start);
 	if (draining_time_ms <= UINT_MAX)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1733,7 +1733,7 @@ static enum task_state kpb_draining_task(void *arg)
 	uint64_t current_time;
 	size_t period_bytes = 0;
 	size_t period_bytes_limit = draining_data->pb_limit;
-	size_t period_copy_start;
+	uint64_t period_copy_start;
 	size_t time_taken;
 	size_t *rt_stream_update = &draining_data->buffered_while_draining;
 	struct comp_data *kpb = comp_get_drvdata(draining_data->dev);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -1730,11 +1730,9 @@ static enum task_state kpb_draining_task(void *arg)
 	uint64_t draining_time_ms;
 	uint64_t drain_interval = draining_data->drain_interval;
 	uint64_t next_copy_time = 0;
-	uint64_t current_time;
 	size_t period_bytes = 0;
 	size_t period_bytes_limit = draining_data->pb_limit;
 	uint64_t period_copy_start;
-	size_t time_taken;
 	size_t *rt_stream_update = &draining_data->buffered_while_draining;
 	struct comp_data *kpb = comp_get_drvdata(draining_data->dev);
 	bool sync_mode_on = draining_data->sync_mode_on;
@@ -1836,12 +1834,8 @@ static enum task_state kpb_draining_task(void *arg)
 			comp_copy(comp_buffer_get_sink_component(sink));
 		}
 
-		if (sync_mode_on && period_bytes >= period_bytes_limit) {
-			current_time = sof_cycle_get_64();
-			time_taken = current_time - period_copy_start;
-			next_copy_time = current_time + drain_interval -
-					 time_taken;
-		}
+		if (sync_mode_on && period_bytes >= period_bytes_limit)
+			next_copy_time = period_copy_start + drain_interval;
 
 		if (drain_req == 0) {
 		/* We have finished draining of requested data however

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -159,6 +159,9 @@ struct draining_data {
 	struct comp_dev *dev;
 	bool sync_mode_on;
 	enum comp_copy_type copy_type;
+	size_t task_iteration;
+	uint64_t prev_adjustment_time;
+	size_t prev_adjustment_drained;
 };
 
 struct history_data {

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -146,11 +146,16 @@ struct draining_data {
 	struct comp_buffer *sink;
 	struct history_buffer *hb;
 	size_t drain_req;
+	size_t drained;
 	uint8_t is_draining_active;
 	size_t sample_width;
 	size_t buffered_while_draining;
+	uint64_t draining_time_start;
 	size_t drain_interval;
+	uint64_t period_copy_start;
 	size_t pb_limit; /**< Period bytes limit */
+	size_t period_bytes;
+	uint64_t next_copy_time;
 	struct comp_dev *dev;
 	bool sync_mode_on;
 	enum comp_copy_type copy_type;


### PR DESCRIPTION
Mainly two fixes:

* Avoid long seizure of EDF scheduler thread.
The draining task could run for quite a long time (e.g., a few seconds). It is implemented as an EDF scheduler task. While working, it blocks other EDF scheduler tasks: the IPC processing task and the mtrace logging task. The fix replaces the while loop in the draining task with a return SOF_TASK_STATE_RESCHEDULE, so other EDF scheduler tasks can have CPU time.

* Fix drain interval calculation
The previous drain interval calculation ignored the actual DSP load by LL and only worked for light LL loads (high DSP clock). The drain interval was not appropriate for slow FPGA, where LL takes half of the DSP time. This update introduces code that dynamically readjusts the drain interval and does not depend on LL load (works on low clock, FPGA).