### PR TITLE
treewide: zephyr: add sof_ prefix to dma_get/put() and struct dma

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -61,13 +61,13 @@ struct chain_dma_data {
 #endif
 
 	/* local host DMA config */
-	struct dma *dma_host;
+	struct sof_dma *dma_host;
 	struct dma_chan_data *chan_host;
 	struct dma_config z_config_host;
 	struct dma_block_config dma_block_cfg_host;
 
 	/* local link DMA config */
-	struct dma *dma_link;
+	struct sof_dma *dma_link;
 	struct dma_chan_data *chan_link;
 	struct dma_config z_config_link;
 	struct dma_block_config dma_block_cfg_link;

--- a/src/audio/copier/host_copier.h
+++ b/src/audio/copier/host_copier.h
@@ -48,7 +48,11 @@ struct hc_buf {
  */
 struct host_data {
 	/* local DMA config */
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	struct sof_dma *dma;
+#else
 	struct dma *dma;
+#endif
 	struct dma_chan_data *chan;
 	struct dma_sg_config config;
 #ifdef __ZEPHYR__

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -125,7 +125,11 @@ void ipc_free(struct ipc *ipc);
  */
 struct ipc_data_host_buffer {
 	/* DMA */
+#if CONFIG_ZEPHYR_NATIVE_DRIVERS
+	struct sof_dma *dmac;
+#else
 	struct dma *dmac;
+#endif
 	uint8_t *page_table;
 };
 

--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -125,7 +125,7 @@ struct dai_data {
 	struct comp_buffer *local_buffer;
 	struct dai_ts_cfg ts_config;
 	struct dai *dai;
-	struct dma *dma;
+	struct sof_dma *dma;
 	struct dai_group *group;		/* NULL if no group assigned */
 	int xrun;				/* true if we are doing xrun recovery */
 

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -85,7 +85,7 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 /*
  * Copy the audio buffer page tables from the host to the DSP max of 4K.
  */
-static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
+static int ipc_get_page_descriptors(struct sof_dma *dmac, uint8_t *page_table,
 				    struct sof_ipc_host_buffer *ring)
 {
 	struct dma_config cfg;

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -34,14 +34,14 @@ SOF_DEFINE_REG_UUID(dma);
 DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
-static int dma_init(struct dma *dma);
+static int dma_init(struct sof_dma *dma);
 
-struct dma *sof_dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
+struct sof_dma *sof_dma_get(uint32_t dir, uint32_t cap, uint32_t dev, uint32_t flags)
 {
 	const struct dma_info *info = dma_info_get();
 	int users, ret = 0;
 	int min_users = INT32_MAX;
-	struct dma *d = NULL, *dmin = NULL;
+	struct sof_dma *d = NULL, *dmin = NULL;
 	k_spinlock_key_t key;
 
 	if (!info->num_dmas) {
@@ -129,7 +129,7 @@ out:
 	return !ret ? dmin : NULL;
 }
 
-void sof_dma_put(struct dma *dma)
+void sof_dma_put(struct sof_dma *dma)
 {
 	k_spinlock_key_t key;
 
@@ -144,7 +144,7 @@ void sof_dma_put(struct dma *dma)
 	k_spin_unlock(&dma->lock, key);
 }
 
-static int dma_init(struct dma *dma)
+static int dma_init(struct sof_dma *dma)
 {
 	struct dma_chan_data *chan;
 	int i;

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -53,7 +53,7 @@ SOF_DEFINE_REG_UUID(lib_manager);
 DECLARE_TR_CTX(lib_manager_tr, SOF_UUID(lib_manager_uuid), LOG_LEVEL_INFO);
 
 struct lib_manager_dma_ext {
-	struct dma *dma;
+	struct sof_dma *dma;
 	struct dma_chan_data *chan;
 	uintptr_t dma_addr;		/**< buffer start pointer */
 	uint32_t addr_align;

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -42,7 +42,7 @@ static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
 };
 
 static const struct dma_info lib_dma = {
-	.dma_array = cache_to_uncache_init((struct dma *)dma),
+	.dma_array = cache_to_uncache_init((void *)dma),
 	.num_dmas = ARRAY_SIZE(dma)
 };
 

--- a/src/platform/posix/dma.c
+++ b/src/platform/posix/dma.c
@@ -176,7 +176,7 @@ DEVICE_DEFINE(pzdma2, "pzdma2", pzdma_init, NULL, &pzdma2_data, &pzdma2_cfg,
 DEVICE_DEFINE(pzdma3, "pzdma3", pzdma_init, NULL, &pzdma3_data, &pzdma3_cfg,
 	      POST_KERNEL, 0, &pzdma_api);
 
-struct dma posix_sof_dma[4];
+struct sof_dma posix_sof_dma[4];
 
 const struct dma_info posix_sof_dma_info = {
 	.dma_array = posix_sof_dma,
@@ -194,7 +194,7 @@ void posix_dma_init(struct sof *sof)
 	};
 
 	for (int i = 0; i < ARRAY_SIZE(posix_sof_dma); i++) {
-		posix_sof_dma[i] = (struct dma) {};
+		posix_sof_dma[i] = (struct sof_dma) {};
 		posix_sof_dma[i].plat_data.dir = 0xffffffff;
 		posix_sof_dma[i].plat_data.caps = 0xffffffff;
 		posix_sof_dma[i].plat_data.devs = 0xffffffff;

--- a/zephyr/include/sof/lib/dma.h
+++ b/zephyr/include/sof/lib/dma.h
@@ -122,7 +122,7 @@ enum sof_dma_cb_status {
 /* Attributes have been ported to Zephyr. This condition is necessary until full support of
  * CONFIG_SOF_ZEPHYR_STRICT_HEADERS.
  */
-struct dma;
+struct sof_dma;
 
 /**
  *  \brief Element of SG list (as array item).
@@ -194,7 +194,7 @@ struct dma_plat_data {
 	uint32_t period_count;
 };
 
-struct dma {
+struct sof_dma {
 	struct dma_plat_data plat_data;
 	struct k_spinlock lock;	/**< locking mechanism */
 	int sref;		/**< simple ref counter, guarded by lock */
@@ -206,7 +206,7 @@ struct dma {
 };
 
 struct dma_chan_data {
-	struct dma *dma;
+	struct sof_dma *dma;
 
 	uint32_t status;
 	uint32_t direction;
@@ -224,14 +224,14 @@ struct dma_chan_data {
 };
 
 struct dma_info {
-	struct dma *dma_array;
+	struct sof_dma *dma_array;
 	size_t num_dmas;
 };
 
 /* generic DMA DSP <-> Host copier */
 struct dma_copy {
 	struct dma_chan_data *chan;
-	struct dma *dmac;
+	struct sof_dma *dmac;
 };
 
 struct audio_stream;
@@ -254,14 +254,14 @@ int dmac_init(struct sof *sof);
  * For exclusive access, ret DMAC with no channels draining.
  * For shared access, ret DMAC with the least number of channels draining.
  */
-struct dma *sof_dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
+struct sof_dma *sof_dma_get(uint32_t dir, uint32_t caps, uint32_t dev, uint32_t flags);
 
 /**
  * \brief API to release a platform DMAC.
  *
  * @param[in] dma DMAC to relese.
  */
-void sof_dma_put(struct dma *dma);
+void sof_dma_put(struct sof_dma *dma);
 
 #ifndef CONFIG_ZEPHYR_NATIVE_DRIVERS
 #include "dma-legacy.h"

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -20,7 +20,7 @@
 #define DW_DMA_BUFFER_PERIOD_COUNT	0x4
 #define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
-SHARED_DATA struct dma dma[] = {
+SHARED_DATA struct sof_dma dma[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {


### PR DESCRIPTION
Add "sof_" namespace to dma_get()/put() in the Zephyr native drivers builds. The main "struct dma" is also renamed, so this touches quite many places in code.

V2 of https://github.com/thesofproject/sof/pull/9728. Now that XTOS code is removed (see https://github.com/thesofproject/sof/issues/9983 ), this is now a very simple patch. No need for ugly typedefs anymore.

I ketp the NATIVE_DRIVERS bits still in the codebase, but that's obviously the next bit that can be removed (along with dai-legacy.c and host-legacy.c -- and their dependencies).