### PR TITLE
Audio: Fix Memory Leaks in Buffer Component Release

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -398,6 +398,7 @@ __cold static void chain_release(struct comp_dev *dev)
 
 	if (cd->dma_buffer) {
 		buffer_free(cd->dma_buffer);
+		rfree(cd->dma_buffer);
 		cd->dma_buffer = NULL;
 	}
 }
@@ -621,6 +622,7 @@ __cold static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uin
 	ret = chain_init(dev, buff_addr, buff_size);
 	if (ret < 0) {
 		buffer_free(cd->dma_buffer);
+		rfree(cd->dma_buffer);
 		cd->dma_buffer = NULL;
 		goto error;
 	}

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -385,8 +385,11 @@ __cold void copier_dai_free(struct copier_data *cd)
 		rfree(cd->dd[i]);
 	}
 	/* only dai have multi endpoint case */
-	if (cd->multi_endpoint_buffer)
+	if (cd->multi_endpoint_buffer) {
 		buffer_free(cd->multi_endpoint_buffer);
+		rfree(cd->multi_endpoint_buffer);
+		cd->multi_endpoint_buffer = NULL;
+	}
 }
 
 int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd)

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -714,6 +714,7 @@ void dai_common_reset(struct dai_data *dd, struct comp_dev *dev)
 
 	if (dd->dma_buffer) {
 		buffer_free(dd->dma_buffer);
+		rfree(dd->dma_buffer);
 		dd->dma_buffer = NULL;
 	}
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1105,6 +1105,7 @@ out:
 	 */
 	if (err < 0) {
 		buffer_free(dd->dma_buffer);
+		rfree(dd->dma_buffer);
 		dd->dma_buffer = NULL;
 		dma_sg_free(&config->elem_array);
 		rfree(dd->z_config);
@@ -1246,6 +1247,7 @@ void dai_common_reset(struct dai_data *dd, struct comp_dev *dev)
 
 	if (dd->dma_buffer) {
 		buffer_free(dd->dma_buffer);
+		rfree(dd->dma_buffer);
 		dd->dma_buffer = NULL;
 	}
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -911,6 +911,7 @@ void host_common_reset(struct host_data *hd, uint16_t state)
 	/* free DMA buffer */
 	if (hd->dma_buffer) {
 		buffer_free(hd->dma_buffer);
+		rfree(hd->dma_buffer);
 		hd->dma_buffer = NULL;
 	}
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -1131,6 +1131,7 @@ void host_common_reset(struct host_data *hd, uint16_t state)
 	/* free DMA buffer */
 	if (hd->dma_buffer) {
 		buffer_free(hd->dma_buffer);
+		rfree(hd->dma_buffer);
 		hd->dma_buffer = NULL;
 	}
 

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -495,6 +495,7 @@ int ipc_buffer_new(struct ipc *ipc, const struct sof_ipc_buffer *desc)
 		      sizeof(struct ipc_comp_dev));
 	if (!ibd) {
 		buffer_free(buffer);
+		rfree(buffer);
 		return -ENOMEM;
 	}
 	ibd->cb = buffer;


### PR DESCRIPTION
This pull request resolves memory leak issues in the buffer component release processes across various audio and IPC components. Each commit ensures the complete deallocation of buffer structures by adding necessary `rfree` calls following `buffer_free`. This prevents potential memory leaks and enhances the stability and reliability of the system.