### PR TITLE
github: workflows: Use ubuntu 24.04 for testbench

### DIFF
--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.10
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout SOF repository (PR source)


### PR DESCRIPTION
The ubuntu LTS releases have far more runners than more recent non LTS releases. Use the LTS to avoid runner timeouts.