### PR TITLE
Virtual heaps core

### DIFF
--- a/src/audio/buffers/ring_buffer.c
+++ b/src/audio/buffers/ring_buffer.c
@@ -239,6 +239,21 @@ static int ring_buffer_release_data(struct sof_source *source, size_t free_size)
 	return 0;
 }
 
+int ring_buffer_module_unbind(struct sof_sink *sink)
+{
+	struct ring_buffer *ring_buffer = ring_buffer_from_sink(sink);
+
+	CORE_CHECK_STRUCT(&ring_buffer->audio_buffer);
+
+	/* in case of disconnection, invalidate all cache. This method is guaranteed be called on
+	 * core that have been using sink API
+	 */
+	ring_buffer_invalidate_shared(ring_buffer, ring_buffer->_data_buffer,
+				      ring_buffer->data_buffer_size);
+
+	return 0;
+}
+
 static struct source_ops ring_buffer_source_ops = {
 	.get_data_available = ring_buffer_get_data_available,
 	.get_data = ring_buffer_get_data,
@@ -249,6 +264,7 @@ static struct sink_ops ring_buffer_sink_ops = {
 	.get_free_size = ring_buffer_get_free_size,
 	.get_buffer = ring_buffer_get_buffer,
 	.commit_buffer = ring_buffer_commit_buffer,
+	.on_unbind = ring_buffer_module_unbind,
 };
 
 static const struct audio_buffer_ops audio_buffer_ops = {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1173,9 +1173,9 @@ __cold static int copier_get_hw_params(struct comp_dev *dev, struct sof_ipc_stre
 	return dai_common_get_hw_params(dd, dev, params, dir);
 }
 
-__cold static int copier_bind(struct processing_module *mod, void *data)
+__cold static int copier_bind(struct processing_module *mod, struct bind_info *bind_data)
 {
-	const struct ipc4_module_bind_unbind *const bu = (struct ipc4_module_bind_unbind *)data;
+	const struct ipc4_module_bind_unbind *const bu = bind_data->ipc4_data;
 	const uint32_t src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
 	const uint32_t src_queue_id = bu->extension.r.src_queue;
 	struct copier_data *cd = module_get_private_data(mod);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1202,7 +1202,7 @@ __cold static int copier_bind(struct processing_module *mod, struct bind_info *b
 	return -ENODEV;
 }
 
-__cold static int copier_unbind(struct processing_module *mod, void *data)
+__cold static int copier_unbind(struct processing_module *mod, struct unbind_info *unbind_data)
 {
 	struct copier_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -1212,7 +1212,7 @@ __cold static int copier_unbind(struct processing_module *mod, void *data)
 	if (dev->ipc_config.type == SOF_COMP_DAI) {
 		struct dai_data *dd = cd->dd[0];
 
-		return dai_zephyr_unbind(dd, dev, data);
+		return dai_zephyr_unbind(dd, dev, unbind_data);
 	}
 
 	return 0;

--- a/src/audio/copier/dai_copier.h
+++ b/src/audio/copier/dai_copier.h
@@ -69,7 +69,7 @@ static inline int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, v
 int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 				   struct comp_buffer *multi_endpoint_buffer,
 				   int num_endpoints);
-int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data);
+int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, struct unbind_info *unbind_data);
 #endif
 
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1930,14 +1930,14 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 }
 
 #ifdef CONFIG_IPC_MAJOR_4
-__cold int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
+__cold int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 	struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 
 	assert_can_be_cold();
 
-	bu = (struct ipc4_module_bind_unbind *)data;
+	bu = unbind_data->ipc4_data;
 	buf_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 
 	if (dd && dd->local_buffer) {

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -333,10 +333,10 @@ static int kpb_get_attribute(struct comp_dev *dev,
 /**
  * \brief Initialize KPB sinks when binding.
  * \param[in] dev - component device pointer.
- * \param[in] data - ipc4 bind/unbind data.
+ * \param[in] bind_data - bind/unbind data.
  * \return: none.
  */
-static int kpb_bind(struct comp_dev *dev, void *data)
+static int kpb_bind(struct comp_dev *dev, struct bind_info *bind_data)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	struct ipc4_module_bind_unbind *bu;
@@ -345,7 +345,7 @@ static int kpb_bind(struct comp_dev *dev, void *data)
 
 	comp_dbg(dev, "kpb_bind()");
 
-	bu = (struct ipc4_module_bind_unbind *)data;
+	bu = bind_data->ipc4_data;
 	buf_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 
 	/* We're assuming here that KPB Real Time sink (kpb->sel_sink) is

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -383,7 +383,7 @@ static int kpb_bind(struct comp_dev *dev, struct bind_info *bind_data)
  * \param[in] data - ipc4 bind/unbind data.
  * \return: none.
  */
-static int kpb_unbind(struct comp_dev *dev, void *data)
+static int kpb_unbind(struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
 	struct ipc4_module_bind_unbind *bu;
@@ -391,7 +391,7 @@ static int kpb_unbind(struct comp_dev *dev, void *data)
 
 	comp_dbg(dev, "kpb_bind()");
 
-	bu = (struct ipc4_module_bind_unbind *)data;
+	bu = unbind_data->ipc4_data;
 	buf_id = IPC4_COMP_ID(bu->extension.r.src_queue, bu->extension.r.dst_queue);
 
 	/* Reset sinks when unbinding */

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -790,7 +790,7 @@ static int mixout_bind(struct processing_module *mod, struct bind_info *bind_dat
 	return 0;
 }
 
-static int mixout_unbind(struct processing_module *mod, void *data)
+static int mixout_unbind(struct processing_module *mod, struct unbind_info *unbind_data)
 {
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *mixin;
@@ -800,7 +800,7 @@ static int mixout_unbind(struct processing_module *mod, void *data)
 
 	comp_dbg(mod->dev, "mixout_unbind()");
 
-	bu = (struct ipc4_module_bind_unbind *)data;
+	bu = unbind_data->ipc4_data;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
 
 	/* we are only interested in unbind for mixin -> mixout pair */

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -743,7 +743,7 @@ static int mixout_prepare(struct processing_module *mod,
 	return 0;
 }
 
-static int mixout_bind(struct processing_module *mod, void *data)
+static int mixout_bind(struct processing_module *mod, struct bind_info *bind_data)
 {
 	struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *mixin;
@@ -751,9 +751,7 @@ static int mixout_bind(struct processing_module *mod, void *data)
 	int src_id;
 	struct mixout_data *mixout_data;
 
-	comp_dbg(mod->dev, "mixout_bind() %p", data);
-
-	bu = (struct ipc4_module_bind_unbind *)data;
+	bu = bind_data->ipc4_data;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
 
 	/* we are only interested in bind for mixin -> mixout pair */

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -493,12 +493,12 @@ int module_set_configuration(struct processing_module *mod,
 }
 EXPORT_SYMBOL(module_set_configuration);
 
-int module_bind(struct processing_module *mod, void *data)
+int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 {
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	if (ops->bind)
-		return ops->bind(mod, data);
+		return ops->bind(mod, bind_data);
 	return 0;
 }
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -502,12 +502,12 @@ int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 	return 0;
 }
 
-int module_unbind(struct processing_module *mod, void *data)
+int module_unbind(struct processing_module *mod, struct unbind_info *unbind_data)
 {
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	if (ops->unbind)
-		return ops->unbind(mod, data);
+		return ops->unbind(mod, unbind_data);
 	return 0;
 }
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -495,7 +495,20 @@ EXPORT_SYMBOL(module_set_configuration);
 
 int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 {
+	int ret;
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
+
+	if (bind_data->as_sink) {
+		ret = sink_bind(bind_data->as_sink, mod);
+		if (ret)
+			return ret;
+	}
+
+	if (bind_data->as_source) {
+		ret = source_bind(bind_data->as_source, mod);
+		if (ret)
+			return ret;
+	}
 
 	if (ops->bind)
 		return ops->bind(mod, bind_data);
@@ -504,7 +517,20 @@ int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 
 int module_unbind(struct processing_module *mod, struct unbind_info *unbind_data)
 {
+	int ret;
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
+
+	if (unbind_data->from_sink) {
+		ret = sink_unbind(unbind_data->from_sink);
+		if (ret)
+			return ret;
+	}
+
+	if (unbind_data->from_source) {
+		ret = source_unbind(unbind_data->from_source);
+		if (ret)
+			return ret;
+	}
 
 	if (ops->unbind)
 		return ops->unbind(mod, unbind_data);

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -219,12 +219,12 @@ static bool module_adapter_multi_sink_source_prepare(struct comp_dev *dev)
 	return false;
 }
 
-int module_adapter_bind(struct comp_dev *dev, void *data)
+int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 {
 	struct processing_module *mod = comp_mod(dev);
 	int ret;
 
-	ret = module_bind(mod, data);
+	ret = module_bind(mod, bind_data);
 	if (ret < 0)
 		return ret;
 

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -234,12 +234,12 @@ int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 }
 EXPORT_SYMBOL(module_adapter_bind);
 
-int module_adapter_unbind(struct comp_dev *dev, void *data)
+int module_adapter_unbind(struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 	struct processing_module *mod = comp_mod(dev);
 	int ret;
 
-	ret = module_unbind(mod, data);
+	ret = module_unbind(mod, unbind_data);
 	if (ret < 0)
 		return ret;
 

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -188,13 +188,13 @@ static int tester_free(struct processing_module *mod)
 	return ret;
 }
 
-static int tester_bind(struct processing_module *mod, void *data)
+static int tester_bind(struct processing_module *mod, struct bind_info *bind_data)
 {
 	struct tester_module_data *cd = module_get_private_data(mod);
 	int ret = 0;
 
 	if (cd->tester_case_interface->bind)
-		ret = cd->tester_case_interface->bind(cd->test_case_ctx, mod, data);
+		ret = cd->tester_case_interface->bind(cd->test_case_ctx, mod, bind_data);
 
 	return ret;
 }

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -199,13 +199,13 @@ static int tester_bind(struct processing_module *mod, struct bind_info *bind_dat
 	return ret;
 }
 
-static int tester_unbind(struct processing_module *mod, void *data)
+static int tester_unbind(struct processing_module *mod, struct unbind_info *unbind_data)
 {
 	struct tester_module_data *cd = module_get_private_data(mod);
 	int ret = 0;
 
 	if (cd->tester_case_interface->unbind)
-		ret = cd->tester_case_interface->unbind(cd->test_case_ctx, mod, data);
+		ret = cd->tester_case_interface->unbind(cd->test_case_ctx, mod, unbind_data);
 
 	return ret;
 }

--- a/src/debug/tester/tester.h
+++ b/src/debug/tester/tester.h
@@ -75,7 +75,7 @@ struct tester_test_case_interface {
 	/**
 	 * copy of module bind method, with additional ctx param
 	 */
-	int (*bind)(void *ctx, struct processing_module *mod, void *data);
+	int (*bind)(void *ctx, struct processing_module *mod, struct bind_info *bind_data);
 
 	/**
 	 * copy of module unbind method, with additional ctx param

--- a/src/debug/tester/tester.h
+++ b/src/debug/tester/tester.h
@@ -80,7 +80,7 @@ struct tester_test_case_interface {
 	/**
 	 * copy of module unbind method, with additional ctx param
 	 */
-	int (*unbind)(void *ctx, struct processing_module *mod, void *data);
+	int (*unbind)(void *ctx, struct processing_module *mod, struct unbind_info *unbind_data);
 
 	/**
 	 * copy of module trigger method, with additional ctx param

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -86,14 +86,14 @@ static int idc_ipc4_bind(uint32_t comp_id)
 {
 	struct ipc_comp_dev *ipc_dev;
 	struct idc_payload *payload;
-	struct ipc4_module_bind_unbind *bu;
+	struct bind_info *bu;
 
 	ipc_dev = ipc_get_comp_by_id(ipc_get(), comp_id);
 	if (!ipc_dev)
 		return -ENODEV;
 
 	payload = idc_payload_get(*idc_get(), cpu_get_id());
-	bu = (struct ipc4_module_bind_unbind *)payload;
+	bu = (struct bind_info *)payload;
 
 	return comp_bind(ipc_dev->cd, bu);
 }

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -102,14 +102,14 @@ static int idc_ipc4_unbind(uint32_t comp_id)
 {
 	struct ipc_comp_dev *ipc_dev;
 	struct idc_payload *payload;
-	struct ipc4_module_bind_unbind *bu;
+	struct unbind_info *bu;
 
 	ipc_dev = ipc_get_comp_by_id(ipc_get(), comp_id);
 	if (!ipc_dev)
 		return -ENODEV;
 
 	payload = idc_payload_get(*idc_get(), cpu_get_id());
-	bu = (struct ipc4_module_bind_unbind *)payload;
+	bu = (struct unbind_info *)payload;
 
 	return comp_unbind(ipc_dev->cd, bu);
 }

--- a/src/include/module/audio/sink_api.h
+++ b/src/include/module/audio/sink_api.h
@@ -51,6 +51,7 @@
 struct sof_sink;
 struct sof_audio_stream_params;
 struct sof_ipc_stream_params;
+struct processing_module;
 
 /**
  * this is a definition of internals of sink API
@@ -101,6 +102,14 @@ struct sink_ops {
 	int (*set_alignment_constants)(struct sof_sink *sink,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
+
+	/**
+	 * OPTIONAL
+	 * events called when a module is starting / finishing using of the API
+	 * on the core that the module and API will executed on
+	 */
+	int (*on_bind)(struct sof_sink *sink, struct processing_module *module);
+	int (*on_unbind)(struct sof_sink *sink);
 };
 
 /** internals of sink API. NOT TO BE MODIFIED OUTSIDE OF sink_api.c */
@@ -111,6 +120,7 @@ struct sof_sink {
 	size_t min_free_space;		  /** minimum buffer space required by the module using sink
 					    *  it is module's OBS as declared in module bind IPC
 					    */
+	struct processing_module *bound_module; /* a pointer module that is using sink API */
 	struct sof_audio_stream_params *audio_stream_params; /** pointer to audio params */
 };
 
@@ -289,6 +299,53 @@ static inline uint32_t sink_get_id(struct sof_sink *sink)
 static inline uint32_t sink_get_pipeline_id(struct sof_sink *sink)
 {
 	return sink->audio_stream_params->pipeline_id;
+}
+
+/**
+ * @brief hook to be called when a module connects to the API
+ *
+ * NOTE! it MUST be called at core that a module is bound to
+ */
+static inline int sink_bind(struct sof_sink *sink, struct processing_module *module)
+{
+	int ret = 0;
+
+	if (sink->bound_module)
+		return -EBUSY;
+
+	if (sink->ops->on_bind)
+		ret = sink->ops->on_bind(sink, module);
+
+	if (!ret)
+		sink->bound_module = module;
+
+	return ret;
+}
+
+/**
+ * @brief hook to be called when a module disconnects from the API
+ *
+ * NOTE! it MUST be called at core that a module is bound to
+ */
+static inline int sink_unbind(struct sof_sink *sink)
+{
+	int ret = 0;
+
+	if (!sink->bound_module)
+		return -EINVAL;
+
+	if (sink->ops->on_unbind)
+		ret = sink->ops->on_unbind(sink);
+
+	if (!ret)
+		sink->bound_module = NULL;
+
+	return ret;
+}
+
+static inline struct processing_module *sink_get_bound_module(struct sof_sink *sink)
+{
+	return sink->bound_module;
 }
 
 #endif /* __MODULE_AUDIO_SINK_API_H__ */

--- a/src/include/module/audio/source_api.h
+++ b/src/include/module/audio/source_api.h
@@ -51,6 +51,7 @@
 struct sof_source;
 struct sof_audio_stream_params;
 struct sof_ipc_stream_params;
+struct processing_module;
 
 /**
  * this is a definition of internals of source API
@@ -101,6 +102,14 @@ struct source_ops {
 	int (*set_alignment_constants)(struct sof_source *source,
 				       const uint32_t byte_align,
 				       const uint32_t frame_align_req);
+
+	/**
+	 * OPTIONAL
+	 * events called when a module is starting / finishing using of the API
+	 * on the core that the module and API will executed on
+	 */
+	int (*on_bind)(struct sof_source *source, struct processing_module *module);
+	int (*on_unbind)(struct sof_source *source);
 };
 
 /** internals of source API. NOT TO BE MODIFIED OUTSIDE OF source_api.c */
@@ -112,7 +121,7 @@ struct sof_source {
 					  * source
 					  * it is module's IBS as declared in module bind IPC
 					  */
-
+	struct processing_module *bound_module; /* a pointer module that is using source API */
 	struct sof_audio_stream_params *audio_stream_params;
 };
 
@@ -265,6 +274,53 @@ static inline uint32_t source_get_id(struct sof_source *source)
 static inline uint32_t source_get_pipeline_id(struct sof_source *source)
 {
 	return source->audio_stream_params->pipeline_id;
+}
+
+/**
+ * @brief hook to be called when a module connects to the API
+ *
+ * NOTE! it MUST be called at core that a module is bound to
+ */
+ static inline int source_bind(struct sof_source *source, struct processing_module *module)
+{
+	int ret = 0;
+
+	if (source->bound_module)
+		return -EBUSY;
+
+	if (source->ops->on_bind)
+		ret = source->ops->on_bind(source, module);
+
+	if (!ret)
+		source->bound_module = module;
+
+	return ret;
+}
+
+/**
+ * @brief hook to be called when a module disconnects from the API
+ *
+ * NOTE! it MUST be called at core that a module is bound to
+ */
+static inline int source_unbind(struct sof_source *source)
+{
+	int ret = 0;
+
+	if (!source->bound_module)
+		return -EINVAL;
+
+	if (source->ops->on_unbind)
+		ret = source->ops->on_unbind(source);
+
+	if (!ret)
+		source->bound_module = NULL;
+
+	return ret;
+}
+
+static inline struct processing_module *source_get_bound_module(struct sof_source *source)
+{
+	return source->bound_module;
 }
 
 #endif /* __MODULE_AUDIO_SOURCE_API_H__ */

--- a/src/include/module/module/interface.h
+++ b/src/include/module/module/interface.h
@@ -66,6 +66,7 @@ struct processing_module;
 struct sof_source;
 struct sof_sink;
 struct bind_info;
+struct unbind_info;
 
 /**
  * \struct module_interface
@@ -237,7 +238,7 @@ struct module_interface {
 	 * (optional) Module specific unbind procedure, called when modules are disconnected from
 	 * one another. Usually can be __cold
 	 */
-	int (*unbind)(struct processing_module *mod, void *data);
+	int (*unbind)(struct processing_module *mod, struct unbind_info *unbind_data);
 
 	/**
 	 * (optional) Module specific trigger procedure, called when modules are triggered. Usually

--- a/src/include/module/module/interface.h
+++ b/src/include/module/module/interface.h
@@ -65,6 +65,7 @@ struct output_stream_buffer {
 struct processing_module;
 struct sof_source;
 struct sof_sink;
+struct bind_info;
 
 /**
  * \struct module_interface
@@ -230,7 +231,7 @@ struct module_interface {
 	 * (optional) Module specific bind procedure, called when modules are bound with each other.
 	 * Usually can be __cold
 	 */
-	int (*bind)(struct processing_module *mod, void *data);
+	int (*bind)(struct processing_module *mod, struct bind_info *bind_data);
 
 	/**
 	 * (optional) Module specific unbind procedure, called when modules are disconnected from

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -291,6 +291,25 @@ struct bind_info {
 	struct sof_sink *as_sink;
 };
 
+struct unbind_info {
+	/* pointer to IPC4 bind data */
+	struct ipc4_module_bind_unbind *ipc4_data;	/* pointer to IPC4 bind data */
+	/* pointers to sink or source API of the data provider/consumer
+	 * that is being unbound from the module
+	 *
+	 * As in pipeline2.0 there may be a binding between modules, without a buffer in between,
+	 * it cannot be a pointer to any buffer type
+	 *
+	 * from_source points to source API if a data source is being disconnected to the module in
+	 * this unbind operation, otherwise is NULL
+	 *
+	 * from_sink points to sink API if a data sink is being disconnected from the module in
+	 * this unbind operation, otherwise is NULL
+	 */
+	struct sof_source *from_source;
+	struct sof_sink *from_sink;
+};
+
 /**
  * Audio component operations.
  *
@@ -509,7 +528,7 @@ struct comp_ops {
 	 *
 	 * Usually can be __cold.
 	 */
-	int (*unbind)(struct comp_dev *dev, void *data);
+	int (*unbind)(struct comp_dev *dev, struct unbind_info *unbind_data);
 
 	/**
 	 * Gets config in component.

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -270,6 +270,26 @@ enum comp_copy_type {
 struct comp_driver;
 struct comp_ipc_config;
 union ipc_config_specific;
+struct ipc4_module_bind_unbind;
+
+struct bind_info {
+	/* pointer to IPC4 bind data */
+	struct ipc4_module_bind_unbind *ipc4_data;
+	/* pointers to sink or source API of the data provider/consumer
+	 * that is being bound to the module
+	 *
+	 * As in pipeline2.0 there may be a binding between modules, without a buffer in between,
+	 * it cannot be a pointer to any buffer type
+	 *
+	 * as_source points to source API if a data source is being connected to the module in
+	 * this bind operation, otherwise is NULL
+	 *
+	 * as_sink points to sink API if a data sink is being connected to the module in
+	 * this bind operation, otherwise is NULL
+	 */
+	struct sof_source *as_source;
+	struct sof_sink *as_sink;
+};
 
 /**
  * Audio component operations.
@@ -480,7 +500,7 @@ struct comp_ops {
 	 *
 	 * Usually can be __cold.
 	 */
-	int (*bind)(struct comp_dev *dev, void *data);
+	int (*bind)(struct comp_dev *dev, struct bind_info *bind_data);
 
 	/**
 	 * Unbind, atomic - used to notify component of unbind event.

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -432,29 +432,29 @@ static inline struct comp_driver_list *comp_drivers_get(void)
 }
 
 #if CONFIG_IPC_MAJOR_4
-static inline int comp_ipc4_bind_remote(struct comp_dev *dev, void *data)
+static inline int comp_ipc4_bind_remote(struct comp_dev *dev, struct bind_info *bind_data)
 {
 	struct idc_msg msg = { IDC_MSG_BIND,
 		IDC_EXTENSION(dev->ipc_config.id), dev->ipc_config.core,
-		sizeof(struct ipc4_module_bind_unbind), data};
+		sizeof(*bind_data), bind_data};
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
 }
 #endif
 
-static inline int comp_bind(struct comp_dev *dev, void *data)
+static inline int comp_bind(struct comp_dev *dev, struct bind_info *bind_data)
 {
 #if CONFIG_IPC_MAJOR_4
 	if (dev->drv->ops.bind)
 		return cpu_is_me(dev->ipc_config.core) ?
-			dev->drv->ops.bind(dev, data) : comp_ipc4_bind_remote(dev, data);
+			dev->drv->ops.bind(dev, bind_data) : comp_ipc4_bind_remote(dev, bind_data);
 
 	return 0;
 #else
 	int ret = 0;
 
 	if (dev->drv->ops.bind)
-		ret = dev->drv->ops.bind(dev, data);
+		ret = dev->drv->ops.bind(dev, bind_data);
 
 	return ret;
 #endif

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -461,29 +461,29 @@ static inline int comp_bind(struct comp_dev *dev, struct bind_info *bind_data)
 }
 
 #if CONFIG_IPC_MAJOR_4
-static inline int comp_ipc4_unbind_remote(struct comp_dev *dev, void *data)
+static inline int comp_ipc4_unbind_remote(struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 	struct idc_msg msg = { IDC_MSG_UNBIND,
 		IDC_EXTENSION(dev->ipc_config.id), dev->ipc_config.core,
-		sizeof(struct ipc4_module_bind_unbind), data};
+		sizeof(*unbind_data), unbind_data};
 
 	return idc_send_msg(&msg, IDC_BLOCKING);
 }
 #endif
 
-static inline int comp_unbind(struct comp_dev *dev, void *data)
+static inline int comp_unbind(struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 #if CONFIG_IPC_MAJOR_4
 	if (dev->drv->ops.unbind)
 		return cpu_is_me(dev->ipc_config.core) ?
-			dev->drv->ops.unbind(dev, data) : comp_ipc4_unbind_remote(dev, data);
+			dev->drv->ops.unbind(dev, unbind_data) : comp_ipc4_unbind_remote(dev, unbind_data);
 
 	return 0;
 #else
 	int ret = 0;
 
 	if (dev->drv->ops.unbind)
-		ret = dev->drv->ops.unbind(dev, data);
+		ret = dev->drv->ops.unbind(dev, unbind_data);
 
 	return ret;
 #endif

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -205,7 +205,7 @@ int module_set_configuration(struct processing_module *mod,
 			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
 			     size_t response_size);
 int module_bind(struct processing_module *mod, struct bind_info *bind_data);
-int module_unbind(struct processing_module *mod, void *data);
+int module_unbind(struct processing_module *mod, struct unbind_info *unbind_data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config, const void *spec);
@@ -245,7 +245,7 @@ int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 }
 
 static inline
-int module_adapter_unbind(struct comp_dev *dev, void *data)
+int module_adapter_unbind(struct comp_dev *dev, struct unbind_info *unbind_data)
 {
 	return 0;
 }
@@ -274,7 +274,7 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			    bool last_block, uint32_t *data_offset, char *data);
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value);
 int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data);
-int module_adapter_unbind(struct comp_dev *dev, void *data);
+int module_adapter_unbind(struct comp_dev *dev, struct unbind_info *unbind_data);
 uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input);
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -204,7 +204,7 @@ int module_set_configuration(struct processing_module *mod,
 			     enum module_cfg_fragment_position pos, size_t data_offset_size,
 			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
 			     size_t response_size);
-int module_bind(struct processing_module *mod, void *data);
+int module_bind(struct processing_module *mod, struct bind_info *bind_data);
 int module_unbind(struct processing_module *mod, void *data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
@@ -239,7 +239,7 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 }
 
 static inline
-int module_adapter_bind(struct comp_dev *dev, void *data)
+int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 {
 	return 0;
 }
@@ -273,7 +273,7 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t *data_offset, char *data);
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value);
-int module_adapter_bind(struct comp_dev *dev, void *data);
+int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data);
 int module_adapter_unbind(struct comp_dev *dev, void *data);
 uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input);

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -476,6 +476,7 @@ static int ll_wait_finished_on_core(struct comp_dev *dev)
 __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 {
 	struct ipc4_module_bind_unbind *bu;
+	struct bind_info bind_data;
 	struct comp_buffer *buffer;
 	struct comp_dev *source;
 	struct comp_dev *sink;
@@ -652,11 +653,16 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	}
 
 	/* these might call comp_ipc4_bind_remote() if necessary */
-	ret = comp_bind(source, bu);
+	bind_data.ipc4_data = bu;
+	bind_data.as_source = NULL;
+	bind_data.as_sink = audio_buffer_get_sink(&buffer->audio_buffer);
+	ret = comp_bind(source, &bind_data);
 	if (ret < 0)
 		goto e_src_bind;
 
-	ret = comp_bind(sink, bu);
+	bind_data.as_sink = NULL;
+	bind_data.as_source = audio_buffer_get_source(&buffer->audio_buffer);
+	ret = comp_bind(sink, &bind_data);
 	if (ret < 0)
 		goto e_sink_bind;
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -683,7 +683,14 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	return IPC4_SUCCESS;
 
 e_sink_bind:
-	comp_unbind(source, bu);
+	{
+		struct unbind_info unbind_data;
+
+		unbind_data.ipc4_data = bind_data.ipc4_data;
+		unbind_data.from_source = bind_data.as_source;
+		unbind_data.from_sink = bind_data.as_sink;
+		comp_unbind(source, &unbind_data);
+	}
 e_src_bind:
 	pipeline_disconnect(sink, buffer, PPL_CONN_DIR_BUFFER_TO_COMP);
 e_sink_connect:
@@ -710,6 +717,7 @@ __cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	uint32_t flags = 0;
 	int ret, ret1;
 	bool cross_core_unbind;
+	struct unbind_info unbind_data;
 
 	assert_can_be_cold();
 
@@ -779,8 +787,14 @@ __cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	pipeline_disconnect(src, buffer, PPL_CONN_DIR_COMP_TO_BUFFER);
 	pipeline_disconnect(sink, buffer, PPL_CONN_DIR_BUFFER_TO_COMP);
 	/* these might call comp_ipc4_bind_remote() if necessary */
-	ret = comp_unbind(src, bu);
-	ret1 = comp_unbind(sink, bu);
+	unbind_data.ipc4_data = bu;
+	unbind_data.from_source = NULL;
+	unbind_data.from_sink = audio_buffer_get_sink(&buffer->audio_buffer);
+	ret = comp_unbind(src, &unbind_data);
+	
+	unbind_data.from_sink = NULL;
+	unbind_data.from_source = audio_buffer_get_source(&buffer->audio_buffer);
+	ret1 = comp_unbind(sink, &unbind_data);
 
 	ll_unblock(cross_core_unbind, flags);
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -731,11 +731,6 @@ __cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		return IPC4_INVALID_RESOURCE_ID;
 	}
 
-	if (src->pipeline == sink->pipeline) {
-		tr_warn(&ipc_tr, "ignoring unbinding of src %x and dst %x", src_id, sink_id);
-		return 0;
-	}
-
 	cross_core_unbind = src->ipc_config.core != sink->ipc_config.core;
 
 	/* Pass IPC to target core if both modules has the same target core,

--- a/zephyr/include/sof/lib/regions_mm.h
+++ b/zephyr/include/sof/lib/regions_mm.h
@@ -58,7 +58,6 @@
  *  governed by sys_mem_blocks API.
  *  @var allocation_sizes[] a table of bit arrays representing sizes of allocations
  *  made in physical_blocks_allocators directly related to physical_blocks_allocators
- *  @var core_id id of the core that heap was created on
  *  @var allocating_continuously configuration value deciding if heap allocations
  *  will be contiguous or single block.
  */
@@ -67,7 +66,6 @@ struct vmh_heap {
 	const struct sys_mm_drv_region *virtual_region;
 	struct sys_mem_blocks *physical_blocks_allocators[MAX_MEMORY_ALLOCATORS_COUNT];
 	struct sys_bitarray *allocation_sizes[MAX_MEMORY_ALLOCATORS_COUNT];
-	int core_id;
 	bool allocating_continuously;
 };
 
@@ -105,15 +103,15 @@ struct vmh_heap_config {
 };
 
 struct vmh_heap *vmh_init_heap(const struct vmh_heap_config *cfg,
-		int memory_region_attribute, int core_id, bool allocating_continuously);
+		int memory_region_attribute, bool allocating_continuously);
 void *vmh_alloc(struct vmh_heap *heap, uint32_t alloc_size);
 int vmh_free_heap(struct vmh_heap *heap);
 int vmh_free(struct vmh_heap *heap, void *ptr);
 struct vmh_heap *vmh_reconfigure_heap(struct vmh_heap *heap,
-		struct vmh_heap_config *cfg, int core_id, bool allocating_continuously);
+		struct vmh_heap_config *cfg, bool allocating_continuously);
 void vmh_get_default_heap_config(const struct sys_mm_drv_region *region,
 		struct vmh_heap_config *cfg);
-struct vmh_heap *vmh_get_heap_by_attribute(uint32_t attr, uint32_t core_id);
+struct vmh_heap *vmh_get_heap_by_attribute(uint32_t attr);
 /**
  * @brief Checks if ptr is in range of given memory range
  *

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -21,7 +21,7 @@
 #if CONFIG_VIRTUAL_HEAP
 #include <sof/lib/regions_mm.h>
 
-struct vmh_heap *virtual_buffers_heap[CONFIG_MP_MAX_NUM_CPUS];
+struct vmh_heap *virtual_buffers_heap;
 struct k_spinlock vmh_lock;
 
 #undef	HEAPMEM_SIZE
@@ -251,12 +251,11 @@ static bool is_virtual_heap_pointer(void *ptr)
 
 static void virtual_heap_free(void *ptr)
 {
-	struct vmh_heap *const heap = virtual_buffers_heap[cpu_get_id()];
 	int ret;
 
 	ptr = (__sparse_force void *)sys_cache_cached_ptr_get(ptr);
 
-	ret = vmh_free(heap, ptr);
+	ret = vmh_free(virtual_buffers_heap, ptr);
 	if (ret) {
 		tr_err(&zephyr_tr, "Unable to free %p! %d", ptr, ret);
 		k_panic();
@@ -279,17 +278,11 @@ static const struct vmh_heap_config static_hp_buffers = {
 
 static int virtual_heap_init(void)
 {
-	int core;
-
 	k_spinlock_init(&vmh_lock);
-
-	for (core = 0; core < CONFIG_MP_MAX_NUM_CPUS; core++) {
-		struct vmh_heap *heap = vmh_init_heap(&static_hp_buffers, MEM_REG_ATTR_CORE_HEAP,
-						      core, false);
-		if (!heap)
-			tr_err(&zephyr_tr, "Unable to init virtual heap for core %d!", core);
-
-		virtual_buffers_heap[core] = heap;
+	virtual_buffers_heap = vmh_init_heap(&static_hp_buffers, MEM_REG_ATTR_CORE_HEAP, false);
+	if (!virtual_buffers_heap) {
+		tr_err(&zephyr_tr, "Unable to init virtual heap");
+		return -ENOMEM;
 	}
 
 	return 0;
@@ -490,9 +483,6 @@ EXPORT_SYMBOL(rzalloc);
 void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 		    uint32_t align)
 {
-#if CONFIG_VIRTUAL_HEAP
-	struct vmh_heap *virtual_heap;
-#endif
 	struct k_heap *heap;
 
 	/* choose a heap */
@@ -510,9 +500,8 @@ void *rballoc_align(uint32_t flags, uint32_t caps, size_t bytes,
 
 #if CONFIG_VIRTUAL_HEAP
 	/* Use virtual heap if it is available */
-	virtual_heap = virtual_buffers_heap[cpu_get_id()];
-	if (virtual_heap)
-		return virtual_heap_alloc(virtual_heap, flags, caps, bytes, align);
+	if (virtual_buffers_heap)
+		return virtual_heap_alloc(virtual_buffers_heap, flags, caps, bytes, align);
 #endif /* CONFIG_VIRTUAL_HEAP */
 
 	if (flags & SOF_MEM_FLAG_COHERENT)

--- a/zephyr/lib/regions_mm.c
+++ b/zephyr/lib/regions_mm.c
@@ -28,14 +28,14 @@ static struct list_item vmh_list = LIST_INIT(vmh_list);
  * @retval NULL on creation failure.
  */
 struct vmh_heap *vmh_init_heap(const struct vmh_heap_config *cfg,
-	int memory_region_attribute, int core_id, bool allocating_continuously)
+	int memory_region_attribute, bool allocating_continuously)
 {
 	const struct sys_mm_drv_region *virtual_memory_regions =
 		sys_mm_drv_query_memory_regions();
 	int i;
 
 	/* Check if we haven't created heap for this region already */
-	if (vmh_get_heap_by_attribute(memory_region_attribute, core_id))
+	if (vmh_get_heap_by_attribute(memory_region_attribute))
 		return NULL;
 
 	struct vmh_heap *new_heap =
@@ -44,7 +44,6 @@ struct vmh_heap *vmh_init_heap(const struct vmh_heap_config *cfg,
 	if (!new_heap)
 		return NULL;
 
-	new_heap->core_id = core_id;
 	list_init(&new_heap->node);
 	struct vmh_heap_config new_config = {0};
 
@@ -54,7 +53,7 @@ struct vmh_heap *vmh_init_heap(const struct vmh_heap_config *cfg,
 	 * available cores
 	 */
 	if (memory_region_attribute == MEM_REG_ATTR_CORE_HEAP) {
-		new_heap->virtual_region = &virtual_memory_regions[core_id];
+		new_heap->virtual_region = &virtual_memory_regions[0];
 	} else {
 		for (i = CONFIG_MP_MAX_NUM_CPUS;
 			i < CONFIG_MP_MAX_NUM_CPUS + VIRTUAL_REGION_COUNT; i++) {
@@ -393,8 +392,6 @@ void *vmh_alloc(struct vmh_heap *heap, uint32_t alloc_size)
 	if (!alloc_size)
 		return NULL;
 	/* Only operations on the same core are allowed */
-	if (heap->core_id != cpu_get_id())
-		return NULL;
 
 	void *ptr = NULL;
 	int mem_block_iterator, allocation_error_code = -ENOMEM;
@@ -560,9 +557,6 @@ int vmh_free(struct vmh_heap *heap, void *ptr)
 {
 	int retval;
 
-	if (heap->core_id != cpu_get_id())
-		return -EINVAL;
-
 	size_t mem_block_iter, i, size_to_free, block_size, ptr_bit_array_offset,
 		ptr_bit_array_position, blocks_to_free;
 	bool ptr_range_found;
@@ -691,15 +685,14 @@ int vmh_free(struct vmh_heap *heap, void *ptr)
  * @retval NULL when reconfiguration failed
  */
 struct vmh_heap *vmh_reconfigure_heap(
-	struct vmh_heap *heap, struct vmh_heap_config *cfg,
-	int core_id, bool allocating_continuously)
+	struct vmh_heap *heap, struct vmh_heap_config *cfg, bool allocating_continuously)
 {
 	uint32_t region_attribute = heap->virtual_region->attr;
 
 	if (vmh_free_heap(heap))
 		return NULL;
 
-	return vmh_init_heap(cfg, region_attribute, core_id, allocating_continuously);
+	return vmh_init_heap(cfg, region_attribute, allocating_continuously);
 }
 
 /**
@@ -740,7 +733,7 @@ void vmh_get_default_heap_config(const struct sys_mm_drv_region *region,
  * @retval heap ptr on success
  * @retval NULL if there was no heap created fitting the attr.
  */
-struct vmh_heap *vmh_get_heap_by_attribute(uint32_t attr, uint32_t core_id)
+struct vmh_heap *vmh_get_heap_by_attribute(uint32_t attr)
 {
 	struct list_item *vm_heaps_iterator;
 	struct vmh_heap *retval;
@@ -753,7 +746,7 @@ struct vmh_heap *vmh_get_heap_by_attribute(uint32_t attr, uint32_t core_id)
 		const struct sys_mm_drv_region *virtual_memory_region =
 			sys_mm_drv_query_memory_regions();
 		/* we move ptr to cpu vmr */
-		virtual_memory_region = &virtual_memory_region[core_id];
+		virtual_memory_region = &virtual_memory_region[0];
 
 		list_for_item(vm_heaps_iterator, &vmh_list) {
 			retval =

--- a/zephyr/test/vmh.c
+++ b/zephyr/test/vmh.c
@@ -21,12 +21,11 @@ LOG_MODULE_DECLARE(sof_boot_test, CONFIG_SOF_LOG_LEVEL);
 /* Test creating and freeing a virtual memory heap */
 static void test_vmh_init_and_free_heap(int memory_region_attribute,
 					struct vmh_heap_config *config,
-					int core_id,
 					bool allocating_continuously,
 					bool expect_success)
 {
 	struct vmh_heap *heap = vmh_init_heap(config, memory_region_attribute,
-		core_id, allocating_continuously);
+					      allocating_continuously);
 	if (expect_success) {
 		zassert_not_null(heap,
 		"Heap initialization expected to succeed but failed");
@@ -146,7 +145,7 @@ static void test_vmh_multiple_allocs(struct vmh_heap *heap, int num_allocs,
 static void test_vmh_alloc_multiple_times(bool allocating_continuously)
 {
 	struct vmh_heap *heap =
-	vmh_init_heap(NULL, MEM_REG_ATTR_CORE_HEAP, 0, allocating_continuously);
+	vmh_init_heap(NULL, MEM_REG_ATTR_CORE_HEAP, allocating_continuously);
 
 	zassert_not_null(heap, "Heap initialization failed");
 
@@ -170,7 +169,7 @@ static void test_vmh_alloc_multiple_times(bool allocating_continuously)
 static void test_vmh_alloc_free(bool allocating_continuously)
 {
 	struct vmh_heap *heap =
-	vmh_init_heap(NULL, MEM_REG_ATTR_CORE_HEAP, 0, allocating_continuously);
+	vmh_init_heap(NULL, MEM_REG_ATTR_CORE_HEAP, allocating_continuously);
 
 	zassert_not_null(heap, "Heap initialization failed");
 
@@ -223,7 +222,7 @@ static void test_alloc_on_configured_heap(bool allocating_continuously)
 
 	/* Create continuous allocation heap for success test */
 	struct vmh_heap *heap =
-	vmh_init_heap(&config, MEM_REG_ATTR_CORE_HEAP, 0, allocating_continuously);
+	vmh_init_heap(&config, MEM_REG_ATTR_CORE_HEAP, allocating_continuously);
 
 	/* Will succeed on continuous and fail with single block alloc */
 	test_vmh_alloc_free_check(heap, 512, allocating_continuously);
@@ -248,8 +247,7 @@ static void test_vmh_init_all_heaps(void)
 		if (!virtual_memory_region[i].size)
 			break;
 
-		struct vmh_heap *heap = vmh_init_heap(NULL, virtual_memory_region[i].attr,
-		i, true);
+		struct vmh_heap *heap = vmh_init_heap(NULL, virtual_memory_region[i].attr, true);
 
 		zassert_not_null(heap, "Heap initialization expected to succeed but failed");
 


### PR DESCRIPTION
this is fix for https://github.com/thesofproject/sof/issues/10024

Rootcause: 
1) In case of cross core buffers, there's no guarantee that buffer is freed on the same core that it was created by. It depends which end of cross-core buffer (which component) is freed as second - the buffer will be freed by the core of second component.

2) buffer memory is managed by a feature called "virtual heaps" that enforces freeing of memory on the same core that it was allocated ====> EXCEPTION

3) even if virtual heaps were cross-core, there's still a problem with invalidation of cache of memory being freed. It MUST be performed on a core that was producing data - and there's no way to override it. If the cache is not invalidated, it will be written back by the core itself leading either to data corruption or to exception in case the virtual memory has been unmapped. 


SOLLUTION: 
  - make virtual memory cross-core capable
  - add "unbind" hook to sink API, invalidate cache in this hook 
