### PR TITLE
kpb: Fix wrong array size

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -553,8 +553,7 @@ static size_t kpb_allocate_history_buffer(struct comp_data *kpb,
 	/*! Current allocation size */
 	size_t ca_size = hb_size;
 	/*! Memory caps priorites for history buffer */
-	int hb_mcp[KPB_NO_OF_MEM_POOLS] = {SOF_MEM_CAPS_LP, SOF_MEM_CAPS_HP,
-					   SOF_MEM_CAPS_RAM };
+	int hb_mcp[] = {SOF_MEM_CAPS_LP, SOF_MEM_CAPS_HP, SOF_MEM_CAPS_RAM};
 	void *new_mem_block = NULL;
 	size_t temp_ca_size;
 	int i = 0;

--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -46,7 +46,6 @@ struct comp_buffer;
 #define KPB_MAX_SINK_CNT (1 + KPB_MAX_NO_OF_CLIENTS)
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100
-#define KPB_NO_OF_MEM_POOLS 5
 #define KPB_BYTES_TO_FRAMES(bytes, sample_width, channels_number) \
 	((bytes) / ((KPB_SAMPLE_CONTAINER_SIZE(sample_width) / 8) * \
 	 (channels_number)))


### PR DESCRIPTION
The hb_mcp[] array is initialized with 3 members (these are memory caps for rballoc()). However, the array size KPB_NO_OF_MEM_POOLS is incorrectly declared as 5. This discrepancy could potentially lead to iterating over uninitialized hb_mcp[] members.