### PR TITLE
test: ztest: Add math basic arithmetic unit tests converted from CMock

### DIFF
--- a/test/ztest/unit/math/basic/arithmetic/CMakeLists.txt
+++ b/test/ztest/unit/math/basic/arithmetic/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_math_arithmetic)
+
+set(SOF_ROOT "${PROJECT_SOURCE_DIR}/../../../../../..")
+
+target_include_directories(app PRIVATE
+	${SOF_ROOT}/zephyr/include
+	${SOF_ROOT}/src/include
+)
+
+# Define SOF-specific configurations for unit testing
+target_compile_definitions(app PRIVATE
+	-DCONFIG_SOF_LOG_LEVEL=CONFIG_LOG_DEFAULT_LEVEL
+	-DCONFIG_ZEPHYR_POSIX=1
+	-DCONFIG_LIBRARY=1
+	-DCONFIG_NUMBERS_VECTOR_FIND=1
+	-DCONFIG_NUMBERS_NORM=1
+	-DUNIT_TEST=1
+)
+
+target_sources(app PRIVATE
+	test_gcd_ztest.c
+	test_ceil_divide_ztest.c
+	test_find_equal_int16_ztest.c
+	test_find_min_int16_ztest.c
+	test_find_max_abs_int32_ztest.c
+	test_norm_int32_ztest.c
+	${SOF_ROOT}/src/math/numbers.c
+)
+
+# Link math library for ceil_divide test
+target_link_libraries(app PRIVATE m)

--- a/test/ztest/unit/math/basic/arithmetic/prj.conf
+++ b/test/ztest/unit/math/basic/arithmetic/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/test/ztest/unit/math/basic/arithmetic/test_ceil_divide_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_ceil_divide_ztest.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+#include <math.h>
+
+/**
+ * @brief Test ceil_divide function with various parameter combinations
+ *
+ * Tests ceil_divide against reference ceilf implementation with multiple
+ * positive and negative integer combinations
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_ceil_divide)
+{
+	int params[8] = {
+		-1000,
+		300,
+		123,
+		-10,
+		1337,
+		-6,
+		999,
+		-2
+	};
+
+	int i, j;
+
+	for (i = 0; i < 8; ++i) {
+		for (j = 0; j < 8; ++j) {
+			int ref = ceilf((float)params[i] / (float)params[j]);
+			int r = ceil_divide(params[i], params[j]);
+
+			zassert_equal(r, ref,
+				      "ceil_divide(%d, %d) = %d, expected %d",
+				       params[i], params[j], r, ref);
+		}
+	}
+}

--- a/test/ztest/unit/math/basic/arithmetic/test_find_equal_int16_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_find_equal_int16_ztest.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+
+/**
+ * @brief Test find_equal_int16 function with array containing matches
+ *
+ * Tests that find_equal_int16 correctly finds all indices where value 123
+ * appears in the array [5, 123, 5, 10, 123, 500, 123]
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_equal_int16_matches)
+{
+	int16_t r[4];
+	int16_t vec[] = {5, 123, 5, 10, 123, 500, 123};
+	int16_t template[] = {1, 4, 6};
+
+	int r_num = find_equal_int16(r, vec, 123, 7, 4);
+
+	zassert_equal(r_num, 3, "Should find 3 occurrences of 123");
+	zassert_mem_equal(r, template, sizeof(int16_t) * 3,
+			  "Result indices should match expected template");
+}
+
+/**
+ * @brief Test find_equal_int16 function with no matches
+ *
+ * Tests that find_equal_int16 returns 0 when searching for value 0
+ * in array [1, 2, 3, 4, 5] where it doesn't exist
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_equal_int16_no_matches)
+{
+	int16_t r[4];
+	int16_t vec[] = {1, 2, 3, 4, 5};
+
+	int r_num = find_equal_int16(r, vec, 0, 5, 4);
+
+	zassert_equal(r_num, 0, "Should find 0 occurrences of 0");
+}

--- a/test/ztest/unit/math/basic/arithmetic/test_find_max_abs_int32_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_find_max_abs_int32_ztest.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+#include <sof/common.h>
+
+/**
+ * @brief Test find_max_abs_int32 function with negative maximum absolute value
+ *
+ * Tests that find_max_abs_int32 correctly finds maximum absolute value
+ * in array [-100, 99, 98, 50] where -100 has the largest absolute value
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_max_abs_int32_negative_max)
+{
+	int32_t vec[] = {-100, 99, 98, 50};
+	int r = find_max_abs_int32(vec, ARRAY_SIZE(vec));
+
+	zassert_equal(r, 100, "find_max_abs_int32([-100, 99, 98, 50]) should return 100");
+}
+
+/**
+ * @brief Test find_max_abs_int32 function with positive maximum absolute value
+ *
+ * Tests that find_max_abs_int32 correctly finds maximum absolute value
+ * in array [-100, 99, 98, 50, 101] where 101 has the largest absolute value
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_max_abs_int32_positive_max)
+{
+	int32_t vec[] = {-100, 99, 98, 50, 101};
+	int r = find_max_abs_int32(vec, ARRAY_SIZE(vec));
+
+	zassert_equal(r, 101, "find_max_abs_int32([-100, 99, 98, 50, 101]) should return 101");
+}

--- a/test/ztest/unit/math/basic/arithmetic/test_find_min_int16_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_find_min_int16_ztest.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+#include <sof/common.h>
+
+/**
+ * @brief Test find_min_int16 function with single element array
+ *
+ * Tests that find_min_int16 returns the single element when array has one item
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_min_int16_for_2_equals_2)
+{
+	int16_t vec[] = {2};
+	int r = find_min_int16(vec, ARRAY_SIZE(vec));
+
+	zassert_equal(r, 2, "find_min_int16([2]) should return 2");
+}
+
+/**
+ * @brief Test find_min_int16 function with multiple elements
+ *
+ * Tests that find_min_int16 correctly finds minimum value in array [5, 2, 3, 4, 1]
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_find_min_int16_for_5_2_3_4_1_equals_1)
+{
+	int16_t vec[] = {5, 2, 3, 4, 1};
+	int r = find_min_int16(vec, ARRAY_SIZE(vec));
+
+	zassert_equal(r, 1, "find_min_int16([5, 2, 3, 4, 1]) should return 1");
+}

--- a/test/ztest/unit/math/basic/arithmetic/test_gcd_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_gcd_ztest.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+
+/**
+ * @brief Test GCD function with typical case
+ *
+ * Tests that gcd(5083, 391) returns 391
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_5083_and_391_equals_391)
+{
+	int r;
+
+	r = gcd(5083, 391);
+	zassert_equal(r, 391, "gcd(5083, 391) should equal 391");
+}
+
+/**
+ * @brief Test GCD function with small positive numbers
+ *
+ * Tests that gcd(12, 9) returns 3
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_12_and_9_equals_3)
+{
+	int r;
+
+	r = gcd(12, 9);
+	zassert_equal(r, 3, "gcd(12, 9) should equal 3");
+}
+
+/**
+ * @brief Test GCD function with zero second argument
+ *
+ * Tests that gcd(5, 0) returns 5
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_5_and_0_equals_5)
+{
+	int r;
+
+	r = gcd(5, 0);
+	zassert_equal(r, 5, "gcd(5, 0) should equal 5");
+}
+
+/**
+ * @brief Test GCD function with zero first argument
+ *
+ * Tests that gcd(0, 5) returns 5
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_0_and_5_equals_5)
+{
+	int r;
+
+	r = gcd(0, 5);
+	zassert_equal(r, 5, "gcd(0, 5) should equal 5");
+}
+
+/**
+ * @brief Test GCD function with both arguments zero
+ *
+ * Tests that gcd(0, 0) returns 0
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_0_and_0_equals_0)
+{
+	int r;
+
+	r = gcd(0, 0);
+	zassert_equal(r, 0, "gcd(0, 0) should equal 0");
+}
+
+/**
+ * @brief Test GCD function with negative first argument
+ *
+ * Tests that gcd(-4, 14) returns 2
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_neg_4_and_14_equals_2)
+{
+	int r;
+
+	r = gcd(-4, 14);
+	zassert_equal(r, 2, "gcd(-4, 14) should equal 2");
+}
+
+/**
+ * @brief Test GCD function with negative second argument
+ *
+ * Tests that gcd(4, -14) returns 2
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_4_and_neg_14_equals_2)
+{
+	int r;
+
+	r = gcd(4, -14);
+	zassert_equal(r, 2, "gcd(4, -14) should equal 2");
+}
+
+/**
+ * @brief Test GCD function with both arguments negative
+ *
+ * Tests that gcd(-4, -14) returns 2
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_gcd_for_neg_4_and_neg_14_equals_2)
+{
+	int r;
+
+	r = gcd(-4, -14);
+	zassert_equal(r, 2, "gcd(-4, -14) should equal 2");
+}
+
+/**
+ * @brief Define and initialize the math arithmetic test suite
+ */
+ZTEST_SUITE(math_arithmetic_suite, NULL, NULL, NULL, NULL, NULL);

--- a/test/ztest/unit/math/basic/arithmetic/test_norm_int32_ztest.c
+++ b/test/ztest/unit/math/basic/arithmetic/test_norm_int32_ztest.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+
+#include <zephyr/ztest.h>
+#include <sof/math/numbers.h>
+
+/**
+ * @brief Test norm_int32 function with zero value
+ *
+ * Tests that norm_int32(0) returns 31 (number of leading zeros in 32-bit zero)
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_norm_int32_for_0_equals_31)
+{
+	int r = norm_int32(0);
+
+	zassert_equal(r, 31, "norm_int32(0) should return 31");
+}
+
+/**
+ * @brief Test norm_int32 function with small positive value
+ *
+ * Tests that norm_int32(35) returns 25 (number of leading zeros)
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_norm_int32_for_35_equals_25)
+{
+	int r = norm_int32(35);
+
+	zassert_equal(r, 25, "norm_int32(35) should return 25");
+}
+
+/**
+ * @brief Test norm_int32 function with maximum positive value
+ *
+ * Tests that norm_int32(2147483647) returns 0 (no leading zeros in max int32)
+ */
+ZTEST(math_arithmetic_suite, test_math_numbers_norm_int32_for_2147483647_equals_0)
+{
+	int r = norm_int32(2147483647);
+
+	zassert_equal(r, 0, "norm_int32(2147483647) should return 0");
+}

--- a/test/ztest/unit/math/basic/arithmetic/testcase.yaml
+++ b/test/ztest/unit/math/basic/arithmetic/testcase.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright(c) 2025 Intel Corporation. All rights reserved.
+#
+# Math basic arithmetic unit tests converted from CMock to Ztest
+#
+# These contents may have been developed with support from one or more Intel-operated
+# generative artificial intelligence solutions.
+#
+
+tests:
+  math.basic.arithmetic:
+    tags: math arithmetic numbers
+    platform_allow: native_sim
+    integration_platforms:
+      - native_sim
+    build_only: false


### PR DESCRIPTION
Convert legacy CMock-based math basic arithmetic unit tests to Zephyr Ztest framework.

This patch converts 6 existing math arithmetic unit tests from CMock/Unity to Zephyr's Ztest framework, maintaining the same test coverage and functionality:

- test_gcd_ztest.c: Greatest common divisor (8 test cases)
- test_ceil_divide_ztest.c: Ceiling division (1 test case)
- test_find_equal_int16_ztest.c: Find equal int16 values (2 test cases)
- test_find_min_int16_ztest.c: Find minimum int16 (2 test cases)
- test_find_max_abs_int32_ztest.c: Find max absolute int32 (2 test cases)
- test_norm_int32_ztest.c: Normalize int32 (3 test cases)

The converted tests validate the same mathematical functions from src/math/numbers.c as the original CMock tests, ensuring no regression in test coverage during the migration to Ztest framework.

This is part of the broader SOF unit test migration from CMock to Zephyr Ztest framework, establishing the foundation for math/basic/arithmetic tests in the new directory structure.