### PR TITLE
topology2: ptl: Generate a topology for HDMI-in capture without headset codec

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -84,6 +84,11 @@ NHLT_BIN=nhlt-sof-ptl-es83x6-ssp1-hdmi-ssp02.bin,HEADSET_SSP_DAI_INDEX=1,\
 HEADSET_CODEC=true,HEADSET_CODEC_NAME=SSP1-Codec,HDMI1_ID=3,HDMI2_ID=4,HDMI3_ID=5,\
 HDMI_IN_CAPTURE=true"
 
+#No HeadsetCodec+HDMI-IN
+"cavs-es83x6\;sof-ptl-hdmi-ssp02\;PLATFORM=ptl,PREPROCESS_PLUGINS=nhlt,\
+NHLT_BIN=nhlt-sof-ptl-hdmi-ssp02.bin,HEADSET_CODEC=false,HDMI_IN_CAPTURE=true,\
+HDMI_IN_1_ID=0,HDMI_IN_2_ID=1"
+
 # Split topologies
 "cavs-sdw\;sof-ptl-dmic-2ch-id5\;PLATFORM=mtl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=2,\
 PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=5,DMIC1_ID=6,PREPROCESS_PLUGINS=nhlt,\


### PR DESCRIPTION
Adding make file changes to generate the topology file for the products which doesn't have ssp-based audio codec but need to support HDMI audio playback and HDMI-in capture via I2S.