### PR TITLE
lib_manager: Set of small fixes for loadable modules (sp1)

### DIFF
--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -145,11 +145,6 @@ static int modules_free(struct processing_module *mod)
 	if (ret)
 		comp_err(dev, "modules_free(): iadk_wrapper_free failed with error: %d", ret);
 
-	/* Free module resources allocated in L2 memory. */
-	ret = lib_manager_free_module(dev->ipc_config.id);
-	if (ret < 0)
-		comp_err(dev, "modules_free(), lib_manager_free_module() failed!");
-
 	return ret;
 }
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -126,6 +126,10 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	comp_dbg(dev, "module_adapter_new() done");
 	return dev;
 err:
+#if CONFIG_IPC_MAJOR_4
+	if (mod)
+		rfree(mod->priv.cfg.input_pins);
+#endif
 	rfree(mod);
 	rfree(dev);
 	return NULL;

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -145,7 +145,7 @@ static inline struct lib_manager_mod_ctx *lib_manager_get_mod_ctx(int module_id)
 	uint32_t lib_id = LIB_MANAGER_GET_LIB_ID(module_id);
 	struct ext_library *_ext_lib = ext_lib_get();
 
-	if (!_ext_lib)
+	if (!_ext_lib || lib_id >= LIB_MANAGER_MAX_LIBS)
 		return NULL;
 
 	return _ext_lib->desc[lib_id];

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -654,7 +654,8 @@ int lib_manager_register_module(const uint32_t component_id)
 			if (build_info->format != SOF_MODULE_API_BUILD_INFO_FORMAT ||
 			    build_info->api_version_number.full != SOF_MODULE_API_CURRENT_VERSION) {
 				tr_err(&lib_manager_tr, "Unsupported module API version");
-				return -ENOEXEC;
+				ret = -ENOEXEC;
+				goto cleanup;
 			}
 		}
 	}

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -386,6 +386,10 @@ int lib_manager_free_module(const uint32_t component_id)
 	tr_dbg(&lib_manager_tr, "mod_id: %#x", component_id);
 
 	mod = lib_manager_get_module_manifest(module_id);
+	if (!mod) {
+		tr_err(&lib_manager_tr, "failed to get module descriptor");
+		return -EINVAL;
+	}
 
 	if (module_is_llext(mod))
 		return llext_manager_free_module(component_id);

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -649,7 +649,6 @@ int lib_manager_register_module(const uint32_t component_id)
 		    build_info->api_version_number.full == IADK_MODULE_API_CURRENT_VERSION) {
 			/* Use module_adapter functions */
 			drv->ops.create = module_adapter_new;
-			drv->ops.prepare = module_adapter_prepare;
 		} else {
 			/* Check if module is NOT native */
 			if (build_info->format != SOF_MODULE_API_BUILD_INFO_FORMAT ||


### PR DESCRIPTION
Simplyfy module instance allocate functions by extend the `lib_manager_get_instance_bss_address function` to also return the size of the `bss` section. This simplify the `lib_manager_allocate_module_instance` and `lib_manager_free_module_instance` functions.

Remove redundant value assignment to `ops.prepare` in the `lib_manager_register_module` function. This value is already set by the `lib_manager_prepare_module_adapter` function.

Fix memory leak in lib_manager_register_module - free allocated driver structure when an unsupported loadable module api version is detected.

Add verification of the module id passed as a parameter to the `lib_manager_get_mod_ctx` function. Add error handling to the
`lib_manager_free_module` function.

Fix memory leak in `module_adapter_new` - add missing memory deallocation in the error handling code. This memory can be allocated by the `module_adapter_init_data` function.

Remove unnecessary call `lib_manager_free_module` from the `modules_free` function. Module release is already handled by lib_manager.