### PR TITLE
iadk: Fix GetConfiguration API function

### DIFF
--- a/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
+++ b/src/audio/module_adapter/iadk/iadk_module_adapter.cpp
@@ -121,9 +121,9 @@ IadkModuleAdapter::IadkModuleAdapter_SetConfiguration(uint32_t config_id,
 AdspErrorCode
 IadkModuleAdapter::IadkModuleAdapter_GetConfiguration(uint32_t config_id,
 						      enum module_cfg_fragment_position pos,
-						      uint32_t data_offset_size,
+						      uint32_t &data_offset_size,
 						      uint8_t *fragment_buffer,
-						      size_t fragment_size)
+						      size_t &fragment_size)
 {
 	intel_adsp::ConfigurationFragmentPosition fragment_position =
 			(intel_adsp::ConfigurationFragmentPosition::Enum) pos;
@@ -219,12 +219,12 @@ int iadk_wrapper_set_configuration(void *md, uint32_t config_id,
 
 int iadk_wrapper_get_configuration(void *md, uint32_t config_id,
 				   enum module_cfg_fragment_position pos,
-				   uint32_t data_offset_size,
+				   uint32_t *data_offset_size,
 				   uint8_t *fragment, size_t fragment_size)
 {
 	struct IadkModuleAdapter *mod_adp = (struct IadkModuleAdapter *) md;
 	return mod_adp->IadkModuleAdapter_GetConfiguration(config_id, pos,
-							   data_offset_size,
+							   *data_offset_size,
 							   fragment,
 							   fragment_size);
 }

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -191,7 +191,7 @@ static int modules_get_configuration(struct processing_module *mod, uint32_t con
 				     size_t fragment_size)
 {
 	return iadk_wrapper_get_configuration(module_get_private_data(mod), config_id,
-					      MODULE_CFG_FRAGMENT_SINGLE, *data_offset_size,
+					      MODULE_CFG_FRAGMENT_SINGLE, data_offset_size,
 					      fragment, fragment_size);
 }
 

--- a/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
+++ b/src/include/sof/audio/module_adapter/iadk/iadk_module_adapter.h
@@ -91,9 +91,9 @@ namespace dsp_fw
 		AdspErrorCode
 		IadkModuleAdapter_GetConfiguration(uint32_t config_id,
 		                               enum module_cfg_fragment_position fragment_position,
-		                               uint32_t data_offset_size,
+		                               uint32_t &data_offset_size,
 		                               uint8_t *fragment_buffer,
-		                               size_t fragment_size);
+		                               size_t &fragment_size);
 		/**
 		 * Module specific reset procedure, called as part of codec_adapter component
 		 * reset in .reset(). This should reset all parameters to their initial stage
@@ -146,7 +146,7 @@ int iadk_wrapper_set_configuration(void *md, uint32_t config_id,
 
 int iadk_wrapper_get_configuration(void *md, uint32_t config_id,
 				   enum module_cfg_fragment_position pos,
-				   uint32_t data_offset_size,
+				   uint32_t *data_offset_size,
 				   uint8_t *fragment, size_t fragment_size);
 
 int iadk_wrapper_process(void *md,


### PR DESCRIPTION
The GetConfiguration function was incorrectly defined for IADK module adapter. This patch fixes the definition.