### PR TITLE
[SKIP SOF-TEST] dram: (cosmetic) rename debugging with dbg_

### DIFF
--- a/posix/include/sof/lib/memory.h
+++ b/posix/include/sof/lib/memory.h
@@ -19,6 +19,6 @@
 #endif
 
 #define assert_can_be_cold() do {} while (0)
-#define mem_hot_path_confirm() do {} while (0)
+#define dbg_path_hot_confirm() do {} while (0)
 
 #endif /* __SOF_LIB_MEMORY_H__ */

--- a/src/debug/dram.c
+++ b/src/debug/dram.c
@@ -7,14 +7,14 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/__assert.h>
 
-LOG_MODULE_REGISTER(dram_debug, CONFIG_SOF_LOG_LEVEL);
+LOG_MODULE_REGISTER(dbg_path, CONFIG_SOF_LOG_LEVEL);
 
 static struct k_spinlock hot_path_lock;
 static unsigned int hot_path_depth;
 static const char *cold_path_fn;
 static bool hot_path_confirmed;
 
-void mem_cold_path_enter(const char *fn)
+void dbg_path_cold_enter(const char *fn)
 {
 	k_spinlock_key_t key = k_spin_lock(&hot_path_lock);
 
@@ -22,9 +22,9 @@ void mem_cold_path_enter(const char *fn)
 
 	k_spin_unlock(&hot_path_lock, key);
 }
-EXPORT_SYMBOL(mem_cold_path_enter);
+EXPORT_SYMBOL(dbg_path_cold_enter);
 
-void mem_hot_path_start_watching(void)
+void dbg_path_hot_start_watching(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&hot_path_lock);
 
@@ -36,7 +36,7 @@ void mem_hot_path_start_watching(void)
 	k_spin_unlock(&hot_path_lock, key);
 }
 
-void mem_hot_path_confirm(void)
+void dbg_path_hot_confirm(void)
 {
 	k_spinlock_key_t key = k_spin_lock(&hot_path_lock);
 
@@ -45,7 +45,7 @@ void mem_hot_path_confirm(void)
 	k_spin_unlock(&hot_path_lock, key);
 }
 
-void mem_hot_path_stop_watching(void)
+void dbg_path_hot_stop_watching(void)
 {
 	bool underrun, error;
 	k_spinlock_key_t key = k_spin_lock(&hot_path_lock);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -425,9 +425,9 @@ void idc_cmd(struct idc_msg *msg)
 		notifier_notify_remote();
 		break;
 	case iTS(IDC_MSG_IPC):
-		mem_hot_path_start_watching();
+		dbg_path_hot_start_watching();
 		idc_ipc();
-		mem_hot_path_stop_watching();
+		dbg_path_hot_stop_watching();
 		break;
 #if CONFIG_IPC_MAJOR_4
 	case iTS(IDC_MSG_BIND):

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -217,14 +217,14 @@ enum task_state ipc_platform_do_cmd(struct ipc *ipc)
 {
 	struct ipc_cmd_hdr *hdr;
 
-	mem_hot_path_start_watching();
+	dbg_path_hot_start_watching();
 
 	hdr = ipc_compact_read_msg();
 
 	/* perform command */
 	ipc_cmd(hdr);
 
-	mem_hot_path_stop_watching();
+	dbg_path_hot_stop_watching();
 
 	if (ipc->task_mask & IPC_TASK_POWERDOWN ||
 	    ipc_get()->pm_prepare_D3) {

--- a/src/ipc/ipc4/handler.c
+++ b/src/ipc/ipc4/handler.c
@@ -484,7 +484,7 @@ int ipc4_pipeline_trigger(struct ipc_comp_dev *ppl_icd, uint32_t cmd, bool *dela
 	 * mem_hot_path_start_watching() - mem_hot_path_stop_watching()
 	 * brackets, the latter will generate an error / trigger a panic.
 	 */
-	mem_hot_path_confirm();
+	dbg_path_hot_confirm();
 
 	/* trigger the component */
 	ret = pipeline_trigger(host->cd->pipeline, host->cd, cmd);

--- a/xtos/include/sof/lib/memory.h
+++ b/xtos/include/sof/lib/memory.h
@@ -19,6 +19,6 @@
 #endif
 
 #define assert_can_be_cold() do {} while (0)
-#define mem_hot_path_confirm() do {} while (0)
+#define dbg_path_hot_confirm() do {} while (0)
 
 #endif /* __SOF_LIB_MEMORY_H__ */

--- a/zephyr/include/sof/lib/memory.h
+++ b/zephyr/include/sof/lib/memory.h
@@ -25,22 +25,22 @@ bool ll_sch_is_current(void);
 #define ll_sch_is_current() false
 #endif
 
-void mem_hot_path_start_watching(void);
-void mem_hot_path_stop_watching(void);
-void mem_hot_path_confirm(void);
-void mem_cold_path_enter(const char *fn);
+void dbg_path_hot_start_watching(void);
+void dbg_path_hot_stop_watching(void);
+void dbg_path_hot_confirm(void);
+void dbg_path_cold_enter(const char *fn);
 
 static inline void __assert_can_be_cold(const char *fn)
 {
 	__ASSERT(!ll_sch_is_current(), "%s() called from an LL thread!", fn);
-	mem_cold_path_enter(fn);
+	dbg_path_cold_enter(fn);
 }
 #define assert_can_be_cold() __assert_can_be_cold(__func__)
 #else
-#define mem_hot_path_start_watching() do {} while (0)
-#define mem_hot_path_stop_watching() do {} while (0)
-#define mem_hot_path_confirm() do {} while (0)
-#define mem_cold_path_enter() do {} while (0)
+#define dbg_path_hot_start_watching() do {} while (0)
+#define dbg_path_hot_stop_watching() do {} while (0)
+#define dbg_path_hot_confirm() do {} while (0)
+#define dbg_path_cold_enter() do {} while (0)
 #define assert_can_be_cold() do {} while (0)
 #endif
 


### PR DESCRIPTION
Rename debugging functions to clearly indicate their debugging purpose.