### PR TITLE
app: boards: imx95: switch to using nxp,edma driver

### DIFF
--- a/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
+++ b/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
@@ -17,9 +17,19 @@
 	rx-fifo-watermark = <96>;
 	fifo-depth = <96>;
 	rx-sync-mode = <1>;
+	dmas = <&edma2 30 60>, <&edma2 31 61>;
 	status = "okay";
 };
 
 &edma2 {
+	compatible = "nxp,edma";
+	reg = <0x42000000 (DT_SIZE_K(64) * 33)>;
+	valid-channels = <30>, <31>;
+	interrupts = <143 0>, <143 0>;
+	/delete-property/ nxp,version;
+	/delete-property/ dma-channels;
+	/delete-property/ dma-requests;
+	/delete-property/ no-error-irq;
+	/delete-property/ channels-shared-irq-mask;
 	status = "okay";
 };


### PR DESCRIPTION
Zephyr commit 774370a1d712 ("boards: nxp: imx95_evk_mimx9596_m7: add uart dma support") replaces the configuration of the "edma2" node with that mandated by the programming model associated with the "nxp,mcux-edma" compatible. This change was done because the EDMA driver associated with said compatible is compatible with multiple peripheral drivers as opposed to the previous "nxp,edma" driver.

However, SOF currently requires using the previous EDMA driver (i.e. the one associated with the "nxp,edma" driver). Therefore, switch back to the previous programming model.

Furthermore, the DMA channels used by the SAI IP were also changed. Since these were not tested, switch back to the previous DMA channels.