### PR TITLE
module_adapter: Don't propagate ENOSPC and ENODATA error codes

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -300,7 +300,7 @@ int module_process_sink_src(struct processing_module *mod,
 	/* reset state to idle */
 	md->state = MODULE_IDLE;
 #endif
-	return ret;
+	return 0;
 }
 
 int module_reset(struct processing_module *mod)

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -990,9 +990,12 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 	ret = module_process_sink_src(mod, mod->sources, mod->num_of_sources,
 				      mod->sinks, mod->num_of_sinks);
 
-	if (ret != -ENOSPC && ret != -ENODATA && ret) {
-		comp_err(dev, "module_adapter_sink_source_copy() process failed with error: %x",
-			 ret);
+	if (ret) {
+		if (ret != -ENOSPC && ret != -ENODATA)
+			comp_err(dev, "module_adapter_sink_source_copy() process failed with error: %d",
+				 ret);
+		else
+			ret = 0;
 	}
 
 	/* count number of processed data. To be removed in pipeline 2.0 */


### PR DESCRIPTION
Do not pass non-critical `ENOSPC` and `ENODATA` error codes from a module processing function to the pipeline. The pipeline will stop and enter xrun recovery if a module processing function returns a non-zero value.