### PR TITLE
audio: mic_privacy: Fix DSP panic during D3 entry with HW managed mode

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -87,7 +87,7 @@ static void suspend_dais(void)
 		mod = comp_mod(icd->cd);
 		cd = module_get_private_data(mod);
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
-		if (cd->mic_priv)
+		if (cd->mic_priv && mic_privacy_manager_get_policy() == MIC_PRIVACY_FW_MANAGED)
 			mic_disable_status = mic_privacy_get_mic_disable_status();
 #endif
 		dd = cd->dd[0];
@@ -125,7 +125,7 @@ static void resume_dais(void)
 		}
 
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
-		if (cd->mic_priv) {
+		if (cd->mic_priv && mic_privacy_manager_get_policy() == MIC_PRIVACY_FW_MANAGED) {
 			uint32_t current_mic_status = mic_privacy_get_mic_disable_status();
 
 			if (mic_disable_status != current_mic_status) {


### PR DESCRIPTION
When transitioning to D3 state with a pipeline containing a DAI that supports microphone privacy but is in HW-managed mode, the DSP can panic. This occurs because the mic_privacy_get_mic_disable_status() function is called unconditionally during suspend/resume regardless of the privacy mode.

Fix the issue by explicitly checking for
mic_privacy_manager_get_policy() == MIC_PRIVACY_FW_MANAGED before attempting to save/restore the mic disable status. This ensures we only interact with the privacy status when the firmware is responsible for managing it, and allows HW-managed configurations to properly transit through D3 power states without exceptions.

This is a small but critical fix to the previous microphone privacy D3 resume patch, addressing panic cases observed with HDA and SoundWire interfaces.