### PR TITLE
[DNM] Test Zephyr without interrupt vector literals

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9075d5335596080291ebcc448819fed2110dcb9a
+      revision: pull/92998/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Test Zephyr PR, removing literal memory regions from interruppt vector area.