### PR TITLE
audio: volume: drop CONFIG_COMP_PEAK_VOL guards

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -49,8 +49,6 @@ LOG_MODULE_REGISTER(volume, CONFIG_SOF_LOG_LEVEL);
 #include "volume_uuid.h"
 #include "volume.h"
 
-#if CONFIG_COMP_PEAK_VOL || CONFIG_COMP_GAIN
-
 #if CONFIG_FORMAT_S16LE
 /**
  * \brief Used to find nearest zero crossing frame for 16 bit format.
@@ -211,8 +209,6 @@ __cold_rodata static const struct comp_zc_func_map zc_func_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, vol_zc_get_s32 },
 #endif /* CONFIG_FORMAT_S32LE */
 };
-
-#endif /* CONFIG_COMP_PEAK_VOL || CONFIG_COMP_GAIN */
 
 #if CONFIG_COMP_VOLUME_LINEAR_RAMP
 /**
@@ -551,7 +547,6 @@ void volume_set_chan_unmute(struct processing_module *mod, int chan)
 	}
 }
 
-#if CONFIG_COMP_PEAK_VOL || CONFIG_COMP_GAIN
 /*
  * \brief Copies and processes stream data.
  * \param[in,out] mod Volume processing module handle
@@ -783,9 +778,7 @@ static int volume_free(struct processing_module *mod)
 
 	return 0;
 }
-#endif
 
-#if CONFIG_COMP_PEAK_VOL
 static const struct module_interface volume_interface = {
 	.init = volume_init,
 	.prepare = volume_prepare,
@@ -795,7 +788,6 @@ static const struct module_interface volume_interface = {
 	.reset = volume_reset,
 	.free = volume_free
 };
-#endif
 
 #if CONFIG_COMP_GAIN
 static const struct module_interface gain_interface = {
@@ -837,10 +829,8 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
-#if CONFIG_COMP_PEAK_VOL
 DECLARE_MODULE_ADAPTER(volume_interface, volume_uuid, volume_tr);
 SOF_MODULE_INIT(volume, sys_comp_module_volume_interface_init);
-#endif
 
 #if CONFIG_COMP_GAIN
 DECLARE_MODULE_ADAPTER(gain_interface, gain_uuid, gain_tr);


### PR DESCRIPTION
Commit https://github.com/thesofproject/sof/commit/fcfcb0770e883e05086dee137eb06903c58041ea ("llext: remove unneeded data and functions")
introduced some "ifdef" guards that make the volume component unusable
unless "CONFIG_COMP_GAIN" or "CONFIG_COMP_PEAK_VOL" is enabled. This
change in behavior results in the following error on the firmware side:

<ERROR_MSG>

<err> ipc: get_drv(): the provided UUID (b77e677e41885ff4a8fb14af8286bfbd)
doesn't match to any driver!

</ERROR_MSG>

for an i.MX platform using the volume component with "CONFIG_COMP_GAIN=n"
and "CONFIG_COMP_PEAK_VOL=n".

Based on the Kconfig description, "CONFIG_COMP_GAIN" refers to the gain
component, while "CONFIG_COMP_PEAK_VOL" refers to (snippet taken from the
volume Kconfig): "This option enables reporting to host peak vol regs.".

This description implies that "CONFIG_COMP_PEAK_VOL" doesn't manage the
component itself. This is further reinforced by the fact that, previously,
using the peak volume component without the "CONFIG_COMP_PEAK_VOL" config
enabled worked fine.

As such, drop all of the "CONFIG_COMP_PEAK_VOL" "ifdef" guards that were
introduced by the aforementioned commit.

Fixes https://github.com/thesofproject/sof/commit/fcfcb0770e883e05086dee137eb06903c58041ea ("llext: remove unneeded data and functions")
Signed-off-by: Laurentiu Mihalcea <laurentiu.mihalcea@nxp.com>