### PR TITLE
llext: remove unneeded data and functions

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -309,9 +309,6 @@ static const struct module_interface aria_interface = {
 	.set_configuration = aria_set_config,
 };
 
-DECLARE_MODULE_ADAPTER(aria_interface, aria_uuid, aria_comp_tr);
-SOF_MODULE_INIT(aria, sys_comp_module_aria_interface_init);
-
 #if CONFIG_COMP_ARIA_MODULE
 /* modular: llext dynamic link */
 
@@ -325,5 +322,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("ARIA", aria_llext_entry, 1, SOF_REG_UUID(aria), 8);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(aria_interface, aria_uuid, aria_comp_tr);
+SOF_MODULE_INIT(aria, sys_comp_module_aria_interface_init);
 
 #endif

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -872,9 +872,6 @@ static const struct module_interface asrc_interface = {
 	.free = asrc_free,
 };
 
-DECLARE_MODULE_ADAPTER(asrc_interface, ASRC_UUID, asrc_tr);
-SOF_MODULE_INIT(asrc, sys_comp_module_asrc_interface_init);
-
 #if CONFIG_COMP_ASRC_MODULE
 /* modular: llext dynamic link */
 
@@ -889,4 +886,10 @@ static const struct sof_man_module_manifest mod_manifest[] __section(".module") 
 };
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(asrc_interface, ASRC_UUID, asrc_tr);
+SOF_MODULE_INIT(asrc, sys_comp_module_asrc_interface_init);
+
 #endif

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -468,9 +468,6 @@ static const struct module_interface dts_interface = {
 	.free = dts_codec_free
 };
 
-DECLARE_MODULE_ADAPTER(dts_interface, dts_uuid, dts_tr);
-SOF_MODULE_INIT(dts, sys_comp_module_dts_interface_init);
-
 #if CONFIG_DTS_CODEC_MODULE
 /* modular: llext dynamic link */
 
@@ -484,5 +481,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("DTS", dts_llext_entry, 1, SOF_REG_UUID(dts), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(dts_interface, dts_uuid, dts_tr);
+SOF_MODULE_INIT(dts, sys_comp_module_dts_interface_init);
 
 #endif

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -633,9 +633,6 @@ static const struct module_interface crossover_interface = {
 	.free = crossover_free
 };
 
-DECLARE_MODULE_ADAPTER(crossover_interface, crossover_uuid, crossover_tr);
-SOF_MODULE_INIT(crossover, sys_comp_module_crossover_interface_init);
-
 #if CONFIG_COMP_CROSSOVER_MODULE
 /* modular: llext dynamic link */
 
@@ -649,5 +646,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("XOVER", crossover_llext_entry, 1, SOF_REG_UUID(crossover), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(crossover_interface, crossover_uuid, crossover_tr);
+SOF_MODULE_INIT(crossover, sys_comp_module_crossover_interface_init);
 
 #endif

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -254,9 +254,6 @@ static const struct module_interface dcblock_interface = {
 	.free = dcblock_free,
 };
 
-DECLARE_MODULE_ADAPTER(dcblock_interface, dcblock_uuid, dcblock_tr);
-SOF_MODULE_INIT(dcblock, sys_comp_module_dcblock_interface_init);
-
 #if CONFIG_COMP_DCBLOCK_MODULE
 /* modular: llext dynamic link */
 
@@ -270,5 +267,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("DCBLOCK", dcblock_llext_entry, 1, SOF_REG_UUID(dcblock), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(dcblock_interface, dcblock_uuid, dcblock_tr);
+SOF_MODULE_INIT(dcblock, sys_comp_module_dcblock_interface_init);
 
 #endif

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -412,9 +412,6 @@ static const struct module_interface drc_interface = {
 	.free = drc_free
 };
 
-DECLARE_MODULE_ADAPTER(drc_interface, drc_uuid, drc_tr);
-SOF_MODULE_INIT(drc, sys_comp_module_drc_interface_init);
-
 #if CONFIG_COMP_DRC_MODULE
 /* modular: llext dynamic link */
 
@@ -427,5 +424,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("DRC", drc_llext_entry, 1, SOF_REG_UUID(drc), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(drc_interface, drc_uuid, drc_tr);
+SOF_MODULE_INIT(drc, sys_comp_module_drc_interface_init);
 
 #endif

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -478,9 +478,6 @@ static const struct module_interface eq_fir_interface = {
 		.reset = eq_fir_reset,
 };
 
-DECLARE_MODULE_ADAPTER(eq_fir_interface, eq_fir_uuid, eq_fir_tr);
-SOF_MODULE_INIT(eq_fir, sys_comp_module_eq_fir_interface_init);
-
 #if CONFIG_COMP_FIR_MODULE
 /* modular: llext dynamic link */
 
@@ -494,5 +491,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("EQFIR", eq_fir_llext_entry, 1, SOF_REG_UUID(eq_fir), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(eq_fir_interface, eq_fir_uuid, eq_fir_tr);
+SOF_MODULE_INIT(eq_fir, sys_comp_module_eq_fir_interface_init);
 
 #endif

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -248,9 +248,6 @@ static const struct module_interface eq_iir_interface = {
 	.free = eq_iir_free
 };
 
-DECLARE_MODULE_ADAPTER(eq_iir_interface, eq_iir_uuid, eq_iir_tr);
-SOF_MODULE_INIT(eq_iir, sys_comp_module_eq_iir_interface_init);
-
 #if CONFIG_COMP_IIR_MODULE
 /* modular: llext dynamic link */
 
@@ -264,5 +261,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("EQIIR", eq_iir_llext_entry, 1, SOF_REG_UUID(eq_iir), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(eq_iir_interface, eq_iir_uuid, eq_iir_tr);
+SOF_MODULE_INIT(eq_iir, sys_comp_module_eq_iir_interface_init);
 
 #endif

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -454,11 +454,6 @@ static const struct module_interface google_ctc_audio_processing_interface = {
 	.reset = ctc_reset,
 };
 
-DECLARE_MODULE_ADAPTER(google_ctc_audio_processing_interface,
-		       google_ctc_audio_processing_uuid, google_ctc_audio_processing_tr);
-SOF_MODULE_INIT(google_ctc_audio_processing,
-		sys_comp_module_google_ctc_audio_processing_interface_init);
-
 #if CONFIG_COMP_GOOGLE_CTC_AUDIO_PROCESSING_MODULE
 /* modular: llext dynamic link */
 
@@ -473,5 +468,12 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 				  1, SOF_REG_UUID(google_ctc_audio_processing), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(google_ctc_audio_processing_interface,
+		       google_ctc_audio_processing_uuid, google_ctc_audio_processing_tr);
+SOF_MODULE_INIT(google_ctc_audio_processing,
+		sys_comp_module_google_ctc_audio_processing_interface_init);
 
 #endif

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -849,11 +849,6 @@ static const struct module_interface google_rtc_audio_processing_interface = {
 	.reset = google_rtc_audio_processing_reset,
 };
 
-DECLARE_MODULE_ADAPTER(google_rtc_audio_processing_interface,
-		       google_rtc_audio_processing_uuid, google_rtc_audio_processing_tr);
-SOF_MODULE_INIT(google_rtc_audio_processing,
-		sys_comp_module_google_rtc_audio_processing_interface_init);
-
 #if CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING_MODULE
 /* modular: llext dynamic link */
 
@@ -868,5 +863,12 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 				  7, SOF_REG_UUID(google_rtc_audio_processing), 1);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(google_rtc_audio_processing_interface,
+		       google_rtc_audio_processing_uuid, google_rtc_audio_processing_tr);
+SOF_MODULE_INIT(google_rtc_audio_processing,
+		sys_comp_module_google_rtc_audio_processing_interface_init);
 
 #endif

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -883,9 +883,6 @@ static const struct module_interface igo_nr_interface = {
 	.free = igo_nr_free
 };
 
-DECLARE_MODULE_ADAPTER(igo_nr_interface, igo_nr_uuid, igo_nr_tr);
-SOF_MODULE_INIT(igo_nr, sys_comp_module_igo_nr_interface_init);
-
 #if CONFIG_COMP_IGO_NR_MODULE
 /* modular: llext dynamic link */
 
@@ -899,5 +896,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("IGO_NR", igo_nr_llext_entry, 1, SOF_REG_UUID(igo_nr), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(igo_nr_interface, igo_nr_uuid, igo_nr_tr);
+SOF_MODULE_INIT(igo_nr, sys_comp_module_igo_nr_interface_init);
 
 #endif

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -256,9 +256,6 @@ static const struct module_interface mfcc_interface = {
 	.reset = mfcc_reset,
 };
 
-DECLARE_MODULE_ADAPTER(mfcc_interface, mfcc_uuid, mfcc_tr);
-SOF_MODULE_INIT(mfcc, sys_comp_module_mfcc_interface_init);
-
 #if CONFIG_COMP_MFCC_MODULE
 /* modular: llext dynamic link */
 
@@ -272,5 +269,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("MFCC", mfcc_llext_entry, 1, SOF_REG_UUID(mfcc), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(mfcc_interface, mfcc_uuid, mfcc_tr);
+SOF_MODULE_INIT(mfcc, sys_comp_module_mfcc_interface_init);
 
 #endif

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -926,9 +926,6 @@ static const struct module_interface mixin_interface = {
 	.free = mixin_free
 };
 
-DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
-SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
-
 static const struct module_interface mixout_interface = {
 	.init = mixout_init,
 	.prepare = mixout_prepare,
@@ -938,9 +935,6 @@ static const struct module_interface mixout_interface = {
 	.bind = mixout_bind,
 	.unbind = mixout_unbind
 };
-
-DECLARE_MODULE_ADAPTER(mixout_interface, mixout_uuid, mixout_tr);
-SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);
 
 #if CONFIG_COMP_MIXIN_MIXOUT_MODULE
 /* modular: llext dynamic link */
@@ -959,5 +953,13 @@ static const struct sof_man_module_manifest mod_manifest[] __section(".module") 
 };
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
+SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
+
+DECLARE_MODULE_ADAPTER(mixout_interface, mixout_uuid, mixout_tr);
+SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);
 
 #endif

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -904,9 +904,6 @@ static const struct module_interface waves_interface = {
 	.free = waves_codec_free
 };
 
-DECLARE_MODULE_ADAPTER(waves_interface, waves_uuid, waves_tr);
-SOF_MODULE_INIT(waves, sys_comp_module_waves_interface_init);
-
 #if CONFIG_WAVES_CODEC_MODULE && CONFIG_WAVES_CODEC_STUB
 /* modular: llext dynamic link */
 
@@ -920,5 +917,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("WAVES", waves_llext_entry, 7, SOF_REG_UUID(waves), 8);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(waves_interface, waves_uuid, waves_tr);
+SOF_MODULE_INIT(waves, sys_comp_module_waves_interface_init);
 
 #endif

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -430,9 +430,6 @@ static const struct module_interface multiband_drc_interface = {
 	.free = multiband_drc_free
 };
 
-DECLARE_MODULE_ADAPTER(multiband_drc_interface, multiband_drc_uuid, multiband_drc_tr);
-SOF_MODULE_INIT(multiband_drc, sys_comp_module_multiband_drc_interface_init);
-
 #if CONFIG_COMP_MULTIBAND_DRC_MODULE
 /* modular: llext dynamic link */
 
@@ -447,5 +444,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 				  SOF_REG_UUID(multiband_drc), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(multiband_drc_interface, multiband_drc_uuid, multiband_drc_tr);
+SOF_MODULE_INIT(multiband_drc, sys_comp_module_multiband_drc_interface_init);
 
 #endif

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -866,9 +866,6 @@ static const struct module_interface rtnr_interface = {
 	.free = rtnr_free
 };
 
-DECLARE_MODULE_ADAPTER(rtnr_interface, rtnr_uuid, rtnr_tr);
-SOF_MODULE_INIT(rtnr, sys_comp_module_rtnr_interface_init);
-
 #if CONFIG_COMP_RTNR_MODULE
 /* modular: llext dynamic link */
 
@@ -882,5 +879,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("RTNR", rtnr_llext_entry, 1, SOF_REG_UUID(rtnr), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(rtnr_interface, rtnr_uuid, rtnr_tr);
+SOF_MODULE_INIT(rtnr, sys_comp_module_rtnr_interface_init);
 
 #endif

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -913,9 +913,6 @@ static const struct module_interface selector_interface = {
 	.free			= selector_free
 };
 
-DECLARE_MODULE_ADAPTER(selector_interface, selector4_uuid, selector_tr);
-SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);
-
 #if CONFIG_COMP_SEL_MODULE
 /* modular: llext dynamic link */
 
@@ -930,6 +927,11 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 				  8);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(selector_interface, selector4_uuid, selector_tr);
+SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);
 
 #endif
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -84,9 +84,6 @@ static const struct module_interface src_interface = {
 	.free = src_free,
 };
 
-DECLARE_MODULE_ADAPTER(src_interface, SRC_UUID, src_tr);
-SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);
-
 #if CONFIG_COMP_SRC_MODULE
 /* modular: llext dynamic link */
 
@@ -110,4 +107,10 @@ static const struct sof_man_module_manifest mod_manifest[] __section(".module") 
 };
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(src_interface, SRC_UUID, src_tr);
+SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);
+
 #endif

--- a/src/audio/src/src_lite.c
+++ b/src/audio/src/src_lite.c
@@ -71,5 +71,7 @@ SOF_DEFINE_REG_UUID(src_lite);
 
 DECLARE_TR_CTX(src_lite_tr, SOF_UUID(src_lite_uuid), LOG_LEVEL_INFO);
 
+#if !CONFIG_COMP_SRC_MODULE
 DECLARE_MODULE_ADAPTER(src_lite_interface, src_lite_uuid, src_lite_tr);
 SOF_MODULE_INIT(src_lite, sys_comp_module_src_lite_interface_init);
+#endif

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -821,9 +821,6 @@ static const struct module_interface tdfb_interface = {
 	.reset = tdfb_reset,
 };
 
-DECLARE_MODULE_ADAPTER(tdfb_interface, tdfb_uuid, tdfb_tr);
-SOF_MODULE_INIT(tdfb, sys_comp_module_tdfb_interface_init);
-
 #if CONFIG_COMP_TDFB_MODULE
 /* modular: llext dynamic link */
 
@@ -837,5 +834,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("TDFB", tdfb_llext_entry, 1, SOF_REG_UUID(tdfb), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(tdfb_interface, tdfb_uuid, tdfb_tr);
+SOF_MODULE_INIT(tdfb, sys_comp_module_tdfb_interface_init);
 
 #endif

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -236,9 +236,6 @@ static const struct module_interface tester_interface = {
 	.trigger = tester_trigger
 };
 
-DECLARE_MODULE_ADAPTER(tester_interface, tester_uuid, tester_tr);
-SOF_MODULE_INIT(tester, sys_comp_module_tester_interface_init);
-
 #if CONFIG_COMP_TESTER_MODULE
 /* modular: llext dynamic link */
 
@@ -252,5 +249,10 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("TESTER", tester_llext_entry, 1, SOF_REG_UUID(tester), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(tester_interface, tester_uuid, tester_tr);
+SOF_MODULE_INIT(tester, sys_comp_module_tester_interface_init);
 
 #endif

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1610,9 +1610,6 @@ static const struct module_interface probe_interface = {
 	.free = probe_free,
 };
 
-DECLARE_MODULE_ADAPTER(probe_interface, PROBE_UUID, pr_tr);
-SOF_MODULE_INIT(probe, sys_comp_module_probe_interface_init);
-
 #if CONFIG_PROBE_MODULE
 /* modular: llext dynamic link */
 
@@ -1626,6 +1623,11 @@ static const struct sof_man_module_manifest mod_manifest __section(".module") __
 	SOF_LLEXT_MODULE_MANIFEST("PROBE", probe_llext_entry, 1, SOF_REG_UUID(probe4), 40);
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(probe_interface, PROBE_UUID, pr_tr);
+SOF_MODULE_INIT(probe, sys_comp_module_probe_interface_init);
 
 #endif /* CONFIG_COMP_PROBE_MODULE */
 

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -374,9 +374,6 @@ static const struct module_interface smart_amp_test_interface = {
 	.free = smart_amp_free
 };
 
-DECLARE_MODULE_ADAPTER(smart_amp_test_interface, smart_amp_test_uuid, smart_amp_test_comp_tr);
-SOF_MODULE_INIT(smart_amp_test, sys_comp_module_smart_amp_test_interface_init);
-
 #if CONFIG_SAMPLE_SMART_AMP_MODULE
 /* modular: llext dynamic link */
 
@@ -392,4 +389,10 @@ static const struct sof_man_module_manifest mod_manifest[] __section(".module") 
 };
 
 SOF_LLEXT_BUILDINFO;
+
+#else
+
+DECLARE_MODULE_ADAPTER(smart_amp_test_interface, smart_amp_test_uuid, smart_amp_test_comp_tr);
+SOF_MODULE_INIT(smart_amp_test, sys_comp_module_smart_amp_test_interface_init);
+
 #endif


### PR DESCRIPTION
All module adapter drivers interface with the infrastructure using entries similar to

DECLARE_MODULE_ADAPTER(src_interface, SRC_UUID, src_tr); SOF_MODULE_INIT(src, sys_comp_module_src_interface_init);

which create instances of struct comp_driver and define several functions. They aren't needed when built as a LLEXT module.