### PR TITLE
[DNM] fix: prevent virtual heap for multiple initialization

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -289,7 +289,9 @@ static const struct vmh_heap_config static_hp_buffers = {
 
 static int virtual_heap_init(void)
 {
-	virtual_buffers_heap = vmh_init_heap(&static_hp_buffers, false);
+	if (!virtual_buffers_heap)
+		virtual_buffers_heap = vmh_init_heap(&static_hp_buffers, false);
+
 	if (!virtual_buffers_heap) {
 		tr_err(&zephyr_tr, "Unable to init virtual heap");
 		return -ENOMEM;


### PR DESCRIPTION
this is a fix for 38c4810513bbd4c04e77ddb093aa51a859a433df

It may happen that virtual_heap_init would be called several times.
This commit prevents the heap for being re-initialized