### PR TITLE
Topology2: Add nocodec DP core 1 test topologies for MTL, LNL, and PTL

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -95,6 +95,8 @@ Define {
 	DMIC0_PCM_0_NAME		"DMIC SFX1"
 	DMIC0_PCM_1_NAME		"DMIC SFX2"
 	SRC_DOMAIN			"default"
+	# Keep DP_SRC_CORE_ID == SSP2_PCM_CORE_ID, no nested define resolvation ATM
+	DP_SRC_CORE_ID			2
 }
 
 # override defaults with platform-specific config
@@ -248,6 +250,7 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.src.1 {
 					scheduler_domain "$SRC_DOMAIN"
+					core_id $DP_SRC_CORE_ID
 				}
 				Object.Widget.pipeline.1 {
 					core	$SSP2_PCM_CORE_ID
@@ -808,6 +811,7 @@ IncludeByKey.PASSTHROUGH {
 					index	    11
 					rate_in     48000
 					scheduler_domain "$SRC_DOMAIN"
+					core_id $DP_SRC_CORE_ID
 
 					<include/components/src_format_s32_convert_from_48k.conf>
 				}

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -309,6 +309,16 @@ PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-lnl-nocodec.bin,SRC_DOMAIN=DP"
 "cavs-nocodec\;sof-ptl-nocodec-dp-test\;PLATFORM=ptl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-nocodec.bin,SRC_DOMAIN=DP"
 
+# SSP test topology for Data Processing on core 1 SRC for MTL
+"cavs-nocodec\;sof-mtl-nocodec-dp-core-test\;PLATFORM=mtl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-mtl-nocodec.bin,SRC_DOMAIN=DP,DP_SRC_CORE_ID=1"
+# SSP test topology for Data Processing on core 1 SRC for LNL
+"cavs-nocodec\;sof-lnl-nocodec-dp-core-test\;PLATFORM=lnl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-lnl-nocodec.bin,SRC_DOMAIN=DP,DP_SRC_CORE_ID=1"
+# SSP test topology for Data Processing on core 1 SRC for PTL
+"cavs-nocodec\;sof-ptl-nocodec-dp-core-test\;PLATFORM=ptl,NUM_DMICS=4,PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-nocodec.bin,SRC_DOMAIN=DP,DP_SRC_CORE_ID=1"
+
 # Add MFCC to 16 kHz DMIC1, 2ch with NHLT - cAVS
 "sof-hda-generic\;sof-hda-generic-cavs25-2ch-mfcc\;HDA_CONFIG=mix,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-hda-generic-cavs25-2ch-mfcc.bin,\


### PR DESCRIPTION
This commit creates three new topologies, sof-mtl-nocodec-dp-core-test.tplg, sof-lnl-nocodec-dp-core-test.tplg, and sof-ptl-nocodec-dp-core-test.tplg.

They are otherwise the same as the corresponding standard nocodec topologies, but both the src.11.1 on SSP2_Playback and src.5.1 on SSP2 Capture have scheduler_domain attribute set to "DP" and core_id to 1.

This configuration executes SRC components for playback and capture to/from hw:0,2 on DSP core 1 in Data Processing mode, while the rest of the SSP2 pipelines are executed on DSP core 2.