### PR TITLE
app: add os_linux_overlay.conf

### DIFF
--- a/app/os_linux_overlay.conf
+++ b/app/os_linux_overlay.conf
@@ -1,0 +1,8 @@
+#
+# Overlay definitions to build SOF firmware for use
+# with SOF driver in Linux kernel
+#
+
+# SOF Linux driver does not require FW to retain its
+# state, so context save can be disabled
+CONFIG_ADSP_IMR_CONTEXT_SAVE=n


### PR DESCRIPTION
Add an OS overlay for Linux. This overlay configures SOF to be used with SOF Linux kernel driver. The overlay modifies Kconfig configuration options to align with requirements of of the Linux driver.

Similar overlays may be added later for other OS'es.