### PR TITLE
cmake/zephyr: unify cmake rules for src/idc

### DIFF
--- a/src/idc/CMakeLists.txt
+++ b/src/idc/CMakeLists.txt
@@ -1,3 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-add_local_sources(sof idc.c )
+is_zephyr(zephyr)
+if(zephyr)
+  add_local_sources_ifdef(CONFIG_SMP sof idc.c)
+  add_local_sources(sof zephyr_idc.c)
+else()
+  add_local_sources(sof idc.c)
+endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -205,6 +205,7 @@ add_subdirectory(../src/math/  math_unused_install/)
 # remaining directories (in alphabetical order)
 add_subdirectory(../src/audio/ audio_unused_install/)
 add_subdirectory(../src/debug/ debug_unused_install/)
+add_subdirectory(../src/idc/ idc_unused_install/)
 add_subdirectory(../src/init/ init_unused_install/)
 add_subdirectory(../src/ipc/  ipc_unused_install/)
 add_subdirectory(../src/lib/ lib_unused_install/)
@@ -461,8 +462,6 @@ zephyr_library_sources(
 	# SOF core infrastructure - runs on top of Zephyr
 	${SOF_SRC_PATH}/arch/xtensa/drivers/cache_attr.c
 
-	${SOF_SRC_PATH}/idc/zephyr_idc.c
-
 	# Bridge wrapper between SOF and Zephyr APIs - Will shrink over time.
 	wrapper.c
 	edf_schedule.c
@@ -481,10 +480,6 @@ add_subdirectory(../src/module module_unused_install/)
 zephyr_library_sources_ifdef(CONFIG_FAST_GET lib/fast-get.c)
 
 # Optional SOF sources - depends on Kconfig - WIP
-
-zephyr_library_sources_ifdef(CONFIG_MULTICORE
-	${SOF_SRC_PATH}/idc/idc.c
-)
 
 zephyr_library_sources_ifdef(CONFIG_DW_DMA
 	${SOF_DRIVERS_PATH}/dw/dma.c


### PR DESCRIPTION
Adding all source files in a single, giant zephyr/CMakeLists.txt is inconvenient and does not scale.

Modify Zephyr rules to use definitions in src/idc/ instead.

Link: https://github.com/thesofproject/sof/issues/8260