### PR TITLE
bugfix in DP/Src: some audio formats have incorrectly estimate period

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -139,8 +139,10 @@ static void module_adapter_calculate_dp_period(struct comp_dev *dev)
 	unsigned int period = UINT32_MAX;
 
 	for (int i = 0; i < mod->num_of_sinks; i++) {
-		/* calculate time required the module to provide OBS data portion - a period */
-		unsigned int sink_period = 1000000 * sink_get_min_free_space(mod->sinks[i]) /
+		/* calculate time required the module to provide OBS data portion - a period
+		 * use 64bit integers to avoid overflows
+		 */
+		unsigned int sink_period = 1000000ULL * sink_get_min_free_space(mod->sinks[i]) /
 					   (sink_get_frame_bytes(mod->sinks[i]) *
 					   sink_get_rate(mod->sinks[i]));
 		/* note the minimal period for the module */

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -105,8 +105,10 @@ int src_set_params(struct processing_module *mod, struct sof_sink *sink)
 		 * according to OBS size and data rate
 		 * as SRC uses period value to calculate its internal buffers,
 		 * it must be done here, right after setting sink parameters
+		 *
+		 * calculate period using 64bit integer to avoid overflows
 		 */
-		dev->period = 1000000 * sink_get_min_free_space(sink) /
+		dev->period = 1000000ULL * sink_get_min_free_space(sink) /
 			      (sink_get_frame_bytes(sink) * sink_get_rate(sink));
 		/* align down period to LL cycle time */
 		dev->period /= LL_TIMER_PERIOD_US;


### PR DESCRIPTION
For DP there's a crucial part to properly estimate period that the module will be called. Period value is used in several places in DP scheduling

There were 3 defects:

1) period should always be a multiplication of LL cycle, currently 1000us. If estimated period is i.e. 1300us, it should be aligned down to 1000

2) periods lower that 1LL cycle is not allowed, DP scheduler is triggered from LL 

3) for some enormous high bitrates, like 192KHz/8 channels, there was an 32bit overflow in period calculations
