### PR TITLE
Add object array abstraction to ipc4_module_init_ext_init and use it to pass stack and heap size for DP modules

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -25,6 +25,48 @@
 
 LOG_MODULE_DECLARE(module_adapter, CONFIG_SOF_LOG_LEVEL);
 
+static const struct ipc4_base_module_extended_cfg *
+module_ext_init_decode(struct comp_dev *dev, struct module_config *dst,
+		       const unsigned char *data, uint32_t *size)
+{
+	const struct ipc4_module_init_ext_init *ext_init =
+		(const struct ipc4_module_init_ext_init *)data;
+	bool last_object = !ext_init->data_obj_array;
+	const struct ipc4_module_init_ext_object *obj;
+
+	/* TODO: Handle ext_init->gna_used and ext_init->rtos_domain here */
+	obj = (const struct ipc4_module_init_ext_object *)(ext_init + 1);
+	while (!last_object) {
+		switch (obj->object_id) {
+		case IPC4_MOD_INIT_DATA_GLB_ID_DP_DATA:
+			struct ipc4_module_init_ext_obj_dp_data *dp_data =
+				(struct ipc4_module_init_ext_obj_dp_data *)(obj + 1);
+			dst->stack_size = dp_data->stack_size;
+			dst->heap_size = dp_data->heap_size;
+			comp_info(dev, "init_ext_obj_dp_data stack %u heap %u",
+				  dp_data->stack_size, dp_data->heap_size);
+			break;
+		default:
+			comp_info(dev, "Unknown ext init object id %u of %u words",
+				  obj->object_id, obj->object_words);
+		}
+		last_object = obj->last_object;
+		obj = (struct ipc4_module_init_ext_object *)
+			(((uint32_t *) (obj + 1)) + obj->object_words);
+		if ((unsigned char *)obj - data > *size) {
+			comp_err(dev, "ext init object array overflow, %u > %u",
+				 (unsigned char *)obj - data, *size);
+			return NULL;
+		}
+	}
+
+	/* Remove decoded ext_init payload from the size */
+	*size -= (unsigned char *) obj - data;
+
+	/* return remaining payload */
+	return (const struct ipc4_base_module_extended_cfg *)obj;
+}
+
 /*
  * \module adapter data initialize.
  * \param[in] dev - device.
@@ -39,11 +81,18 @@ int module_adapter_init_data(struct comp_dev *dev,
 			     const struct comp_ipc_config *config,
 			     const void *spec)
 {
+	const struct ipc4_base_module_extended_cfg *cfg;
 	const struct ipc_config_process *args = spec;
-	const struct ipc4_base_module_extended_cfg *cfg = (void *)args->data;
 	size_t cfgsz = args->size;
 
 	assert(dev->drv->type == SOF_COMP_MODULE_ADAPTER);
+	if (config->ipc_extended_init)
+		cfg = module_ext_init_decode(dev, dst, args->data, &cfgsz);
+	else
+		cfg = (const struct ipc4_base_module_extended_cfg *)args->data;
+
+	if (cfg == NULL)
+		return -EINVAL;
 	if (cfgsz < sizeof(cfg->base_cfg))
 		return -EINVAL;
 

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -73,6 +73,27 @@ struct ipc4_vendor_error {
 	uint32_t err_code;
 };
 
+/* IDs for all global object types in struct ipc4_module_init_ext_object */
+enum ipc4_mod_init_data_glb_id {
+	IPC4_MOD_INIT_DATA_GLB_ID_INVALID = 0,
+	IPC4_MOD_INIT_DATA_GLB_ID_DP_DATA = 1,
+	IPC4_MOD_INIT_DATA_GLB_ID_MAX = IPC4_MOD_INIT_DATA_GLB_ID_DP_DATA,
+};
+
+/* data object for vendor bespoke data with ABI growth and backwards compat */
+struct ipc4_module_init_ext_object {
+	uint32_t last_object : 1;	/* object is last in array if 1 else object follows. */
+	uint32_t object_id : 15;	/* unique ID for this object or globally */
+	uint32_t object_words : 16;	/* size in dwords (excluding this structure) */
+} __attribute__((packed, aligned(4)));
+/* the object data will be placed in memory here and will have size "object_words" */
+
+/* Ext init array data object for Data Processing module memory requirements */
+struct ipc4_module_init_ext_obj_dp_data {
+	uint32_t stack_size;
+	uint32_t heap_size;
+} __attribute__((packed, aligned(4)));
+
 /*
  * Host Driver sends this message to create a new module instance.
  */
@@ -83,7 +104,8 @@ struct ipc4_module_init_ext_init {
 	/**< Indicates that GNA is used by a module and additional information */
 	/* (gna_config) is passed after ExtendedData. */
 	uint32_t gna_used    : 1;
-	uint32_t rsvd_0      : 30;
+	uint32_t data_obj_array : 1;	/* struct ipc4_module_init_ext_object data */
+	uint32_t rsvd_0      : 29;
 	uint32_t rsvd_1[2];
 } __attribute__((packed, aligned(4)));
 

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -34,6 +34,8 @@ struct module_config {
 	uint8_t nb_output_pins;
 	struct ipc4_input_pin_format *input_pins;
 	struct ipc4_output_pin_format *output_pins;
+	uint32_t stack_size;	/* stack size in bytes, 0 means default value */
+	uint32_t heap_size;	/* stack size in bytes, 0 means default value */
 #endif
 };
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -582,6 +582,7 @@ struct comp_ipc_config {
 	uint32_t frame_fmt;		/**< SOF_IPC_FRAME_ */
 	uint32_t xrun_action;		/**< action we should take on XRUN */
 #if CONFIG_IPC_MAJOR_4
+	bool ipc_extended_init;		/**< true if extended init is included in ipc payload */
 	uint32_t ipc_config_size;	/**< size of a config received by ipc */
 #endif
 };

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -137,6 +137,7 @@ __cold struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_i
 	ipc_config.pipeline_id = module_init->extension.r.ppl_instance_id;
 	ipc_config.core = module_init->extension.r.core_id;
 	ipc_config.ipc_config_size = module_init->extension.r.param_block_size * sizeof(uint32_t);
+	ipc_config.ipc_extended_init = module_init->extension.r.extended_init;
 
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
 				 MAILBOX_HOSTBOX_SIZE);

--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -248,6 +248,8 @@ IncludeByKey.PASSTHROUGH {
 				}
 				Object.Widget.src.1 {
 					scheduler_domain "$SRC_DOMAIN"
+					stack_size_requirement 4096
+					heap_size_requirement 8192
 				}
 				Object.Widget.pipeline.1 {
 					core	$SSP2_PCM_CORE_ID
@@ -808,6 +810,8 @@ IncludeByKey.PASSTHROUGH {
 					index	    11
 					rate_in     48000
 					scheduler_domain "$SRC_DOMAIN"
+					stack_size_requirement 4096
+					heap_size_requirement 8192
 
 					<include/components/src_format_s32_convert_from_48k.conf>
 				}

--- a/tools/topology/topology2/include/common/tokens.conf
+++ b/tools/topology/topology2/include/common/tokens.conf
@@ -26,6 +26,8 @@ Object.Base.VendorToken {
 		num_output_audio_formats 416
 		no_wname_in_kcontrol_name 417
 		scheduler_domain	418
+		stack_size_requirement	419
+		heap_size_requirement	420
 	}
 
 	"2" {

--- a/tools/topology/topology2/include/components/widget-common.conf
+++ b/tools/topology/topology2/include/components/widget-common.conf
@@ -136,3 +136,16 @@ DefineAttribute."scheduler_domain" {
 		]
 	}
 }
+
+## Stack size requirement for this component. Zero indicates default stack size.
+DefineAttribute."stack_size_requirement" {
+	# Token set reference name and type
+	token_ref	"comp.word"
+}
+
+## Heap size requirement for this component. Zero indicates default heap size.
+DefineAttribute."heap_size_requirement" {
+	# Token set reference name and type
+	token_ref	"comp.word"
+}
+


### PR DESCRIPTION
Extend the existing struct ipc4_module_init_ext_init payload with an abstract object array, and use the object array to pass DP module memory configuration e.g. stack and heap size. The PR contains decoding of the payload and extraction of stack and heap size properties, but no actual functionality for applying the memory configuration for the module. The decoding also lacks the decoding of rtos_domain and gna_used flags and payload. 