### PR TITLE
comp: Add initial support for NXP Essential Audio Processing component

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -108,6 +108,8 @@ if(NOT CONFIG_COMP_MODULE_SHARED_LIBRARY_BUILD)
 		add_subdirectory(codec)
 	endif()
 	add_subdirectory(google)
+	add_subdirectory(nxp)
+
 	if(CONFIG_INTEL_ADSP_MIC_PRIVACY)
 		add_subdirectory(mic_privacy_manager)
 	endif()

--- a/src/audio/Kconfig
+++ b/src/audio/Kconfig
@@ -127,6 +127,8 @@ endif # COMP_KPB
 
 rsource "google/Kconfig"
 
+rsource "nxp/Kconfig"
+
 rsource "selector/Kconfig"
 
 rsource "crossover/Kconfig"

--- a/src/audio/nxp/CMakeLists.txt
+++ b/src/audio/nxp/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+if(CONFIG_COMP_NXP_EAP)
+
+	zephyr_include_directories(${sof_top_dir}/eap_sdk)
+	zephyr_include_directories(${sof_top_dir}/third_party)
+
+	zephyr_library_sources(eap.c)
+	zephyr_library_import(EAPLibrary
+		${sof_top_dir}/eap_sdk/EAP_Library/libEAP16_3_0_13_FP1_RT600.a)
+
+endif()

--- a/src/audio/nxp/CMakeLists.txt
+++ b/src/audio/nxp/CMakeLists.txt
@@ -6,7 +6,12 @@ if(CONFIG_COMP_NXP_EAP)
 	zephyr_include_directories(${sof_top_dir}/third_party)
 
 	zephyr_library_sources(eap.c)
-	zephyr_library_import(EAPLibrary
-		${sof_top_dir}/eap_sdk/EAP_Library/libEAP16_3_0_13_FP1_RT600.a)
+
+	if(CONFIG_COMP_NXP_EAP_STUB)
+		zephyr_library_sources(eap_stub.c)
+	else()
+		zephyr_library_import(EAPLibrary
+			${sof_top_dir}/eap_sdk/EAP_Library/libEAP16_3_0_13_FP1_RT600.a)
+	endif()
 
 endif()

--- a/src/audio/nxp/Kconfig
+++ b/src/audio/nxp/Kconfig
@@ -7,3 +7,10 @@ config COMP_NXP_EAP
 	  Select for NXP Essential Audio Processing Component.
 	  The EAP is a bundle of audio processing blocks for enhancing the tonal
 	  and spatial perception of sound in audio applications.
+
+config COMP_NXP_EAP_STUB
+	tristate "NXP EAP Component stub"
+	default n
+	depends on COMP_NXP_EAP
+	help
+	  Select for NXP EAP stub support.

--- a/src/audio/nxp/Kconfig
+++ b/src/audio/nxp/Kconfig
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+config COMP_NXP_EAP
+	tristate "NXP EAP Component"
+	default n
+	help
+	  Select for NXP Essential Audio Processing Component.
+	  The EAP is a bundle of audio processing blocks for enhancing the tonal
+	  and spatial perception of sound in audio applications.

--- a/src/audio/nxp/eap.c
+++ b/src/audio/nxp/eap.c
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2025 NXP
+//
+// Author: Daniel Baluta <daniel.baluta@nxp.com>
+
+#include <rtos/panic.h>
+#include <rtos/alloc.h>
+#include <rtos/cache.h>
+#include <rtos/init.h>
+#include <rtos/string.h>
+#include <sof/audio/buffer.h>
+#include <sof/audio/format.h>
+#include <sof/audio/pipeline.h>
+#include <sof/ipc/msg.h>
+#include <sof/lib/uuid.h>
+#include <sof/list.h>
+#include <sof/audio/module_adapter/module/generic.h>
+#include <sof/ut.h>
+#include <sof/trace/trace.h>
+#include <ipc/dai.h>
+#include <user/trace.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <module/module/interface.h>
+#include <zephyr/logging/log.h>
+
+#include <sof/audio/nxp/eap/eap_lib_defines.h>
+#include <nxp/eap/EAP_Includes/EAP16.h>
+#include <sof/audio/nxp/eap/EAP_Parameter_presets.h>
+
+LOG_MODULE_REGISTER(nxp_eap, CONFIG_SOF_LOG_LEVEL);
+SOF_DEFINE_REG_UUID(nxp_eap);
+DECLARE_TR_CTX(nxp_eap_tr, SOF_UUID(nxp_eap_uuid), LOG_LEVEL_INFO);
+
+#define NXP_EAP_DEFAULT_MAX_BLOCK_SIZE 480
+
+struct nxp_eap_data  {
+	LVM_Handle_t instance;
+	LVM_MemTab_t mem_tab;
+	LVM_InstParams_t inst_params;
+	LVM_ControlParams_t ctrl_params;
+	int sample_rate;
+	int channels;
+	int frame_bytes;
+	int audio_time_ms;
+	uint32_t buffer_bytes;
+};
+
+struct nxp_eap_preset_params {
+	char *name;
+	LVM_ControlParams_t *params;
+};
+
+struct nxp_eap_preset_params nxp_eap_effect_presets[] = {
+	{
+		.name	= "AllEffectsOff",
+		.params = (LVM_ControlParams_t *)&ControlParamSet_allEffectOff,
+	},
+	{
+		.name	= "AutoVolumeLeveler",
+		.params	= (LVM_ControlParams_t *)&ControlParamSet_autoVolumeLeveler,
+	},
+	{
+		.name	= "ConcertSound",
+		.params	= (LVM_ControlParams_t *)&ControlParamSet_concertSound,
+	},
+	{
+		.name	= "LoudnessMaximiser",
+		.params	= (LVM_ControlParams_t *)&ControlParamSet_loudnessMaximiser,
+	},
+	{
+		.name	= "MusicEnhancer",
+		.params	= (LVM_ControlParams_t *)&ControlParamSet_musicEnhancerRmsLimiter,
+	},
+	{
+		.name = "VoiceEnhancer",
+		.params = (LVM_ControlParams_t *)&ControlParamSet_voiceEnhancer,
+	}
+};
+
+static int nxp_eap_init(struct processing_module *mod)
+{
+	struct comp_dev *dev = mod->dev;
+	struct nxp_eap_data *eap;
+	LVM_VersionInfo_st info;
+	LVM_ReturnStatus_en lvm_ret;
+	int ret = 0;
+
+	LVM_GetVersionInfo(&info);
+
+	tr_info(mod->dev, "NXP EAP library, platform: %s version:%s",
+		info.pPlatform, info.pVersionNumber);
+
+	eap = rballoc(0, SOF_MEM_CAPS_RAM, sizeof(*eap));
+	if (!eap) {
+		comp_err(dev, "nxp_eap_init() failed to allocate module private data");
+		return -ENOMEM;
+	}
+
+	module_set_private_data(mod, eap);
+
+	memcpy(&eap->inst_params, &InstParams_allEffectOff, sizeof(eap->inst_params));
+
+	lvm_ret = LVM_GetMemoryTable(LVM_NULL, &eap->mem_tab, &eap->inst_params);
+	if (lvm_ret != LVM_SUCCESS) {
+		comp_err(dev, "nxp_eap_init() failed to get memory table %d", lvm_ret);
+		rfree(eap);
+		return -EINVAL;
+	}
+
+	/* mark all pBaseAddress with NULL so that would be easier to implement cleanup */
+	for (int i = 0; i < LVM_NR_MEMORY_REGIONS; i++)
+		eap->mem_tab.Region[i].pBaseAddress = NULL;
+
+	for (int i = 0; i < LVM_NR_MEMORY_REGIONS; i++) {
+		eap->mem_tab.Region[i].pBaseAddress = rballoc(0, SOF_MEM_CAPS_RAM,
+							      eap->mem_tab.Region[i].Size);
+		if (!eap->mem_tab.Region[i].pBaseAddress) {
+			comp_err(dev, "nxp_eap_init() failed to allocate memory for region %d", i);
+			ret = -ENOMEM;
+			goto free_mem;
+		}
+	}
+
+	lvm_ret = LVM_GetInstanceHandle(&eap->instance, &eap->mem_tab, &eap->inst_params);
+	if (lvm_ret != LVM_SUCCESS) {
+		comp_err(dev, "nxp_eap_init() failed to get instance handle err: %d", lvm_ret);
+		ret = -EINVAL;
+		goto free_mem;
+	}
+
+	/* default parameters, no effects */
+	memcpy(&eap->ctrl_params, &ControlParamSet_allEffectOff, sizeof(eap->ctrl_params));
+
+	return 0;
+
+free_mem:
+	for (int i = 0; i < LVM_NR_MEMORY_REGIONS; i++) {
+		if (eap->mem_tab.Region[i].pBaseAddress) {
+			rfree(eap->mem_tab.Region[i].pBaseAddress);
+			eap->mem_tab.Region[i].pBaseAddress = NULL;
+		}
+	}
+	rfree(eap);
+	return ret;
+}
+
+static int nxp_eap_free(struct processing_module *mod)
+{
+	struct comp_dev *dev = mod->dev;
+	struct nxp_eap_data *eap = module_get_private_data(mod);
+
+	comp_dbg(dev, "nxp_eap_free()");
+
+	for (int i = 0; i < LVM_NR_MEMORY_REGIONS; i++) {
+		if (eap->mem_tab.Region[i].pBaseAddress) {
+			rfree(eap->mem_tab.Region[i].pBaseAddress);
+			eap->mem_tab.Region[i].pBaseAddress = NULL;
+		}
+	}
+
+	rfree(eap);
+
+	return 0;
+}
+
+static int nxp_eap_prepare(struct processing_module *mod,
+			   struct sof_source **sources, int num_of_sources,
+			   struct sof_sink **sinks, int num_of_sinks)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *md = &mod->priv;
+	struct nxp_eap_data *eap = module_get_private_data(mod);
+	struct comp_buffer *source = comp_dev_get_first_data_producer(dev);
+	const struct audio_stream *stream;
+
+	comp_dbg(dev, "nxp_eap_prepare()");
+
+	stream = &source->stream;
+	eap->sample_rate = audio_stream_get_rate(stream);
+	eap->channels = audio_stream_get_channels(stream);
+	eap->frame_bytes = audio_stream_frame_bytes(stream);
+	eap->audio_time_ms = 0;
+
+	/* total bytes needed to be in the input buffer to be processed
+	 * by the EAP library
+	 */
+	eap->buffer_bytes = NXP_EAP_DEFAULT_MAX_BLOCK_SIZE;
+
+	md->mpd.in_buff = rballoc_align(0, SOF_MEM_CAPS_RAM, eap->buffer_bytes, 32);
+	if (!md->mpd.in_buff)
+		return -ENOMEM;
+
+	md->mpd.out_buff = rballoc_align(0, SOF_MEM_CAPS_RAM, eap->buffer_bytes, 32);
+	if (!md->mpd.out_buff) {
+		rfree(md->mpd.in_buff);
+		return -ENOMEM;
+	}
+
+	md->mpd.in_buff_size = eap->buffer_bytes;
+	md->mpd.out_buff_size = eap->buffer_bytes;
+
+	return 0;
+}
+
+static int nxp_eap_reset(struct processing_module *mod)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *md = &mod->priv;
+
+	comp_dbg(dev, "nxp_eap_reset");
+
+	if (md->mpd.in_buff) {
+		rfree(md->mpd.in_buff);
+		md->mpd.in_buff = NULL;
+		md->mpd.in_buff_size = 0;
+	}
+
+	if (md->mpd.out_buff) {
+		rfree(md->mpd.out_buff);
+		md->mpd.out_buff = NULL;
+		md->mpd.out_buff_size = 0;
+	}
+
+	return 0;
+}
+
+static int nxp_eap_process(struct processing_module *mod,
+			   struct input_stream_buffer *input_buffers, int num_input_buffers,
+			   struct output_stream_buffer *output_buffers, int num_output_buffers)
+{
+	struct comp_dev *dev = mod->dev;
+	struct module_data *eap = &mod->priv;
+	struct nxp_eap_data *eap_data = module_get_private_data(mod);
+	LVM_INT16 *buffer_table[2];
+	LVM_ReturnStatus_en ret;
+
+	comp_dbg(dev, "nxp_eap_process()");
+
+	/* we need to input buffer to be completely full to be able to process it */
+	if (input_buffers[0].size < eap->mpd.in_buff_size)
+		return -ENODATA;
+
+	memcpy_s(eap->mpd.in_buff, eap->mpd.in_buff_size,
+		 (uint8_t *)input_buffers[0].data + input_buffers[0].consumed,
+		 eap->mpd.in_buff_size);
+	eap->mpd.avail = eap->mpd.in_buff_size;
+
+	buffer_table[0] = eap->mpd.out_buff;
+	buffer_table[1] = LVM_NULL;
+
+	eap_data->audio_time_ms += eap->mpd.avail / (eap_data->sample_rate / 1000);
+
+	ret = LVM_Process(eap_data->instance, (LVM_INT16 *)eap->mpd.in_buff,
+			  (LVM_INT16 **)buffer_table, eap->mpd.avail / eap_data->frame_bytes,
+			  eap_data->audio_time_ms);
+	if (ret != LVM_SUCCESS) {
+		comp_err(dev, "nxp_eap_process() failed with error %d", ret);
+		return -EIO;
+	}
+
+	eap->mpd.produced = eap->mpd.in_buff_size;
+	eap->mpd.consumed = eap->mpd.in_buff_size;
+
+	input_buffers[0].consumed = eap->mpd.consumed;
+
+	/* copy produced samples to output buffer */
+	memcpy_s(output_buffers[0].data, eap->mpd.produced, eap->mpd.out_buff, eap->mpd.produced);
+	output_buffers[0].size = eap->mpd.produced;
+
+	return 0;
+}
+
+static int nxp_eap_cmd_set_value(struct processing_module *mod, struct sof_ipc_ctrl_data *cdata)
+{
+	int index;
+	LVM_ReturnStatus_en ret;
+	struct comp_dev *dev = mod->dev;
+	struct nxp_eap_data *eap = module_get_private_data(mod);
+
+	index = cdata->chanv[0].value;
+
+	if (index >= ARRAY_SIZE(nxp_eap_effect_presets)) {
+		comp_info(dev, "nxp_eap_cmd_set_value() invalid index (%d), config not changed",
+			  index);
+	} else {
+		memcpy(&eap->ctrl_params, nxp_eap_effect_presets[index].params,
+		       sizeof(eap->ctrl_params));
+		comp_info(dev, "New config set to %s", nxp_eap_effect_presets[index].name);
+	}
+
+	ret = LVM_SetControlParameters(eap->instance, &eap->ctrl_params);
+	if (ret != LVM_SUCCESS) {
+		comp_err(dev, "LVM_SetControlParameters failed with error %d", ret);
+		return -EIO;
+	}
+	return 0;
+}
+
+static int nxp_eap_set_config(struct processing_module *mod, uint32_t param_id,
+			      enum module_cfg_fragment_position pos, uint32_t data_offset_size,
+			      const uint8_t *fragment, size_t fragment_size, uint8_t *response,
+			      size_t response_size)
+{
+	struct comp_dev *dev = mod->dev;
+	struct sof_ipc_ctrl_data *cdata = (struct sof_ipc_ctrl_data *)fragment;
+
+	comp_dbg(dev, "nxp_eap_set_config()");
+
+	if (cdata->cmd != SOF_CTRL_CMD_BINARY)
+		return nxp_eap_cmd_set_value(mod, cdata);
+
+	comp_err(dev, "nxp_set_config() binary config not supported");
+	return -EINVAL;
+}
+
+static int nxp_eap_get_config(struct processing_module *mod,
+			      uint32_t param_id, uint32_t *data_offset_size,
+			      uint8_t *fragment, size_t fragment_size)
+{
+	struct comp_dev *dev = mod->dev;
+
+	comp_dbg(dev, "nxp_eap_get_config()");
+
+	return 0;
+}
+
+static const struct module_interface nxp_eap_interface = {
+	.init = nxp_eap_init,
+	.prepare = nxp_eap_prepare,
+	.process_raw_data = nxp_eap_process,
+	.set_configuration = nxp_eap_set_config,
+	.get_configuration = nxp_eap_get_config,
+	.reset = nxp_eap_reset,
+	.free = nxp_eap_free,
+};
+
+DECLARE_MODULE_ADAPTER(nxp_eap_interface, nxp_eap_uuid, nxp_eap_tr);
+SOF_MODULE_INIT(nxp_eap, sys_comp_module_nxp_eap_interface_init);

--- a/src/audio/nxp/eap_stub.c
+++ b/src/audio/nxp/eap_stub.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright 2025 NXP
+
+
+#include <sof/audio/nxp/eap/eap_lib_defines.h>
+#include <nxp/eap/EAP_Includes/EAP16.h>
+
+LVM_ReturnStatus_en LVM_GetVersionInfo(LVM_VersionInfo_st  *pVersion)
+{
+	return LVM_SUCCESS;
+}
+
+LVM_ReturnStatus_en LVM_GetInstanceHandle(LVM_Handle_t *phInstance,
+					  LVM_MemTab_t        *pMemoryTable,
+					  LVM_InstParams_t    *pInstParams)
+{
+	return LVM_SUCCESS;
+};
+
+LVM_ReturnStatus_en LVM_GetMemoryTable(LVM_Handle_t hInstance, LVM_MemTab_t *pMemoryTable,
+				       LVM_InstParams_t *pInstParams)
+{
+	return LVM_SUCCESS;
+}
+
+LVM_ReturnStatus_en LVM_Process(LVM_Handle_t hInstance, const LVM_INT16 *pInData,
+				LVM_INT16 **pOutData, LVM_UINT16 NumSamples,
+				LVM_UINT32 AudioTime)
+{
+	return LVM_SUCCESS;
+}
+
+LVM_ReturnStatus_en LVM_SetControlParameters(LVM_Handle_t hInstance, LVM_ControlParams_t *pParams)
+{
+	return LVM_SUCCESS;
+}

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -875,6 +875,7 @@ void sys_comp_host_init(void);
 void sys_comp_kpb_init(void);
 void sys_comp_selector_init(void);
 
+void sys_comp_module_nxp_eap_interface_init(void);
 void sys_comp_module_aria_interface_init(void);
 void sys_comp_module_copier_interface_init(void);
 void sys_comp_module_crossover_interface_init(void);

--- a/src/include/sof/audio/nxp/eap/EAP_Parameter_presets.h
+++ b/src/include/sof/audio/nxp/eap/EAP_Parameter_presets.h
@@ -3,11 +3,23 @@
 
 #include <nxp/eap/EAP_Includes/EAP16.h>
 
+#ifndef CONFIG_COMP_NXP_EAP_STUB
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_AllEffectOff.h>
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_AutoVolumeLeveler.h>
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_ConcertSound.h>
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_LoudnessMaximiser.h>
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_MusicEnhancerRMSLimiter.h>
 #include <Example_Application/CONFIG_HEADER/EAP_Parameter_VoiceEnhancer.h>
+
+#else
+
+uint8_t InstParams_allEffectOff[28] = {};
+uint8_t ControlParamSet_allEffectOff[216] = {};
+uint8_t ControlParamSet_autoVolumeLeveler[216] = {};
+uint8_t ControlParamSet_concertSound[216] = {};
+uint8_t ControlParamSet_loudnessMaximiser[216] = {};
+uint8_t ControlParamSet_musicEnhancerRmsLimiter[216] = {};
+uint8_t ControlParamSet_voiceEnhancer[216] = {};
+#endif
 
 #endif /* EAP_PARAMETER_PRESETS_H_ */

--- a/src/include/sof/audio/nxp/eap/EAP_Parameter_presets.h
+++ b/src/include/sof/audio/nxp/eap/EAP_Parameter_presets.h
@@ -1,0 +1,13 @@
+#ifndef EAP_PARAMETER_PRESETS_H_
+#define EAP_PARAMETER_PRESETS_H_
+
+#include <nxp/eap/EAP_Includes/EAP16.h>
+
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_AllEffectOff.h>
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_AutoVolumeLeveler.h>
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_ConcertSound.h>
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_LoudnessMaximiser.h>
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_MusicEnhancerRMSLimiter.h>
+#include <Example_Application/CONFIG_HEADER/EAP_Parameter_VoiceEnhancer.h>
+
+#endif /* EAP_PARAMETER_PRESETS_H_ */

--- a/src/include/sof/audio/nxp/eap/eap_lib_defines.h
+++ b/src/include/sof/audio/nxp/eap/eap_lib_defines.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright 2025 NXP
+ */
+
+#ifndef EAP_LIB_DEFINES_H_
+#define EAP_LIB_DEFINES_H_
+
+#define LVCS_MS_COEFFS_SMALL	1
+#define ALGORITHM_CS		1
+#define ALGORITHM_DBE		1
+#define ALGORITHM_EQNB		1
+#define ALGORITHM_PR_EQNB	1
+#define ALGORITHM_LM		1
+#define ALGORITHM_TE		1
+#define ALGORITHM_TG		1
+#define ALGORITHM_AVL		1
+#define ALGORITHM_PSA		1
+#define ALGORITHM_VC		1
+#define ALGORITHM_LIMP		1
+#define ALGORITHM_LIMR		1
+#define ALGORITHM_XO		1
+#define NXP_PLATFORM_PROTECTION	0
+
+#endif /* EAP_LIB_DEFINES_H_ */

--- a/third_party/include/nxp/eap/EAP_Includes/EAP16.h
+++ b/third_party/include/nxp/eap/EAP_Includes/EAP16.h
@@ -1,0 +1,1033 @@
+/*  Copyright 2004-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ * This license applies ONLY to this header file EAP16.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*****************************************************************************************
+
+     $Author: beq03888 $
+     $Revision: 16643 $
+     $Date: 2011-10-14 09:00:36 +0200 (Fri, 14 Oct 2011) $
+
+*****************************************************************************************/
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Header file for the application layer interface of Concert Sound, Bass Enhancement  */
+/*  and volume management bundle.                                                       */
+/*                                                                                      */
+/*  This files includes all definitions, types, structures and function                 */
+/*  prototypes required by the calling layer. All other types, structures and           */
+/*  functions are private.                                                              */
+/*                                                                                      */
+/****************************************************************************************/
+/*                                                                                      */
+/*  Note: 1                                                                             */
+/*  =======                                                                             */
+/*  The algorithm can execute either with separate input and output buffers or with     */
+/*  a common buffer, i.e. the data is processed in-place.                               */
+/*                                                                                      */
+/****************************************************************************************/
+/*                                                                                      */
+/*  Note: 2                                                                             */
+/*  =======                                                                             */
+/*  Three data formats are support Stereo and Mono. The input data is					*/
+/*  interleaved as follows:                             -----                           */
+/*                                                                                      */
+/*  Byte Offset         Stereo Input                Mono Input							*/
+/*  ===========         ============         ====================						*/
+/*      0               Left Sample #1          Mono Sample #1							*/
+/*      2               Right Sample #1         Mono Sample #1							*/
+/*      4               Left Sample #2          Mono Sample #2							*/
+/*      6               Right Sample #2         Mono Sample #2							*/
+/*      .                      .                     .                                  */
+/*      .                      .                     .                                  */
+/*																						*/		
+/*	For output buffer there is 3 cases :												*/
+/*		------																			*/
+/*		1) CROSSOVER is DISABLE															*/
+/*	Byte Offset       Stereo Input/Output       Mono Input/Output						*/
+/*  ===========       ===================       =================						*/
+/*      0               Left Sample #1            Mono Sample #1						*/
+/*      2               Right Sample #1           Mono Sample #1						*/
+/*      4               Left Sample #2            Mono Sample #2						*/
+/*      6               Right Sample #2           Mono Sample #2						*/
+/*      .                      .                     .                                  */
+/*      .                      .                     .                                  */
+/*																						*/
+/*      2) CROSSOVER is ENABLE & input/output in STEREO									*/
+/*          pOutData[0] will be the output Low band and pOutData[1] the High band       */	
+/*  Stereo Input		   pOutData[0] in stereo       pOutData[1] in stereo 			*/
+/*  ===================    =====================       =====================			*/
+/*  Left Sample  #1          Left Sample LB  #1           Left Sample HB  #1			*/
+/*  Right Sample #1          Right Sample LB #1           Right Sample HB #1			*/
+/*  Left Sample  #2          Left Sample LB  #2           Left Sample HB  #2			*/
+/*  Right Sample #2          Right Sample LB #2           Right Sample HB #2			*/
+/*      .                            .                            .                     */
+/*      .                            .                            .                     */
+/*																						*/
+/*      3) CROSSOVER is ENABLE & input/output in MONO									*/
+/*          pOutData[0] will be the output Low band and pOutData[1] the High band       */
+/*  Mono Input		       pOutData[0] in mono         pOutData[1] in mono 			    */
+/*  ===============        =====================       =====================			*/
+/*  MONO Sample  #1          MONO Sample LB  #1           MONO Sample HB  #1			*/
+/*  MONO Sample  #2          MONO Sample LB  #2           MONO Sample HB  #2			*/
+/*  MONO Sample  #3          MONO Sample LB  #3           MONO Sample HB  #3			*/
+/*  MONO Sample  #4          MONO Sample LB  #4           MONO Sample HB  #4			*/
+/*      .                            .                            .                     */
+/*      .                            .                            .                     */
+/*																						*/
+/****************************************************************************************/
+
+#ifndef __LVM_H__
+#define __LVM_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+
+#ifdef  ALGORITHM_CS
+#define ALGORITHM_VIRTUALIZER
+#endif  /* ALGORITHM_CS */
+
+#ifdef ALGORITHM_DBE
+#define ALGORITHM_BASS
+#else
+#ifdef ALGORITHM_PB
+#define ALGORITHM_BASS
+#endif   /* ALGORITHM_PB */
+#endif   /* ALGORITHM_DBE */
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Includes                                                                            */
+/*                                                                                      */
+/****************************************************************************************/
+
+#include "LVC_Types.h"
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Definitions                                                                         */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* MAXIMAL VALUE LIMIT */
+#define LVM_MAX_NUM_CHANNELS                  2     /* Maximum number of interleaved input channels */
+#define MAX_INTERNAL_BLOCKSIZE             1024     /* Maximum internal block size authorized (multiple of 64)*/
+#define LVM_HEADROOM_MAX_NBANDS               5     /* Headroom management */
+#define LVM_EQNB_MAX_BANDS_NBR               10     /* EQNB Maximal band number */
+#define LVM_PSA_MAX_NUMBANDS                 64     /* Maximum Number of PSA Bands*/
+
+/* Memory table*/
+#define LVM_NR_MEMORY_REGIONS                 4     /* Number of memory regions */
+
+/* Concert Sound effect level presets */
+#ifdef ALGORITHM_VIRTUALIZER 
+#define LVM_CS_EFFECT_NONE                    0     /* 0% effect, minimum value */
+#define LVM_CS_EFFECT_LOW                 16384     /* 50% effect */
+#define LVM_CS_EFFECT_MED                 24576     /* 75% effect */
+#define LVM_CS_EFFECT_HIGH                32767     /* 100% effect, maximum value */
+#endif /*end  ALGORITHM_VIRTUALIZER */
+
+#ifdef ALGORITHM_TE
+#define LVM_TE_LOW_MIPS                   32767     /* Treble enhancement 6dB Mips saving mode */
+#endif /* end ALGORITHM_TE */
+
+/* Bass enhancement effect level presets */
+#ifdef ALGORITHM_BASS
+#define LVM_BE_0DB                            0     /* 0dB boost, no effect */
+#define LVM_BE_3DB                            3     /* +3dB boost */
+#define LVM_BE_6DB                            6     /* +6dB boost */
+#define LVM_BE_9DB                            9     /* +9dB boost */
+#define LVM_BE_12DB                          12     /* +12dB boost */
+#define LVM_BE_15DB                          15     /* +15dB boost */
+#endif /* end ALGORITHM_BASS */
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Types                                                                               */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* Instance handle */
+typedef void *LVM_Handle_t;
+
+
+/* Status return values */
+typedef enum
+{
+    LVM_SUCCESS            = 0,                     /* Successful return from a routine */
+    LVM_ALIGNMENTERROR     = 1,                     /* Memory alignment error */
+    LVM_NULLADDRESS        = 2,                     /* NULL allocation address */
+    LVM_INVALIDNUMSAMPLES  = 3,                     /* Invalid number of samples */
+    LVM_WRONGAUDIOTIME     = 4,                     /* Wrong time value for audio time*/
+    LVM_ALGORITHMDISABLED  = 5,                     /* Algorithm is disabled*/
+    LVM_NOT_INITIALIZED    = 6,                     /* Process function was called for a non-initialized module */
+	LVM_INVALIDNXPPLATFORM = 7,                     /* Invalid NXP platform */
+	// OUT OF RANGE HANDLE Must stay at the end of the enum
+	LVM_OUTOFRANGE         = 8,                     /* Out of range control parameter (without details) */
+	/* OUT OF RANGE WITH DETAILS */
+	LVM_OUTOFRANGE_GENERAL_PARAMS			= 9,
+	LVM_OUTOFRANGE_SPEAKER_TYPES			= 10,
+	LVM_OUTOFRANGE_VIRTUALIZER_OM			= 11,
+	LVM_OUTOFRANGE_VIRTUALIZER_TYPE         = 12,
+	LVM_OUTOFRANGE_VIRTUALIZER_REVERB       = 13,
+	LVM_OUTOFRANGE_CS_EFFECT				= 14,
+	LVM_OUTOFRANGE_USER_EQNB				= 15,
+	LVM_OUTOFRANGE_USER_EQNB_BAND_DEF       = 16,
+	LVM_OUTOFRANGE_PRODUCT_EQNB				= 17,
+	LVM_OUTOFRANGE_PRODUCT_EQNB_BAND_DEF    = 18,
+	LVM_OUTOFRANGE_BE						= 19,
+	LVM_OUTOFRANGE_PB						= 20,
+	LVM_OUTOFRANGE_VC_LEVEL					= 21,
+	LVM_OUTOFRANGE_VC_BALANCE				= 22,
+	LVM_OUTOFRANGE_TE						= 23,
+	LVM_OUTOFRANGE_LM						= 24,
+	LVM_OUTOFRANGE_LM_SPEAKER_CUTOFF        = 25,
+	LVM_OUTOFRANGE_AVL						= 26,
+	LVM_OUTOFRANGE_TG_OM					= 27,
+	LVM_OUTOFRANGE_TG						= 28,
+	LVM_OUTOFRANGE_PSA_RATE					= 29,
+	LVM_OUTOFRANGE_PSA_ENABLE				= 30,
+	LVM_OUTOFRANGE_PSA_NUMBAND				= 31,
+	LVM_OUTOFRANGE_LIMP_OM					= 32,
+	LVM_OUTOFRANGE_LIMP_THRESHOLD			= 33,
+	LVM_OUTOFRANGE_LIMR_OM					= 34,
+	LVM_OUTOFRANGE_LIMR_THRESHOLD			= 35,
+	LVM_OUTOFRANGE_LIMR_REFERENCE			= 36,
+	LVM_OUTOFRANGE_CS_AP_MODE				= 37,
+	LVM_OUTOFRANGE_CS_AP					= 38,
+	LVM_OUTOFRANGE_XO_OPERATINGMODE			= 39,                
+	LVM_OUTOFRANGE_XO_CUTOFFFREQUENCY		= 40,               
+	
+
+	LVM_RETURNSTATUS_DUMMY = LVM_MAXENUM
+} LVM_ReturnStatus_en;
+
+
+/* Buffer Management mode */
+typedef enum
+{
+    LVM_MANAGED_BUFFERS   = 0,
+    LVM_UNMANAGED_BUFFERS = 1,
+    LVM_BUFFERS_DUMMY     = LVM_MAXENUM
+} LVM_BufferMode_en;
+
+
+
+/* Output device type */
+typedef enum
+{
+    LVM_HEADPHONES             = 0,
+    LVM_MOBILE_SPEAKERS_SMALL  = 2,
+    LVM_MOBILE_SPEAKERS_MEDIUM = 3,
+    LVM_MOBILE_SPEAKERS_LARGE  = 4,
+    LVM_SPEAKERTYPE_MAX        = LVM_MAXENUM
+} LVM_OutputDeviceType_en;
+
+typedef enum
+{
+	LVM_IMXRT1050 = 1,						   // I.MXRT1050 : EAP running on Cortex-M7
+	LVM_IMXRT1060 = 2,                         // I.MXRT1060 : EAP running on Cortex-M7
+	LVM_IMXRT1064 = 3,						   // I.MXRT1064 : EAP running on Cortex-M7
+	LVM_IMXRT1170 = 4,                         // I.MXRT1170 : EAP running on Cortex-M7
+	LVM_LPC55     = 5,						   // LPC55	     : EAP running on Cortex-M33
+	LVM_IMXRT500  = 6,                         // I.MXRT500  : EAP running on FusionF1
+	LVM_IMXRT600  = 7,                         // I.MXRT600  : EAP running on HIFI4
+	LVM_MAX_PLATFORM = LVM_MAXENUM,
+}EAP_NXPPlatform_en;
+
+/* Virtualizer mode selection*/
+#ifdef ALGORITHM_VIRTUALIZER
+typedef enum
+{
+    LVM_CONCERTSOUND       = 0,
+    LVM_VIRTUALIZERTYPE_DUMMY   = LVM_MAXENUM
+} LVM_VirtualizerType_en;
+#endif  /* ALGORITHM_VIRTUALIZER */
+
+/* N-Band Equaliser operating mode */
+#if (ALGORITHM_EQNB) || (ALGORITHM_PR_EQNB)
+typedef enum
+{
+    LVM_EQNB_OFF   = 0,
+    LVM_EQNB_ON    = 1,
+    LVM_EQNB_DUMMY = LVM_MAXENUM
+} LVM_EQNB_Mode_en;
+#endif /* ALGORITHM_EQNB  || ALGORITHM_PR_EQNB*/
+
+/* Filter mode control */
+typedef enum
+{
+    LVM_EQNB_FILTER_OFF = 0,
+    LVM_EQNB_FILTER_ON  = 1,
+    LVM_EQNB_FILTER_DUMMY = LVM_MAXENUM
+} LVM_EQNB_FilterMode_en;
+
+/* Bass Enhancement operating mode */
+#ifdef ALGORITHM_BASS
+typedef enum
+{
+    LVM_BE_OFF   = 0,
+    LVM_BE_ON    = 1,
+    LVM_BE_DUMMY = LVM_MAXENUM
+} LVM_BE_Mode_en;
+
+/* Bass Enhancement centre frequency selection control */
+typedef enum
+{
+    LVM_BE_CENTRE_55Hz  = 0,
+    LVM_BE_CENTRE_66Hz  = 1,
+    LVM_BE_CENTRE_78Hz  = 2,
+    LVM_BE_CENTRE_90Hz  = 3,
+    LVM_BE_CENTRE_DUMMY = LVM_MAXENUM
+} LVM_BE_CentreFreq_en;
+
+/* Bass Enhancement HPF selection control */
+typedef enum
+{
+    LVM_BE_HPF_OFF   = 0,
+    LVM_BE_HPF_ON    = 1,
+    LVM_BE_HPF_DUMMY = LVM_MAXENUM
+} LVM_BE_FilterSelect_en;
+
+
+#endif /* ALGORITHM_BASS */
+
+/* Volume Control operating mode */
+typedef enum
+{
+    LVM_VC_OFF   = 0,
+    LVM_VC_ON    = 1,
+    LVM_VC_DUMMY = LVM_MAXENUM
+} LVM_VC_Mode_en;
+
+/* Treble Enhancement operating mode */
+#ifdef ALGORITHM_TE
+typedef enum
+{
+    LVM_TE_OFF   = 0,
+    LVM_TE_ON    = 1,
+    LVM_TE_DUMMY = LVM_MAXENUM
+} LVM_TE_Mode_en;
+#endif /* ALGORITHM_TE */
+
+/* Loudness Maximiser operating mode */
+#ifdef ALGORITHM_LM
+typedef enum
+{
+    LVM_LM_OFF   = 0,
+    LVM_LM_ON    = 1,
+    LVM_LM_DUMMY = LVM_MAXENUM
+}LVM_LM_Mode_en;
+
+/* Loudness Maximiser effect setting */
+typedef enum
+{
+    LVM_LM_GENTLE       = 0,
+    LVM_LM_MEDIUM       = 1,
+    LVM_LM_EXTREME      = 2,
+    LVM_LM_EFFECT_DUMMY = LVM_MAXENUM
+}LVM_LM_Effect_en;
+#endif /* ALGORITHM_LM */
+
+/* AVL operating mode */
+#ifdef ALGORITHM_AVL
+typedef enum
+{
+    LVM_AVL_OFF   = 0,
+    LVM_AVL_ON    = 1,
+    LVM_AVL_DUMMY = LVM_MAXENUM
+} LVM_AVL_Mode_en;
+#endif /* ALGORITHM_AVL */
+
+/* Headroom management operating mode */
+typedef enum
+{
+    LVM_HEADROOM_OFF   = 0,
+    LVM_HEADROOM_ON    = 1,
+    LVM_Headroom_DUMMY = LVM_MAXENUM
+} LVM_Headroom_Mode_en;
+
+/* Tone Generator operating mode */
+#ifdef ALGORITHM_TG
+typedef enum
+{
+    LVM_TG_OFF        = 0,
+    LVM_TG_CONTINUOUS = 1,
+    LVM_TG_ONESHOT    = 2,
+    LVM_TG_DUMMY      = LVM_MAXENUM
+} LVM_TG_Mode_en;
+
+/* Tone Generator sweep mode */
+typedef enum
+{
+    LVM_TG_SWEEPLIN    = 0,
+    LVM_TG_SWEEPLOG    = 1,
+    LVM_TG_SWEEP_DUMMY = LVM_MAXENUM
+} LVM_TG_SweepMode_en;
+#endif /* ALGORITHM_TG */
+
+#ifdef ALGORITHM_XO
+typedef enum
+{
+	LVM_XO_MODE_OFF = 0,
+	LVM_XO_MODE_ON = 1
+}LVM_XO_MODE_en;
+#endif /*ALGORITHM_XO*/
+
+
+#ifdef ALGORITHM_PSA
+typedef enum
+{
+    LVM_PSA_SPEED_SLOW,                                  /* Peak decaying at slow speed */
+    LVM_PSA_SPEED_MEDIUM,                                /* Peak decaying at medium speed */
+    LVM_PSA_SPEED_FAST,                                  /* Peak decaying at fast speed */
+    LVM_PSA_SPEED_DUMMY = LVM_MAXENUM
+} LVM_PSA_DecaySpeed_en;
+
+typedef enum
+{
+    LVM_PSA_OFF   = 0,
+    LVM_PSA_ON    = 1,
+    LVM_PSA_DUMMY = LVM_MAXENUM
+} LVM_PSA_Mode_en;
+#endif /* ALGORITHM_PSA */
+
+#ifdef ALGORITHM_LIMP
+typedef enum
+{
+    LVM_LIMP_OFF   = 0,
+    LVM_LIMP_ON    = 1,
+    LVM_LIMP_DUMMY = LVM_MAXENUM
+} LVM_LIMP_Mode_en;
+#endif /* ALGORITHM_LIMP */
+
+#ifdef ALGORITHM_LIMR
+typedef enum
+{
+    LVM_LIMR_OFF   = 0,
+    LVM_LIMR_ON    = 1,
+    LVM_LIMR_DUMMY = LVM_MAXENUM
+} LVM_LIMR_Mode_en;
+
+typedef enum
+{
+    LVM_LIMR_REF_INPUT  = 0,
+    LVM_LIMR_REF_0DBFS  = 1,
+    LVM_LIMR_REF_DUMMY  = LVM_MAXENUM
+} LVM_LIMR_Reference_en;
+#endif /* ALGORITHM_LIMR */
+
+// Adavanced parameter mode
+typedef enum
+{
+    LVM_AP_DEFAULT  = 0,
+    LVM_AP_MANUAL   = 1,
+    LVM_AP_DUMMY  = LVM_MAXENUM
+} LVM_AP_MODE_en;
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Structures                                                                          */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* Version information */
+typedef struct
+{
+    LVM_CHAR                    *pVersionNumber;        /* Pointer to the version number in the format X.YY.ZZ */
+    LVM_CHAR                    *pPlatform;             /* Pointer to the library platform type */
+} LVM_VersionInfo_st;
+
+/* Memory table containing the region definitions */
+typedef struct
+{
+    LVM_MemoryRegion_st         Region[LVM_NR_MEMORY_REGIONS];  /* One definition for each region */
+} LVM_MemTab_t;
+
+
+/* N-Band equaliser band definition */
+typedef struct
+{
+    LVM_INT16                   Gain;                   /* Band gain in dB */
+    LVM_UINT16                  Frequency;              /* Band centre frequency in Hz */
+    LVM_UINT16                  QFactor;                /* Band quality factor (x100) */
+} LVM_EQNB_BandDef_t;
+
+/* Headroom band definition */
+typedef struct
+{
+    LVM_UINT16                  Limit_Low;              /* Low frequency limit of the band in Hertz */
+    LVM_UINT16                  Limit_High;             /* High frequency limit of the band in Hertz */
+    LVM_INT16                   Headroom_Offset;        /* Headroom = biggest band gain - Headroom_Offset */
+} LVM_HeadroomBandDef_t;
+
+/* Control Parameter structure */
+typedef struct
+{
+    /* General parameters */
+    LVM_Mode_en                 OperatingMode;          /* Bundle operating mode On/Bypass */
+    LVM_Fs_en                   SampleRate;             /* Sample rate */
+    LVM_Format_en               SourceFormat;           /* Input data format */
+    LVM_OutputDeviceType_en     SpeakerType;            /* Output device type */
+    LVM_SpeakerType_en          SpeakerTypeInternal;    /* Device speaker type, mono or stereo */
+
+#ifdef ALGORITHM_CS
+    /* Concert Sound Virtualizer parameters*/
+    LVM_Mode_en                 VirtualizerOperatingMode; /* Virtualizer operating mode On/Off */
+    LVM_VirtualizerType_en      VirtualizerType;          /* Virtualizer type: ConcertSound, CinemaSound Music or CinemaSound Movie */
+    LVM_UINT16                  VirtualizerReverbLevel;   /* Virtualizer reverb level in % */
+    LVM_INT16                   CS_EffectLevel;           /* Concert Sound effect level */
+#endif /* ALGORITHM_CS */
+
+#ifdef ALGORITHM_EQNB
+    /* N-Band Equaliser parameters */
+    LVM_EQNB_Mode_en            EQNB_OperatingMode;     /* N-Band Equaliser operating mode */
+    LVM_EQNB_FilterMode_en      EQNB_LPF_Mode;          /* Low pass filter */
+    LVM_INT16                   EQNB_LPF_CornerFreq;
+    LVM_EQNB_FilterMode_en      EQNB_HPF_Mode;          /* High pass filter */
+    LVM_INT16                   EQNB_HPF_CornerFreq;
+    LVM_UINT16                  EQNB_NBands;            /* Number of bands */
+    LVM_EQNB_BandDef_t          *pEQNB_BandDefinition;  /* Pointer to equaliser definitions */
+#endif /* ALGORITHM_EQNB */
+
+#ifdef ALGORITHM_PR_EQNB
+    /* N-Band Equaliser parameters */
+    LVM_EQNB_Mode_en            PR_EQNB_OperatingMode;     /* N-Band Equaliser operating mode */
+    LVM_EQNB_FilterMode_en      PR_EQNB_LPF_Mode;          /* Low pass filter */
+    LVM_INT16                   PR_EQNB_LPF_CornerFreq;
+	LVM_EQNB_FilterMode_en      PR_EQNB_HPF_Mode;          /* High pass filter */
+    LVM_INT16                   PR_EQNB_HPF_CornerFreq;
+    LVM_UINT16                  PR_EQNB_NBands;            /* Number of bands */
+    LVM_EQNB_BandDef_t          *pPR_EQNB_BandDefinition;  /* Pointer to equaliser definitions */
+#endif /* ALGORITHM_PR_EQNB */
+
+#ifdef ALGORITHM_DBE
+    /* Bass Enhancement parameters */
+    LVM_BE_Mode_en              BE_OperatingMode;       /* Bass Enhancement operating mode */
+    LVM_INT16                   BE_EffectLevel;         /* Bass Enhancement effect level */
+    LVM_BE_CentreFreq_en        BE_CentreFreq;          /* Bass Enhancement centre frequency */
+    LVM_BE_FilterSelect_en      BE_HPF;                 /* Bass Enhancement high pass filter selector */
+
+#endif /* ALGORITHM_DBE */
+#ifdef ALGORITHM_PB
+    /* Bass Enhancement parameters */
+    LVM_BE_Mode_en              BE_OperatingMode;       /* Bass Enhancement operating mode */
+    LVM_INT16                   BE_EffectLevel;         /* Bass Enhancement effect level */
+    LVM_BE_CentreFreq_en        BE_CentreFreq;          /* Bass Enhancement centre frequency */
+    LVM_BE_FilterSelect_en      BE_HPF;                 /* Bass Enhancement high pass filter selector */
+
+#endif /* ALGORITHM_PB */
+    /* Volume Control parameters */
+    LVM_INT16                   VC_EffectLevel;         /* Volume Control setting in dBs */
+    LVM_INT16                   VC_Balance;             /* Left Right Balance control in dB (-96 to 96 dB), -ve values reduce */
+
+#ifdef ALGORITHM_TE
+    /* Treble Enhancement parameters */
+    LVM_TE_Mode_en              TE_OperatingMode;       /* Treble Enhancement On/Off */
+    LVM_INT16                   TE_EffectLevel;         /* Treble Enhancement gain dBs */
+
+#endif /* ALGORITHM_TE */
+#ifdef ALGORITHM_LM
+    /* Loudness Maximiser parameters */
+    LVM_LM_Mode_en              LM_OperatingMode;       /* Loudness Maximiser operating mode */
+    LVM_LM_Effect_en            LM_EffectLevel;         /* Loudness Maximiser effect level */
+    LVM_UINT16                  LM_Attenuation;         /* Loudness Maximiser output attenuation */
+    LVM_UINT16                  LM_CompressorGain;      /* Loudness Maximiser output compressor gain */
+    LVM_UINT16                  LM_SpeakerCutOff;       /* Loudness Maximiser speaker cut off frequency */
+
+#endif /* ALGORITHM_LM */
+
+#ifdef ALGORITHM_AVL
+    /* AVL parameters */
+    LVM_AVL_Mode_en             AVL_OperatingMode;      /* AVL operating mode */
+
+#endif /* ALGORITHM_AVL */
+
+#ifdef ALGORITHM_TG
+    /* Tone Generator parameters */
+    LVM_TG_Mode_en              TG_OperatingMode;       /* Tone generator mode */
+    LVM_TG_SweepMode_en         TG_SweepMode;           /* Log or linear sweep */
+    LVM_UINT16                  TG_StartFrequency;      /* Sweep start frequency in Hz */
+    LVM_INT16                   TG_StartAmplitude;      /* Sweep start amplitude in dBr */
+    LVM_UINT16                  TG_StopFrequency;       /* Sweep stop frequency in Hz */
+    LVM_INT16                   TG_StopAmplitude;       /* Sweep stop amplitude in dBr */
+    LVM_UINT16                  TG_SweepDuration;       /* Sweep duration in seconds, 0 for infinite duration tone */
+    LVM_Callback                pTG_CallBack;           /* End of sweep callback */
+    LVM_INT16                   TG_CallBackID;          /* Callback ID*/
+    void                        *pTGAppMemSpace;        /* Application instance handle or memory area */
+#endif /* ALGORITHM_TG */
+
+#ifdef ALGORITHM_PSA
+    /* General Control */
+    LVM_PSA_Mode_en             PSA_Enable;
+
+    /* Spectrum Analyzer parameters */
+    LVM_PSA_DecaySpeed_en       PSA_PeakDecayRate;      /* Peak value decay rate*/
+    LVM_UINT16                  PSA_NumBands;           /* Number of Bands*/
+#endif /* ALGORITHM_PSA */
+
+#ifdef ALGORITHM_LIMP
+	LVM_LIMP_Mode_en			LIMP_OperatingMode;		/* LIMP operating mode */
+	LVM_INT16					LIMP_Threshold;		    /* LIMP threshold in dB */
+#endif /* ALGORITHM_LIMP */
+
+#ifdef ALGORITHM_LIMR
+	LVM_LIMR_Mode_en			LIMR_OperatingMode;		/* LIMR operating mode */
+	LVM_LIMR_Reference_en		LIMR_Reference;	 		/* LIMR reference input */	
+	LVM_INT16					LIMR_Threshold;		    /* LIMR threshold in dB */
+#endif /* ALGORITHM_LIMR */
+
+#ifdef ALGORITHM_CS
+    LVM_AP_MODE_en				CS_AP_Mode;				  /* concert sound advanced paramameter mode */
+	LVM_INT16                   CS_AP_MidGain;            /* MidChannelGain */
+    LVM_UINT16                  CS_AP_MidCornerFreq;      /* Shelving Filter Corner Frequency */
+    LVM_UINT16                  CS_AP_SideHighPassCutoff; /* SideBoost HighPassFilter Corner Frequency */
+    LVM_UINT16                  CS_AP_SideLowPassCutoff;  /* SideBoost LowPassFilter Corner Frequency */
+    LVM_INT16                   CS_AP_SideGain;           /* Side Channel Gain */
+#endif
+
+#ifdef ALGORITHM_XO
+	LVM_Mode_en					XO_OperatingMode;		  /* Crossover operating mode*/
+	LVM_UINT16					XO_cutoffFrequency;		  /* Crossover cut-off frequency*/
+
+#endif/*ALGORITHM_XO*/
+} LVM_ControlParams_t;
+
+
+/* Instance Parameter structure */
+typedef struct
+{
+    /* General */
+    LVM_BufferMode_en           BufferMode;             /* Buffer management mode */
+    LVM_UINT16                  MaxBlockSize;           /* Maximum processing block size */
+
+    /* N-Band Equaliser */
+    LVM_UINT16                  EQNB_NumBands;          /* Maximum number of User equaliser bands */
+	LVM_UINT16                  PR_EQNB_NumBands;       /* Maximum number of Product equaliser bands */
+	EAP_NXPPlatform_en			Platform;				/* NXP Platform where EAP is playing on (LVM_IMXRT1050,LVM_IMXRT1060, LVM_IMXRT1064, LVM_IMXRT1170, LVM_LPC55, LVM_IMXRT500, LVM_IMXRT600)*/
+	
+
+#ifdef ALGORITHM_PSA
+    /* PSA */
+    LVM_UINT16                  PSA_HistorySize;         /* PSA History size in ms: 200 to 5000 */
+    LVM_UINT16                  PSA_MaxBands;            /* Maximum number of bands: 6 to 64 */
+    LVM_UINT16                  PSA_SpectrumUpdateRate;  /* Spectrum update rate : 10 to 25*/
+    LVM_PSA_Mode_en             PSA_Included;            /* Controls the instance memory allocation for PSA: ON/OFF */
+#endif /* ALGORITHM_PSA */
+} LVM_InstParams_t;
+
+
+/* Headroom management parameter structure */
+typedef struct
+{
+    LVM_Headroom_Mode_en        Headroom_OperatingMode; /* Headroom Control On/Off */
+    LVM_HeadroomBandDef_t       *pHeadroomDefinition;   /* Pointer to headroom bands definition */
+    LVM_UINT16                  NHeadroomBands;         /* Number of headroom bands */
+} LVM_HeadroomParams_t;
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Function Prototypes                                                                 */
+/*                                                                                      */
+/****************************************************************************************/
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetVersionInfo                                          */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to retrieve information about the library's version.          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  pVersion                Pointer to an empty version info structure                  */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         when pVersion is NULL                                       */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetVersionInfo(LVM_VersionInfo_st  *pVersion);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetMemoryTable                                          */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used for memory allocation and free. It can be called in           */
+/*  two ways:                                                                           */
+/*                                                                                      */
+/*      hInstance = NULL                Returns the memory requirements                 */
+/*      hInstance = Instance handle     Returns the memory requirements and             */
+/*                                      allocated base addresses for the instance       */
+/*                                                                                      */
+/*  When this function is called for memory allocation (hInstance=NULL) the memory      */
+/*  base address pointers are NULL on return.                                           */
+/*                                                                                      */
+/*  When the function is called for free (hInstance = Instance Handle) the memory       */
+/*  table returns the allocated memory and base addresses used during initialisation.   */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pMemoryTable            Pointer to an empty memory definition table                 */
+/*  pInstParams             Pointer to the instance parameters                          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When one of pMemoryTable or pInstParams is NULL             */
+/*  LVM_OUTOFRANGE          When any of the Instance parameters are out of range        */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetMemoryTable(LVM_Handle_t         hInstance,
+                                       LVM_MemTab_t         *pMemoryTable,
+                                       LVM_InstParams_t     *pInstParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetInstanceHandle                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to create a bundle instance. It returns the created instance  */
+/*  handle through phInstance. All parameters are set to their default, inactive state. */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  phInstance              pointer to the instance handle                              */
+/*  pMemoryTable            Pointer to the memory definition table                      */
+/*  pInstParams             Pointer to the instance parameters                          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Initialisation succeeded                                    */
+/*  LVM_ALIGNMENTERROR      Instance or scratch memory on incorrect alignment           */
+/*  LVM_NULLADDRESS         Instance or scratch memory has a NULL pointer               */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function must not be interrupted by the LVM_Process function                */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetInstanceHandle(LVM_Handle_t        *phInstance,
+                                          LVM_MemTab_t        *pMemoryTable,
+                                          LVM_InstParams_t    *pInstParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_ClearAudioBuffers                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to clear the internal audio buffers of the bundle.            */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Buffers Cleared                                             */
+/*  LVM_NULLADDRESS         Instance is NULL                                            */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_ClearAudioBuffers(LVM_Handle_t  hInstance);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                 LVM_GetControlParameters                                   */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Request the LifeVibes module parameters. The current parameter set is returned      */
+/*  via the parameter pointer.                                                          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance                Instance handle                                            */
+/*  pParams                  Pointer to an empty parameter structure                    */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS          Succeeded                                                      */
+/*  LVM_NULLADDRESS      when any of hInstance or pParams is NULL                       */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetControlParameters(LVM_Handle_t           hInstance,
+                                             LVM_ControlParams_t    *pParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetControlParameters                                    */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Sets or changes the LifeVibes module parameters.                                    */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*  pParams                 Pointer to a parameter structure                            */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance, pParams or any control pointers are NULL    */
+/*  LVM_OUTOFRANGE          When any of the control parameters are out of range         */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetControlParameters(LVM_Handle_t           hInstance,
+                                             LVM_ControlParams_t    *pParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_Process                                                 */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Process function for the LifeVibes module.                                          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*  pInData                 Pointer to the input data                                   */
+/*  pOutData                Pointer to the output data                                  */
+/*  NumSamples              Number of samples in the input buffer                       */
+/*  AudioTime               Audio Time of the current input data in milli-seconds       */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS            Succeeded                                                    */
+/*  LVM_INVALIDNUMSAMPLES  When the NumSamples is not a valied multiple in unmanaged    */
+/*                         buffer mode                                                  */
+/*  LVM_ALIGNMENTERROR     When either the input our output buffers are not 32-bit      */
+/*                         aligned in unmanaged mode                                    */
+/*  LVM_NULLADDRESS        When one of hInstance, pInData or pOutData is NULL           */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. The input and output buffers must be 32-bit aligned                              */
+/*  2. Number of samples is defined as follows:                                         */
+/*      MONO                the number of samples in the block                          */
+/*      MONOINSTEREO        the number of sample pairs in the block                     */
+/*      STEREO              the number of sample pairs in the block                     */
+/*                                                                                      */
+/*   3. If Crossover Disable, pOutData[0] MUST be initialize as a non-null pointer      */
+/*   4. If Crossover Enable, pOutData[0] & pOutData[1] MUST be initialize as            */
+/*      a non-null pointer                                                              */
+/*                                                                                      */
+/*                                                                                      */
+/*                                                                                      */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_Process(LVM_Handle_t                hInstance,
+                                const LVM_INT16             *pInData,
+                                LVM_INT16                   **pOutData,
+                                LVM_UINT16                  NumSamples,
+                                LVM_UINT32                  AudioTime);
+
+
+#ifdef ALGORITHM_AVL
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetAVLGain                                              */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to retrieve the AVL last generated gain in Q16.15             */
+/*  linear values.                                                                      */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pAVL_Gain               Pointer to the gain                                         */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance or pAVL_Gain are null addresses              */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetAVLGain( LVM_Handle_t    hInstance,
+                                    LVM_INT32       *pAVL_Gain);
+
+
+#endif /* ALGORITHM_AVL */
+
+#ifdef ALGORITHM_EQNB
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetHeadroomParams                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to set the automatic headroom management parameters.         */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pHeadroomParams         Pointer to headroom parameter structure                     */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetHeadroomParams(  LVM_Handle_t            hInstance,
+                                            LVM_HeadroomParams_t    *pHeadroomParams);
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetHeadroomParams                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to get the automatic headroom management parameters.          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pHeadroomParams         Pointer to headroom parameter structure (output)            */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance or pHeadroomParams are NULL                  */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetHeadroomParams(  LVM_Handle_t            hInstance,
+                                            LVM_HeadroomParams_t    *pHeadroomParams);
+#endif /* ALGORITHM_EQNB */
+
+#ifdef ALGORITHM_PSA
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetSpectrum                                             */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/* This function is used to retrieve Spectral information at a given Audio time         */
+/* for display usage                                                                    */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pCurrentPeaks           Pointer to location where currents peaks are to be saved    */
+/*  pPastPeaks              Pointer to location where past peaks are to be saved        */
+/*  pCentreFreqs            Pointer to location where centre frequency of each band is  */
+/*                          to be saved                                                 */
+/*  AudioTime               Audio time at which the spectral information is needed      */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         If any of input addresses are NULL                          */
+/*  LVM_WRONGAUDIOTIME      Failure due to audio time error                             */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                     */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetSpectrum( LVM_Handle_t            hInstance,
+                                     LVM_INT8                *pCurrentPeaks,
+                                     LVM_INT8                *pPastPeaks,
+                                     LVM_UINT16              *pCentreFreqs,
+                                     LVM_UINT32              AudioTime);
+
+
+#endif /* ALGORITHM_PSA */
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetVolumeNoSmoothing                                    */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/* This function is used to set output volume without any smoothing                     */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pParams                 Control Parameters, only volume value is used here          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         If any of input addresses are NULL                          */
+/*  LVM_OUTOFRANGE          When any of the control parameters are out of range         */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                     */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetVolumeNoSmoothing( LVM_Handle_t           hInstance,
+                                              LVM_ControlParams_t    *pParams);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif      /* __LVM_H__ */
+

--- a/third_party/include/nxp/eap/EAP_Includes/EAP32.h
+++ b/third_party/include/nxp/eap/EAP_Includes/EAP32.h
@@ -1,0 +1,1016 @@
+/*  Copyright 2004-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ * This license applies ONLY to this header file EAP32.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Header file for the application layer interface of Concert Sound, Bass Enhancement  */
+/*  and volume management bundle.                                                       */
+/*                                                                                      */
+/*  This files includes all definitions, types, structures and function                 */
+/*  prototypes required by the calling layer. All other types, structures and           */
+/*  functions are private.                                                              */
+/*                                                                                      */
+/****************************************************************************************/
+/*                                                                                      */
+/*  Note: 1                                                                             */
+/*  =======                                                                             */
+/*  The algorithm can execute either with separate input and output buffers or with     */
+/*  a common buffer, i.e. the data is processed in-place.                               */
+/*                                                                                      */
+/****************************************************************************************/
+/*                                                                                      */
+/*  Note: 2                                                                             */
+/*  =======                                                                             */
+/*  Three data formats are support Stereo,Mono-In-Stereo and Mono. The data is          */
+/*  interleaved as follows:                                                             */
+/*                                                                                      */
+/*  Byte Offset         Stereo Input                Mono Input							*/
+/*  ===========         ============         ====================						*/
+/*      0               Left Sample #1          Mono Sample #1							*/
+/*      2               Right Sample #1         Mono Sample #1							*/
+/*      4               Left Sample #2          Mono Sample #2							*/
+/*      6               Right Sample #2         Mono Sample #2							*/
+/*      .                      .                     .                                  */
+/*      .                      .                     .                                  */
+/*																						*/		
+/*	For output buffer there is 3 cases :												*/
+/*		------																			*/
+/*		1) CROSSOVER is DISABLE															*/
+/*	Byte Offset       Stereo Input/Output       Mono Input/Output						*/
+/*  ===========       ===================       =================						*/
+/*      0               Left Sample #1            Mono Sample #1						*/
+/*      2               Right Sample #1           Mono Sample #1						*/
+/*      4               Left Sample #2            Mono Sample #2						*/
+/*      6               Right Sample #2           Mono Sample #2						*/
+/*      .                      .                     .                                  */
+/*      .                      .                     .                                  */
+/*																						*/
+/*      2) CROSSOVER is ENABLE & input/output in STEREO									*/
+/*          pOutData[0] will be the output Low band and pOutData[1] the High band       */	
+/*  Stereo Input		   pOutData[0] in stereo       pOutData[1] in stereo 			*/
+/*  ===================    =====================       =====================			*/
+/*  Left Sample  #1          Left Sample LB  #1           Left Sample HB  #1			*/
+/*  Right Sample #1          Right Sample LB #1           Right Sample HB #1			*/
+/*  Left Sample  #2          Left Sample LB  #2           Left Sample HB  #2			*/
+/*  Right Sample #2          Right Sample LB #2           Right Sample HB #2			*/
+/*      .                            .                            .                     */
+/*      .                            .                            .                     */
+/*																						*/
+/*      3) CROSSOVER is ENABLE & input/output in MONO									*/
+/*          pOutData[0] will be the output Low band and pOutData[1] the High band       */
+/*  Mono Input		       pOutData[0] in mono         pOutData[1] in mono 			    */
+/*  ===============        =====================       =====================			*/
+/*  MONO Sample  #1          MONO Sample LB  #1           MONO Sample HB  #1			*/
+/*  MONO Sample  #2          MONO Sample LB  #2           MONO Sample HB  #2			*/
+/*  MONO Sample  #3          MONO Sample LB  #3           MONO Sample HB  #3			*/
+/*  MONO Sample  #4          MONO Sample LB  #4           MONO Sample HB  #4			*/
+/*      .                            .                            .                     */
+/*      .                            .                            .                     */
+/*																						*/
+/****************************************************************************************/
+
+#ifndef __LVM_H__
+#define __LVM_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+
+#ifdef  ALGORITHM_CS
+#define ALGORITHM_VIRTUALIZER
+#endif  /* ALGORITHM_CS */
+
+#ifdef ALGORITHM_DBE
+#define ALGORITHM_BASS
+#else
+#ifdef ALGORITHM_PB
+#define ALGORITHM_BASS
+#endif   /* ALGORITHM_PB */
+#endif   /* ALGORITHM_DBE */
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Includes                                                                            */
+/*                                                                                      */
+/****************************************************************************************/
+
+#include "LVC_Types.h"
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Definitions                                                                         */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* MAXIMAL VALUE LIMIT */
+#define LVM_MAX_NUM_CHANNELS                  2     /* Maximum number of interleaved input channels */
+#define MAX_INTERNAL_BLOCKSIZE             1024     /* Maximum internal block size authorized (multiple of 64)*/
+#define LVM_HEADROOM_MAX_NBANDS               5     /* Headroom management */
+#define LVM_EQNB_MAX_BANDS_NBR               10     /* EQNB Maximal band number */
+#define LVM_PSA_MAX_NUMBANDS                 64     /* Maximum Number of PSA Bands*/
+
+/* Memory table*/
+#define LVM_NR_MEMORY_REGIONS                 4     /* Number of memory regions */
+
+/* Concert Sound effect level presets */
+#ifdef ALGORITHM_VIRTUALIZER 
+#define LVM_CS_EFFECT_NONE                    0     /* 0% effect, minimum value */
+#define LVM_CS_EFFECT_LOW                 16384     /* 50% effect */
+#define LVM_CS_EFFECT_MED                 24576     /* 75% effect */
+#define LVM_CS_EFFECT_HIGH                32767     /* 100% effect, maximum value */
+#endif /*end  ALGORITHM_VIRTUALIZER */
+
+#ifdef ALGORITHM_TE
+#define LVM_TE_LOW_MIPS                   32767     /* Treble enhancement 6dB Mips saving mode */
+#endif /* end ALGORITHM_TE */
+
+/* Bass enhancement effect level presets */
+#ifdef ALGORITHM_BASS
+#define LVM_BE_0DB                            0     /* 0dB boost, no effect */
+#define LVM_BE_3DB                            3     /* +3dB boost */
+#define LVM_BE_6DB                            6     /* +6dB boost */
+#define LVM_BE_9DB                            9     /* +9dB boost */
+#define LVM_BE_12DB                          12     /* +12dB boost */
+#define LVM_BE_15DB                          15     /* +15dB boost */
+#endif /* end ALGORITHM_BASS */
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Types                                                                               */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* Instance handle */
+typedef void *LVM_Handle_t;
+
+
+/* Status return values */
+typedef enum
+{
+    LVM_SUCCESS            = 0,                     /* Successful return from a routine */
+    LVM_ALIGNMENTERROR     = 1,                     /* Memory alignment error */
+    LVM_NULLADDRESS        = 2,                     /* NULL allocation address */
+    LVM_INVALIDNUMSAMPLES  = 3,                     /* Invalid number of samples */
+    LVM_WRONGAUDIOTIME     = 4,                     /* Wrong time value for audio time*/
+    LVM_ALGORITHMDISABLED  = 5,                     /* Algorithm is disabled*/
+    LVM_NOT_INITIALIZED    = 6,                     /* Process function was called for a non-initialized module */
+	LVM_INVALIDNXPPLATFORM = 7,                     /* Invalid NXP platform */
+	// OUT OF RANGE HANDLE Must stay at the end of the enum
+	LVM_OUTOFRANGE         = 8,                     /* Out of range control parameter (without details) */
+	/* OUT OF RANGE WITH DETAILS */
+	LVM_OUTOFRANGE_GENERAL_PARAMS			= 9,
+	LVM_OUTOFRANGE_SPEAKER_TYPES			= 10,
+	LVM_OUTOFRANGE_VIRTUALIZER_OM			= 11,
+	LVM_OUTOFRANGE_VIRTUALIZER_TYPE         = 12,
+	LVM_OUTOFRANGE_VIRTUALIZER_REVERB       = 13,
+	LVM_OUTOFRANGE_CS_EFFECT				= 14,
+	LVM_OUTOFRANGE_USER_EQNB				= 15,
+	LVM_OUTOFRANGE_USER_EQNB_BAND_DEF       = 16,
+	LVM_OUTOFRANGE_PRODUCT_EQNB				= 17,
+	LVM_OUTOFRANGE_PRODUCT_EQNB_BAND_DEF    = 18,
+	LVM_OUTOFRANGE_BE						= 19,
+	LVM_OUTOFRANGE_PB						= 20,
+	LVM_OUTOFRANGE_VC_LEVEL					= 21,
+	LVM_OUTOFRANGE_VC_BALANCE				= 22,
+	LVM_OUTOFRANGE_TE						= 23,
+	LVM_OUTOFRANGE_LM						= 24,
+	LVM_OUTOFRANGE_LM_SPEAKER_CUTOFF        = 25,
+	LVM_OUTOFRANGE_AVL						= 26,	
+	LVM_OUTOFRANGE_TG_OM					= 27,
+	LVM_OUTOFRANGE_TG						= 28,
+	LVM_OUTOFRANGE_PSA_RATE					= 29,
+	LVM_OUTOFRANGE_PSA_ENABLE				= 30,
+	LVM_OUTOFRANGE_PSA_NUMBAND				= 31,
+	LVM_OUTOFRANGE_LIMP_OM					= 32,
+	LVM_OUTOFRANGE_LIMP_THRESHOLD			= 33,
+	LVM_OUTOFRANGE_LIMR_OM					= 34,
+	LVM_OUTOFRANGE_LIMR_THRESHOLD			= 35,
+	LVM_OUTOFRANGE_LIMR_REFERENCE			= 36,
+	LVM_OUTOFRANGE_CS_AP_MODE				= 37,
+	LVM_OUTOFRANGE_CS_AP					= 38,
+	LVM_OUTOFRANGE_XO_OPERATINGMODE			= 39,                
+	LVM_OUTOFRANGE_XO_CUTOFFFREQUENCY		= 40,   
+	LVM_OUTOFRANGE_FBSP_OPERATINGMODE       = 41,
+	
+
+	LVM_RETURNSTATUS_DUMMY = LVM_MAXENUM
+} LVM_ReturnStatus_en;
+
+
+/* Buffer Management mode */
+typedef enum
+{
+    LVM_MANAGED_BUFFERS   = 0,
+    LVM_UNMANAGED_BUFFERS = 1,
+    LVM_BUFFERS_DUMMY     = LVM_MAXENUM
+} LVM_BufferMode_en;
+
+
+
+/* Output device type */
+typedef enum
+{
+    LVM_HEADPHONES             = 0,
+    LVM_MOBILE_SPEAKERS_SMALL  = 2,
+    LVM_MOBILE_SPEAKERS_MEDIUM = 3,
+    LVM_MOBILE_SPEAKERS_LARGE  = 4,
+    LVM_SPEAKERTYPE_MAX        = LVM_MAXENUM
+} LVM_OutputDeviceType_en;
+typedef enum
+{
+	LVM_IMXRT1050 = 1,						   // I.MXRT1050 : EAP running on Cortex-M7
+	LVM_IMXRT1060 = 2,                         // I.MXRT1060 : EAP running on Cortex-M7
+	LVM_IMXRT1064 = 3,						   // I.MXRT1064 : EAP running on Cortex-M7
+	LVM_IMXRT1170 = 4,                         // I.MXRT1170 : EAP running on Cortex-M7
+	LVM_LPC55 = 5,						   // LPC55	     : EAP running on Cortex-M33
+	LVM_IMXRT500 = 6,                         // I.MXRT500  : EAP running on FusionF1
+	LVM_IMXRT600 = 7,                         // I.MXRT600  : EAP running on HIFI4
+	LVM_MAX_PLATFORM = LVM_MAXENUM,
+}EAP_NXPPlatform_en;
+/* Virtualizer mode selection*/
+#ifdef ALGORITHM_VIRTUALIZER
+typedef enum
+{
+    LVM_CONCERTSOUND       = 0,
+    LVM_VIRTUALIZERTYPE_DUMMY   = LVM_MAXENUM
+} LVM_VirtualizerType_en;
+#endif  /* ALGORITHM_VIRTUALIZER */
+
+/* N-Band Equaliser operating mode */
+#if defined (ALGORITHM_EQNB) || defined (ALGORITHM_PR_EQNB)
+typedef enum
+{    LVM_EQNB_OFF   = 0,
+    LVM_EQNB_ON    = 1,
+    LVM_EQNB_DUMMY = LVM_MAXENUM
+} LVM_EQNB_Mode_en;
+#endif /* ALGORITHM_EQNB  || ALGORITHM_PR_EQNB*/
+
+/* Filter mode control */
+typedef enum
+{
+    LVM_EQNB_FILTER_OFF = 0,
+    LVM_EQNB_FILTER_ON  = 1,
+    LVM_EQNB_FILTER_DUMMY = LVM_MAXENUM
+} LVM_EQNB_FilterMode_en;
+
+/* Bass Enhancement operating mode */
+#ifdef ALGORITHM_BASS
+typedef enum
+{
+    LVM_BE_OFF   = 0,
+    LVM_BE_ON    = 1,
+    LVM_BE_DUMMY = LVM_MAXENUM
+} LVM_BE_Mode_en;
+
+/* Bass Enhancement centre frequency selection control */
+typedef enum
+{
+    LVM_BE_CENTRE_55Hz  = 0,
+    LVM_BE_CENTRE_66Hz  = 1,
+    LVM_BE_CENTRE_78Hz  = 2,
+    LVM_BE_CENTRE_90Hz  = 3,
+    LVM_BE_CENTRE_DUMMY = LVM_MAXENUM
+} LVM_BE_CentreFreq_en;
+
+/* Bass Enhancement HPF selection control */
+typedef enum
+{
+    LVM_BE_HPF_OFF   = 0,
+    LVM_BE_HPF_ON    = 1,
+    LVM_BE_HPF_DUMMY = LVM_MAXENUM
+} LVM_BE_FilterSelect_en;
+
+
+#endif /* ALGORITHM_BASS */
+
+/* Volume Control operating mode */
+typedef enum
+{
+    LVM_VC_OFF   = 0,
+    LVM_VC_ON    = 1,
+    LVM_VC_DUMMY = LVM_MAXENUM
+} LVM_VC_Mode_en;
+
+/* Treble Enhancement operating mode */
+#ifdef ALGORITHM_TE
+typedef enum
+{
+    LVM_TE_OFF   = 0,
+    LVM_TE_ON    = 1,
+    LVM_TE_DUMMY = LVM_MAXENUM
+} LVM_TE_Mode_en;
+#endif /* ALGORITHM_TE */
+
+/* Loudness Maximiser operating mode */
+#ifdef ALGORITHM_LM
+typedef enum
+{
+    LVM_LM_OFF   = 0,
+    LVM_LM_ON    = 1,
+    LVM_LM_DUMMY = LVM_MAXENUM
+}LVM_LM_Mode_en;
+
+/* Loudness Maximiser effect setting */
+typedef enum
+{
+    LVM_LM_GENTLE       = 0,
+    LVM_LM_MEDIUM       = 1,
+    LVM_LM_EXTREME      = 2,
+    LVM_LM_EFFECT_DUMMY = LVM_MAXENUM
+}LVM_LM_Effect_en;
+#endif /* ALGORITHM_LM */
+
+/* AVL operating mode */
+#ifdef ALGORITHM_AVL
+typedef enum
+{
+    LVM_AVL_OFF   = 0,
+    LVM_AVL_ON    = 1,
+    LVM_AVL_DUMMY = LVM_MAXENUM
+} LVM_AVL_Mode_en;
+#endif /* ALGORITHM_AVL */
+
+/* Headroom management operating mode */
+typedef enum
+{
+    LVM_HEADROOM_OFF   = 0,
+    LVM_HEADROOM_ON    = 1,
+    LVM_Headroom_DUMMY = LVM_MAXENUM
+} LVM_Headroom_Mode_en;
+
+/* Tone Generator operating mode */
+#ifdef ALGORITHM_TG
+typedef enum
+{
+    LVM_TG_OFF        = 0,
+    LVM_TG_CONTINUOUS = 1,
+    LVM_TG_ONESHOT    = 2,
+    LVM_TG_DUMMY      = LVM_MAXENUM
+} LVM_TG_Mode_en;
+
+/* Tone Generator sweep mode */
+typedef enum
+{
+    LVM_TG_SWEEPLIN    = 0,
+    LVM_TG_SWEEPLOG    = 1,
+    LVM_TG_SWEEP_DUMMY = LVM_MAXENUM
+} LVM_TG_SweepMode_en;
+#endif /* ALGORITHM_TG */
+
+#ifdef ALGORITHM_XO
+typedef enum
+{
+	LVM_XO_MODE_OFF = 0,
+	LVM_XO_MODE_ON = 1
+}LVM_XO_MODE_en;
+#endif /*ALGORITHM_XO*/
+
+
+#ifdef ALGORITHM_PSA
+typedef enum
+{
+    LVM_PSA_SPEED_SLOW,                                  /* Peak decaying at slow speed */
+    LVM_PSA_SPEED_MEDIUM,                                /* Peak decaying at medium speed */
+    LVM_PSA_SPEED_FAST,                                  /* Peak decaying at fast speed */
+    LVM_PSA_SPEED_DUMMY = LVM_MAXENUM
+} LVM_PSA_DecaySpeed_en;
+
+typedef enum
+{
+    LVM_PSA_OFF   = 0,
+    LVM_PSA_ON    = 1,
+    LVM_PSA_DUMMY = LVM_MAXENUM
+} LVM_PSA_Mode_en;
+#endif /* ALGORITHM_PSA */
+
+#ifdef ALGORITHM_LIMP
+typedef enum
+{
+    LVM_LIMP_OFF   = 0,
+    LVM_LIMP_ON    = 1,
+    LVM_LIMP_DUMMY = LVM_MAXENUM
+} LVM_LIMP_Mode_en;
+#endif /* ALGORITHM_LIMP */
+
+#ifdef ALGORITHM_LIMR
+typedef enum
+{
+    LVM_LIMR_OFF   = 0,
+    LVM_LIMR_ON    = 1,
+    LVM_LIMR_DUMMY = LVM_MAXENUM
+} LVM_LIMR_Mode_en;
+
+typedef enum
+{
+    LVM_LIMR_REF_INPUT  = 0,
+    LVM_LIMR_REF_0DBFS  = 1,
+    LVM_LIMR_REF_DUMMY  = LVM_MAXENUM
+} LVM_LIMR_Reference_en;
+#endif /* ALGORITHM_LIMR */
+
+// Adavanced parameter mode
+typedef enum
+{
+    LVM_AP_DEFAULT  = 0,
+    LVM_AP_MANUAL   = 1,
+    LVM_AP_DUMMY  = LVM_MAXENUM
+} LVM_AP_MODE_en;
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Structures                                                                          */
+/*                                                                                      */
+/****************************************************************************************/
+
+/* Version information */
+typedef struct
+{
+    LVM_CHAR                    *pVersionNumber;        /* Pointer to the version number in the format X.YY.ZZ */
+    LVM_CHAR                    *pPlatform;             /* Pointer to the library platform type */
+} LVM_VersionInfo_st;
+
+/* Memory table containing the region definitions */
+typedef struct
+{
+    LVM_MemoryRegion_st         Region[LVM_NR_MEMORY_REGIONS];  /* One definition for each region */
+} LVM_MemTab_t;
+
+
+/* N-Band equaliser band definition */
+typedef struct
+{
+    LVM_INT16                   Gain;                   /* Band gain in dB */
+    LVM_UINT16                  Frequency;              /* Band centre frequency in Hz */
+    LVM_UINT16                  QFactor;                /* Band quality factor (x100) */
+} LVM_EQNB_BandDef_t;
+
+/* Headroom band definition */
+typedef struct
+{
+    LVM_UINT16                  Limit_Low;              /* Low frequency limit of the band in Hertz */
+    LVM_UINT16                  Limit_High;             /* High frequency limit of the band in Hertz */
+    LVM_INT16                   Headroom_Offset;        /* Headroom = biggest band gain - Headroom_Offset */
+} LVM_HeadroomBandDef_t;
+
+/* Control Parameter structure */
+typedef struct
+{
+    /* General parameters */
+    LVM_Mode_en                 OperatingMode;          /* Bundle operating mode On/Bypass */
+    LVM_Fs_en                   SampleRate;             /* Sample rate */
+    LVM_Format_en               SourceFormat;           /* Input data format */
+    LVM_OutputDeviceType_en     SpeakerType;            /* Output device type */
+    LVM_SpeakerType_en          SpeakerTypeInternal;    /* Device speaker type, mono or stereo */
+
+#ifdef ALGORITHM_CS
+    /* Concert Sound Virtualizer parameters*/
+    LVM_Mode_en                 VirtualizerOperatingMode; /* Virtualizer operating mode On/Off */
+    LVM_VirtualizerType_en      VirtualizerType;          /* Virtualizer type: ConcertSound, CinemaSound Music or CinemaSound Movie */
+    LVM_UINT16                  VirtualizerReverbLevel;   /* Virtualizer reverb level in % */
+    LVM_INT16                   CS_EffectLevel;           /* Concert Sound effect level */
+#endif /* ALGORITHM_CS */
+
+#ifdef ALGORITHM_EQNB
+    /* N-Band Equaliser parameters */
+    LVM_EQNB_Mode_en            EQNB_OperatingMode;     /* N-Band Equaliser operating mode */
+    LVM_EQNB_FilterMode_en      EQNB_LPF_Mode;          /* Low pass filter */
+    LVM_INT16                   EQNB_LPF_CornerFreq;
+    LVM_EQNB_FilterMode_en      EQNB_HPF_Mode;          /* High pass filter */
+    LVM_INT16                   EQNB_HPF_CornerFreq;
+    LVM_UINT16                  EQNB_NBands;            /* Number of bands */
+    LVM_EQNB_BandDef_t          *pEQNB_BandDefinition;  /* Pointer to equaliser definitions */
+#endif /* ALGORITHM_EQNB */
+
+#ifdef ALGORITHM_PR_EQNB
+    /* N-Band Equaliser parameters */
+    LVM_EQNB_Mode_en            PR_EQNB_OperatingMode;     /* N-Band Equaliser operating mode */
+    LVM_EQNB_FilterMode_en      PR_EQNB_LPF_Mode;          /* Low pass filter */
+    LVM_INT16                   PR_EQNB_LPF_CornerFreq;
+	LVM_EQNB_FilterMode_en      PR_EQNB_HPF_Mode;          /* High pass filter */
+    LVM_INT16                   PR_EQNB_HPF_CornerFreq;
+    LVM_UINT16                  PR_EQNB_NBands;            /* Number of bands */
+    LVM_EQNB_BandDef_t          *pPR_EQNB_BandDefinition;  /* Pointer to equaliser definitions */
+#endif /* ALGORITHM_PR_EQNB */
+
+#ifdef ALGORITHM_DBE
+    /* Bass Enhancement parameters */
+    LVM_BE_Mode_en              BE_OperatingMode;       /* Bass Enhancement operating mode */
+    LVM_INT16                   BE_EffectLevel;         /* Bass Enhancement effect level */
+    LVM_BE_CentreFreq_en        BE_CentreFreq;          /* Bass Enhancement centre frequency */
+    LVM_BE_FilterSelect_en      BE_HPF;                 /* Bass Enhancement high pass filter selector */
+
+#endif /* ALGORITHM_DBE */
+#ifdef ALGORITHM_PB
+    /* Bass Enhancement parameters */
+    LVM_BE_Mode_en              BE_OperatingMode;       /* Bass Enhancement operating mode */
+    LVM_INT16                   BE_EffectLevel;         /* Bass Enhancement effect level */
+    LVM_BE_CentreFreq_en        BE_CentreFreq;          /* Bass Enhancement centre frequency */
+    LVM_BE_FilterSelect_en      BE_HPF;                 /* Bass Enhancement high pass filter selector */
+
+#endif /* ALGORITHM_PB */
+    /* Volume Control parameters */
+    LVM_INT16                   VC_EffectLevel;         /* Volume Control setting in dBs */
+    LVM_INT16                   VC_Balance;             /* Left Right Balance control in dB (-96 to 96 dB), -ve values reduce */
+
+#ifdef ALGORITHM_TE
+    /* Treble Enhancement parameters */
+    LVM_TE_Mode_en              TE_OperatingMode;       /* Treble Enhancement On/Off */
+    LVM_INT16                   TE_EffectLevel;         /* Treble Enhancement gain dBs */
+
+#endif /* ALGORITHM_TE */
+#ifdef ALGORITHM_LM
+    /* Loudness Maximiser parameters */
+    LVM_LM_Mode_en              LM_OperatingMode;       /* Loudness Maximiser operating mode */
+    LVM_LM_Effect_en            LM_EffectLevel;         /* Loudness Maximiser effect level */
+    LVM_UINT16                  LM_Attenuation;         /* Loudness Maximiser output attenuation */
+    LVM_UINT16                  LM_CompressorGain;      /* Loudness Maximiser output compressor gain */
+    LVM_UINT16                  LM_SpeakerCutOff;       /* Loudness Maximiser speaker cut off frequency */
+
+#endif /* ALGORITHM_LM */
+
+#ifdef ALGORITHM_AVL
+    /* AVL parameters */
+    LVM_AVL_Mode_en             AVL_OperatingMode;      /* AVL operating mode */
+
+#endif /* ALGORITHM_AVL */
+
+#ifdef ALGORITHM_TG
+    /* Tone Generator parameters */
+    LVM_TG_Mode_en              TG_OperatingMode;       /* Tone generator mode */
+    LVM_TG_SweepMode_en         TG_SweepMode;           /* Log or linear sweep */
+    LVM_UINT16                  TG_StartFrequency;      /* Sweep start frequency in Hz */
+    LVM_INT16                   TG_StartAmplitude;      /* Sweep start amplitude in dBr */
+    LVM_UINT16                  TG_StopFrequency;       /* Sweep stop frequency in Hz */
+    LVM_INT16                   TG_StopAmplitude;       /* Sweep stop amplitude in dBr */
+    LVM_UINT16                  TG_SweepDuration;       /* Sweep duration in seconds, 0 for infinite duration tone */
+    LVM_Callback                pTG_CallBack;           /* End of sweep callback */
+    LVM_INT16                   TG_CallBackID;          /* Callback ID*/
+    void                        *pTGAppMemSpace;        /* Application instance handle or memory area */
+#endif /* ALGORITHM_TG */
+
+#ifdef ALGORITHM_PSA
+    /* General Control */
+    LVM_PSA_Mode_en             PSA_Enable;
+
+    /* Spectrum Analyzer parameters */
+    LVM_PSA_DecaySpeed_en       PSA_PeakDecayRate;      /* Peak value decay rate*/
+    LVM_UINT16                  PSA_NumBands;           /* Number of Bands*/
+#endif /* ALGORITHM_PSA */
+
+#ifdef ALGORITHM_LIMP
+	LVM_LIMP_Mode_en			LIMP_OperatingMode;		/* LIMP operating mode */
+	LVM_INT16					LIMP_Threshold;		    /* LIMP threshold in dB */
+#endif /* ALGORITHM_LIMP */
+
+#ifdef ALGORITHM_LIMR
+	LVM_LIMR_Mode_en			LIMR_OperatingMode;		/* LIMR operating mode */
+	LVM_LIMR_Reference_en		LIMR_Reference;	 		/* LIMR reference input */	
+	LVM_INT16					LIMR_Threshold;		    /* LIMR threshold in dB */
+#endif /* ALGORITHM_LIMR */
+
+#ifdef ALGORITHM_CS
+    LVM_AP_MODE_en				CS_AP_Mode;				  /* concert sound advanced paramameter mode */
+	LVM_INT16                   CS_AP_MidGain;            /* MidChannelGain */
+    LVM_UINT16                  CS_AP_MidCornerFreq;      /* Shelving Filter Corner Frequency */
+    LVM_UINT16                  CS_AP_SideHighPassCutoff; /* SideBoost HighPassFilter Corner Frequency */
+    LVM_UINT16                  CS_AP_SideLowPassCutoff;  /* SideBoost LowPassFilter Corner Frequency */
+    LVM_INT16                   CS_AP_SideGain;           /* Side Channel Gain */
+#endif
+
+#ifdef ALGORITHM_XO
+	LVM_Mode_en					XO_OperatingMode;		  /* Crossover operating mode*/
+	LVM_UINT16					XO_cutoffFrequency;		  /* Crossover cut-off frequency*/
+
+#endif/*ALGORITHM_XO*/
+
+} LVM_ControlParams_t;
+
+
+/* Instance Parameter structure */
+typedef struct
+{
+    /* General */
+    LVM_BufferMode_en           BufferMode;             /* Buffer management mode */
+    LVM_UINT16                  MaxBlockSize;           /* Maximum processing block size */
+
+    /* N-Band Equaliser */
+    LVM_UINT16                  EQNB_NumBands;          /* Maximum number of User equaliser bands */
+	LVM_UINT16                  PR_EQNB_NumBands;       /* Maximum number of Product equaliser bands */
+	EAP_NXPPlatform_en			Platform;				/* NXP Platform where EAP is playing on (LVM_IMXRT1050,LVM_IMXRT1060, LVM_IMXRT1064, LVM_IMXRT1170, LVM_LPC55, LVM_IMXRT500, LVM_IMXRT600)*/
+#ifdef ALGORITHM_PSA
+    /* PSA */
+    LVM_UINT16                  PSA_HistorySize;         /* PSA History size in ms: 200 to 5000 */
+    LVM_UINT16                  PSA_MaxBands;            /* Maximum number of bands: 6 to 64 */
+    LVM_UINT16                  PSA_SpectrumUpdateRate;  /* Spectrum update rate : 10 to 25*/
+    LVM_PSA_Mode_en             PSA_Included;            /* Controls the instance memory allocation for PSA: ON/OFF */
+#endif /* ALGORITHM_PSA */
+} LVM_InstParams_t;
+
+
+/* Headroom management parameter structure */
+typedef struct
+{
+    LVM_Headroom_Mode_en        Headroom_OperatingMode; /* Headroom Control On/Off */
+    LVM_HeadroomBandDef_t       *pHeadroomDefinition;   /* Pointer to headroom bands definition */
+    LVM_UINT16                  NHeadroomBands;         /* Number of headroom bands */
+} LVM_HeadroomParams_t;
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Function Prototypes                                                                 */
+/*                                                                                      */
+/****************************************************************************************/
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetVersionInfo                                          */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to retrieve information about the library's version.          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  pVersion                Pointer to an empty version info structure                  */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         when pVersion is NULL                                       */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetVersionInfo(LVM_VersionInfo_st  *pVersion);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetMemoryTable                                          */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used for memory allocation and free. It can be called in           */
+/*  two ways:                                                                           */
+/*                                                                                      */
+/*      hInstance = NULL                Returns the memory requirements                 */
+/*      hInstance = Instance handle     Returns the memory requirements and             */
+/*                                      allocated base addresses for the instance       */
+/*                                                                                      */
+/*  When this function is called for memory allocation (hInstance=NULL) the memory      */
+/*  base address pointers are NULL on return.                                           */
+/*                                                                                      */
+/*  When the function is called for free (hInstance = Instance Handle) the memory       */
+/*  table returns the allocated memory and base addresses used during initialisation.   */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pMemoryTable            Pointer to an empty memory definition table                 */
+/*  pInstParams             Pointer to the instance parameters                          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When one of pMemoryTable or pInstParams is NULL             */
+/*  LVM_OUTOFRANGE          When any of the Instance parameters are out of range        */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetMemoryTable(LVM_Handle_t         hInstance,
+                                       LVM_MemTab_t         *pMemoryTable,
+                                       LVM_InstParams_t     *pInstParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetInstanceHandle                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to create a bundle instance. It returns the created instance  */
+/*  handle through phInstance. All parameters are set to their default, inactive state. */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  phInstance              pointer to the instance handle                              */
+/*  pMemoryTable            Pointer to the memory definition table                      */
+/*  pInstParams             Pointer to the instance parameters                          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Initialisation succeeded                                    */
+/*  LVM_ALIGNMENTERROR      Instance or scratch memory on incorrect alignment           */
+/*  LVM_NULLADDRESS         Instance or scratch memory has a NULL pointer               */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function must not be interrupted by the LVM_Process function                */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetInstanceHandle(LVM_Handle_t        *phInstance,
+                                          LVM_MemTab_t        *pMemoryTable,
+                                          LVM_InstParams_t    *pInstParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_ClearAudioBuffers                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to clear the internal audio buffers of the bundle.            */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Buffers Cleared                                             */
+/*  LVM_NULLADDRESS         Instance is NULL                                            */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_ClearAudioBuffers(LVM_Handle_t  hInstance);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                 LVM_GetControlParameters                                   */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Request the LifeVibes module parameters. The current parameter set is returned      */
+/*  via the parameter pointer.                                                          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance                Instance handle                                            */
+/*  pParams                  Pointer to an empty parameter structure                    */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS          Succeeded                                                      */
+/*  LVM_NULLADDRESS      when any of hInstance or pParams is NULL                       */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetControlParameters(LVM_Handle_t           hInstance,
+                                             LVM_ControlParams_t    *pParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetControlParameters                                    */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Sets or changes the LifeVibes module parameters.                                    */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*  pParams                 Pointer to a parameter structure                            */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance, pParams or any control pointers are NULL    */
+/*  LVM_OUTOFRANGE          When any of the control parameters are out of range         */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetControlParameters(LVM_Handle_t           hInstance,
+                                             LVM_ControlParams_t    *pParams);
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_Process                                                 */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  Process function for the LifeVibes module.                                          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance handle                                             */
+/*  pInData                 Pointer to the input data                                   */
+/*  pOutData                Pointer to the output data                                  */
+/*  NumSamples              Number of samples in the input buffer                       */
+/*  AudioTime               Audio Time of the current input data in milli-seconds       */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS            Succeeded                                                    */
+/*  LVM_INVALIDNUMSAMPLES  When the NumSamples is not a valied multiple in unmanaged    */
+/*                         buffer mode                                                  */
+/*  LVM_ALIGNMENTERROR     When either the input our output buffers are not 32-bit      */
+/*                         aligned in unmanaged mode                                    */
+/*  LVM_NULLADDRESS        When one of hInstance, pInData or pOutData is NULL           */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. The input and output buffers must be 32-bit aligned                              */
+/*  2. Number of samples is defined as follows:                                         */
+/*      MONO                the number of samples in the block                          */
+/*      MONOINSTEREO        the number of sample pairs in the block                     */
+/*      STEREO              the number of sample pairs in the block                     */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_Process(LVM_Handle_t                hInstance,
+                                const LVM_INT32             *pInData,
+                                LVM_INT32                   **pOutData,
+                                LVM_UINT16                  NumSamples,
+                                LVM_UINT32                  AudioTime);
+
+
+#ifdef ALGORITHM_AVL
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetAVLGain                                              */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to retrieve the AVL last generated gain in Q16.15             */
+/*  linear values.                                                                      */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pAVL_Gain               Pointer to the gain                                         */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance or pAVL_Gain are null addresses              */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetAVLGain( LVM_Handle_t    hInstance,
+                                    LVM_INT32       *pAVL_Gain);
+
+
+#endif /* ALGORITHM_AVL */
+
+#ifdef ALGORITHM_EQNB
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetHeadroomParams                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to set the automatic headroom management parameters.         */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pHeadroomParams         Pointer to headroom parameter structure                     */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetHeadroomParams(  LVM_Handle_t            hInstance,
+                                            LVM_HeadroomParams_t    *pHeadroomParams);
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetHeadroomParams                                       */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/*  This function is used to get the automatic headroom management parameters.          */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pHeadroomParams         Pointer to headroom parameter structure (output)            */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         When hInstance or pHeadroomParams are NULL                  */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1.  This function may be interrupted by the LVM_Process function                    */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetHeadroomParams(  LVM_Handle_t            hInstance,
+                                            LVM_HeadroomParams_t    *pHeadroomParams);
+#endif /* ALGORITHM_EQNB */
+
+#ifdef ALGORITHM_PSA
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_GetSpectrum                                             */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/* This function is used to retrieve Spectral information at a given Audio time         */
+/* for display usage                                                                    */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pCurrentPeaks           Pointer to location where currents peaks are to be saved    */
+/*  pPastPeaks              Pointer to location where past peaks are to be saved        */
+/*  pCentreFreqs            Pointer to location where centre frequency of each band is  */
+/*                          to be saved                                                 */
+/*  AudioTime               Audio time at which the spectral information is needed      */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         If any of input addresses are NULL                          */
+/*  LVM_WRONGAUDIOTIME      Failure due to audio time error                             */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                     */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_GetSpectrum( LVM_Handle_t            hInstance,
+                                     LVM_INT8                *pCurrentPeaks,
+                                     LVM_INT8                *pPastPeaks,
+                                     LVM_UINT16              *pCentreFreqs,
+                                     LVM_UINT32              AudioTime);
+
+
+#endif /* ALGORITHM_PSA */
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/* FUNCTION:                LVM_SetVolumeNoSmoothing                                    */
+/*                                                                                      */
+/* DESCRIPTION:                                                                         */
+/* This function is used to set output volume without any smoothing                     */
+/*                                                                                      */
+/* PARAMETERS:                                                                          */
+/*  hInstance               Instance Handle                                             */
+/*  pParams                 Control Parameters, only volume value is used here          */
+/*                                                                                      */
+/* RETURNS:                                                                             */
+/*  LVM_SUCCESS             Succeeded                                                   */
+/*  LVM_NULLADDRESS         If any of input addresses are NULL                          */
+/*  LVM_OUTOFRANGE          When any of the control parameters are out of range         */
+/*                                                                                      */
+/* NOTES:                                                                               */
+/*  1. This function may be interrupted by the LVM_Process function                     */
+/*                                                                                      */
+/****************************************************************************************/
+#ifdef __DLL_EXPORT
+__declspec(dllexport)
+#endif /* __DLL_EXPORT */
+LVM_ReturnStatus_en LVM_SetVolumeNoSmoothing( LVM_Handle_t           hInstance,
+                                              LVM_ControlParams_t    *pParams);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif      /* __LVM_H__ */
+
+

--- a/third_party/include/nxp/eap/EAP_Includes/LVC_Types.h
+++ b/third_party/include/nxp/eap/EAP_Includes/LVC_Types.h
@@ -1,0 +1,417 @@
+/*  Copyright 2004-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ * This license applies ONLY to this header file LVC_Types.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/****************************************************************************************
+
+     $Author: beq07720 $
+     $Revision: 130089 $
+     $Date: 2019-07-24 07:46:43 +0200 (Wed, 24 Jul 2019) $
+
+*****************************************************************************************/
+
+/** @file
+ *  Header file defining the standard LifeVibes types for use in the application layer
+ *  interface of all LifeVibes modules
+ */
+
+#ifndef LVC_TYPES_H
+#define LVC_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  definitions                                                                         */
+/*                                                                                      */
+/****************************************************************************************/
+
+#define LVM_NULL                (void *)0           ///< NULL pointer
+
+#define LVM_TRUE                1                   ///< Boolean True
+#define LVM_FALSE               0                   ///< Boolean False
+
+#define LVM_MAXINT_8            127                 ///< Maximum positive integer size
+#define LVM_MAXINT_16           32767               ///< Maximum signed int 16 bits number
+#define LVM_MAXUINT_16          65535U              ///< Maximum un-signed int 16 bits number
+#define LVM_MAXINT_32           2147483647          ///< Maximum signed int 32 bits number
+#define LVM_MAXUINT_32          4294967295U         ///< Maximum un-signed int 32 bits number
+#define LVM_MININT_32           0x80000000U         ///< Minimum signed int 32 bit number in 2's complement form
+
+#define LVM_MAXENUM             2147483647          ///< Maximum value for enumerator
+#define LVM_MODULEID_MASK       0xFF00              ///< Mask to extract the calling module ID from callbackId
+#define LVM_EVENTID_MASK        0x00FF              ///< Mask to extract the callback event from callbackId
+
+/* Memory table*/
+#define LVM_MEMREGION_PERSISTENT_SLOW_DATA      0   ///< Offset to the instance memory region
+#define LVM_MEMREGION_PERSISTENT_FAST_DATA      1   ///< Offset to the persistent data memory region
+#define LVM_MEMREGION_PERSISTENT_FAST_COEF      2   ///< Offset to the persistent coefficient memory region
+#define LVM_MEMREGION_TEMPORARY_FAST            3   ///< Offset to temporary memory region
+
+#define LVM_NR_MEMORY_REGIONS                   4   ///< Number of memory regions
+
+#define LVM_MODE_LVWIREFORMAT_LENGTH (4) ///< Number of bytes to encode @ref LVM_Mode_en in LVWireFormat
+#define LVM_CONFIG_LVWIREFORMAT_LENGTH (4) ///< Number of bytes to encode @ref LVM_Config_en in LVWireFormat
+#define LVM_FS_LVWIREFORMAT_LENGTH (4) ///< Number of bytes to encode @ref LVM_Fs_en sample Rate in LVWireFormat
+#define LVM_CHANNELTYPE_LVWIREFORMAT_LENGTH (4) ///< Number of bytes to encode @ref LVM_ChannelType_en in LVWireFormat
+
+#define LVM_CHAR_LVWIREFORMAT_LENGTH   (1) ///< Number of bytes to encode ASCII character in LVWireFormat
+#define LVM_INT8_LVWIREFORMAT_LENGTH   (1) ///< Number of bytes to encode Signed 8-bit word in LVWireFormat
+#define LVM_UINT8_LVWIREFORMAT_LENGTH   (1) ///< Number of bytes to encode Unsigned 8-bit word in LVWireFormat
+
+#define LVM_INT16_LVWIREFORMAT_LENGTH   (2) ///< Number of bytes to encode Signed 16-bit word in LVWireFormat
+#define LVM_UINT16_LVWIREFORMAT_LENGTH   (2) ///< Number of bytes to encode Unsigned 16-bit word in LVWireFormat
+
+#define LVM_INT32_LVWIREFORMAT_LENGTH   (4) ///< Number of bytes to encode Signed 32-bit word in LVWireFormat
+#define LVM_UINT32_LVWIREFORMAT_LENGTH   (4) ///< Number of bytes to encode Unsigned 32-bit word in LVWireFormat
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Basic types                                                                         */
+/*                                                                                      */
+/****************************************************************************************/
+
+typedef     char                LVM_CHAR;           ///< ASCII character
+
+typedef     char                LVM_INT8;           ///< Signed 8-bit word
+typedef     unsigned char       LVM_UINT8;          ///< Unsigned 8-bit word
+
+typedef     short               LVM_INT16;          ///< Signed 16-bit word
+typedef     unsigned short      LVM_UINT16;         ///< Unsigned 16-bit word
+
+#if (defined __LP64__) && __LP64__
+typedef     int                 LVM_INT32;          ///< Signed 32-bit word
+typedef     unsigned int        LVM_UINT32;         ///< Unsigned 32-bit word
+// Type macros
+#define LVM_PRINTF_FORMAT_SPECIFIER_INT32 "d"
+#define LVM_PRINTF_FORMAT_SPECIFIER_UINT32 "u"
+#elif defined(TOOLCHAIN_ADK)                        // CSR ADK
+typedef     int                 LVM_INT32;          ///< Signed 32-bit word
+typedef     unsigned int        LVM_UINT32;         ///< Unsigned 32-bit word
+// Type macros
+#define LVM_PRINTF_FORMAT_SPECIFIER_INT32 "d"
+#define LVM_PRINTF_FORMAT_SPECIFIER_UINT32 "u"
+#else // (defined __LP64__) && __LP64__
+typedef     long                 LVM_INT32;         ///< Signed 32-bit word
+typedef     unsigned long        LVM_UINT32;        ///< Unsigned 32-bit word
+// Type macros
+#define LVM_PRINTF_FORMAT_SPECIFIER_INT32 "li"
+#define LVM_PRINTF_FORMAT_SPECIFIER_UINT32 "lu"
+#endif // (defined __LP64__) && __LP64__
+
+typedef     float                 LVM_FLOAT;          ///< Single Precision floating point type
+typedef     double                LVM_DOUBLE;         ///< Double Precision floating point type
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Standard Enumerated types                                                           */
+/*                                                                                      */
+/****************************************************************************************/
+
+/**
+The @ref LVM_Mode_en enumerated type is used to set the operating mode of a particular feature inside the LifeVibes modules.
+The feature can be separately set to enable the feature processing (i.e., ON) or to disable all feature processing
+modules (i.e., OFF).
+*/
+typedef enum
+{
+    LVM_MODE_OFF    = 0,     ///< LVM module disabled
+    LVM_MODE_ON     = 1,     ///< LVM module enabled
+	LVM_MODE_MUTE   = 2,     ///< LVM module muted
+    LVM_MODE_DUMMY  = LVM_MAXENUM
+} LVM_Mode_en;
+
+/**
+Sets stream Format
+*/
+typedef enum
+{
+    LVM_STEREO          = 0,           ///<Stereo stream
+    LVM_MONOINSTEREO    = 1,           ///<Mono in stereo stream
+    LVM_MONO            = 2,           ///<Mono stream
+    LVM_5DOT1           = 3,           ///<stream 5.1 formatted
+    LVM_7DOT1           = 4,           ///<stream 7.1 formatted
+    LVM_SOURCE_DUMMY    = LVM_MAXENUM
+} LVM_Format_en;
+
+/**
+Sets Speaker type
+*/
+typedef enum
+{
+    LVM_SPEAKER_MONO    = 0,        ///< Mono type speaker
+    LVM_SPEAKER_STEREO  = 1,        ///< Stereo type speaker
+    LVM_SPEAKER_DUMMY   = LVM_MAXENUM
+} LVM_SpeakerType_en;
+
+/**
+Sets Word length
+*/
+typedef enum
+{
+    LVM_16_BIT      = 0,           ///< 16 bit word length
+    LVM_32_BIT      = 1,           ///< 32 bit word length
+    LVM_WORDLENGTH_DUMMY = LVM_MAXENUM
+} LVM_WordLength_en;
+
+/**
+The LVM product supports the sample rates specified in @ref LVM_Fs_en. The input and output sample rates are always the same.
+*/
+typedef enum
+{
+    LVM_FS_8000  = 0,              ///< 8k sampling rate
+    LVM_FS_11025 = 1,              ///< 11.025k sampling rate
+    LVM_FS_12000 = 2,              ///< 12k sampling rate
+    LVM_FS_16000 = 3,              ///< 16k sampling rate
+    LVM_FS_22050 = 4,              ///< 22.050k sampling rate
+    LVM_FS_24000 = 5,              ///< 24k sampling rate
+    LVM_FS_32000 = 6,              ///< 32k sampling rate
+    LVM_FS_44100 = 7,              ///< 44.1k sampling rate
+    LVM_FS_48000 = 8,              ///< 48k sampling rate
+	LVM_FS_96000 = 9,
+    LVM_FS_COUNT = 10,             ///< Max sampling rate count
+    LVM_FS_INVALID = LVM_MAXENUM-1,
+    LVM_FS_DUMMY = LVM_MAXENUM
+} LVM_Fs_en;
+
+/**
+The LVM product supports the sample rates specified in @ref LVM_Fs_HDAudio_en. The input and output sample rates are always the same.
+*/
+typedef enum
+{
+    LVM_FS_HDAUDIO_8000  = 0,              ///< 8k sampling rate
+    LVM_FS_HDAUDIO_11025 = 1,              ///< 11.025k sampling rate
+    LVM_FS_HDAUDIO_16000 = 2,              ///< 16k sampling rate
+    LVM_FS_HDAUDIO_22050 = 3,              ///< 22.050k sampling rate
+    LVM_FS_HDAUDIO_32000 = 4,              ///< 32k sampling rate
+    LVM_FS_HDAUDIO_44100 = 5,              ///< 44.1k sampling rate
+    LVM_FS_HDAUDIO_48000 = 6,              ///< 48k sampling rate
+    LVM_FS_HDAUDIO_88200 = 7,              ///< 88.2k sampling rate
+    LVM_FS_HDAUDIO_96000 = 8,              ///< 96k sampling rate
+    LVM_FS_HDAUDIO_176400 = 9,             ///< 176.4k sampling rate
+    LVM_FS_HDAUDIO_192000 = 10,            ///< 192k sampling rate
+    LVM_FS_HDAUDIO_COUNT = 11,             ///< Max sampling rate count
+    LVM_FS_HDAUDIO_INVALID = LVM_MAXENUM-1,
+    LVM_FS_HDAUDIO_DUMMY = LVM_MAXENUM
+} LVM_Fs_HDAudio_en;
+
+/**
+The @ref LVM_PcmFormat_en enumerated type identifies the different PCM formats that can be configured
+*/
+typedef enum {
+    LVM_PCMFORMAT_16_BIT             = 0, ///< PCM signed Q0.15
+    LVM_PCMFORMAT_32_BIT             = 1, ///< PCM signed Q0.31
+    LVM_PCMFORMAT_8_24_BIT           = 2, ///< PCM signed Q7.24
+    LVM_PCMFORMAT_COUNT              = 3, ///< Max PCM Format count
+    LVM_PCMFORMAT_DUMMY              = LVM_MAXENUM
+} LVM_PcmFormat_en;
+
+/**
+The enumerated type is used to select the reset mode for the module.
+@ref LVM_RESET_SOFT is used to select a soft reset (or partial reset) and @ref LVM_RESET_HARD is
+used to select a hard reset (full re-initialization).
+*/
+typedef enum
+{
+/**
+<table border>
+   <tr>
+       <td><b>Name</b></td>
+       <td><b>MODE</b></td>
+   </tr>
+   <tr>
+       <td>ResetType</td>
+       <td>@ref LVM_RESET_SOFT</td>
+   </tr>
+   <tr>
+       <td></td>
+       <td>@ref LVM_RESET_HARD</td>
+   </tr>
+</table>
+*/
+    LVM_RESET_SOFT    = 0,         ///< Reset type for LVM where a partial reset of the module should be performed
+    LVM_RESET_HARD    = 1,         ///< Reset type for LVM where a full reset of the module should be performed
+    LVM_RESET_DUMMY   = LVM_MAXENUM
+} LVM_ResetType_en;
+
+/**
+The @ref LVM_MemoryTypes_en enumerated type identifies the memory region types so that they can be correctly placed in memory
+by the calling application.
+The module initially has no permanent memory storage and makes no use of persistent memory allocation internally.
+The calling application must allocate memory for the module to use.
+
+Four memory regions are required:
+@li @ref LVM_MEMREGION_PERSISTENT_SLOW_DATA : this type of memory is used to store all the control data that needs to be saved between two consecutive calls to the process function.
+@li @ref LVM_MEMREGION_PERSISTENT_FAST_DATA : this type of memory is used to store data such as filter history
+@li @ref LVM_MEMREGION_PERSISTENT_FAST_COEF : this type of memory is used to store filter coefficients.
+@li @ref LVM_MEMREGION_TEMPORARY_FAST (scratch): this type of memory is used to store temporary data. This memory can be reused by the application in between calls to the process function.
+
+This collection of memory regions forms the module instance.
+
+Typically the memory is allocated by the application dynamically; however, it can be allocated statically if required.
+The sizes of the memory regions can be found by running the GetMemoryTable functions on a simulator and noting
+the returned values. Alternatively contact NXP who can provide the figures.
+It is possible that these memory sizes will change between release versions of the library and hence the dynamic memory allocation method is preferred where possible.
+On some target platforms the placement of memory regions is critical for achieving optimal performance of the module.
+*/
+typedef enum
+{
+    LVM_PERSISTENT_SLOW_DATA    = LVM_MEMREGION_PERSISTENT_SLOW_DATA,       ///< Persistent slow memory region
+    LVM_PERSISTENT_FAST_DATA    = LVM_MEMREGION_PERSISTENT_FAST_DATA,       ///< Persistent fast memory region
+    LVM_PERSISTENT_FAST_COEF    = LVM_MEMREGION_PERSISTENT_FAST_COEF,       ///< Persisten fast memory for coefficient storage
+    LVM_TEMPORARY_FAST          = LVM_MEMREGION_TEMPORARY_FAST,             ///< Temporary fast memory region
+    LVM_MEMORYTYPE_DUMMY        = LVM_MAXENUM
+} LVM_MemoryTypes_en;
+
+/**
+Sets mod of Configuration
+*/
+typedef enum
+{
+    LVM_CONFIG_HANDSET                       = 0,                  ///< Handset configuration
+    LVM_CONFIG_SPEAKERPHONE                  = 1,                  ///< Speaker mod configuration
+    LVM_CONFIG_STEREOHEADSET                 = 2,                  ///< Stereo Headset configuration
+    LVM_CONFIG_HEADSET_ENDFIRE               = 3,                  ///< Close-microphone endfire headset configuration
+    LVM_CONFIG_HEADSET_CALLING               = 4,                  ///< Ear cup mics for calling
+    LVM_CONFIG_HEADSET_CALLING_BOOM          = 5,                  ///< Ear cup and boom mics for calling
+    LVM_CONFIG_HEADSET_FRONTEND              = 6,                  ///< Ear cup mics for frontend pre enhancement
+    LVM_CONFIG_HEADSET_FRONTEND_BOOM         = 7,                  ///< Ear cup and boom mics for frontend pre enhancement
+    LVM_CONFIG_DUMMY                         = LVM_MAXENUM
+} LVM_Config_en;
+
+/**
+Sets Channel Type
+*/
+typedef enum
+{
+    LVM_MICROPHONE_CHANNEL        = 0,                  ///< Microphone Channel
+    LVM_SPEAKER_CHANNEL           = 1,                  ///< Speaker Channel
+    LVM_SPEAKER_AS_MIC_CHANNEL    = 2,                  ///< Speaker or Receiver behaving as a Microphone Channel
+    LVM_MICROPHONE_AS_FAREND_REFERENCE_CHANNEL = 3,     ///< Microphone as Farend Reference Channel
+    LVM_CHANNEL_DUMMY             = LVM_MAXENUM
+} LVM_ChannelType_en;
+
+/**
+Sets Tunability of tuning parameters
+*/
+typedef enum
+{
+    LVM_TUNABILITY_BASIC     = 0,                  ///< Basic tuning parameter, always visible
+    LVM_TUNABILITY_ADVANCED  = 1,                  ///< Expert tuning parameter, only visible in advanced tuning mode
+    LVM_TUNABILITY_RESERVED  = 2,                  ///< Reserved tuning parameter, not visible
+    LVM_TUNABILITY_DUMMY     = LVM_MAXENUM
+} LVM_Tunability_en;
+
+/**
+Sets Volume Dependence
+*/
+typedef enum
+{
+    LVM_VOLUME_DEPENDENT          = 0,                  ///< Volume dependent
+    LVM_VOLUME_INDEPENDENT        = 1,                  ///< Volume independent
+    LVM_VOLUMEDEPENDENCE_DUMMY    = LVM_MAXENUM
+} LVM_VolumeDependence_en;
+
+/**
+The @ref LVM_MemoryRegion_st type defines a memory region by specifying its size in bytes, its region type and its base pointer.
+@see LVM_MemoryTypes_en
+*/
+typedef struct
+{
+    LVM_UINT32                  Size;                   ///< The size of the memory region in bytes
+    LVM_MemoryTypes_en          Type;                   ///< Type of memory region
+    void                        *pBaseAddress;          ///< Pointer to the memory region base address
+} LVM_MemoryRegion_st;
+
+/**
+The LVM_MemoryTable_st type defines the memory requirements of the module as an array of region definitions.
+The number of required memory regions is given by the constant @ref LVM_NR_MEMORY_REGIONS
+@see LVM_MemoryRegion_st
+*/
+typedef struct
+{
+    LVM_MemoryRegion_st         Region[LVM_NR_MEMORY_REGIONS];  ///< One definition of all memory regions
+} LVM_MemoryTable_st;
+
+/**
+The LVM_ContextTable_st type defines a memory region by specifying its size in bytes and its base pointer.
+@see LVM_ContextTable_st
+*/
+typedef struct
+{
+    LVM_UINT32 ContextTableLength;  ///< its size in bytes
+    LVM_CHAR   *pContext;           ///< its base pointer
+} LVM_ContextTable_st;
+
+/**
+Beats Per Minute Structure
+*/
+typedef struct
+{
+    LVM_INT16                   ShortTermMinimum;       ///< Beats per minute in Q9.6 format
+    LVM_INT16                   ShortTermAverage;       ///< Beats per minute in Q9.6 format
+    LVM_INT16                   ShortTermMaximum;       ///< Beats per minute in Q9.6 format
+
+    LVM_INT16                   Confidence;             ///< Beat confidence level: 0 = no confidence, 32767 = maximum confidence
+    LVM_INT16                   Strength;               ///< Beat strength level:   0 = no beat, 32767 = maximum strength beat
+    LVM_INT16                   LongTermMinimum;        ///< Beats per minute in Q9.6 format
+    LVM_INT16                   LongTermAverage;        ///< Beats per minute in Q9.6 format
+    LVM_INT16                   LongTermMaximum;        ///< Beats per minute in Q9.6 format
+
+} LVM_BPMModuleStats_st;
+
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  Standard Function Prototypes                                                        */
+/*                                                                                      */
+/****************************************************************************************/
+/**
+@brief General purpose callback function
+
+@param pCallbackData           Pointer to the callback data structure
+@param pGeneralPurpose         General purpose pointer (e.g. to a data structure needed in the callback)
+@param PresetLength            General purpose variable (e.g. to be used as callback ID)
+@return \ref LVM_INT32
+*/
+typedef LVM_INT32 (*LVM_Callback)(void          *pCallbackData,
+                                  void          *pGeneralPurpose,
+                                  LVM_INT16     GeneralPurpose );
+
+/****************************************************************************************/
+/*                                                                                      */
+/*  End of file                                                                         */
+/*                                                                                      */
+/****************************************************************************************/
+
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif  /* LVC_TYPES_H */

--- a/tools/topology/topology1/CMakeLists.txt
+++ b/tools/topology/topology1/CMakeLists.txt
@@ -56,6 +56,7 @@ set(TPLGS
 	"sof-imx8mp-micfil\;sof-imx8mp-micfil"
 	"sof-imx8mp-btsco-dual-8ch\;sof-imx8mp-btsco-dual-8ch"
 	"sof-imx8-wm8960\;sof-imx8mp-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3"
+	"sof-imx8-wm8960\;sof-imx8mp-eap-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eap\;-DSAI_INDEX=3"
 	"sof-imx8-wm8960\;sof-imx8mp-wm8904\;-DCODEC=wm8904\;-DRATE=44100\;-DPPROC=volume\;-DSAI_INDEX=3"
 	"sof-imx8-wm8960\;sof-imx8mp-wm8962\;-DCODEC=wm8962\;-DRATE=48000\;-DPPROC=volume\;-DSAI_INDEX=3"
 	"sof-imx8-wm8960\;sof-imx8mp-eq-iir-wm8960\;-DCODEC=wm8960\;-DRATE=48000\;-DPPROC=eq-iir-volume\;-DSAI_INDEX=3"

--- a/tools/topology/topology1/m4/eap.m4
+++ b/tools/topology/topology1/m4/eap.m4
@@ -1,0 +1,69 @@
+divert(-1)
+
+dnl Define macro for EAP (Essential Audio Processing) widget
+DECLARE_SOF_RT_UUID("eap", eap_uuid, 0x127f4eec, 0x23fa, 0x11f0,
+                    0xa4, 0xa6, 0xbf, 0x0c, 0xd6, 0xb4, 0x58, 0x3b)
+
+dnl EAP(name)
+define(`N_EAP', `EAP'PIPELINE_ID`.'$1)
+
+dnl W_EAP(name, format, periods_sink, periods_source, core, kcontrols_list)
+define(`W_EAP',
+`SectionVendorTuples."'N_EAP($1)`_tuples_uuid" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."uuid" {'
+`		SOF_TKN_COMP_UUID'		STR(eap_uuid)
+`	}'
+`}'
+`SectionData."'N_EAP($1)`_data_uuid" {'
+`	tuples "'N_EAP($1)`_tuples_uuid"'
+`}'
+`SectionVendorTuples."'N_EAP($1)`_tuples_w" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."word" {'
+`		SOF_TKN_COMP_PERIOD_SINK_COUNT'		STR($3)
+`		SOF_TKN_COMP_PERIOD_SOURCE_COUNT'	STR($4)
+`		SOF_TKN_COMP_CORE_ID'			STR($5)
+`	}'
+`}'
+`SectionData."'N_EAP($1)`_data_w" {'
+`	tuples "'N_EAP($1)`_tuples_w"'
+`}'
+`SectionVendorTuples."'N_EAP($1)`_tuples_str" {'
+`	tokens "sof_comp_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_COMP_FORMAT'	STR($2)
+`	}'
+`}'
+`SectionData."'N_EAP($1)`_data_str" {'
+`	tuples "'N_EAP($1)`_tuples_str"'
+`}'
+`SectionVendorTuples."'N_EAP($1)`_tuples_str_type" {'
+`	tokens "sof_process_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_PROCESS_TYPE'	"EAP"
+`	}'
+`}'
+`SectionData."'N_EAP($1)`_data_str_type" {'
+`	tuples "'N_EAP($1)`_tuples_str_type"'
+`}'
+`SectionWidget."'N_EAP($1)`" {'
+`	index "'PIPELINE_ID`"'
+`	type "effect"'
+`	no_pm "true"'
+`	data ['
+`		"'N_EAP($1)`_data_uuid"'
+`		"'N_EAP($1)`_data_w"'
+`		"'N_EAP($1)`_data_str"'
+`		"'N_EAP($1)`_data_str_type"'
+`	]'
+`	enum ['
+		$6
+		$7
+`	]'
+`	bytes ['
+		$8
+`	]'
+`}')
+
+divert(0)dnl

--- a/tools/topology/topology1/m4/eap_controls.m4
+++ b/tools/topology/topology1/m4/eap_controls.m4
@@ -1,0 +1,12 @@
+
+# EAP supported Audio Processing algorithms
+CONTROLENUM_LIST(DEF_EAP_CFG_VALUES,
+	LIST(`	', `"Off"', `"AutoVolumeLeveler"', `"ConcertSound"', `"LoudnessMaximiser"', `"MusicEnhancerRMSLimiter"', `"VoiceEnhancer"'))
+
+# TDFB enum control
+C_CONTROLENUM(DEF_EAP_CFG, PIPELINE_ID,
+	DEF_EAP_CFG_VALUES,
+	LIST(`	', ENUM_CHANNEL(FC, 3, 0)),
+	CONTROLENUM_OPS(enum,
+	257 binds the mixer control to enum get/put handlers,
+	257, 257))

--- a/tools/topology/topology1/sof/pipe-eap-playback.m4
+++ b/tools/topology/topology1/sof/pipe-eap-playback.m4
@@ -1,0 +1,70 @@
+# Low Latency Passthrough with volume Pipeline and PCM
+#
+# Pipeline Endpoints for connection are :-
+#
+#  host PCM_P --> B0 --> EAP 0 --> B1 --> sink DAI0
+
+# Include topology builder
+include(`utils.m4')
+include(`buffer.m4')
+include(`pcm.m4')
+include(`dai.m4')
+include(`mixercontrol.m4')
+include(`bytecontrol.m4')
+include(`enumcontrol.m4')
+include(`pipeline.m4')
+include(`eap.m4')
+
+#
+# Controls
+#
+# Include defines for EAP controls
+include(`eap_controls.m4')
+
+#
+# Components and Buffers
+#
+# Host "EAP Playback" PCM
+# with 2 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, EAP Playback, 2, 0)
+
+# "EAP 0" has x sink period and 2 source periods
+W_EAP(0, PIPELINE_FORMAT, DAI_PERIODS, 2, SCHEDULE_CORE,
+	LIST(`		', "DEF_EAP_CFG"))
+
+# Playback Buffers
+W_BUFFER(0, COMP_BUFFER_SIZE(2,
+	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS,
+	COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_HOST_MEM_CAP)
+W_BUFFER(1, COMP_BUFFER_SIZE(DAI_PERIODS,
+	COMP_SAMPLE_SIZE(DAI_FORMAT), PIPELINE_CHANNELS,
+	COMP_PERIOD_FRAMES(PCM_MAX_RATE, SCHEDULE_PERIOD)),
+	PLATFORM_DAI_MEM_CAP)
+
+#
+# Pipeline Graph
+#
+#  host PCM_P --> B0 --> EAP --> B1 --> sink DAI0
+P_GRAPH(pipe-eap-playback, PIPELINE_ID,
+	LIST(`		',
+	`dapm(N_BUFFER(0), N_PCMP(PCM_ID))',
+	`dapm(N_EAP(0), N_BUFFER(0))',
+	`dapm(N_BUFFER(1), N_EAP(0))'))
+
+#
+# Pipeline Source and Sinks
+#
+indir(`define', concat(`PIPELINE_SOURCE_', PIPELINE_ID), N_BUFFER(1))
+indir(`define', concat(`PIPELINE_PCM_', PIPELINE_ID),
+	EAP Playback PCM_ID)
+
+#
+# PCM Configuration
+
+#
+PCM_CAPABILITIES(EAP Playback PCM_ID, `S16_LE',
+	PCM_MIN_RATE, PCM_MAX_RATE, 2, PIPELINE_CHANNELS,
+	2, 16, 192, 16384, 65536, 65536)
+
+undefine(`DAI_EAP_CFG')

--- a/uuid-registry.txt
+++ b/uuid-registry.txt
@@ -161,6 +161,7 @@ a62de1af-5964-4e2e-b1677fdc97279a29 template_comp
 e93326d8-0d14-4bf0-bcb9e063d3d80136 twb_sched
 42f8060c-832f-4dbf-b24751e961997b34 up_down_mixer
 b77e677e-5ff4-4188-af14fba8bdbf8682 volume
+127f4eec-23fa-11f0-a4a6bf0cd6b4583b nxp_eap
 8a171323-94a3-4e1d-afe9fe5dbaa4c393 volume4
 1028070e-04e8-46ab-8d8110a0116ce738 wait
 d944281a-afe9-4695-a043d7f62b89538e waves


### PR DESCRIPTION
    comp: Add initial NXP Essential Audio Processing component
    
    NXP’s Essential Audio Processing (EAP) library is a bundle of audio
    processing blocks for enhancing the tonal and spatial perception
    of sound in audio applications
    
    The initial support adds some presets parameters that can be set
    using the standard alsamixer interface.
        * AllEffectOff
        * VoiceEnhancer
        * MusicEnhancer
        * AutoVolumeLeveler
        * ConcertSound
        * LoudnessMaximiser

Library binaries, headers and more documentation can be found here: https://github.com/nxp-mcuxpresso/EAP