### PR TITLE
[stable-v2.13] audio: mic_privacy: Fix feature functionality after D3 resume

### DIFF
--- a/src/include/sof/audio/mic_privacy_manager.h
+++ b/src/include/sof/audio/mic_privacy_manager.h
@@ -51,6 +51,7 @@ uint32_t mic_privacy_get_policy_register(void);
 void mic_privacy_propagate_settings(struct mic_privacy_settings *settings);
 uint32_t mic_privacy_get_dma_zeroing_wait_time(void);
 uint32_t mic_privacy_get_privacy_mask(void);
+uint32_t mic_privacy_get_mic_disable_status(void);
 void mic_privacy_enable_dmic_irq(bool enable_irq);
 void mic_privacy_fill_settings(struct mic_privacy_settings *settings, uint32_t mic_disable_status);
 void mic_privacy_set_gtw_mic_state(struct mic_privacy_data *mic_priv_data,


### PR DESCRIPTION
When resuming from D3 state, the microphone privacy feature wasn't properly restored, causing two critical issues:

1. The system didn't respond to privacy button inputs after D3 transitions
2. A short fade-out effect appeared in audio when privacy was enabled, causing test failures that expected complete silence

This patch provides a comprehensive solution by:
- Adding mic_privacy_manager_init() to resume_dais() to ensure proper re-initialization of the microphone privacy subsystem after D3
- Implementing mic_privacy_get_mic_disable_status() to correctly retrieve the current microphone disable status
- Storing the mic_disable_status before entering D3 and comparing it after resume to detect changes during low power state
- Enhancing mic_privacy_enable_dmic_irq() to immediately check for IRQ status after D3 transitions to catch events that occurred during suspended state
- Explicitly resetting fade parameters (fade_in_out_bytes, gain parameters) to ensure immediate silence without fade artifacts when privacy is enabled
- Adding proper error handling and validation to ensure the mic_priv structure is valid before access

With these changes, the microphone privacy feature works correctly through power state transitions and properly mutes audio without fade artifacts when privacy is enabled after D3 resume.


(cherry picked from commit aea81019855fda81692a7c917f95ed29ff82311f)