### PR TITLE
cmake/zephyr: unify cmake rules for lib, probes and... 

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,31 +1,46 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
+set(common_files notifier.c dma.c dai.c)
+
 if(CONFIG_LIBRARY)
-	add_local_sources(sof
-		lib.c
-		dai.c
-		dma.c
-		notifier.c
-                agent.c)
-	return()
+  add_local_sources(sof
+    lib.c
+    agent.c
+    ${common_files}
+    )
+  return()
 endif()
 
 if(CONFIG_HAVE_AGENT)
-	add_local_sources(sof agent.c)
+  add_local_sources(sof agent.c)
 endif()
 
-add_local_sources(sof
-	lib.c
-	alloc.c
-	notifier.c
-	pm_runtime.c
-	clk.c
-	dma.c
-	dai.c
-	wait.c
-	cpu-clk-manager.c
-)
-
 if(CONFIG_AMS)
-add_local_sources(sof ams.c)
+  add_local_sources(sof ams.c)
+endif()
+
+if(CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL)
+  add_local_sources(sof cpu-clk-manager.c)
+endif()
+
+is_zephyr(zephyr)
+if(zephyr) ###  Zephyr ###
+
+  add_local_sources(sof ${common_files})
+
+  if(NOT CONFIG_SOF_ZEPHYR_NO_SOF_CLOCK)
+    add_local_sources(sof clk.c)
+  endif()
+
+else() ### XTOS ###
+
+  add_local_sources(sof
+    ${common_files}
+    lib.c
+    alloc.c
+    pm_runtime.c
+    clk.c
+    wait.c
+    )
+
 endif()

--- a/src/library_manager/CMakeLists.txt
+++ b/src/library_manager/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 if(CONFIG_LIBRARY_MANAGER)
-    add_local_sources(sof lib_manager.c, lib_notifications.c)
+  add_local_sources(sof lib_manager.c lib_notification.c)
+
+  if (CONFIG_MM_DRV AND CONFIG_LLEXT)
+    add_local_sources(sof llext_manager.c)
+  endif()
 endif()

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_local_sources_ifdef(CONFIG_LOG_BACKEND_SOF_PROBE sof log_backend_probe.c)

--- a/src/probe/CMakeLists.txt
+++ b/src/probe/CMakeLists.txt
@@ -1,3 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof probe.c)
+if(CONFIG_PROBE STREQUAL "m")
+  add_subdirectory(llext ${PROJECT_BINARY_DIR}/probe_llext)
+  add_dependencies(app probe)
+elseif(CONFIG_PROBE)
+  add_local_sources(sof probe.c)
+endif()

--- a/src/samples/audio/CMakeLists.txt
+++ b/src/samples/audio/CMakeLists.txt
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
-if(CONFIG_SAMPLE_SMART_AMP)
-	if(CONFIG_IPC_MAJOR_3)
-		add_local_sources(sof
-			smart_amp_test_ipc3.c
-		)
-	elseif(CONFIG_IPC_MAJOR_4)
-		add_local_sources(sof
-			smart_amp_test_ipc4.c
-		)
-	endif()
+
+if(CONFIG_IPC_MAJOR_3)
+  set(ipc_suffix ipc3)
+elseif(CONFIG_IPC_MAJOR_4)
+  set(ipc_suffix ipc4)
+endif()
+
+if(CONFIG_SAMPLE_SMART_AMP STREQUAL "m")
+  add_subdirectory(smart_amp_test_llext ${PROJECT_BINARY_DIR}/smart_amp_test_llext)
+  add_dependencies(app smart_amp_test)
+elseif(CONFIG_SAMPLE_SMART_AMP)
+  add_local_sources(sof smart_amp_test_${ipc_suffix}.c)
 endif()
 
 if(CONFIG_SAMPLE_KEYPHRASE)
-	add_local_sources(sof
-		detect_test.c
-	)
+  add_local_sources(sof detect_test.c)
 endif()
 
 if(CONFIG_KWD_NN_SAMPLE_KEYPHRASE)
-	add_local_sources(sof kwd_nn_detect_test.c)
+  add_local_sources(sof kwd_nn_detect_test.c)
 endif()

--- a/src/trace/CMakeLists.txt
+++ b/src/trace/CMakeLists.txt
@@ -1,3 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof dma-trace.c trace.c)
+if(CONFIG_TRACE)
+  add_local_sources(sof dma-trace.c trace.c)
+endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -210,6 +210,7 @@ add_subdirectory(../src/init/ init_unused_install/)
 add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
 add_subdirectory(../src/library_manager/ library_manager_unused_install/)
+add_subdirectory(../src/logging/ logging_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
 add_subdirectory(../src/trace/ trace_unused_install/)
 add_subdirectory(test/)
@@ -475,9 +476,6 @@ zephyr_library_sources(
 
 # SOF module interface functions
 add_subdirectory(../src/module module_unused_install/)
-
-zephyr_library_sources_ifdef(CONFIG_LOG_BACKEND_SOF_PROBE
-      ${SOF_SRC_PATH}/logging/log_backend_probe.c)
 
 zephyr_library_sources_ifdef(CONFIG_FAST_GET lib/fast-get.c)
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -211,8 +211,8 @@ add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
 add_subdirectory(../src/library_manager/ library_manager_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
+add_subdirectory(../src/trace/ trace_unused_install/)
 add_subdirectory(test/)
-
 
 # Old way below: all .c files added by this giant CMake file.
 
@@ -475,10 +475,6 @@ zephyr_library_sources(
 
 # SOF module interface functions
 add_subdirectory(../src/module module_unused_install/)
-
-zephyr_library_sources_ifdef(CONFIG_TRACE
-	${SOF_SRC_PATH}/trace/dma-trace.c
-	${SOF_SRC_PATH}/trace/trace.c)
 
 zephyr_library_sources_ifdef(CONFIG_LOG_BACKEND_SOF_PROBE
       ${SOF_SRC_PATH}/logging/log_backend_probe.c)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -134,7 +134,6 @@ cmake_path(SET sof_top_dir NORMALIZE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(SOF_SRC_PATH "${sof_top_dir}/src")
 
 set(SOF_PLATFORM_PATH "${SOF_SRC_PATH}/platform")
-set(SOF_SAMPLES_PATH "${SOF_SRC_PATH}/samples")
 set(SOF_DRIVERS_PATH "${SOF_SRC_PATH}/drivers")
 set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
@@ -211,6 +210,7 @@ add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
 add_subdirectory(../src/library_manager/ library_manager_unused_install/)
 add_subdirectory(../src/logging/ logging_unused_install/)
+add_subdirectory(../src/samples/ samples_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
 add_subdirectory(../src/trace/ trace_unused_install/)
 add_subdirectory(test/)
@@ -480,26 +480,6 @@ add_subdirectory(../src/module module_unused_install/)
 zephyr_library_sources_ifdef(CONFIG_FAST_GET lib/fast-get.c)
 
 # Optional SOF sources - depends on Kconfig - WIP
-
-if(CONFIG_IPC_MAJOR_3)
-set(ipc_suffix ipc3)
-elseif(CONFIG_IPC_MAJOR_4)
-set(ipc_suffix ipc4)
-endif()
-
-zephyr_library_sources_ifdef(CONFIG_SAMPLE_KEYPHRASE
-	${SOF_SAMPLES_PATH}/audio/detect_test.c
-)
-
-if(CONFIG_SAMPLE_SMART_AMP STREQUAL "m")
-	add_subdirectory(${SOF_SAMPLES_PATH}/audio/smart_amp_test_llext
-			 ${PROJECT_BINARY_DIR}/smart_amp_test_llext)
-	add_dependencies(app smart_amp_test)
-elseif(CONFIG_SAMPLE_SMART_AMP)
-	zephyr_library_sources(
-		${SOF_SAMPLES_PATH}/audio/smart_amp_test_${ipc_suffix}.c
-	)
-endif()
 
 if(CONFIG_PROBE STREQUAL "m")
 	add_subdirectory(${SOF_SRC_PATH}/probe/llext

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -135,7 +135,6 @@ set(SOF_SRC_PATH "${sof_top_dir}/src")
 
 set(SOF_PLATFORM_PATH "${SOF_SRC_PATH}/platform")
 set(SOF_SAMPLES_PATH "${SOF_SRC_PATH}/samples")
-set(SOF_LIB_PATH "${SOF_SRC_PATH}/lib")
 set(SOF_DRIVERS_PATH "${SOF_SRC_PATH}/drivers")
 set(SOF_TRACE_PATH "${SOF_SRC_PATH}/trace")
 
@@ -209,6 +208,7 @@ add_subdirectory(../src/audio/ audio_unused_install/)
 add_subdirectory(../src/debug/ debug_unused_install/)
 add_subdirectory(../src/init/ init_unused_install/)
 add_subdirectory(../src/ipc/  ipc_unused_install/)
+add_subdirectory(../src/lib/ lib_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
 add_subdirectory(test/)
 
@@ -455,11 +455,6 @@ zephyr_include_directories(${SOF_PLATFORM_PATH}/${PLATFORM}/include)
 # Commented files will be added/removed as integration dictates.
 zephyr_library_sources(
 
-	# SOF library - parts to transition to Zephyr over time
-	${SOF_LIB_PATH}/notifier.c
-	${SOF_LIB_PATH}/dma.c
-	${SOF_LIB_PATH}/dai.c
-
 	# SOF core infrastructure - runs on top of Zephyr
 	${SOF_SRC_PATH}/arch/xtensa/drivers/cache_attr.c
 
@@ -475,14 +470,6 @@ zephyr_library_sources(
 
 	# Common library functions - Will be moved to Zephyr over time
 	lib.c
-)
-
-if(NOT CONFIG_SOF_ZEPHYR_NO_SOF_CLOCK)
-	zephyr_library_sources(${SOF_LIB_PATH}/clk.c)
-endif()
-
-zephyr_library_sources_ifdef(CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL
-	${SOF_LIB_PATH}/cpu-clk-manager.c
 )
 
 # SOF module interface functions
@@ -540,14 +527,6 @@ endif()
 
 zephyr_library_sources_ifdef(CONFIG_MULTICORE
 	${SOF_SRC_PATH}/idc/idc.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_HAVE_AGENT
-	${SOF_LIB_PATH}/agent.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_AMS
-	${SOF_LIB_PATH}/ams.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_DW_DMA

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -210,6 +210,7 @@ add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
 add_subdirectory(../src/library_manager/ library_manager_unused_install/)
 add_subdirectory(../src/logging/ logging_unused_install/)
+add_subdirectory(../src/probe/ probes_unused_install/)
 add_subdirectory(../src/samples/ samples_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
 add_subdirectory(../src/trace/ trace_unused_install/)
@@ -480,14 +481,6 @@ add_subdirectory(../src/module module_unused_install/)
 zephyr_library_sources_ifdef(CONFIG_FAST_GET lib/fast-get.c)
 
 # Optional SOF sources - depends on Kconfig - WIP
-
-if(CONFIG_PROBE STREQUAL "m")
-	add_subdirectory(${SOF_SRC_PATH}/probe/llext
-			 ${PROJECT_BINARY_DIR}/probe_llext)
-	add_dependencies(app probe)
-elseif(CONFIG_PROBE)
-	zephyr_library_sources(${SOF_SRC_PATH}/probe/probe.c)
-endif()
 
 zephyr_library_sources_ifdef(CONFIG_MULTICORE
 	${SOF_SRC_PATH}/idc/idc.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -209,6 +209,7 @@ add_subdirectory(../src/debug/ debug_unused_install/)
 add_subdirectory(../src/init/ init_unused_install/)
 add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
+add_subdirectory(../src/library_manager/ library_manager_unused_install/)
 add_subdirectory(../src/schedule/  schedule_unused_install/)
 add_subdirectory(test/)
 
@@ -495,17 +496,6 @@ endif()
 zephyr_library_sources_ifdef(CONFIG_SAMPLE_KEYPHRASE
 	${SOF_SAMPLES_PATH}/audio/detect_test.c
 )
-
-zephyr_library_sources_ifdef(CONFIG_LIBRARY_MANAGER
-	${SOF_SRC_PATH}/library_manager/lib_manager.c
-	${SOF_SRC_PATH}/library_manager/lib_notification.c
-)
-
-if (CONFIG_MM_DRV AND CONFIG_LLEXT)
-zephyr_library_sources_ifdef(CONFIG_LIBRARY_MANAGER
-	${SOF_SRC_PATH}/library_manager/llext_manager.c
-)
-endif()
 
 if(CONFIG_SAMPLE_SMART_AMP STREQUAL "m")
 	add_subdirectory(${SOF_SAMPLES_PATH}/audio/smart_amp_test_llext


### PR DESCRIPTION
Last set of Zephyr cmake changes. This has all the commits from #9918. The gdb rule change is not included as @lyakh has those in #9907 .

UPDATE: #9918 and #9907 merged, so dependencies are all in main