### PR TITLE
topology2: add support for sof-lnl-rt1320-l12-rt714-l0

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -47,6 +47,9 @@ NHLT_BIN=nhlt-sof-lnl-dmic-4ch-id5.bin"
 "cavs-sdw\;sof-lnl-rt1318-l12-rt714-l0\;PLATFORM=lnl,SDW_JACK=false,SDW_DMIC=1,\
 NUM_SDW_AMP_LINKS=2,SDW_DMIC_STREAM=SDW0-Capture"
 
+"cavs-sdw\;sof-lnl-rt1320-l12-rt714-l0\;PLATFORM=lnl,SDW_JACK=false,SDW_DMIC=1,\
+NUM_SDW_AMP_LINKS=2,SDW_AMP_FEEDBACK=false,SDW_DMIC_STREAM=SDW0-Capture"
+
 # SDW bridge to SPK and SDW Jack+DMIC+SPK
 "cavs-sdw\;sof-lnl-cs42l43-l0\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\


### PR DESCRIPTION
This topology support for rt1320 left, right amplifiers on two Soundwire link 1, 2 and rt714 dmic codec on Sounwire link 0. No JACK codec and rt1320 AMP_IN capture DAI is unused.


(cherry picked from commit 913223387a60f5685024d396fcc86893c7c4ebdf)