### PR TITLE
[SKIP SOFCI-TEST] tools: plugin: Fix incorrect tilde expansion in environment variable

### DIFF
--- a/tools/plugin/README.md
+++ b/tools/plugin/README.md
@@ -121,7 +121,7 @@ repository to make sure OpenVino and OpenCV are configured properly.
 
 4. Set environment variable NOISE_SUPPRESSION_MODEL_NAME to point to the model file
 ```
-export NOISE_SUPPRESSION_MODEL_NAME="~/open_model_zoo/demos/noise_suppression_demo/cpp/intel/noise-suppression-poconetlike-0001/FP16/noise-suppression-poconetlike-0001.xml"
+export NOISE_SUPPRESSION_MODEL_NAME=~/open_model_zoo/demos/noise_suppression_demo/cpp/intel/noise-suppression-poconetlike-0001/FP16/noise-suppression-poconetlike-0001.xml
 
 ```
 5. Enable noise suppression by setting NOISE_SUPPRESSION=true in the tplg-targets for the sof-plugin topology


### PR DESCRIPTION
### Overview
The current documentation suggests setting the
NOISE_SUPPRESSION_MODEL_NAME variable using a quoted tilde (~):

`export NOISE_SUPPRESSION_MODEL_NAME="~/path/to/model.xml"  `

However, when quoted, ~ is not expanded to the home directory,
causing ls -l $NOISE_SUPPRESSION_MODEL_NAME to fail with
"No such file or directory." & Getting error while testing OpenVino noise 
suppression model with the SOF plugin.

### Fix

The correct way to set this variable is without quotes:

`export NOISE_SUPPRESSION_MODEL_NAME=~/path/to/model.xml  `

This ensures the path expands correctly.
### Testing

![image](https://github.com/user-attachments/assets/80be6aaa-dc59-4e07-b3b9-6aa1a70ee951)

Manually tested by setting the variable and verifying with ls -l.



This PR updates the documentation accordingly.
