### PR TITLE
dp: change notifier "LL post run" to "pre run"

### DIFF
--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -31,7 +31,7 @@ enum notify_id {
 	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
 	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
 	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
-	NOTIFIER_ID_LL_POST_RUN,		/* NULL */
+	NOTIFIER_ID_LL_PRE_RUN,			/* NULL */
 	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */
 	NOTIFIER_ID_DAI_TRIGGER,		/* struct dai_group * */
 	NOTIFIER_ID_MIC_PRIVACY_STATE_CHANGE,	/* struct mic_privacy_settings * */

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -313,12 +313,12 @@ static void schedule_ll_tasks_run(void *data)
 
 	perf_cnt_init(&sch->pcd);
 
+	notifier_event(sch, NOTIFIER_ID_LL_PRE_RUN,
+		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
+
 	/* run tasks if there are any pending */
 	if (schedule_ll_is_pending(sch))
 		schedule_ll_tasks_execute(sch);
-
-	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
-		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
 
 	perf_cnt_stamp(&sch->pcd, perf_ll_sched_trace, 0 /* ignored */);
 	perf_cnt_average(&sch->pcd, perf_avg_ll_sched_trace, 0 /* ignored */);

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -464,7 +464,7 @@ int scheduler_dp_init(void)
 	if (ret)
 		return ret;
 
-	notifier_register(NULL, NULL, NOTIFIER_ID_LL_POST_RUN, scheduler_dp_ll_tick, 0);
+	notifier_register(NULL, NULL, NOTIFIER_ID_LL_PRE_RUN, scheduler_dp_ll_tick, 0);
 
 	return 0;
 }

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -176,6 +176,9 @@ static void zephyr_ll_run(void *data)
 	struct list_item *list, *tmp, task_head = LIST_INIT(task_head);
 	uint32_t flags;
 
+	notifier_event(sch, NOTIFIER_ID_LL_PRE_RUN,
+		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
+
 	zephyr_ll_lock(sch, &flags);
 
 	/*
@@ -185,7 +188,6 @@ static void zephyr_ll_run(void *data)
 	 * always consistent and contains the tasks, that we haven't run in this
 	 * cycle yet.
 	 */
-
 	for (list = sch->tasks.next; !list_is_empty(&sch->tasks); list = sch->tasks.next) {
 		enum task_state state;
 		struct zephyr_ll_pdata *pdata;
@@ -247,9 +249,6 @@ static void zephyr_ll_run(void *data)
 	}
 
 	zephyr_ll_unlock(sch, &flags);
-
-	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
-		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
 }
 
 static void schedule_ll_callback(void *data)


### PR DESCRIPTION
For DP a deadline time starts at the beginning
of LL cycle, so it needs to be calculated there.
As DP is the only users of NOTIFIER_ID_LL_POST_RUN I's changed it to NOTIFIER_ID_LL_PRE_RUN
instead of introducing another hook