### PR TITLE
rimage: Add support for resigning ace manifest

### DIFF
--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -1730,7 +1730,7 @@ int resign_image(struct image *image)
 		goto out;
 	}
 
-	image->image_end = size;
+	image->image_end = size - i;
 
 	/* check that key size matches */
 	if (image->adsp->man_v2_5 || image->adsp->man_ace_v1_5) {

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -1733,7 +1733,7 @@ int resign_image(struct image *image)
 	image->image_end = size;
 
 	/* check that key size matches */
-	if (image->adsp->man_v2_5) {
+	if (image->adsp->man_v2_5 || image->adsp->man_ace_v1_5) {
 		key_size = 384;
 	} else {
 		key_size = 256;
@@ -1755,6 +1755,8 @@ int resign_image(struct image *image)
 		ret = ri_manifest_sign_v1_8(image);
 	else if (image->adsp->man_v2_5)
 		ret = ri_manifest_sign_v2_5(image);
+	else if (image->adsp->man_ace_v1_5)
+		ret = ri_manifest_sign_ace_v1_5(image);
 	else
 		ret = -EINVAL;
 

--- a/tools/rimage/src/manifest.c
+++ b/tools/rimage/src/manifest.c
@@ -1773,6 +1773,13 @@ int resign_image(struct image *image)
 		goto out;
 	}
 
+	/* Rewrite content before CSE header */
+	size = fwrite(buffer, 1, i, image->out_fd);
+	if (size != i) {
+		ret = file_error("Extended manifest write error", image->out_file);
+		goto out;
+	}
+
 	man_write_fw_mod(image);
 
 out:


### PR DESCRIPTION
Add support for ace 1.5 manifest to resign_image function. Subtract the number of skipped bytes from the file size to avoid going
beyond of memory buffer. Copy data preceding the cse header to the output file to preserve extended manifest.