### PR TITLE
[SKIP SOFCI-TEST] ci: Remove XTOS-make-install job from daily-tests workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,5 +1,7 @@
 ---
 name: "Close stale issues"
+
+# yamllint disable-line rule:truthy
 on:
   schedule:
     - cron: "30 1 * * *"

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -23,9 +23,6 @@ jobs:
   # TODO: separate "fetchPRcommits" which can't work in daily tests
   # uses: ./.github/workflows/codestyle.yml
 
-  XTOS-make-install:
-    uses: ./.github/workflows/installer.yml
-
   zephyr-fuzz-IPC:
     uses: ./.github/workflows/ipc_fuzzer.yml
     with:


### PR DESCRIPTION
The XTOS-make-install job is removed from the daily tests
workflow since the workflow is no longer
present in the sof repo.

Signed-off-by: Christopher Turner <christopher.g.turner@intel.com>