### PR TITLE
[SKIP SOFCI-TEST] zephyr: docker: change docker image to zephyr-lite

### DIFF
--- a/scripts/docker_build/zephyr_lite/Dockerfile
+++ b/scripts/docker_build/zephyr_lite/Dockerfile
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2025 Intel Corporation. All rights reserved.
+
+# Use zephyr-build as base image
+FROM ghcr.io/zephyrproject-rtos/zephyr-build:v0.27.4 as base
+
+# Remove additional toolchains.
+# As this is not ideal solution there is a plan to build docker image without zephyr-build as the base
+# and install only needeed toolchains in the future.
+RUN cd /opt/toolchains/zephyr-sdk-0.17.0 && \
+    sudo rm -rvf arc* \
+        micro* \
+        mips* \
+        nios* \
+        risc* \
+        sparc* \
+        x86* \
+        xtensa-espressif* \
+        xtensa-sample* \
+        xtensa-dc233c*
+
+# Some of tests require python 3.12 - instll it from source
+RUN cd /tmp && wget -q --show-progress --progress=bar:force:noscroll --no-check-certificate https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tgz && \
+    tar -xf Python-3.12.9.tgz && \
+    cd Python-3.12.9 && \
+    ./configure && \
+    sudo make -j$(nproc) && \
+    sudo make install && \
+    sudo rm -rf /tmp/Python-3*
+
+# Reinstall python3.10 packages with python3.12
+RUN python3.10 -m pip freeze > /tmp/python3.10.pip.txt && \
+    cat /tmp/python3.10.pip.txt | xargs -n 1 python3.12 -m pip install || true
+
+# Use ubuntu24.04 as base for zephyr-lite
+FROM ubuntu:24.04 as zephyr-lite
+
+# Copy needed files from base to zephyr-lite
+# /opt for toolchains and sdk
+# /usr for binaries and libs
+# /home for libs installed in .local
+COPY --from=base /opt /opt
+COPY --from=base /usr /usr
+COPY --from=base /home /home
+
+USER root
+
+# Create a user if it doesn't already exist and grant them permission to /home/user.
+# Add user to dialout and sudo group
+RUN useradd -ms /bin/bash user && \
+    chown -R user:user /home/user && \
+    usermod -a -G dialout,sudo user
+
+USER user
+
+# Set zephyr env variables
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.0
+ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -54,8 +54,10 @@ main()
 
 run_command()
 {
-    # zephyr-build:v0.27.4 has /opt/toolchains/zephyr-sdk-0.17.0
+    # zephyr-lite:v0.27.4 has /opt/toolchains/zephyr-sdk-0.17.0
+    # zephyr-lite:v0.27.4 is based on zephyr-build:v0.27.4
     # https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags
+    # https://hub.docker.com/r/thesofproject/zephyr-lite/tags
     #
     # Keep this SDK version identical to the one in
     #    .github/workflows/zephyr.yml#Windows
@@ -63,7 +65,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           ghcr.io/zephyrproject-rtos/zephyr-build:v0.27.4 \
+           thesofproject/zephyr-lite:v0.27.4 \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
Change docker image used in zephyr workflows to zephyr-lite built for the sof project.

zephyr-lite contains less toolchains compared to zephyr-build to fit into 14GB max storage of free tier runners.
Final size of zephyr-lite is appx 10.5GB vs 16.2GB of zephyr-build.

List of toolchains left in the docker:
```bash
aarch64-zephyr-elf
arm-zephyr-eabi
xtensa-amd_acp_6_0_adsp_zephyr-elf
xtensa-intel_ace15_mtpm_zephyr-elf
xtensa-intel_ace30_ptl_zephyr-elf
xtensa-intel_tgl_adsp_zephyr-elf
xtensa-mtk_mt8195_adsp_zephyr-elf
xtensa-nxp_imx8m_adsp_zephyr-elf
xtensa-nxp_imx8ulp_adsp_zephyr-elf
xtensa-nxp_imx_adsp_zephyr-elf
xtensa-nxp_rt500_adsp_zephyr-elf
xtensa-nxp_rt600_adsp_zephyr-elf
xtensa-nxp_rt700_hifi1_zephyr-elf
xtensa-nxp_rt700_hifi4_zephyr-elf
```
New docker also includes python3.12 which resolves: https://github.com/thesofproject/sof/actions/runs/16050152241/job/45290644811?pr=10091#step:8:179
```bash
Could NOT find Python3: Found unsuitable version "3.10.12", but required is
  at least "3.12.1" (found /usr/bin/python3, found components: Interpreter)
```

zephyr sparse probe run: https://github.com/thesofproject/sof/actions/runs/16051752607
zephyr probe run: https://github.com/thesofproject/sof/actions/runs/16051752595

docker was pushed to public ```thesofproject/zephyr-lite``` hub: https://hub.docker.com/r/thesofproject/zephyr-lite

Signed-off-by: Mateusz Redzynia <mateuszx.redzynia@intel.com>