### PR TITLE
Fix with a partial revert. "topology: cmake: use local ALSA utilities to build topology"

### DIFF
--- a/tools/ctl/CMakeLists.txt
+++ b/tools/ctl/CMakeLists.txt
@@ -4,9 +4,6 @@ add_executable(sof-ctl
 	ctl.c
 )
 
-target_link_directories(sof-ctl BEFORE
-	PRIVATE "${SOF_ROOT_SOURCE_DIRECTORY}/../tools/lib")
-
 target_link_libraries(sof-ctl PRIVATE
 	"-lasound"
 )
@@ -16,7 +13,6 @@ target_compile_options(sof-ctl PRIVATE
 )
 
 target_include_directories(sof-ctl PRIVATE
-	"${SOF_ROOT_SOURCE_DIRECTORY}/../tools/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}"
 )


### PR DESCRIPTION
This reverts commit 47dd8d33fc9ead3ee2d3e378a9ad93e889d41e68.

sof-ctl does not need git version of alsa-lib like the topology compiler but can use system version of alsa-lib to build.