### PR TITLE
[SKIP SOFCI-TEST] .github: workflow: use 24.04LTS for testbench build

### DIFF
--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.10
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout SOF repository (PR source)
@@ -38,11 +38,13 @@ jobs:
         with:
           path: sof
 
+      # note: libasound-dev needed for testbench build which still
+      #       requires system ALSA headers to be present
       - name: apt get
         run: sudo apt-get update &&
                sudo apt-get -y install valgrind ninja-build
                   octave octave-signal automake autoconf libtool
-                  gettext linux-headers-6.11.0-8
+                  gettext libasound2-dev
 
       - name: Build Alsa-lib
         run: |


### PR DESCRIPTION
The 24.10 runner availability is not great and 24.10 is not strictly needed, so use 24.04LTS instead.