### PR TITLE
userspace: Preparation for userspace loadable modules support

### DIFF
--- a/posix/include/rtos/alloc.h
+++ b/posix/include/rtos/alloc.h
@@ -33,19 +33,21 @@
  */
 
  /** \brief Indicates we should return DMA-able memory. */
-#define SOF_MEM_FLAG_DMA	BIT(0)
+#define SOF_MEM_FLAG_DMA		BIT(0)
 /** \brief Indicates that original content should not be copied by realloc. */
-#define SOF_MEM_FLAG_NO_COPY	BIT(1)
+#define SOF_MEM_FLAG_NO_COPY		BIT(1)
 /** \brief Indicates that if we should return uncached address. */
-#define SOF_MEM_FLAG_COHERENT	BIT(2)
+#define SOF_MEM_FLAG_COHERENT		BIT(2)
 /** \brief Indicates that if we should return L3 address. */
-#define SOF_MEM_FLAG_L3		BIT(3)
+#define SOF_MEM_FLAG_L3			BIT(3)
 /** \brief Indicates that if we should return Low power memory address. */
-#define SOF_MEM_FLAG_LOW_POWER	BIT(4)
+#define SOF_MEM_FLAG_LOW_POWER		BIT(4)
 /** \brief Indicates that if we should return kernel memory address. */
-#define SOF_MEM_FLAG_KERNEL	BIT(5)
+#define SOF_MEM_FLAG_KERNEL		BIT(5)
 /** \brief Indicates that if we should return user memory address. */
-#define SOF_MEM_FLAG_USER	BIT(6)
+#define SOF_MEM_FLAG_USER		BIT(6)
+/** \brief Indicates that if we should return shared user memory address. */
+#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(7)
 
 /** @} */
 

--- a/posix/include/rtos/userspace_helper.h
+++ b/posix/include/rtos/userspace_helper.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2025 Intel Corporation. All rights reserved.
+ *
+ * Author: Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ *	   Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+/**
+ * \brief Userspace support functions.
+ */
+#ifndef __RTOS_USERSPACE_HELPER_H__
+#define __RTOS_USERSPACE_HELPER_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <rtos/alloc.h>
+
+struct sys_heap;
+
+#ifdef CONFIG_USERSPACE
+/**
+ * Initialize private processing module heap.
+ * @param N/A.
+ * @return pointer to the sys_heap structure.
+ *
+ * @note
+ * Function used only when CONFIG_USERSPACE is set.
+ * The private heap is used only for non-privileged modules for all processing module allocations
+ * that should be isolated. The heap helps to accumulate all dynamic allocations in single memory
+ * region which is then added to modules memory domain.
+ */
+static inline struct sys_heap *module_driver_heap_init(void)
+{
+	return NULL;
+}
+
+#endif
+
+/**
+ * Allocates memory block from private module sys_heap if exists, otherwise call rballoc_align().
+ * @param sys_heap  - pointer to the sys_heap structure
+ * @param flags     - Flags, see SOF_MEM_FLAG_...
+ * @param bytes     - Size in bytes.
+ * @param alignment - Alignment in bytes.
+ * @return Pointer to the allocated memory or NULL if failed.
+ *
+ * @note When CONFIG_USERSPACE not set function calls rballoc_align()
+ */
+static inline void *module_driver_heap_aligned_alloc(struct sys_heap *mod_drv_heap, uint32_t flags,
+						     size_t bytes, uint32_t align)
+{
+	return rballoc_align(flags, bytes, align);
+}
+
+/**
+ * Allocates memory block from private module sys_heap if exists, otherwise call rmalloc.
+ * @param sys_heap - pointer to the sys_heap structure
+ * @param flags    - Flags, see SOF_MEM_FLAG_...
+ * @param bytes    - Size in bytes.
+ * @return         - Pointer to the allocated memory or NULL if failed.
+ *
+ *  * @note When CONFIG_USERSPACE not set function calls rmalloc()
+ */
+static inline void *module_driver_heap_rmalloc(struct sys_heap *mod_drv_heap, uint32_t flags,
+					       size_t bytes)
+{
+	return rmalloc(flags, bytes);
+}
+
+/**
+ * Similar to user_rmalloc(), guarantees that returned block is zeroed.
+ *
+ * @note When CONFIG_USERSPACE not set function calls rzalloc()
+ */
+static inline void *module_driver_heap_rzalloc(struct sys_heap *mod_drv_heap, uint32_t flags,
+					       size_t bytes)
+{
+	return rzalloc(flags, bytes);
+}
+
+/**
+ * Frees the memory block from private module sys_heap if exists. Otherwise call rfree.
+ * @param ptr Pointer to the memory block.
+ *
+ * @note User should take care to not free memory allocated from sys_heap
+ *       with module_driver_heap set to NULL. It will cause exception.
+ *
+ *       When CONFIG_USERSPACE not set function calls rfree()
+ */
+static inline void module_driver_heap_free(struct sys_heap *mod_drv_heap, void *mem)
+{
+	rfree(mem);
+}
+
+/**
+ * Free private processing module heap.
+ * @param sys_heap pointer to the sys_heap structure.
+ *
+ * @note
+ * Function used only when CONFIG_USERSPACE is set.
+ * Frees private module heap.
+ */
+static inline void module_driver_heap_remove(struct sys_heap *mod_drv_heap)
+{ }
+
+#endif /* __RTOS_USERSPACE_HELPER_H__ */

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -90,7 +90,7 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	int flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 			     SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
 
-	mod = rzalloc(flags, sizeof(*mod));
+	mod = module_driver_heap_rzalloc(drv->user_heap, flags, sizeof(*mod));
 	if (!mod) {
 		comp_err(dev, "module_adapter_new(), failed to allocate memory for module");
 		goto err;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -210,6 +210,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	struct list_item *blist, *_blist;
 	uint32_t buff_periods;
 	uint32_t buff_size; /* size of local buffer */
+	int memory_flags;
 	int i = 0;
 
 	comp_dbg(dev, "module_adapter_prepare() start");
@@ -342,11 +343,11 @@ int module_adapter_prepare(struct comp_dev *dev)
 
 	module_adapter_check_data(mod, dev, sink);
 
+	memory_flags = user_get_buffer_memory_region(dev->drv);
 	/* allocate memory for input buffers */
 	if (mod->max_sources) {
 		mod->input_buffers =
-			rzalloc(SOF_MEM_FLAG_USER,
-				sizeof(*mod->input_buffers) * mod->max_sources);
+			rzalloc(memory_flags, sizeof(*mod->input_buffers) * mod->max_sources);
 		if (!mod->input_buffers) {
 			comp_err(dev, "failed to allocate input buffers");
 			return -ENOMEM;
@@ -358,8 +359,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* allocate memory for output buffers */
 	if (mod->max_sinks) {
 		mod->output_buffers =
-			rzalloc(SOF_MEM_FLAG_USER,
-				sizeof(*mod->output_buffers) * mod->max_sinks);
+			rzalloc(memory_flags, sizeof(*mod->output_buffers) * mod->max_sinks);
 		if (!mod->output_buffers) {
 			comp_err(dev, "failed to allocate output buffers");
 			ret = -ENOMEM;
@@ -425,7 +425,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsource_list) {
 		size_t size = MAX(mod->deep_buff_bytes, mod->period_bytes);
 
-		mod->input_buffers[i].data = rballoc(SOF_MEM_FLAG_USER, size);
+		mod->input_buffers[i].data = rballoc(memory_flags, size);
 		if (!mod->input_buffers[i].data) {
 			comp_err(mod->dev, "Failed to alloc input buffer data");
 			ret = -ENOMEM;
@@ -437,7 +437,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	/* allocate memory for output buffer data */
 	i = 0;
 	list_for_item(blist, &dev->bsink_list) {
-		mod->output_buffers[i].data = rballoc(SOF_MEM_FLAG_USER, md->mpd.out_buff_size);
+		mod->output_buffers[i].data = rballoc(memory_flags, md->mpd.out_buff_size);
 		if (!mod->output_buffers[i].data) {
 			comp_err(mod->dev, "Failed to alloc output buffer data");
 			ret = -ENOMEM;
@@ -450,7 +450,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	if (list_is_empty(&mod->raw_data_buffers_list)) {
 		for (i = 0; i < mod->num_of_sinks; i++) {
 			/* allocate not shared buffer */
-			struct comp_buffer *buffer = buffer_alloc(buff_size, SOF_MEM_FLAG_USER,
+			struct comp_buffer *buffer = buffer_alloc(buff_size, memory_flags,
 								  PLATFORM_DCACHE_ALIGN, false);
 			uint32_t flags;
 

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -136,7 +136,9 @@ int module_adapter_init_data(struct comp_dev *dev,
 		if (cfgsz == (sizeof(*cfg) + pinsz)) {
 			dst->nb_input_pins = n_in;
 			dst->nb_output_pins = n_out;
-			dst->input_pins = rmalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, pinsz);
+			dst->input_pins = module_driver_heap_rmalloc(dev->drv->user_heap,
+								     SOF_MEM_FLAG_USER |
+								     SOF_MEM_FLAG_COHERENT, pinsz);
 			if (!dst->input_pins)
 				return -ENOMEM;
 

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -21,6 +21,7 @@
 #include <sof/audio/pipeline.h>
 #include <sof/debug/telemetry/telemetry.h>
 #include <rtos/idc.h>
+#include <rtos/userspace_helper.h>
 #include <sof/lib/dai.h>
 #include <sof/schedule/schedule.h>
 #include <ipc/control.h>
@@ -590,6 +591,7 @@ struct comp_driver {
 							  * Intended to replace the ops field.
 							  * Currently used by module_adapter.
 							  */
+	struct sys_heap *user_heap;			/**< Userspace heap */
 };
 
 /** \brief Holds constant pointer to component driver */
@@ -853,8 +855,7 @@ static inline enum sof_comp_type dev_comp_type(const struct comp_dev *dev)
  * @param bytes Size of the component device in bytes.
  * @return Pointer to the component device.
  */
-static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
-					  size_t bytes)
+static inline struct comp_dev *comp_alloc(const struct comp_driver *drv, size_t bytes)
 {
 	struct comp_dev *dev = NULL;
 
@@ -862,7 +863,8 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv,
 	 * Use uncached address everywhere to access components to rule out
 	 * multi-core failures. TODO: verify if cached alias may be used in some cases
 	 */
-	dev = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, bytes);
+	dev = module_driver_heap_rzalloc(drv->user_heap, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
+					 bytes);
 	if (!dev)
 		return NULL;
 	dev->size = bytes;

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -1194,4 +1194,12 @@ void comp_init_performance_data(struct comp_dev *dev);
  */
 bool comp_update_performance_data(struct comp_dev *dev, uint32_t cycles_used);
 
+static inline int user_get_buffer_memory_region(const struct comp_driver *drv)
+{
+#if CONFIG_USERSPACE
+	return drv->user_heap ? SOF_MEM_FLAG_USER_SHARED_BUFFER : SOF_MEM_FLAG_USER;
+#else
+	return SOF_MEM_FLAG_USER;
+#endif
+}
 #endif /* __SOF_AUDIO_COMPONENT_H__ */

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -164,13 +164,32 @@ int module_prepare(struct processing_module *mod,
 		   struct sof_sink **sinks, int num_of_sinks);
 
 static inline
+bool generic_module_is_ready_to_process(struct processing_module *mod,
+					struct sof_source **sources,
+					int num_of_sources,
+					struct sof_sink **sinks,
+					int num_of_sinks)
+{
+	int i;
+
+	for (i = 0; i < num_of_sources; i++)
+		if (source_get_data_available(sources[i]) < source_get_min_available(sources[i]))
+			return false;
+
+	for (i = 0; i < num_of_sinks; i++)
+		if (sink_get_free_size(sinks[i]) < sink_get_min_free_space(sinks[i]))
+			return false;
+
+	return true;
+}
+
+static inline
 bool module_is_ready_to_process(struct processing_module *mod,
 				struct sof_source **sources,
 				int num_of_sources,
 				struct sof_sink **sinks,
 				int num_of_sinks)
 {
-	int i;
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
 
 	/* LL module has to be always ready for processing */
@@ -182,15 +201,8 @@ bool module_is_ready_to_process(struct processing_module *mod,
 	/* default action - the module is ready if there's enough data for processing and enough
 	 * space to store result. IBS/OBS as declared in init_instance
 	 */
-	for (i = 0; i < num_of_sources; i++)
-		if (source_get_data_available(sources[i]) < source_get_min_available(sources[i]))
-			return false;
-
-	for (i = 0; i < num_of_sinks; i++)
-		if (sink_get_free_size(sinks[i]) < sink_get_min_free_space(sinks[i]))
-			return false;
-
-	return true;
+	return generic_module_is_ready_to_process(mod, sources, num_of_sources, sinks,
+						  num_of_sinks);
 }
 
 int module_process_sink_src(struct processing_module *mod,

--- a/src/include/sof/audio/ring_buffer.h
+++ b/src/include/sof/audio/ring_buffer.h
@@ -97,6 +97,7 @@
  *		always means "buffer full"
  */
 
+struct comp_dev;
 struct ring_buffer;
 struct sof_audio_stream_params;
 
@@ -114,6 +115,7 @@ struct ring_buffer {
 
 /**
  *
+ * @param dev pointer to the DP module device structure
  * @param min_available  minimum data available in queue required by the module using
  *			 ring_buffer's source api
  * @param min_free_space minimum buffer space in queue required by the module using
@@ -122,7 +124,8 @@ struct ring_buffer {
  * @param id a stream ID, accessible later by sink_get_id/source_get_id
  *
  */
-struct ring_buffer *ring_buffer_create(size_t min_available, size_t min_free_space, bool is_shared,
+struct ring_buffer *ring_buffer_create(struct comp_dev *dev, size_t min_available,
+				       size_t min_free_space, bool is_shared,
 				       uint32_t id);
 
 #endif /* __SOF_RING_BUFFER_H__ */

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -187,6 +187,18 @@ int lib_manager_register_module(const uint32_t component_id);
 const struct sof_man_fw_desc *lib_manager_get_library_manifest(int module_id);
 
 /*
+ * \brief Get address and size of the bss section for given module instance
+ *
+ * param[in] instance_id - instance id
+ * param[in] mod - module manifest
+ * param[out] va_addr - address of the bss section
+ * param[out] size - size of the bss section
+ */
+void lib_manager_get_instance_bss_address(uint32_t instance_id,
+					  const struct sof_man_module *mod,
+					  void __sparse_cache **va_addr, size_t *size);
+
+/*
  * \brief Free module
  *
  * param[in] component_id - component id coming from ipc config. This function reguires valid

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -603,25 +603,23 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 
 	if (sink->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP ||
 	    source->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
-		struct sof_source *source = audio_buffer_get_source(&buffer->audio_buffer);
-		struct sof_sink *sink = audio_buffer_get_sink(&buffer->audio_buffer);
+		bool dp_on_source = source->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP;
+		struct sof_source *src = audio_buffer_get_source(&buffer->audio_buffer);
+		struct sof_sink *snk = audio_buffer_get_sink(&buffer->audio_buffer);
 
-		ring_buffer = ring_buffer_create(source_get_min_available(source),
-						 sink_get_min_free_space(sink),
+		ring_buffer = ring_buffer_create(dp_on_source ? source : sink,
+						 source_get_min_available(src),
+						 sink_get_min_free_space(snk),
 						 audio_buffer_is_shared(&buffer->audio_buffer),
 						 buf_get_id(buffer));
 		if (!ring_buffer)
 			goto free;
+
+		/* data destination module needs to use ring_buffer */
+		audio_buffer_attach_secondary_buffer(&buffer->audio_buffer, dp_on_source,
+						     &ring_buffer->audio_buffer);
 	}
 
-	if (sink->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP)
-		/* data destination module needs to use ring_buffer */
-		audio_buffer_attach_secondary_buffer(&buffer->audio_buffer, false, /* at_input */
-						     &ring_buffer->audio_buffer);
-	else if (source->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP)
-		/* data source module needs to use ring_buffer */
-		audio_buffer_attach_secondary_buffer(&buffer->audio_buffer, true, /* at_input */
-						     &ring_buffer->audio_buffer);
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 	/*
 	 * Connect and bind the buffer to both source and sink components with LL processing been

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -273,9 +273,9 @@ static int lib_manager_unload_libcode_modules(const uint32_t module_id)
 }
 #endif /* CONFIG_LIBCODE_MODULE_SUPPORT */
 
-static void lib_manager_get_instance_bss_address(uint32_t instance_id,
-						 const struct sof_man_module *mod,
-						 void __sparse_cache **va_addr, size_t *size)
+void lib_manager_get_instance_bss_address(uint32_t instance_id,
+					  const struct sof_man_module *mod,
+					  void __sparse_cache **va_addr, size_t *size)
 {
 	*size = mod->segment[SOF_MAN_SEGMENT_BSS].flags.r.length / mod->instance_max_count *
 		PAGE_SZ;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -474,6 +474,7 @@ zephyr_library_sources(
 	lib/alloc.c
 	lib/cpu.c
 	lib/pm_runtime.c
+	lib/userspace_helper.c
 
 	# Common library functions - Will be moved to Zephyr over time
 	lib.c

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -522,6 +522,10 @@ if (NOT CONFIG_COMPILER_INLINE_FUNCTION_OPTION)
 target_compile_options(SOF INTERFACE -fno-inline-functions)
 endif()
 
+if (CONFIG_USERSPACE)
+target_compile_options(SOF INTERFACE -mno-global-merge)
+endif()
+
 # SOF needs `typeof`, `__VA_ARGS__` and maybe other GNU C99
 # extensions. TODO other flags required ?
 target_compile_options(SOF INTERFACE $<$<COMPILE_LANGUAGE:C,ASM>: -std=gnu99>)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -41,6 +41,18 @@ config SOF_ZEPHYR_HEAP_SIZE
 	 NOTE: Keep in mind that the heap size should not be greater than the physical
 	 memory size of the system defined in DT (and this includes baseFW text/data).
 
+config SOF_ZEPHYR_SHARED_BUFFER_HEAP_SIZE
+	hex "Size of the shared buffer heap for SOF userspace modules"
+	default 0x1E000 if SOC_INTEL_ACE15_MTPM || SOC_INTEL_ACE20_LNL
+	default 0x1A000 if SOC_INTEL_ACE30
+	default 0x0
+	help
+	 The size of the zephyr heap portion designated as the shared buffer heap.
+	 This heap is shared between the sof and userspace modules. It is used exclusively for
+	 allocating audio buffers between the kernel and userspace modules.
+	 NOTE: Keep in mind that the shared heap size should not be greater than the
+	 heap size.
+
 config SOF_ZEPHYR_VIRTUAL_HEAP_SIZE
 	hex "Size of the Zephyr virtual heap for SOF"
 	depends on VIRTUAL_HEAP

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -69,6 +69,14 @@ config SOF_ZEPHYR_VIRTUAL_HEAP_REGION_SIZE
 	help
 	  This config defines size of virtual heap region shared between all cores
 
+config SOF_ZEPHYR_USERSPACE_MODULE_HEAP_SIZE
+	hex "Size of the private heap created for each userspace module"
+	default 0x1000
+	help
+	 The size of the private heap created for each userspace module. Each userspace
+	 module has its own independent heap to which only it has access. This heap is
+	 shared between instances of the same module.
+
 config ZEPHYR_NATIVE_DRIVERS
 	bool "Use Zephyr native drivers"
 	default n

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -24,19 +24,21 @@
  */
 
  /** \brief Indicates we should return DMA-able memory. */
-#define SOF_MEM_FLAG_DMA	BIT(0)
+#define SOF_MEM_FLAG_DMA		BIT(0)
 /** \brief Indicates that original content should not be copied by realloc. */
-#define SOF_MEM_FLAG_NO_COPY	BIT(1)
+#define SOF_MEM_FLAG_NO_COPY		BIT(1)
 /** \brief Indicates that if we should return uncached address. */
-#define SOF_MEM_FLAG_COHERENT	BIT(2)
+#define SOF_MEM_FLAG_COHERENT		BIT(2)
 /** \brief Indicates that if we should return L3 address. */
-#define SOF_MEM_FLAG_L3		BIT(3)
+#define SOF_MEM_FLAG_L3			BIT(3)
 /** \brief Indicates that if we should return Low power memory address. */
-#define SOF_MEM_FLAG_LOW_POWER	BIT(4)
+#define SOF_MEM_FLAG_LOW_POWER		BIT(4)
 /** \brief Indicates that if we should return kernel memory address. */
-#define SOF_MEM_FLAG_KERNEL	BIT(5)
+#define SOF_MEM_FLAG_KERNEL		BIT(5)
 /** \brief Indicates that if we should return user memory address. */
-#define SOF_MEM_FLAG_USER	BIT(6)
+#define SOF_MEM_FLAG_USER		BIT(6)
+/** \brief Indicates that if we should return shared user memory address. */
+#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(7)
 
 /** @} */
 
@@ -110,5 +112,22 @@ void l3_heap_save(void);
 static inline void heap_trace_all(int force) {}
 
 /** @}*/
+
+#if CONFIG_USERSPACE
+/**
+ * Returns the start address of shared memory heap for buffers.
+ *
+ * @return pointer to shared memory heap start
+ */
+uintptr_t get_shared_buffer_heap_start(void);
+
+/**
+ * Returns the size of shared memory heap for buffers.
+ *
+ * @return size of shared memory heap start
+ */
+size_t get_shared_buffer_heap_size(void);
+
+#endif
 
 #endif /* __ZEPHYR_RTOS_ALLOC_H__ */

--- a/zephyr/include/rtos/userspace_helper.h
+++ b/zephyr/include/rtos/userspace_helper.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2025 Intel Corporation. All rights reserved.
+ *
+ * Author: Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ *	   Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+/**
+ * \brief Userspace support functions.
+ */
+#ifndef __ZEPHYR_LIB_USERSPACE_HELPER_H__
+#define __ZEPHYR_LIB_USERSPACE_HELPER_H__
+
+#ifdef CONFIG_USERSPACE
+#define DRV_HEAP_SIZE	ALIGN_UP(CONFIG_SOF_ZEPHYR_USERSPACE_MODULE_HEAP_SIZE, \
+				 CONFIG_MM_DRV_PAGE_SIZE)
+
+/**
+ * Initialize private processing module heap.
+ * @param N/A.
+ * @return pointer to the sys_heap structure.
+ *
+ * @note
+ * Function used only when CONFIG_USERSPACE is set.
+ * The private heap is used only for non-privileged modules for all processing module allocations
+ * that should be isolated. The heap helps to accumulate all dynamic allocations in single memory
+ * region which is then added to modules memory domain.
+ */
+struct sys_heap *module_driver_heap_init(void);
+
+#endif
+
+/**
+ * Allocates memory block from private module sys_heap if exists, otherwise call rballoc_align().
+ * @param sys_heap - pointer to the sys_heap structure
+ * @param flags    - Flags, see SOF_MEM_FLAG_...
+ * @param bytes     - Size in bytes.
+ * @param alignment - Alignment in bytes.
+ * @return Pointer to the allocated memory or NULL if failed.
+ *
+ * @note When CONFIG_USERSPACE not set function calls rballoc_align()
+ */
+void *module_driver_heap_aligned_alloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes,
+				       uint32_t align);
+
+/**
+ * Allocates memory block from private module sys_heap if exists, otherwise call rmalloc.
+ * @param sys_heap - pointer to the sys_heap structure
+ * @param flags    - Flags, see SOF_MEM_FLAG_...
+ * @param bytes    - Size in bytes.
+ * @return         - Pointer to the allocated memory or NULL if failed.
+ *
+ *  * @note When CONFIG_USERSPACE not set function calls rmalloc()
+ */
+void *module_driver_heap_rmalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes);
+
+/**
+ * Similar to user_rmalloc(), guarantees that returned block is zeroed.
+ *
+ * @note When CONFIG_USERSPACE not set function calls rzalloc()
+ */
+void *module_driver_heap_rzalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes);
+
+/**
+ * Frees the memory block from private module sys_heap if exists. Otherwise call rfree.
+ * @param ptr Pointer to the memory block.
+ *
+ * @note User should take care to not free memory allocated from sys_heap
+ *       with mod_drv_heap set to NULL. It will cause exception.
+ *
+ *       When CONFIG_USERSPACE not set function calls rfree()
+ */
+void module_driver_heap_free(struct sys_heap *mod_drv_heap, void *mem);
+
+/**
+ * Free private processing module heap.
+ * @param sys_heap pointer to the sys_heap structure.
+ *
+ * @note
+ * Function used only when CONFIG_USERSPACE is set.
+ * Frees private module heap.
+ */
+void module_driver_heap_remove(struct sys_heap *mod_drv_heap);
+
+#endif /* __ZEPHYR_LIB_USERSPACE_HELPER_H__ */

--- a/zephyr/lib/userspace_helper.c
+++ b/zephyr/lib/userspace_helper.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// Author: Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+//	   Adrian Warecki <adrian.warecki@intel.com>
+
+/**
+ * \file
+ * \brief Zephyr userspace helper functions
+ * \authors Jaroslaw Stelter <jaroslaw.stelter@intel.com>
+ * \authors Adrian Warecki <adrian.warecki@intel.com>
+ */
+
+#include <stdint.h>
+
+#include <rtos/alloc.h>
+#include <rtos/userspace_helper.h>
+
+#define MODULE_DRIVER_HEAP_CACHED		CONFIG_SOF_ZEPHYR_HEAP_CACHED
+
+#if CONFIG_USERSPACE
+struct sys_heap *module_driver_heap_init(void)
+{
+	struct sys_heap *mod_drv_heap = rballoc(SOF_MEM_FLAG_USER, sizeof(struct sys_heap));
+
+	if (!mod_drv_heap)
+		return NULL;
+
+	void *mem = rballoc_align(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, DRV_HEAP_SIZE,
+				  CONFIG_MM_DRV_PAGE_SIZE);
+	if (!mem) {
+		rfree(mod_drv_heap);
+		return NULL;
+	}
+
+	sys_heap_init(mod_drv_heap, mem, DRV_HEAP_SIZE);
+	mod_drv_heap->init_mem = mem;
+	mod_drv_heap->init_bytes = DRV_HEAP_SIZE;
+
+	return mod_drv_heap;
+}
+
+void *module_driver_heap_aligned_alloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes,
+				       uint32_t align)
+{
+#ifdef MODULE_DRIVER_HEAP_CACHED
+	const bool cached = (flags & SOF_MEM_FLAG_COHERENT) == 0;
+#endif /* MODULE_DRIVER_HEAP_CACHED */
+
+	if (mod_drv_heap) {
+#ifdef MODULE_DRIVER_HEAP_CACHED
+		if (cached) {
+			/*
+			 * Zephyr sys_heap stores metadata at start of each
+			 * heap allocation. To ensure no allocated cached buffer
+			 * overlaps the same cacheline with the metadata chunk,
+			 * align both allocation start and size of allocation
+			 * to cacheline. As cached and non-cached allocations are
+			 * mixed, same rules need to be followed for both type of
+			 * allocations.
+			 */
+			align = MAX(PLATFORM_DCACHE_ALIGN, align);
+			bytes = ALIGN_UP(bytes, align);
+		}
+#endif /* MODULE_DRIVER_HEAP_CACHED */
+		void *mem = sys_heap_aligned_alloc(mod_drv_heap, align, bytes);
+#ifdef MODULE_DRIVER_HEAP_CACHED
+		if (cached)
+			return sys_cache_cached_ptr_get(mem);
+#endif	/* MODULE_DRIVER_HEAP_CACHED */
+		return mem;
+	} else {
+		return rballoc_align(flags, bytes, align);
+	}
+}
+
+void *module_driver_heap_rmalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes)
+{
+	if (mod_drv_heap)
+		return module_driver_heap_aligned_alloc(mod_drv_heap, flags, bytes, 0);
+	else
+		return rmalloc(flags, bytes);
+}
+
+void *module_driver_heap_rzalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes)
+{
+	void *ptr;
+
+	ptr = module_driver_heap_rmalloc(mod_drv_heap, flags, bytes);
+	if (ptr)
+		memset(ptr, 0, bytes);
+
+	return ptr;
+}
+
+void module_driver_heap_free(struct sys_heap *mod_drv_heap, void *mem)
+{
+	if (mod_drv_heap) {
+#ifdef MODULE_DRIVER_HEAP_CACHED
+		if (is_cached(mem)) {
+			void *mem_uncached = sys_cache_uncached_ptr_get(
+				(__sparse_force void __sparse_cache *)mem);
+
+			sys_cache_data_invd_range(mem,
+						  sys_heap_usable_size(mod_drv_heap, mem_uncached));
+
+			mem = mem_uncached;
+		}
+#endif
+		sys_heap_free(mod_drv_heap, mem);
+	} else {
+		rfree(mem);
+	}
+}
+
+void module_driver_heap_remove(struct sys_heap *mod_drv_heap)
+{
+	if (mod_drv_heap) {
+		rfree(mod_drv_heap->init_mem);
+		rfree(mod_drv_heap);
+	}
+}
+
+#else /* CONFIG_USERSPACE */
+
+void *module_driver_heap_rmalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes)
+{
+	return rmalloc(flags, bytes);
+}
+
+void *module_driver_heap_aligned_alloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes,
+				       uint32_t align)
+{
+	return rballoc_align(flags, bytes, align);
+}
+
+void *module_driver_heap_rzalloc(struct sys_heap *mod_drv_heap, uint32_t flags, size_t bytes)
+{
+	return rzalloc(flags, bytes);
+}
+
+void module_driver_heap_free(struct sys_heap *mod_drv_heap, void *mem)
+{
+	rfree(mem);
+}
+
+void module_driver_heap_remove(struct sys_heap *mod_drv_heap)
+{ }
+
+#endif /* CONFIG_USERSPACE */


### PR DESCRIPTION
- Introduce MMU shared memory heap commit splits system heap into two sections. One section which will contatin shareable data will be located in separate memory partition. Each non-privilidged module will obtain it in its private memory domain. In case of CONFIG_USERSPACE enabled, all memory is accessible form kernel space. For accessing it from user space we need to grant access to its explicitly. However there are some infrastructure components that could be shared between kernel and user spaces.

- Introduce driver heap for non-privileged modules. Non-privileged modules should be isolated each other. It means that module related data should be located in memory available for kernel and the owner module only. To manage access all such data should be allocated from single, separate region.

- Separate generic_module_is_ready_to_process function in module_adapter.
- Remove static keyword from lib_manager_get_instance_bss_address function and add function declaraton.
- Allocates audio data buffer from shared memory heap.
