### PR TITLE
github: workflows: fix yaml error for issue close workflowRun yamllin…

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,6 +1,7 @@
 ---
 name: "Close stale issues"
-on:
+# yamllint disable-line rule:truthy
+on: [true]
   schedule:
     - cron: "30 1 * * *"
 


### PR DESCRIPTION
Fix
…t -f parsable -d "$yamllint_config" --strict .github/workflows/*.yml *.yml

yamllint -f parsable -d "$yamllint_config" --strict .github/workflows/*.yml *.yml
  shell: /usr/bin/bash -e {0}
  env:
    yamllint_config: {extends: default, rules: {line-length: {max: 100}}}
Warning: orkflows/close-stale.yml:3:1: [warning] truthy value should be one of [false, true] (truthy) Error: Process completed with exit code 2.

Looks like a copy and paste error from:
https://docs.github.com/en/actions/how-tos/use-cases-and-examples/project-management/closing-inactive-issues