### PR TITLE
global: Avoid warnings about unused variables

### DIFF
--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -675,7 +675,7 @@ static int igo_nr_set_config(struct processing_module *mod, uint32_t param_id,
 
 static void igo_nr_print_config(struct processing_module *mod)
 {
-	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_data __maybe_unused *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 
 	comp_dbg(dev, "  igo_params_ver		%d",

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -733,7 +733,6 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	struct smart_amp_data *sad = comp_get_drvdata(dev);
 	uint16_t ff_src_fmt, fb_src_fmt, resolved_mod_fmt;
 	uint32_t least_req_depth;
-	uint32_t rate;
 	int ret;
 
 	comp_dbg(dev, "smart_amp_prepare()");

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -221,7 +221,6 @@ static void feed_s32_to_s24(const struct smart_amp_mod_stream *sink_mod, uint32_
 			    const struct audio_stream __sparse_cache *sink)
 {
 	int i;
-	int sink_ch = audio_stream_get_channels(sink);
 	int n_mod = frames * sink_mod->channels;
 	int32_t *mod_ptr = (int32_t *)sink_mod->buf.data;
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -942,7 +942,7 @@ int ipc4_process_on_core(uint32_t core, bool blocking)
 
 __cold static const struct comp_driver *ipc4_get_drv(const void *uuid)
 {
-	const struct sof_uuid *const sof_uuid = (const struct sof_uuid *)uuid;
+	const struct sof_uuid *const __maybe_unused sof_uuid = (const struct sof_uuid *)uuid;
 	struct comp_driver_list *drivers = comp_drivers_get();
 	struct list_item *clist;
 	const struct comp_driver *drv = NULL;

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -87,8 +87,6 @@ static void fuzz_isr(const void *arg)
 	// on only rarely, fill it in manually.
 	*(uint32_t *)global_ipc->comp_data = msgsz;
 
-	struct sof_ipc_comp *cc = global_ipc->comp_data;
-
 	// "Adjust" the command to represent a "comp new" command per
 	// above.  Basically we want to copy in the UUID value for one
 	// of the runtime-enumerated drivers based on data already

--- a/src/platform/posix/ipc.c
+++ b/src/platform/posix/ipc.c
@@ -45,8 +45,6 @@ static size_t fuzz_in_sz;
 static void fuzz_isr(const void *arg)
 {
 	size_t rem, i, n = MIN(posix_fuzz_sz, sizeof(fuzz_in) - fuzz_in_sz);
-	bool comp_new = false;
-	int comp_idx = 0;
 
 	for (i = 0; i < n; i++)
 		fuzz_in[fuzz_in_sz++] = posix_fuzz_buf[i];
@@ -68,6 +66,9 @@ static void fuzz_isr(const void *arg)
 	fuzz_in_sz = rem;
 
 #ifdef CONFIG_IPC_MAJOR_3
+	bool comp_new = false;
+	int comp_idx = 0;
+
 	// One special case: a first byte of 0xff (which is in the
 	// otherwise-ignored size value at the front of the command --
 	// we rewrite those) is interpreted as a "component new"


### PR DESCRIPTION
Fixes to IGO NR, Smart Amp, IPC4 Helper, POSIX IPC to fix stub-build check.