### PR TITLE
build: xtensa-build-zephyr.py: remove Intel ehl target

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -138,7 +138,7 @@ platform_configs_all = {
 		f"RG-2017.8{xtensa_tools_version_postfix}",
 		"cavs2x_LX6HiFi3_2017_8",
 		"xcc",
-		aliases = ['adl', 'adl-n', 'ehl', 'rpl'],
+		aliases = ['adl', 'adl-n', 'rpl'],
 		ipc4 = True
 	),
 	"tgl-h" : PlatformConfig(


### PR DESCRIPTION
Remove the Intel EHL platform from list of aliases. This platform is supported from old stable-v2.2 branch and upgrade to IPC4 is not planned.