### PR TITLE
src: audio: module_adapter: Do the params config right after init

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -123,6 +123,20 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 
 	dev->state = COMP_STATE_READY;
 
+#if CONFIG_IPC_MAJOR_4
+	struct sof_ipc_stream_params params;
+
+	/*
+	 * retrieve the stream params based on the module base cfg. There's no need to initialize
+	 * params here because it will be filled in based on the module base_cfg.
+	 */
+	ret = module_adapter_params(dev, &params);
+	if (ret) {
+		comp_err(dev, "module_adapter_new() %d: module params failed", ret);
+		goto err;
+	}
+#endif
+
 	comp_dbg(dev, "module_adapter_new() done");
 	return dev;
 err:
@@ -179,7 +193,28 @@ int module_adapter_prepare(struct comp_dev *dev)
 	int i = 0;
 
 	comp_dbg(dev, "module_adapter_prepare() start");
+#if CONFIG_IPC_MAJOR_4
+	/*
+	 * if the stream_params are valid, just update the sink/source buffer params. If not,
+	 * retrieve the params from the basecfg, allocate stream_params and then update the
+	 * sink/source buffer params.
+	 */
+	if (!mod->stream_params) {
+		struct sof_ipc_stream_params params;
 
+		ret = module_adapter_params(dev, &params);
+		if (ret) {
+			comp_err(dev, "module_adapter_new() %d: module params failed", ret);
+			return ret;
+		}
+	} else {
+		ret = comp_verify_params(dev, mod->verify_params_flags, mod->stream_params);
+		if (ret < 0) {
+			comp_err(dev, "module_adapter_params(): comp_verify_params() failed.");
+			return ret;
+		}
+	}
+#endif
 	/* Prepare module */
 	if (IS_PROCESSING_MODE_SINK_SOURCE(mod))
 		ret = module_adapter_sink_src_prepare(dev);


### PR DESCRIPTION
The module_adapter_params() functions set the stream params based on the base config for each module which is available right after module init. So configure the params for IPC4 during module_new() and remove the call to ipc4_pipeline_params(). This should help with reducing the time to trigger pipelines during start.