### PR TITLE
kconfig: staging: add support for SOF staging features

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,4 +1,14 @@
 if SOF
+
+config SOF_STAGING
+	bool "Enable SOF staging features and modules"
+	default n
+	help
+	  SOF staging features are not ready for production but are
+	  upstream to enable developers to continue development in order
+	  to bring the feature to production level faster using the
+	  upstream codebase.
+
 rsource "../Kconfig.sof"
 
 config SOF_ZEPHYR_HEAP_CACHED


### PR DESCRIPTION
Add a top level Kconfig to enable large non production staging quality features to be developed upstream whilst living alongside production code.