### PR TITLE
tools: testbench: Add missing dependencies in README.md

### DIFF
--- a/tools/testbench/README.md
+++ b/tools/testbench/README.md
@@ -14,6 +14,15 @@
  * Allows easy use of conventional debugger, profiler, leak and memory check
    tools usage for DSP firmware code.
 
+### Prerequisites
+
+Before running the SOF testbench, install the required dependencies:
+
+```
+sudo apt install valgrind octave-signal octave # For Ubuntu/Debian
+sudo dnf install valgrind octave-signal octave # For Fedora
+```
+
 ### Quick how-to
 
 The simplest way to build and execute testbench is with supplied


### PR DESCRIPTION
### Changes  
Updated `tools/testbench/README.md` to include missing dependencies
for Ubuntu/Debian and Fedora. This ensures users can install the
required packages beforehand, avoiding setup issues.

### Why?  
Running `scripts/host-testbench.sh` failed due to missing dependencies  
like `octave`, `valgrind`, and `signal` package in Octave. This update  
helps prevent similar errors for newcomers.  

### Additional Context  
Attached screenshots show the errors encountered before installing  
the missing dependencies: 
![image](https://github.com/user-attachments/assets/91a3196e-9420-417a-91b3-a6bf85cb9710)
![image](https://github.com/user-attachments/assets/865f79ee-dcad-4039-a6a8-a34faa2dc9f8)
![image](https://github.com/user-attachments/assets/27646334-aaef-487d-b36d-9b460e693bd0)

Let me know if any modifications are needed.  
