### PR TITLE
WCL BEP CS42l43 Topology

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -3,6 +3,17 @@
 # Array of "input-file-name;output-file-name;comma separated pre-processor variables"
 list(APPEND TPLGS
 # SDW topology for PTL RVP
+#CS42L43
+"cavs-sdw\;sof-ptl-cs42l43-l3\;PLATFORM=ptl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
+
+"cavs-sdw\;sof-ptl-cs42l43-l3-4ch\;PLATFORM=ptl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=0,NUM_DMICS=4,\
+PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,HDMI1_ID=5,HDMI2_ID=6,HDMI3_ID=7,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-cs42l43-l3-4ch.bin"
+
 # RT721 eval board with SDW-DMIC, sof_sdw_quirk_table without SOC_SDW_PCH_DMIC
 "cavs-sdw\;sof-ptl-rt721\;PLATFORM=ptl,SDW_DMIC=1,NUM_SDW_AMP_LINKS=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\


### PR DESCRIPTION
topology2: add support for cs42l43-sdw topology

Adding topology support for cs42l43-sdw monolithic codec at l3
Verified on ptl & wcl-bep platforms for configuration:
1. sof-ptl-cs42l43-l3: uses SDW-DMIC
2. sof-ptl-cs42l43-l3-4ch: uses PCH-DMIC

md5sum sof-ptl-cs42l43-l3-4ch.tplg 1c1b8eb8758a1827bc8f9748826496a8
md5sum sof-ptl-cs42l43-l3.tplg fa54c27123619df1bfff47c8f2bad3d4