### PR TITLE
Tools: Testbench: Add sof-ctl simulation to control scripts

### DIFF
--- a/tools/testbench/include/testbench/utils.h
+++ b/tools/testbench/include/testbench/utils.h
@@ -23,6 +23,7 @@
 #define TB_MAX_CTL_NAME_CHARS		128
 #define TB_MAX_VOLUME_SIZE		120
 #define TB_MAX_BYTES_DATA_SIZE		8192
+#define TB_MAX_BLOB_CONTENT_CHARS	32768
 
 /* number of widgets types supported in testbench */
 #define TB_NUM_WIDGETS_SUPPORTED	16
@@ -159,6 +160,7 @@ int tb_pipeline_reset(struct ipc *ipc, struct pipeline *p);
 int tb_pipeline_start(struct ipc *ipc, struct pipeline *p);
 int tb_pipeline_stop(struct ipc *ipc, struct pipeline *p);
 int tb_read_controls(struct testbench_prm *tp, int64_t *sleep_ns);
+int tb_set_bytes_control(struct testbench_prm *tp, struct tb_ctl *ctl, uint32_t *data);
 int tb_set_enum_control(struct testbench_prm *tp, struct tb_ctl *ctl, char *control_params);
 int tb_set_reset_state(struct testbench_prm *tp);
 int tb_set_mixer_control(struct testbench_prm *tp, struct tb_ctl *ctl, char *control_params);

--- a/tools/testbench/utils_ipc3.c
+++ b/tools/testbench/utils_ipc3.c
@@ -435,4 +435,9 @@ int tb_set_mixer_control(struct testbench_prm *tp, struct tb_ctl *ctl, char *con
 	return 0;
 }
 
+int tb_set_bytes_control(struct testbench_prm *tp, struct tb_ctl *ctl, uint32_t *data)
+{
+	return 0;
+}
+
 #endif /* CONFIG_IPC_MAJOR_3 */

--- a/tools/testbench/utils_ipc4.c
+++ b/tools/testbench/utils_ipc4.c
@@ -691,4 +691,11 @@ int tb_set_mixer_control(struct testbench_prm *tp, struct tb_ctl *ctl, char *con
 	return ret;
 }
 
+int tb_set_bytes_control(struct testbench_prm *tp, struct tb_ctl *ctl, uint32_t *data)
+{
+	return tb_send_bytes_data(&tp->ipc_tx, &tp->ipc_rx,
+				  ctl->module_id, ctl->instance_id,
+				  (struct sof_abi_hdr *)data);
+}
+
 #endif /* CONFIG_IPC_MAJOR_4 */


### PR DESCRIPTION
With this change sof-ctl commands can be executed during sof-testbench4 simulation, e.g.

sof-ctl -c name='Post Mixer Analog Playback IIR Eq bytes' \ -s tools/ctl/ipc4/eq_iir/loudness.txt

No other than switches -c and -s are supported for simulated sof-ctl. The blob file must be in normal comma separated ASCII uint32_t numbers format with nothing else in it.

With this change the SOF processing components can be tested extensively for their controls during simulated audio streaming.