### PR TITLE
boards: ptl: add Google RTC Audio Processing to PTL configuration

### DIFF
--- a/app/boards/intel_adsp_ace30_ptl.conf
+++ b/app/boards/intel_adsp_ace30_ptl.conf
@@ -14,6 +14,12 @@ CONFIG_COMP_UP_DOWN_MIXER=y
 CONFIG_COMP_VOLUME_WINDOWS_FADE=y
 CONFIG_FORMAT_CONVERT_HIFI3=n
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL=n
 CONFIG_PROBE=y

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -716,6 +716,11 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	else
 		hd->local_buffer = comp_dev_get_first_data_producer(dev);
 
+	if (!hd->local_buffer) {
+		comp_err(dev, "no local buffer found");
+		return -EINVAL;
+	}
+
 	period_bytes = dev->frames *
 		audio_stream_frame_bytes(&hd->local_buffer->stream);
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -903,6 +903,11 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	else
 		hd->local_buffer = comp_dev_get_first_data_producer(dev);
 
+	if (!hd->local_buffer) {
+		comp_err(dev, "no local buffer found");
+		return -EINVAL;
+	}
+
 	period_bytes = dev->frames * get_frame_bytes(params->frame_fmt, params->channels);
 
 	if (!period_bytes) {


### PR DESCRIPTION
This patch introduces the Google RTC Audio Processing component into the PTL configuration for the SOF firmware. The component is added as a loadable module (`m`).

**Changes:**
- Added `CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m` to enable Google RTC Audio Processing.
- Included `CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y` for mock testing support.