### PR TITLE
mem: workaround - remove MEM_REG_ATTR_SHARED_HEAP from SOF

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -50,6 +50,13 @@ config SOF_ZEPHYR_VIRTUAL_HEAP_SIZE
 	 NOTE: Keep in mind that the heap size should not be greater than the physical
 	 memory size of the system defined in DT (and this includes baseFW text/data).
 
+config SOF_ZEPHYR_VIRTUAL_HEAP_REGION_SIZE
+	hex "Size in bytes of virtual memory region for virtual heap shared for all cores"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default 0x100000
+	help
+	  This config defines size of virtual heap region shared between all cores
+
 config ZEPHYR_NATIVE_DRIVERS
 	bool "Use Zephyr native drivers"
 	default n

--- a/zephyr/include/sof/lib/regions_mm.h
+++ b/zephyr/include/sof/lib/regions_mm.h
@@ -17,6 +17,9 @@
 #include <zephyr/init.h>
 #include <zephyr/sys/mem_blocks.h>
 
+/* Attributes for memory regions */
+#define VIRTUAL_REGION_SHARED_HEAP_ATTR 1U	  /*< region dedicated for shared virtual heap */
+
 /* Dependency on ipc/topology.h created due to memory capability definitions
  * that are defined there
  */


### PR DESCRIPTION
This PR does 2 things:
 - removes MEM_REG_ATTR_SHARED_HEAP, add function stubs and  - to allow merging changes to zephyr
 - forces buffers location in the very first memory region. This is required because of conflict of virtual addresses with loadable modules in case the platform has 5 cores