### PR TITLE
Tools: Topology2: cavs-nocodec: Fix formats for Port0 first/second ca…

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -414,6 +414,43 @@ IncludeByKey.PASSTHROUGH {
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_PCM_NAME Capture Volume'
 					}
+
+					num_input_audio_formats 1
+
+					Object.Base.input_audio_format [
+						# 32-bit 48KHz 2ch
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
+				}
+				Object.Widget.module-copier.2 {
+					num_input_audio_formats 1
+
+					Object.Base.input_audio_format [
+						# 32-bit 48KHz 2ch
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
 			}
 
@@ -429,6 +466,43 @@ IncludeByKey.PASSTHROUGH {
 					Object.Control.mixer.1 {
 						name 'Post Demux $SSP0_CAPTURE_PCM Volume'
 					}
+
+					num_input_audio_formats 1
+
+					Object.Base.input_audio_format [
+						# 32-bit 48KHz 2ch
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
+				}
+				Object.Widget.module-copier.2 {
+					num_input_audio_formats 1
+
+					Object.Base.input_audio_format [
+						# 32-bit 48KHz 2ch
+						{
+							in_bit_depth            32
+							in_valid_bit_depth      32
+						}
+					]
+
+					num_output_audio_formats 1
+					Object.Base.output_audio_format [
+						{
+							out_bit_depth           32
+							out_valid_bit_depth     32
+						}
+					]
 				}
 			}
 		]


### PR DESCRIPTION
…pture

The 'Port0' and 'Port0 2nd' branches out at module-copier.8.2, which only supports 32bit in/out format.
The two branch on top of it is identical:
module-copier.X.2 - 16/32 in/out support
gain.X.1 - 16/32 in/out support
host-copier.X.capture - 32bit in, and various output formats.

In these branches from module-copier.8.2 to the host-copier we cannot have 16bit format, so update the module-copier and gain audio format definitions to reflect this.

The current way causes errors if one of the branch is already in use and the second branch is started since the module-copier.8.2 has been already configured, we skip it's configuration but the next copier have multiple formats to be chosen from and this can cause misconfiguration of formats.