### PR TITLE
tools: topology2: cavs-nocodec: Fix PASSTHROUGH configuration for SSPs

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -516,36 +516,16 @@ IncludeByKey.PASSTHROUGH {
 					stream_name "NoCodec-0"
 					node_type $I2S_LINK_OUTPUT_CLASS
 					num_input_pins 1
-					num_input_audio_formats 3
+					num_input_audio_formats 1
 					Object.Base.input_audio_format [
-						{
-							in_rate			$SSP0_RATE
-							in_bit_depth            16
-							in_valid_bit_depth      16
-						}
-						{
-							in_rate			$SSP0_RATE
-							in_bit_depth            32
-							in_valid_bit_depth      24
-						}
 						{
 							in_rate                 $SSP0_RATE
 							in_bit_depth            32
 							in_valid_bit_depth      32
 						}
 					]
-					num_output_audio_formats 3
+					num_output_audio_formats 1
 					Object.Base.output_audio_format [
-						{
-							out_rate		$SSP0_RATE
-							out_bit_depth           16
-							out_valid_bit_depth     16
-						}
-						{
-							out_rate		$SSP0_RATE
-							out_bit_depth           32
-							out_valid_bit_depth     24
-						}
 						{
 							out_rate		$SSP0_RATE
 							out_bit_depth           32
@@ -565,36 +545,16 @@ IncludeByKey.PASSTHROUGH {
 					stream_name "NoCodec-2"
 					node_type $I2S_LINK_OUTPUT_CLASS
 					num_input_pins 1
-					num_input_audio_formats 3
+					num_input_audio_formats 1
 					Object.Base.input_audio_format [
-						{
-							in_rate			$SSP2_RATE
-							in_bit_depth            16
-							in_valid_bit_depth      16
-						}
-						{
-							in_rate			$SSP2_RATE
-							in_bit_depth            32
-							in_valid_bit_depth      24
-						}
 						{
 							in_rate			$SSP2_RATE
 							in_bit_depth            32
 							in_valid_bit_depth      32
 						}
 					]
-					num_output_audio_formats 3
+					num_output_audio_formats 1
 					Object.Base.output_audio_format [
-						{
-							out_rate		$SSP2_RATE
-							out_bit_depth           16
-							out_valid_bit_depth     16
-						}
-						{
-							out_rate		$SSP2_RATE
-							out_bit_depth           32
-							out_valid_bit_depth     24
-						}
 						{
 							out_rate		$SSP2_RATE
 							out_bit_depth           32
@@ -629,18 +589,8 @@ IncludeByKey.PASSTHROUGH {
 							in_valid_bit_depth      32
 						}
 					]
-					num_output_audio_formats 3
+					num_output_audio_formats 1
 					Object.Base.output_audio_format [
-						{
-							out_rate		$SSP0_RATE
-							out_bit_depth           16
-							out_valid_bit_depth     16
-						}
-						{
-							out_rate		$SSP0_RATE
-							out_bit_depth           32
-							out_valid_bit_depth     24
-						}
 						{
 							out_rate		$SSP0_RATE
 							out_bit_depth           32
@@ -673,18 +623,8 @@ IncludeByKey.PASSTHROUGH {
 							in_valid_bit_depth      32
 						}
 					]
-					num_output_audio_formats 3
+					num_output_audio_formats 1
 					Object.Base.output_audio_format [
-						{
-							out_rate		$SSP2_RATE
-							out_bit_depth           16
-							out_valid_bit_depth     16
-						}
-						{
-							out_rate		$SSP2_RATE
-							out_bit_depth           32
-							out_valid_bit_depth     24
-						}
 						{
 							out_rate		$SSP2_RATE
 							out_bit_depth           32
@@ -702,18 +642,8 @@ IncludeByKey.PASSTHROUGH {
 				Object.Widget.host-copier.1 {
 					stream_name 'SSP0 Capture'
 					pcm_id 0
-					num_input_audio_formats 3
+					num_input_audio_formats 1
 					Object.Base.input_audio_format [
-						{
-							in_rate			$SSP0_RATE
-							in_bit_depth            16
-							in_valid_bit_depth      16
-						}
-						{
-							in_rate			$SSP0_RATE
-							in_bit_depth            32
-							in_valid_bit_depth      24
-						}
 						{
 							in_rate			$SSP0_RATE
 							in_bit_depth            32
@@ -747,18 +677,8 @@ IncludeByKey.PASSTHROUGH {
                                 Object.Widget.host-copier.1 {
                                         stream_name 'SSP2 Capture'
                                         pcm_id 2
-					num_input_audio_formats 3
+					num_input_audio_formats 1
 					Object.Base.input_audio_format [
-						{
-							in_rate			$SSP2_RATE
-							in_bit_depth		16
-							in_valid_bit_depth	16
-						}
-						{
-							in_rate			$SSP2_RATE
-							in_bit_depth		32
-							in_valid_bit_depth	24
-						}
 						{
 							in_rate			$SSP2_RATE
 							in_bit_depth		32
@@ -1535,36 +1455,16 @@ IncludeByKey.SSP1_ENABLED {
 							copier_type "SSP"
 							stream_name "NoCodec-1"
 							node_type $I2S_LINK_OUTPUT_CLASS
-							num_input_audio_formats 3
+							num_input_audio_formats 1
 							Object.Base.input_audio_format [
-								{
-									in_rate         $SSP1_RATE
-									in_bit_depth            16
-									in_valid_bit_depth      16
-								}
-								{
-									in_rate         $SSP1_RATE
-									in_bit_depth            32
-									in_valid_bit_depth      24
-								}
 								{
 									in_rate         $SSP1_RATE
 									in_bit_depth            32
 									in_valid_bit_depth      32
 								}
 							]
-							num_output_audio_formats 3
+							num_output_audio_formats 1
 							Object.Base.output_audio_format [
-								{
-									out_rate        $SSP1_RATE
-									out_bit_depth           16
-									out_valid_bit_depth     16
-								}
-								{
-									out_rate        $SSP1_RATE
-									out_bit_depth           32
-									out_valid_bit_depth     24
-								}
 								{
 									out_rate        $SSP1_RATE
 									out_bit_depth           32
@@ -1598,18 +1498,8 @@ IncludeByKey.SSP1_ENABLED {
 									in_valid_bit_depth      32
 								}
 							]
-							num_output_audio_formats 3
+							num_output_audio_formats 1
 							Object.Base.output_audio_format [
-								{
-									out_rate        $SSP1_RATE
-									out_bit_depth           16
-									out_valid_bit_depth     16
-								}
-								{
-									out_rate        $SSP1_RATE
-									out_bit_depth           32
-									out_valid_bit_depth     24
-								}
 								{
 									out_rate        $SSP1_RATE
 									out_bit_depth           32


### PR DESCRIPTION
The purpose of PASSTHROUGH is to exclude processing modules from paths, but in case of the nocodec topologies the PASSTHROUGH enables formats on the SSP DAI side for which we don't have a blob generated and no hw_config either.
We only really support in this mode S32_LE and nothing else, S16_LE and S24_LE formats are invalid.

Support only S32_LE on dai side only and do the conversion if needed on the host side so all internal (non-)processing is 32bit.


Link: https://github.com/thesofproject/sof/issues/9979