### PR TITLE
llext: fix undefined symbols

### DIFF
--- a/src/ipc/ipc4/notification.c
+++ b/src/ipc/ipc4/notification.c
@@ -11,6 +11,8 @@
 #include <stdbool.h>
 #include <ipc4/notification.h>
 
+#include <rtos/symbol.h>
+
 static void resource_notif_header_init(struct ipc_msg *msg)
 {
 	struct ipc4_resource_event_data_notification *notif_data = msg->tx_data;
@@ -77,6 +79,7 @@ void mixer_underrun_notif_msg_init(struct ipc_msg *msg, uint32_t resource_id, ui
 	notif_data->event_data.mixer_underrun.data_mixed = data_mixed;
 	notif_data->event_data.mixer_underrun.expected_data_mixed = expected_data_mixed;
 }
+EXPORT_SYMBOL(mixer_underrun_notif_msg_init);
 
 void process_data_error_notif_msg_init(struct ipc_msg *msg, uint32_t resource_id,
 				       uint32_t error_code)

--- a/src/ipc/notification_pool.c
+++ b/src/ipc/notification_pool.c
@@ -10,6 +10,8 @@
 #include <sof/list.h>
 #include <sof/ipc/notification_pool.h>
 
+#include <rtos/symbol.h>
+
 #define NOTIFICATION_POOL_MAX_PAYLOAD_SIZE	40	/* IPC4 Resource Event needs 10dw */
 #define NOTIFICATION_POOL_MAX_DEPTH		8	/* Maximum number of notifications
 							 * in the pool
@@ -98,3 +100,4 @@ struct ipc_msg *ipc_notification_pool_get(size_t size)
 	item->msg.tx_size = size;
 	return &item->msg;
 }
+EXPORT_SYMBOL(ipc_notification_pool_get);


### PR DESCRIPTION
The recently added xrun notification framework failed to export symbols to LLEXT modules. This might remain unnoticed until an xrun happens and a module attempts to send a notification, at which popint it will cause an exception. This might be the cause of recent CI failures. This commit adds the missing exports.