### PR TITLE
west.yml: update zephyr to e4c2cecb7d8

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 8bdf533d76471873090aad3d511e037f14ee7cad
+      revision: e4c2cecb7d8fb3f3b576633c3a4bf8e4647c93f8
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 562 commits.

Changes include:

- **9cadc8cbec3** xtensa: userspace: use ADDX4 to calculate syscall table index
- **277fa9e8ac0** xtensa: userspace: swap page tables via assembly code
- **689e1121cf6** kernel: typedef k_mem_domain_t and _mem_domain_info_t
- **2abf7ce2f12** xtensa: userspace: prevent potential privilege escalation
- **d5c2e4b03c8** xtensa: userspace: workaround return PC calc with loops
- **bdb5723f282** xtensa: userspace: remove ununsed syscall helpers
- **b0693ee41b4** xtensa: userspace: handle privileged stack in arch_cohere_stacks
- **9ebe16b6e78** xtensa: no need to restore A0/A1 if not coherence in irq exit
- **0dce0bdc0b7** xtensa: userspace: pre-compute MMU registers at domain init
- **36064939d3a** xtensa: no need for flush register if threads are pin only
- **50abe899703** xtensa: userspace: use ZSR_RFI_LEVEL for userspace enter
- **af5dfff3ae4** xtensa: userspace: use ZSR_RFI_LEVEL for syscall return
- **514cd384318** xtensa: userspace: remove jump to _syscall_returned
- **7f028e2f6e3** xtensa: userspace: align stack before calling syscall handler
- **482f9fbbfbc** xtensa: pad IRQ stack frame to be 16 bytes aligned
- **7229b004332** xtensa: window may overflow during irq stack crossing
- **9610f1a2293** xtensa: mmu: do not force small vector table
- **774b73c8a45** xtensa: userspace: swap page table at end of cross stack call
- **e0752c29380** xtensa: userspace: swap page table earlier in xtensa_switch
- **6874cdcf19f** xtensa: fix unneeded cache invalidation in arch_cohere_stacks()
- **9fb87cf5864** xtensa: remove second cross stack trampoline
- **3f8e4d7400f** xtensa: rework IRQ masking during IRQ entrance
- **dcf75319e2a** xtensa: set pointer to privileged stack only if user mode
- **d725f37d5ea** xtensa: userspace: calculate PC earlier at syscall entry
- **1203ed05d94** xtensa: syscall: fix setting up PS for window spilling
- **7f693679b8d** xtensa: move FPU_REG_SAVE out of ODD_REG_SAVE
- **c13c4995570** xtensa: add ODD_REG_RESTORE
- **fc85aface12** xtensa: parameterized ODD_REG_SAVE
- **10f8882eeca** xtensa: userspace: remove saving HiFi registers for syscalls
- **d9f68820714** xtensa: rsync before reading ZSR_FLUSH
- **a4367eb5145** xtensa: remove CONFIG_XTENSA_INVALIDATE_MEM_DOMAIN_TLB_ON_SWAP
- **ee9ddb0eeba** xtensa: remove CALC_PTEVADDR_BASE and PRELOAD_PTEVADDR macros
- **833bb667b2c** xtensa: fix thread_page_tables_get being unused
- **71a0f39568e** pm: device: correct state in `pm_device_driver_init`
- **226c6ae17c8** pm: Optimize pre-wakeup in suspend procedure

The current update does not point to the top of the main branch because since commit ecabcf5db56, changes have been introduced that break the compatibility of SOF's CONFIG_PM_POLICY_CUSTOM. The lost compatibility will be restored in subsequent PRs and the additional CONFIG_PM_POLICY_CUSTOM will be disabled in favor of the default version (at the moment this is not yet possible).