### PR TITLE
Topology2 sched domain support

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -94,6 +94,7 @@ Define {
 	SSP2_PCM_CORE_ID		2
 	DMIC0_PCM_0_NAME		"DMIC SFX1"
 	DMIC0_PCM_1_NAME		"DMIC SFX2"
+	SRC_DOMAIN			"default"
 }
 
 # override defaults with platform-specific config
@@ -244,6 +245,9 @@ IncludeByKey.PASSTHROUGH {
 					Object.Control.mixer.1 {
 						name 'Pre Mixer $SSP2_PCM_NAME Playback Volume'
 					}
+				}
+				Object.Widget.src.1 {
+					scheduler_domain "$SRC_DOMAIN"
 				}
 				Object.Widget.pipeline.1 {
 					core	$SSP2_PCM_CORE_ID
@@ -883,6 +887,7 @@ IncludeByKey.PASSTHROUGH {
 				Object.Widget.src.1 {
 					index	    11
 					rate_in     48000
+					scheduler_domain "$SRC_DOMAIN"
 
 					<include/components/src_format_s32_convert_from_48k.conf>
 				}

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -299,6 +299,16 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-crossover.bin,EFX_CROSSOVE
 "development/cavs-nocodec-rtcaec\;sof-tgl-nocodec-rtcaec\;PLATFORM=tgl,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-tgl-nocodec-rtcaec.bin"
 
+# SSP test topology for Data Processing SRC on MTL
+"cavs-nocodec\;sof-mtl-nocodec-dp-test\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,SRC_DOMAIN=DP"
+# SSP test topology for Data Processing SRC on LNL
+"cavs-nocodec\;sof-lnl-nocodec-dp-test\;PLATFORM=lnl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-lnl-nocodec.bin,SRC_DOMAIN=DP"
+# SSP test topology for Data Processing SRC on PTL
+"cavs-nocodec\;sof-ptl-nocodec-dp-test\;PLATFORM=ptl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-nocodec.bin,SRC_DOMAIN=DP"
+
 # Add MFCC to 16 kHz DMIC1, 2ch with NHLT - cAVS
 "sof-hda-generic\;sof-hda-generic-cavs25-2ch-mfcc\;HDA_CONFIG=mix,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-2ch-mfcc.bin,\

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -25,6 +25,7 @@ Object.Base.VendorToken {
 		num_input_audio_formats	415
 		num_output_audio_formats 416
 		no_wname_in_kcontrol_name 417
+		scheduler_domain	418
 	}
 
 	"2" {

--- a/tools/topology/topology2/include/components/widget-common.conf
+++ b/tools/topology/topology2/include/components/widget-common.conf
@@ -119,3 +119,20 @@ DefineAttribute."no_wname_in_kcontrol_name" {
 }
 
 no_wname_in_kcontrol_name	"true"
+
+## widget format
+DefineAttribute."scheduler_domain" {
+	type	"string"
+	# Token set reference name and type
+	token_ref	"comp.string"
+	constraints {
+		!valid_values [
+			# Low Latency
+			"LL"
+			# Data Processing
+			"DP"
+			# Use manifest value
+			"default"
+		]
+	}
+}


### PR DESCRIPTION
NOTE: https://github.com/thesofproject/linux/pull/5382 is needed before this PR does anything.

The PR defines a new topology2 attribute for any widget. With the scheduler_domain attribute one can select if the component defined by the widget node is execute in Low Latency thread or in Data Processing mode. The PR also adds new test topologies for testing the DP mode.