### PR TITLE
audio: mic_privacy: Fix incorrect state after D3 exit

### DIFF
--- a/src/include/sof/audio/mic_privacy_manager.h
+++ b/src/include/sof/audio/mic_privacy_manager.h
@@ -51,6 +51,7 @@ uint32_t mic_privacy_get_policy_register(void);
 void mic_privacy_propagate_settings(struct mic_privacy_settings *settings);
 uint32_t mic_privacy_get_dma_zeroing_wait_time(void);
 uint32_t mic_privacy_get_privacy_mask(void);
+uint32_t mic_privacy_get_mic_disable_status(void);
 void mic_privacy_enable_dmic_irq(bool enable_irq);
 void mic_privacy_fill_settings(struct mic_privacy_settings *settings, uint32_t mic_disable_status);
 void mic_privacy_set_gtw_mic_state(struct mic_privacy_data *mic_priv_data,


### PR DESCRIPTION
This PR fixes two issues with the microphone privacy feature during D3 state transitions:

1. Re-establishes proper microphone privacy functionality after D3 resume by:
   - Re-initializing the `mic_privacy_manager` in the `resume_dais()` function
   - Restoring privacy settings after D3 transitions
   - Re-enabling privacy IRQ handlers to ensure continued operation

2. Eliminates unwanted fade effect in audio when resuming from D3 with privacy enabled by:
   - Force setting `mic_privacy_state` to `MUTED` without fade effects

These changes ensure microphone privacy works reliably through power state transitions and correctly mutes audio without any fade artifacts when privacy is enabled.