### PR TITLE
west.yml: Import cmsis_6 to be used by SOF for Cortex-M targets

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -59,7 +59,7 @@ manifest:
           - mipi-sys-t
           - lz4
           - tinycrypt
-          - cmsis
+          - cmsis_6
 
   self:
     # Changes to submanifests/*.yml files _are_ effective; these have no


### PR DESCRIPTION
After commit
f726cb5123eda12fe ("modules: CMSIS_6: Switch to CMSIS_6 for Cortex-M") SOF needs cmsis_6 to be used for Cortex-M (imx95).

So import cmsis_6 and fix the compilation error.

Fixes: https://github.com/thesofproject/sof/issues/10014