### PR TITLE
lib_manager: modules: Set of improvements for loadable module 

### DIFF
--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -126,7 +126,7 @@ typedef int (*create_instance_f)(uint32_t module_id, uint32_t instance_id, uint3
 
 int system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
 		       uint32_t core_id, uint32_t log_handle, void* mod_cfg,
-		       void **adapter)
+		       const void **adapter)
 {
 	uint32_t ret;
 	SystemAgent system_agent(module_id, instance_id, core_id, log_handle);

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -124,7 +124,7 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 typedef int (*create_instance_f)(uint32_t module_id, uint32_t instance_id, uint32_t core_id,
 				 void *mod_cfg, void *parent_ppl, void **mod_ptr);
 
-int system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+int system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
 		       uint32_t core_id, uint32_t log_handle, void* mod_cfg,
 		       void **adapter)
 {

--- a/src/audio/module_adapter/library/native_system_agent.c
+++ b/src/audio/module_adapter/library/native_system_agent.c
@@ -19,17 +19,24 @@ typedef void* (*native_create_instance_f)(void *mod_cfg, void *parent_ppl,
 
 struct native_system_agent native_sys_agent;
 
-void *native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
-				uint32_t core_id, uint32_t log_handle, void *mod_cfg)
+int native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+			      uint32_t core_id, uint32_t log_handle, void *mod_cfg,
+			      const void **iface)
 {
 	native_sys_agent.module_id = module_id;
 	native_sys_agent.instance_id = instance_id;
 	native_sys_agent.core_id = core_id;
 	native_sys_agent.log_handle = log_handle;
+	const void *ret;
 
 	void *system_agent_p = &native_sys_agent;
 
 	native_create_instance_f ci = (native_create_instance_f)entry_point;
 
-	return ci(mod_cfg, NULL, &system_agent_p);
+	ret = ci(mod_cfg, NULL, &system_agent_p);
+	if (!ret)
+		return -EINVAL;
+
+	*iface = ret;
+	return 0;
 }

--- a/src/audio/module_adapter/library/native_system_agent.c
+++ b/src/audio/module_adapter/library/native_system_agent.c
@@ -19,7 +19,7 @@ typedef void* (*native_create_instance_f)(void *mod_cfg, void *parent_ppl,
 
 struct native_system_agent native_sys_agent;
 
-int native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+int native_system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
 			      uint32_t core_id, uint32_t log_handle, void *mod_cfg,
 			      const void **iface)
 {

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -34,12 +34,31 @@ LOG_MODULE_REGISTER(module_adapter, CONFIG_SOF_LOG_LEVEL);
  * \param[in] drv - component driver pointer.
  * \param[in] config - component ipc descriptor pointer.
  * \param[in] spec - passdowned data from driver.
+ * \param[in] mod_priv - Pointer to private data for processing module.
  *
  * \return: a pointer to newly created module adapter component on success. NULL on error.
  */
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
-				    const struct comp_ipc_config *config,
-				    const void *spec)
+				    const struct comp_ipc_config *config, const void *spec)
+{
+	return module_adapter_new_ext(drv, config, spec, NULL);
+}
+
+/*
+ * \brief Create a module adapter component.
+ * \param[in] drv - component driver pointer.
+ * \param[in] config - component ipc descriptor pointer.
+ * \param[in] spec - passdowned data from driver.
+ * \param[in] mod_priv - Pointer to private data for processing module.
+ *
+ * \return: a pointer to newly created module adapter component on success. NULL on error.
+ *
+ * Note: Use the ext version if you need to set the module's private data before calling
+ *	 the create method.
+ */
+struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
+					const struct comp_ipc_config *config, const void *spec,
+					void *mod_priv)
 {
 	int ret;
 	struct comp_dev *dev;
@@ -79,6 +98,7 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 
 	dst = &mod->priv.cfg;
 
+	module_set_private_data(mod, mod_priv);
 	mod->dev = dev;
 	dev->mod = mod;
 

--- a/src/include/sof/audio/module_adapter/iadk/system_agent.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_agent.h
@@ -107,7 +107,7 @@ extern "C" {
  * method (the variant with 7 parameters) via a parameter that initially contained the address to
  * the agent system. The system_agent_start function returns it in the variable adapter.
  */
-int system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+int system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
 		       uint32_t core_id, uint32_t log_handle, void *mod_cfg, void **adapter);
 #ifdef __cplusplus
 }

--- a/src/include/sof/audio/module_adapter/iadk/system_agent.h
+++ b/src/include/sof/audio/module_adapter/iadk/system_agent.h
@@ -108,7 +108,7 @@ extern "C" {
  * the agent system. The system_agent_start function returns it in the variable adapter.
  */
 int system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
-		       uint32_t core_id, uint32_t log_handle, void *mod_cfg, void **adapter);
+		       uint32_t core_id, uint32_t log_handle, void *mod_cfg, const void **adapter);
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/sof/audio/module_adapter/library/native_system_agent.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_agent.h
@@ -35,7 +35,7 @@ struct native_system_agent {
  *
  * @return Returns 0 on success or an error code on failure.
  */
-int native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+int native_system_agent_start(uintptr_t entry_point, uint32_t module_id, uint32_t instance_id,
 			      uint32_t core_id, uint32_t log_handle, void *mod_cfg,
 			      const void **iface);
 

--- a/src/include/sof/audio/module_adapter/library/native_system_agent.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_agent.h
@@ -11,6 +11,10 @@
 #include <sof/audio/module_adapter/module/module_interface.h>
 #include <native_system_service.h>
 
+typedef int (*system_agent_start_fn)(uintptr_t entry_point, uint32_t module_id,
+				     uint32_t instance_id, uint32_t core_id, uint32_t log_handle,
+				     void *mod_cfg, const void **adapter);
+
 struct native_system_agent {
 	struct system_service system_service;
 	uint32_t log_handle;

--- a/src/include/sof/audio/module_adapter/library/native_system_agent.h
+++ b/src/include/sof/audio/module_adapter/library/native_system_agent.h
@@ -20,7 +20,23 @@ struct native_system_agent {
 	uint32_t module_size;
 };
 
-void *native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
-				uint32_t core_id, uint32_t log_handle, void *mod_cfg);
+/**
+ * @brief Starts the native system agent.
+ *
+ * This function initializes and starts the native system agent with the provided parameters.
+ *
+ * @param[in] entry_point - The module entry point function address.
+ * @param[in] module_id - The identifier for the module.
+ * @param[in] instance_id - The instance identifier of the module.
+ * @param[in] core_id - Core on which the module will run.
+ * @param[in] log_handle - The handle for logging purposes.
+ * @param[in] mod_cfg - Pointer to the module configuration data.
+ * @param[out] iface - Pointer to the module interface.
+ *
+ * @return Returns 0 on success or an error code on failure.
+ */
+int native_system_agent_start(uint32_t entry_point, uint32_t module_id, uint32_t instance_id,
+			      uint32_t core_id, uint32_t log_handle, void *mod_cfg,
+			      const void **iface);
 
 #endif /* __NATIVE_SYSTEM_AGENT_H__ */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -209,6 +209,9 @@ int module_unbind(struct processing_module *mod, struct bind_info *unbind_data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config, const void *spec);
+struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
+					const struct comp_ipc_config *config, const void *spec,
+					void *mod_priv);
 int module_adapter_prepare(struct comp_dev *dev);
 int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *params);
 int module_adapter_copy(struct comp_dev *dev);

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -73,9 +73,9 @@
 
 #define LIB_MANAGER_MAX_LIBS				16
 #define LIB_MANAGER_LIB_ID_SHIFT			12
-#define LIB_MANAGER_LIB_NOTIX_MAX_COUNT		4
+#define LIB_MANAGER_LIB_NOTIX_MAX_COUNT			4
 
-#define LIB_MANAGER_GET_LIB_ID(module_id) ((module_id) >> LIB_MANAGER_LIB_ID_SHIFT)
+#define LIB_MANAGER_GET_LIB_ID(module_id) (((module_id) & 0xF000) >> LIB_MANAGER_LIB_ID_SHIFT)
 #define LIB_MANAGER_GET_MODULE_INDEX(module_id) ((module_id) & 0xFFF)
 
 #ifdef CONFIG_LIBRARY_MANAGER

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -63,6 +63,8 @@
 #define __SOF_LIB_MANAGER_H__
 
 #include <stdint.h>
+#include <sof/list.h>
+#include <sof/audio/component.h>
 #include <rimage/sof/user/manifest.h>
 #if CONFIG_LIBRARY_AUTH_SUPPORT
 #include <sof/auth_api_iface.h>

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -186,21 +186,6 @@ int lib_manager_register_module(const uint32_t component_id);
  */
 const struct sof_man_fw_desc *lib_manager_get_library_manifest(int module_id);
 
-struct processing_module;
-struct comp_ipc_config;
-/*
- * \brief Allocate module
- *
- * param[in] drv - component driver
- * param[in] ipc_config - audio component base configuration from IPC at creation
- * param[in] ipc_specific_config - ipc4 base configuration
- *
- * Function is responsible to allocate module in available free memory and assigning proper address.
- * (WIP) These feature will contain module validation and proper memory management.
- */
-uintptr_t lib_manager_allocate_module(const struct comp_ipc_config *ipc_config,
-				      const void *ipc_specific_config);
-
 /*
  * \brief Free module
  *

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -496,7 +496,9 @@ static struct comp_dev *lib_manager_module_create(const struct comp_driver *drv,
 	const uint32_t module_id = IPC4_MOD_ID(config->id);
 	const uint32_t instance_id = IPC4_INST_ID(config->id);
 	const uint32_t log_handle = (uint32_t)drv->tctx;
+	const struct module_interface *ops;
 	byte_array_t mod_cfg;
+	int ret;
 
 	/*
 	 * Variable used by llext_manager to temporary store llext handle before creation
@@ -518,11 +520,9 @@ static struct comp_dev *lib_manager_module_create(const struct comp_driver *drv,
 	/* Intel modules expects DW size here */
 	mod_cfg.size = args->size >> 2;
 
-	const struct module_interface *ops = native_system_agent_start(module_entry_point,
-								       module_id, instance_id,
-								       0, log_handle, &mod_cfg);
-
-	if (!ops) {
+	ret = native_system_agent_start(module_entry_point, module_id, instance_id, 0, log_handle,
+					&mod_cfg, (const void **)&ops);
+	if (ret) {
 		lib_manager_free_module(module_id);
 		tr_err(&lib_manager_tr, "native_system_agent_start failed!");
 		return NULL;


### PR DESCRIPTION
- Move module allocation and system agent call from modules_init to lib_manager_module_create to unify the module loading process.

- Add a bitmask to the LIB_MANAGER_GET_LIB_ID macro to discard the instance identifier placed on the high order bits of the component id.
- Create a function `module_adapter_new_ext` that allows to assign a pointer to the private data of the module for which the adapter is being created.
- Add missing include headers for list and component in lib_manager.
- Change type of the `entry_point` parameter in the `native_system_agent_start` and `system_agent_start` functions to uintptr_t which allows safe pointer passing.
- Change signature of the `native_system_agent_start` function to match with the `system_agent_start` function. The function returns an error code and a pointer to the module interface is returned via the parameter.