### PR TITLE
global: remove function names from logging format strings

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -139,7 +139,7 @@ static int aria_init(struct processing_module *mod)
 	att = aria->attenuation;
 
 	if (aria->attenuation > ARIA_MAX_ATT) {
-		comp_warn(dev, "init_aria(): Attenuation value %d must not be greater than %d",
+		comp_warn(dev, "Attenuation value %d must not be greater than %d",
 			  att, ARIA_MAX_ATT);
 		att = ARIA_MAX_ATT;
 	}
@@ -149,7 +149,7 @@ static int aria_init(struct processing_module *mod)
 
 	if (!buf) {
 		rfree(cd);
-		comp_err(dev, "init_aria(): allocation failed for size %d", req_mem);
+		comp_err(dev, "allocation failed for size %d", req_mem);
 		return -ENOMEM;
 	}
 
@@ -201,12 +201,12 @@ static int aria_prepare(struct processing_module *mod,
 
 	if (audio_stream_get_valid_fmt(&source->stream) != SOF_IPC_FRAME_S24_4LE ||
 	    audio_stream_get_valid_fmt(&sink->stream) != SOF_IPC_FRAME_S24_4LE) {
-		comp_err(dev, "aria_prepare(): format is not supported");
+		comp_err(dev, "format is not supported");
 		return -EINVAL;
 	}
 
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "aria_prepare(): Component is in active state.");
+		comp_info(dev, "Component is in active state.");
 		return 0;
 	}
 
@@ -291,7 +291,7 @@ static int aria_set_config(struct processing_module *mod, uint32_t param_id,
 		memcpy_s(&cd->att, sizeof(uint32_t), fragment, sizeof(uint32_t));
 		if (cd->att > ARIA_MAX_ATT) {
 			comp_warn(dev,
-				  "aria_set_config(): Attenuation parameter %d is limited to %d",
+				  "Attenuation parameter %d is limited to %d",
 				  cd->att, ARIA_MAX_ATT);
 			cd->att = ARIA_MAX_ATT;
 		}

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -354,14 +354,14 @@ static int asrc_verify_params(struct processing_module *mod,
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		if (asrc_get_source_rate(&cd->ipc_config) &&
 		    params->rate != asrc_get_source_rate(&cd->ipc_config)) {
-			comp_err(dev, "asrc_verify_params(): runtime stream pcm rate %u does not match rate %u fetched from ipc.",
+			comp_err(dev, "runtime stream pcm rate %u does not match rate %u fetched from ipc.",
 				 params->rate, asrc_get_source_rate(&cd->ipc_config));
 			return -EINVAL;
 		}
 	} else {
 		if (asrc_get_sink_rate(&cd->ipc_config) &&
 		    params->rate != asrc_get_sink_rate(&cd->ipc_config)) {
-			comp_err(dev, "asrc_verify_params(): runtime stream pcm rate %u does not match rate %u fetched from ipc.",
+			comp_err(dev, "runtime stream pcm rate %u does not match rate %u fetched from ipc.",
 				 params->rate, asrc_get_sink_rate(&cd->ipc_config));
 			return -EINVAL;
 		}
@@ -371,7 +371,7 @@ static int asrc_verify_params(struct processing_module *mod,
 	 */
 	ret = comp_verify_params(dev, BUFF_PARAMS_RATE, params);
 	if (ret < 0) {
-		comp_err(dev, "asrc_verify_params(): comp_verify_params() failed.");
+		comp_err(dev, "comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -393,7 +393,7 @@ static int asrc_params(struct processing_module *mod)
 
 	err = asrc_verify_params(mod, pcm_params);
 	if (err < 0) {
-		comp_err(dev, "asrc_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return -EINVAL;
 	}
 
@@ -572,7 +572,7 @@ static int asrc_prepare(struct processing_module *mod,
 
 	if (audio_stream_get_size(&sinkb->stream) <
 	    dev->ipc_config.periods_sink * sink_period_bytes) {
-		comp_err(dev, "asrc_prepare(): sink buffer size %d is insufficient < %d * %d",
+		comp_err(dev, "sink buffer size %d is insufficient < %d * %d",
 			 audio_stream_get_size(&sinkb->stream), dev->ipc_config.periods_sink,
 			 sink_period_bytes);
 		ret = -ENOMEM;

--- a/src/audio/asrc/asrc_farrow.c
+++ b/src/audio/asrc/asrc_farrow.c
@@ -1367,7 +1367,7 @@ enum asrc_error_code asrc_process_pull32(struct comp_dev *dev,
 			}
 
 			if (src_obj->time_value_pull > TIME_VALUE_LIMIT) {
-				comp_err(dev, "process_pull32(): Time value = %d",
+				comp_err(dev, "Time value = %d",
 					 src_obj->time_value_pull);
 				return ASRC_EC_FAILED_PULL_MODE;
 			}

--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -184,7 +184,7 @@ __cold static int basefw_mem_state_info(uint32_t *data_offset, char *data)
 	/* size is also saved as tuple length */
 	tuple_data = rballoc(SOF_MEM_FLAG_USER, size);
 	if (!tuple_data) {
-		LOG_ERR("basefw_mem_state_info(): allocation failed");
+		LOG_ERR("allocation failed");
 		return IPC4_ERROR_INVALID_PARAM;
 	}
 

--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -201,7 +201,7 @@ static struct comp_buffer *buffer_alloc_struct(void *stream_addr, size_t size,
 	buffer = rzalloc(flags, sizeof(*buffer));
 
 	if (!buffer) {
-		tr_err(&buffer_tr, "buffer_alloc_struct(): could not alloc structure");
+		tr_err(&buffer_tr, "could not alloc structure");
 		return NULL;
 	}
 
@@ -236,20 +236,20 @@ struct comp_buffer *buffer_alloc(size_t size, uint32_t flags, uint32_t align,
 
 	/* validate request */
 	if (size == 0) {
-		tr_err(&buffer_tr, "buffer_alloc(): new size = %zu is invalid", size);
+		tr_err(&buffer_tr, "new size = %zu is invalid", size);
 		return NULL;
 	}
 
 	stream_addr = rballoc_align(flags, size, align);
 	if (!stream_addr) {
-		tr_err(&buffer_tr, "buffer_alloc(): could not alloc size = %zu bytes of flags = 0x%x",
+		tr_err(&buffer_tr, "could not alloc size = %zu bytes of flags = 0x%x",
 		       size, flags);
 		return NULL;
 	}
 
 	buffer = buffer_alloc_struct(stream_addr, size, flags, is_shared);
 	if (!buffer) {
-		tr_err(&buffer_tr, "buffer_alloc(): could not alloc buffer structure");
+		tr_err(&buffer_tr, "could not alloc buffer structure");
 		rfree(stream_addr);
 	}
 
@@ -263,11 +263,11 @@ struct comp_buffer *buffer_alloc_range(size_t preferred_size, size_t minimum_siz
 	size_t size;
 	void *stream_addr = NULL;
 
-	tr_dbg(&buffer_tr, "buffer_alloc_range(): %zu -- %zu bytes", minimum_size, preferred_size);
+	tr_dbg(&buffer_tr, "%zu -- %zu bytes", minimum_size, preferred_size);
 
 	/* validate request */
 	if (minimum_size == 0 || preferred_size < minimum_size) {
-		tr_err(&buffer_tr, "buffer_alloc_range(): new size range %zu -- %zu is invalid",
+		tr_err(&buffer_tr, "new size range %zu -- %zu is invalid",
 		       minimum_size, preferred_size);
 		return NULL;
 	}
@@ -282,17 +282,17 @@ struct comp_buffer *buffer_alloc_range(size_t preferred_size, size_t minimum_siz
 			break;
 	}
 
-	tr_dbg(&buffer_tr, "buffer_alloc_range(): allocated %zu bytes", size);
+	tr_dbg(&buffer_tr, "allocated %zu bytes", size);
 
 	if (!stream_addr) {
-		tr_err(&buffer_tr, "buffer_alloc_range(): could not alloc size = %zu bytes of type = 0x%x",
+		tr_err(&buffer_tr, "could not alloc size = %zu bytes of type = 0x%x",
 		       minimum_size, flags);
 		return NULL;
 	}
 
 	buffer = buffer_alloc_struct(stream_addr, size, flags, is_shared);
 	if (!buffer) {
-		tr_err(&buffer_tr, "buffer_alloc_range(): could not alloc buffer structure");
+		tr_err(&buffer_tr, "could not alloc buffer structure");
 		rfree(stream_addr);
 	}
 

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -84,7 +84,7 @@ static int chain_host_start(struct comp_dev *dev)
 	if (err < 0)
 		return err;
 
-	comp_info(dev, "chain_host_start(): dma_start() host chan_index = %u",
+	comp_info(dev, "dma_start() host chan_index = %u",
 		  cd->chan_host->index);
 	return 0;
 }
@@ -470,7 +470,7 @@ __cold static int chain_init(struct comp_dev *dev, void *addr, size_t length)
 	channel = cd->host_connector_node_id.f.v_index;
 	channel = dma_request_channel(cd->dma_host->z_dev, &channel);
 	if (channel < 0) {
-		comp_err(dev, "chain_init(): dma_request_channel() failed");
+		comp_err(dev, "dma_request_channel() failed");
 		return -EINVAL;
 	}
 

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -28,7 +28,7 @@ struct sof_ipc_channel_map *chmap_get(struct sof_ipc_stream_map *smap,
 	uint32_t byte = 0;
 
 	if (index >= smap->num_ch_map) {
-		tr_err(&chmap_tr, "chmap_get(): index %d out of bounds %d",
+		tr_err(&chmap_tr, "index %d out of bounds %d",
 		       index, smap->num_ch_map);
 
 		return NULL;

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -251,7 +251,7 @@ dts_codec_process(struct processing_module *mod,
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
 	if (input_buffers[0].size < codec->mpd.in_buff_size) {
-		comp_dbg(dev, "dts_codec_process(): not enough data to process");
+		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
 
@@ -425,21 +425,21 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	ret = module_set_configuration(mod, config_id, pos, data_offset_size, fragment,
 				       fragment_size, response, response_size);
 	if (ret < 0) {
-		comp_err(dev, "dts_codec_set_configuration(): error %x from module_set_configuration()",
+		comp_err(dev, "error %x from module_set_configuration()",
 			 ret);
 		return ret;
 	}
 
 	/* return if more fragments are expected */
 	if (pos != MODULE_CFG_FRAGMENT_LAST && pos != MODULE_CFG_FRAGMENT_SINGLE) {
-		comp_err(dev, "dts_codec_set_configuration(): pos %d error", pos);
+		comp_err(dev, "pos %d error", pos);
 		return 0;
 	}
 
 #if CONFIG_IPC_MAJOR_3
 	// return if the module is not prepared
 	if (md->state < MODULE_INITIALIZED) {
-		comp_err(dev, "dts_codec_set_configuration(): state %d error", md->state);
+		comp_err(dev, "state %d error", md->state);
 		return 0;
 	}
 #endif
@@ -447,12 +447,12 @@ dts_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	/* whole configuration received, apply it now */
 	ret = dts_codec_apply_config(mod);
 	if (ret) {
-		comp_err(dev, "dts_codec_set_configuration(): error %x: runtime config apply failed",
+		comp_err(dev, "error %x: runtime config apply failed",
 			 ret);
 		return ret;
 	}
 
-	comp_dbg(dev, "dts_codec_set_configuration(): config applied");
+	comp_dbg(dev, "config applied");
 
 	return 0;
 }

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -115,14 +115,14 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	switch (cmd) {
 	case COMP_TRIGGER_START:
 		if (dev->state != COMP_STATE_PRE_ACTIVE) {
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_START",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_START",
 				 dev->state);
 			return -EINVAL;
 		}
 		break;
 	case COMP_TRIGGER_RELEASE:
 		if (dev->state != COMP_STATE_PRE_ACTIVE) {
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_RELEASE",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_RELEASE",
 				 dev->state);
 			return -EINVAL;
 		}
@@ -130,7 +130,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_STOP:
 		if (dev->state != COMP_STATE_ACTIVE &&
 		    dev->state != COMP_STATE_PAUSED) {
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_STOP",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_STOP",
 				 dev->state);
 			return -EINVAL;
 		}
@@ -138,7 +138,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_PAUSE:
 		/* only support pausing for running */
 		if (dev->state != COMP_STATE_ACTIVE) {
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_PAUSE",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_PAUSE",
 				 dev->state);
 			return -EINVAL;
 		}
@@ -146,15 +146,15 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_RESET:
 		/* reset always succeeds */
 		if (dev->state == COMP_STATE_ACTIVE)
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_RESET",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_RESET",
 				 dev->state);
 		else if (dev->state == COMP_STATE_PAUSED)
-			comp_info(dev, "comp_set_state(): state = %u, COMP_TRIGGER_RESET",
+			comp_info(dev, "state = %u, COMP_TRIGGER_RESET",
 				  dev->state);
 		break;
 	case COMP_TRIGGER_PREPARE:
 		if (dev->state != COMP_STATE_READY) {
-			comp_err(dev, "comp_set_state(): wrong state = %u, COMP_TRIGGER_PREPARE",
+			comp_err(dev, "wrong state = %u, COMP_TRIGGER_PREPARE",
 				 dev->state);
 			return -EINVAL;
 		}
@@ -162,7 +162,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_PRE_START:
 		if (dev->state != COMP_STATE_PREPARE) {
 			comp_err(dev,
-				 "comp_set_state(): wrong state = %u, COMP_TRIGGER_PRE_START",
+				 "wrong state = %u, COMP_TRIGGER_PRE_START",
 				 dev->state);
 			return -EINVAL;
 		}
@@ -170,7 +170,7 @@ int comp_set_state(struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_PRE_RELEASE:
 		if (dev->state != COMP_STATE_PAUSED) {
 			comp_err(dev,
-				 "comp_set_state(): wrong state = %u, COMP_TRIGGER_PRE_RELEASE",
+				 "wrong state = %u, COMP_TRIGGER_PRE_RELEASE",
 				 dev->state);
 			return -EINVAL;
 		}

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -102,7 +102,7 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 	if (!dev)
 		return -ENODEV;
 
-	comp_dbg(dev, "copier_ipcgtw_process(): %x %x",
+	comp_dbg(dev, "%x %x",
 		 cmd->primary.dat, cmd->extension.dat);
 
 	buf = get_buffer(dev);
@@ -113,7 +113,7 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 		 * case do not report error but return 0 bytes available for GET_DATA and
 		 * 0 bytes free for SET_DATA.
 		 */
-		comp_warn(dev, "copier_ipcgtw_process(): no buffer found");
+		comp_warn(dev, "no buffer found");
 	}
 
 	out = (struct ipc4_ipc_gateway_cmd_data_reply *)reply_payload;
@@ -162,7 +162,7 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 		break;
 
 	default:
-		comp_err(dev, "copier_ipcgtw_process(): unexpected cmd: %u",
+		comp_err(dev, "unexpected cmd: %u",
 			 (unsigned int)cmd->primary.r.cmd);
 		return -EINVAL;
 	}
@@ -180,7 +180,7 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 
 	buf = get_buffer(dev);
 	if (!buf) {
-		comp_err(dev, "ipcgtw_params(): no buffer found");
+		comp_err(dev, "no buffer found");
 		return -EINVAL;
 	}
 
@@ -188,7 +188,7 @@ int copier_ipcgtw_params(struct ipcgtw_data *ipcgtw_data, struct comp_dev *dev,
 	err = buffer_set_size(buf, ipcgtw_data->buf_size, 0);
 
 	if (err < 0) {
-		comp_err(dev, "ipcgtw_params(): failed to resize buffer to %u bytes",
+		comp_err(dev, "failed to resize buffer to %u bytes",
 			 ipcgtw_data->buf_size);
 		return err;
 	}
@@ -203,7 +203,7 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	if (buf) {
 		audio_stream_reset(&buf->stream);
 	} else {
-		comp_warn(dev, "ipcgtw_reset(): no buffer found");
+		comp_warn(dev, "no buffer found");
 	}
 }
 
@@ -221,7 +221,7 @@ __cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 
 	gtw_cfg = &copier->gtw_cfg;
 	if (!gtw_cfg->config_length) {
-		comp_err(dev, "ipcgtw_create(): empty ipc4_gateway_config_data");
+		comp_err(dev, "empty ipc4_gateway_config_data");
 		return -EINVAL;
 	}
 
@@ -244,7 +244,7 @@ __cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	/* The buffer connected to the IPC gateway will be resized later in ipcgtw_params()
 	 * to the size specified in the IPC gateway blob.
 	 */
-	comp_dbg(dev, "ipcgtw_create(): buffer_size: %u", blob->buffer_size);
+	comp_dbg(dev, "buffer_size: %u", blob->buffer_size);
 	ipcgtw_data->buf_size = blob->buffer_size;
 
 	cd->converter[IPC4_COPIER_GATEWAY_PIN] =

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -321,7 +321,7 @@ static int crossover_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "crossover_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail;
 	}
@@ -329,13 +329,13 @@ static int crossover_init(struct processing_module *mod)
 	/* Get configuration data and reset Crossover state */
 	ret = comp_init_data_blob(cd->model_handler, bs, ipc_crossover->data);
 	if (ret < 0) {
-		comp_err(dev, "crossover_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto cd_fail;
 	}
 
 	ret = crossover_output_pin_init(mod);
 	if (ret < 0) {
-		comp_err(dev, "crossover_init(): crossover_init_output_pins() failed.");
+		comp_err(dev, "crossover_init_output_pins() failed.");
 		goto cd_fail;
 	}
 
@@ -552,7 +552,7 @@ static int crossover_prepare(struct processing_module *mod,
 	/* Validate frame format and buffer size of sinks */
 	comp_dev_for_each_consumer(dev, sink) {
 		if (cd->source_format != audio_stream_get_frm_fmt(&sink->stream)) {
-			comp_err(dev, "crossover_prepare(): Source fmt %d and sink fmt %d are different.",
+			comp_err(dev, "Source fmt %d and sink fmt %d are different.",
 				 cd->source_format, audio_stream_get_frm_fmt(&sink->stream));
 			return -EINVAL;
 		}

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -154,7 +154,7 @@ int dai_common_new(struct dai_data *dd, struct comp_dev *dev, const struct ipc_c
 
 	dd->dai = dai_get(dai->type, dai->dai_index, DAI_CREAT);
 	if (!dd->dai) {
-		comp_cl_err(&comp_dai, "dai_common_new(): dai_get() failed to create DAI.");
+		comp_cl_err(&comp_dai, "dai_get() failed to create DAI.");
 		return -ENODEV;
 	}
 	dd->dai->dd = dd;
@@ -169,7 +169,7 @@ int dai_common_new(struct dai_data *dd, struct comp_dev *dev, const struct ipc_c
 
 	dd->dma = dma_get(dir, caps, dma_dev, DMA_ACCESS_SHARED);
 	if (!dd->dma) {
-		comp_cl_err(&comp_dai, "dai_common_new(): dma_get() failed to get shared access to DMA.");
+		comp_cl_err(&comp_dai, "dma_get() failed to get shared access to DMA.");
 		return -ENODEV;
 	}
 
@@ -263,7 +263,7 @@ int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,
 	/* fetching hw dai stream params */
 	ret = dai_get_hw_params(dd->dai, params, dir);
 	if (ret < 0) {
-		comp_err(dev, "dai_comp_get_hw_params(): dai_get_hw_params failed ret %d",
+		comp_err(dev, "dai_get_hw_params failed ret %d",
 			 ret);
 		return ret;
 	}
@@ -298,7 +298,7 @@ static int dai_comp_hw_params(struct comp_dev *dev,
 	/* configure hw dai stream params */
 	ret = dai_hw_params(dd->dai, params);
 	if (ret < 0) {
-		comp_err(dev, "dai_comp_hw_params(): dai_hw_params failed ret %d",
+		comp_err(dev, "dai_hw_params failed ret %d",
 			 ret);
 		return ret;
 	}
@@ -323,13 +323,13 @@ static int dai_verify_params(struct dai_data *dd, struct comp_dev *dev,
 	 * pcm_converter functions.
 	 */
 	if (hw_params.rate && hw_params.rate != params->rate) {
-		comp_err(dev, "dai_verify_params(): pcm rate parameter %d does not match hardware rate %d",
+		comp_err(dev, "pcm rate parameter %d does not match hardware rate %d",
 			 params->rate, hw_params.rate);
 		return -EINVAL;
 	}
 
 	if (hw_params.channels && hw_params.channels != params->channels) {
-		comp_err(dev, "dai_verify_params(): pcm channels parameter %d does not match hardware channels %d",
+		comp_err(dev, "pcm channels parameter %d does not match hardware channels %d",
 			 params->channels, hw_params.channels);
 		return -EINVAL;
 	}
@@ -355,7 +355,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 	dd->process = pcm_get_conversion_function(local_fmt, dma_fmt);
 
 	if (!dd->process) {
-		comp_err(dev, "dai_playback_params(): converter function NULL: local fmt %d dma fmt %d\n",
+		comp_err(dev, "converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
 		return -EINVAL;
 	}
@@ -388,7 +388,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
-			comp_err(dev, "dai_playback_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
+			comp_err(dev, "dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
 
@@ -409,7 +409,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 	dd->process = pcm_get_conversion_function(dma_fmt, local_fmt);
 
 	if (!dd->process) {
-		comp_err(dev, "dai_capture_params(): converter function NULL: local fmt %d dma fmt %d\n",
+		comp_err(dev, "converter function NULL: local fmt %d dma fmt %d\n",
 			 local_fmt, dma_fmt);
 		return -EINVAL;
 	}
@@ -453,7 +453,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 				   (uintptr_t)(audio_stream_get_addr(&dd->dma_buffer->stream)),
 				   fifo);
 		if (err < 0)
-			comp_err(dev, "dai_capture_params(): dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
+			comp_err(dev, "dma_sg_alloc() for period_count %d period_bytes %d failed with err = %d",
 				 period_count, period_bytes, err);
 	}
 
@@ -481,14 +481,14 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 
 	err = dai_verify_params(dd, dev, params);
 	if (err < 0) {
-		comp_err(dev, "dai_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return -EINVAL;
 	}
 
 	/* params verification passed, so now configure hw dai stream params */
 	err = dai_comp_hw_params(dev, params);
 	if (err < 0) {
-		comp_err(dev, "dai_params(): dai_comp_hw_params failed err %d", err);
+		comp_err(dev, "dai_comp_hw_params failed err %d", err);
 		return err;
 	}
 
@@ -505,7 +505,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 
 	/* can set params on only init state */
 	if (dev->state != COMP_STATE_READY) {
-		comp_err(dev, "dai_params(): Component is in state %d, expected COMP_STATE_READY.",
+		comp_err(dev, "Component is in state %d, expected COMP_STATE_READY.",
 			 dev->state);
 		return -EINVAL;
 	}
@@ -513,14 +513,14 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 	err = dma_get_attribute_legacy(dd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				       &addr_align);
 	if (err < 0) {
-		comp_err(dev, "dai_params(): could not get dma buffer address alignment, err = %d",
+		comp_err(dev, "could not get dma buffer address alignment, err = %d",
 			 err);
 		return err;
 	}
 
 	err = dma_get_attribute_legacy(dd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		comp_err(dev, "dai_params(): could not get valid dma buffer alignment, err = %d, align = %u",
+		comp_err(dev, "could not get valid dma buffer alignment, err = %d, align = %u",
 			 err, align);
 		return -EINVAL;
 	}
@@ -528,7 +528,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 	err = dma_get_attribute_legacy(dd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
 				       &period_count);
 	if (err < 0 || !period_count) {
-		comp_err(dev, "dai_params(): could not get valid dma buffer period count, err = %d, period_count = %u",
+		comp_err(dev, "could not get valid dma buffer period count, err = %d, period_count = %u",
 			 err, period_count);
 		return -EINVAL;
 	}
@@ -540,7 +540,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 	/* calculate period size */
 	period_bytes = dev->frames * frame_size;
 	if (!period_bytes) {
-		comp_err(dev, "dai_params(): invalid period_bytes.");
+		comp_err(dev, "invalid period_bytes.");
 		return -EINVAL;
 	}
 
@@ -556,7 +556,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		err = buffer_set_size(dd->dma_buffer, buffer_size, addr_align);
 
 		if (err < 0) {
-			comp_err(dev, "dai_params(): buffer_set_size() failed, buffer_size = %u",
+			comp_err(dev, "buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
 			return err;
 		}
@@ -564,7 +564,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
 					      addr_align, false);
 		if (!dd->dma_buffer) {
-			comp_err(dev, "dai_params(): failed to alloc dma buffer");
+			comp_err(dev, "failed to alloc dma buffer");
 			return -ENOMEM;
 		}
 
@@ -599,7 +599,7 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_common_config_prepare(): Component is in active state.");
+		comp_info(dev, "Component is in active state.");
 		return 0;
 	}
 
@@ -609,7 +609,7 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	}
 
 	if (dd->chan) {
-		comp_info(dev, "dai_common_config_prepare(): dma channel index %d already configured",
+		comp_info(dev, "dma channel index %d already configured",
 			  dd->chan->index);
 		return 0;
 	}
@@ -626,14 +626,14 @@ int dai_common_config_prepare(struct dai_data *dd, struct comp_dev *dev)
 	/* allocate DMA channel */
 	dd->chan = dma_channel_get_legacy(dd->dma, channel);
 	if (!dd->chan) {
-		comp_err(dev, "dai_common_config_prepare(): dma_channel_get() failed");
+		comp_err(dev, "dma_channel_get() failed");
 		dd->chan = NULL;
 		return -EIO;
 	}
 
 	dd->chan->dev_data = dd;
 
-	comp_info(dev, "dai_common_config_prepare(): new configured dma channel index %d",
+	comp_info(dev, "new configured dma channel index %d",
 		  dd->chan->index);
 
 	/* setup callback */
@@ -650,13 +650,13 @@ int dai_common_prepare(struct dai_data *dd, struct comp_dev *dev)
 	dd->total_data_processed = 0;
 
 	if (!dd->chan) {
-		comp_err(dev, "dai_prepare(): Missing dd->chan.");
+		comp_err(dev, "Missing dd->chan.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
 
 	if (!dd->config.elem_array.elems) {
-		comp_err(dev, "dai_prepare(): Missing dd->config.elem_array.elems.");
+		comp_err(dev, "Missing dd->config.elem_array.elems.");
 		comp_set_state(dev, COMP_TRIGGER_RESET);
 		return -EINVAL;
 	}
@@ -902,10 +902,10 @@ static void dai_report_xrun(struct comp_dev *dev, uint32_t bytes)
 	struct dai_data *dd = comp_get_drvdata(dev);
 
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
-		comp_err(dev, "dai_report_xrun(): underrun due to no data available");
+		comp_err(dev, "underrun due to no data available");
 		comp_underrun(dev, dd->local_buffer, bytes);
 	} else {
-		comp_err(dev, "dai_report_xrun(): overrun due to no space available");
+		comp_err(dev, "overrun due to no space available");
 		comp_overrun(dev, dd->local_buffer, bytes);
 	}
 }
@@ -958,16 +958,16 @@ int dai_common_copy(struct dai_data *dd, struct comp_dev *dev, pcm_converter_fun
 	/* Check possibility of glitch occurrence */
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK &&
 	    copy_bytes + avail_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_common_copy(): Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
+		comp_warn(dev, "Copy_bytes %d + avail bytes %d < period bytes %d, possible glitch",
 			  copy_bytes, avail_bytes, dd->period_bytes);
 	else if (dev->direction == SOF_IPC_STREAM_CAPTURE &&
 		 copy_bytes + free_bytes < dd->period_bytes)
-		comp_warn(dev, "dai_common_copy(): Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
+		comp_warn(dev, "Copy_bytes %d + free bytes %d < period bytes %d, possible glitch",
 			  copy_bytes, free_bytes, dd->period_bytes);
 
 	/* return if nothing to copy */
 	if (!copy_bytes) {
-		comp_warn(dev, "dai_common_copy(): nothing to copy");
+		comp_warn(dev, "nothing to copy");
 		return 0;
 	}
 

--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -72,7 +72,7 @@ void *comp_get_data_blob(struct comp_data_blob_handler *blob_handler,
 
 	/* Function returns new data blob if available */
 	if (comp_is_new_data_blob_available(blob_handler)) {
-		comp_dbg(blob_handler->dev, "comp_get_data_blob(): new data available");
+		comp_dbg(blob_handler->dev, "new data available");
 
 		/* Free "old" data blob and set data to data_new pointer */
 		blob_handler->free(blob_handler->data);
@@ -95,7 +95,7 @@ void *comp_get_data_blob(struct comp_data_blob_handler *blob_handler,
 		 * data blob it means that component hasn't got any config yet.
 		 * Function returns NULL in that case.
 		 */
-		comp_warn(blob_handler->dev, "comp_get_data_blob(): blob_handler->data is not set.");
+		comp_warn(blob_handler->dev, "blob_handler->data is not set.");
 	}
 
 	if (size)
@@ -145,7 +145,7 @@ int comp_init_data_blob(struct comp_data_blob_handler *blob_handler,
 	/* Data blob allocation */
 	blob_handler->data = blob_handler->alloc(size);
 	if (!blob_handler->data) {
-		comp_err(blob_handler->dev, "comp_init_data_blob(): model->data allocation failed");
+		comp_err(blob_handler->dev, "model->data allocation failed");
 		return -ENOMEM;
 	}
 
@@ -243,7 +243,7 @@ int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		if (!blob_handler->data_new) {
 			blob_handler->data_new = blob_handler->alloc(data_offset_size);
 			if (!blob_handler->data_new) {
-				comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): blob_handler->data_new allocation failed.");
+				comp_err(blob_handler->dev, "blob_handler->data_new allocation failed.");
 				return -ENOMEM;
 			}
 		}
@@ -255,7 +255,7 @@ int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 
 	/* return an error in case when we do not have allocated memory for model data */
 	if (!blob_handler->data_new) {
-		comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): buffer not allocated");
+		comp_err(blob_handler->dev, "buffer not allocated");
 		return -ENOMEM;
 	}
 
@@ -263,20 +263,20 @@ int comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		       blob_handler->new_data_size - blob_handler->data_pos,
 		       fragment, fragment_size);
 	if (ret) {
-		comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): failed to copy fragment");
+		comp_err(blob_handler->dev, "failed to copy fragment");
 		return ret;
 	}
 
 	blob_handler->data_pos += fragment_size;
 
 	if (pos == MODULE_CFG_FRAGMENT_SINGLE || pos == MODULE_CFG_FRAGMENT_LAST) {
-		comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd(): final package received");
+		comp_dbg(blob_handler->dev, "final package received");
 		if (blob_handler->validator) {
-			comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd(): validating new data...");
+			comp_dbg(blob_handler->dev, "validating new data...");
 			ret = blob_handler->validator(blob_handler->dev, blob_handler->data_new,
 						      blob_handler->new_data_size);
 			if (ret < 0) {
-				comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): new data is invalid! discarding it...");
+				comp_err(blob_handler->dev, "new data is invalid! discarding it...");
 				blob_handler->free(blob_handler->data_new);
 				blob_handler->data_new = NULL;
 				return ret;
@@ -327,7 +327,7 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 	assert(blob_handler);
 
 	comp_dbg(blob_handler->dev,
-		 "ipc4_comp_data_blob_set(): data_offset = %d",
+		 "data_offset = %d",
 		 data_offset);
 
 	/* in case when the current package is the first, we should allocate
@@ -353,7 +353,7 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 
 			if (!blob_handler->data_new) {
 				comp_err(blob_handler->dev,
-					 "ipc4_comp_data_blob_set(): blob_handler allocation failed!");
+					 "blob_handler allocation failed!");
 				return -ENOMEM;
 			}
 		}
@@ -375,13 +375,13 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		 */
 		if (!blob_handler->data_new) {
 			comp_err(blob_handler->dev,
-				 "ipc4_comp_data_blob_set(): Buffer not allocated!");
+				 "Buffer not allocated!");
 			return -ENOMEM;
 		}
 
 		if (blob_handler->data_pos != data_offset) {
 			comp_err(blob_handler->dev,
-				 "ipc4_comp_data_blob_set(): Wrong data offset received!");
+				 "Wrong data offset received!");
 			return -EINVAL;
 		}
 
@@ -399,7 +399,7 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 
 	if (last_block) {
 		comp_dbg(blob_handler->dev,
-			 "ipc4_comp_data_blob_set(): final package received");
+			 "final package received");
 
 		/* If component state is READY we can omit old
 		 * configuration immediately. When in playback/capture
@@ -497,7 +497,7 @@ int comp_data_blob_set_cmd(struct comp_data_blob_handler *blob_handler,
 			blob_handler->data_new =
 				blob_handler->alloc(cdata->data->size);
 			if (!blob_handler->data_new) {
-				comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): blob_handler->data_new allocation failed.");
+				comp_err(blob_handler->dev, "blob_handler->data_new allocation failed.");
 				return -ENOMEM;
 			}
 		}
@@ -511,7 +511,7 @@ int comp_data_blob_set_cmd(struct comp_data_blob_handler *blob_handler,
 	 * model data
 	 */
 	if (!blob_handler->data_new) {
-		comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): buffer not allocated");
+		comp_err(blob_handler->dev, "buffer not allocated");
 		return -ENOMEM;
 	}
 
@@ -523,14 +523,14 @@ int comp_data_blob_set_cmd(struct comp_data_blob_handler *blob_handler,
 	blob_handler->data_pos += cdata->num_elems;
 
 	if (!cdata->elems_remaining) {
-		comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd(): final package received");
+		comp_dbg(blob_handler->dev, "final package received");
 
 		if (blob_handler->validator) {
-			comp_dbg(blob_handler->dev, "comp_data_blob_set_cmd(): validating new data blob");
+			comp_dbg(blob_handler->dev, "validating new data blob");
 			ret = blob_handler->validator(blob_handler->dev, blob_handler->data_new,
 						      blob_handler->new_data_size);
 			if (ret < 0) {
-				comp_err(blob_handler->dev, "comp_data_blob_set_cmd(): new data blob invalid, discarding");
+				comp_err(blob_handler->dev, "new data blob invalid, discarding");
 				blob_handler->free(blob_handler->data_new);
 				blob_handler->data_new = NULL;
 				return ret;
@@ -598,7 +598,7 @@ int comp_data_blob_get_cmd(struct comp_data_blob_handler *blob_handler,
 		 * required size
 		 */
 		if (cdata->num_elems > size) {
-			comp_err(blob_handler->dev, "comp_data_blob_get_cmd(): invalid cdata->num_elems %d",
+			comp_err(blob_handler->dev, "invalid cdata->num_elems %d",
 				 cdata->num_elems);
 			return -EINVAL;
 		}
@@ -613,7 +613,7 @@ int comp_data_blob_get_cmd(struct comp_data_blob_handler *blob_handler,
 		cdata->data->size = blob_handler->data_size;
 		blob_handler->data_pos += cdata->num_elems;
 	} else {
-		comp_warn(blob_handler->dev, "comp_data_blob_get_cmd(): model->data not allocated yet.");
+		comp_warn(blob_handler->dev, "model->data not allocated yet.");
 		cdata->data->abi = SOF_ABI_VERSION;
 		cdata->data->size = 0;
 	}

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -99,14 +99,14 @@ static int dcblock_init(struct processing_module *mod)
 	/* component model data handler */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "dcblock_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err_cd;
 	}
 
 	ret = comp_init_data_blob(cd->model_handler, bs, ipc_dcblock->data);
 	if (ret < 0) {
-		comp_err(dev, "dcblock_init(): comp_init_data_blob() failed with error: %d", ret);
+		comp_err(dev, "comp_init_data_blob() failed with error: %d", ret);
 		goto err_model_cd;
 	}
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -173,7 +173,7 @@ __cold static int drc_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "drc_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail;
 	}
@@ -181,7 +181,7 @@ __cold static int drc_init(struct processing_module *mod)
 	/* Get configuration data and reset DRC state */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "drc_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto cd_fail;
 	}
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -99,7 +99,7 @@ static int eq_fir_init_coef(struct comp_dev *dev, struct sof_eq_fir_config *conf
 		nch = cd->nch;
 	}
 
-	comp_info(dev, "eq_fir_init_coef(): %u responses, %u channels, stream %d channels",
+	comp_info(dev, "%u responses, %u channels, stream %d channels",
 		  config->number_of_responses, config->channels_in_config, nch);
 
 	/* Sanity checks */
@@ -259,7 +259,7 @@ static int eq_fir_init(struct processing_module *mod)
 	 * blob size is sane.
 	 */
 	if (bs > SOF_EQ_FIR_MAX_SIZE) {
-		comp_err(dev, "eq_fir_init(): coefficients blob size = %zu > SOF_EQ_FIR_MAX_SIZE",
+		comp_err(dev, "coefficients blob size = %zu > SOF_EQ_FIR_MAX_SIZE",
 			 bs);
 		return -EINVAL;
 	}
@@ -276,7 +276,7 @@ static int eq_fir_init(struct processing_module *mod)
 	/* component model data handler */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "eq_fir_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -288,7 +288,7 @@ static int eq_fir_init(struct processing_module *mod)
 	 */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->init_data);
 	if (ret < 0) {
-		comp_err(dev, "eq_fir_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto err_init;
 	}
 
@@ -439,11 +439,11 @@ static int eq_fir_prepare(struct processing_module *mod,
 	if (cd->config) {
 		ret = eq_fir_setup(dev, cd, channels);
 		if (ret < 0)
-			comp_err(dev, "eq_fir_prepare(): eq_fir_setup failed.");
+			comp_err(dev, "eq_fir_setup failed.");
 		else if (cd->fir_delay_size)
 			ret = set_fir_func(mod, frame_fmt);
 		else
-			comp_dbg(dev, "eq_fir_prepare(): pass-through");
+			comp_dbg(dev, "pass-through");
 	}
 
 	if (ret < 0)

--- a/src/audio/eq_fir/eq_fir_ipc4.c
+++ b/src/audio/eq_fir/eq_fir_ipc4.c
@@ -24,7 +24,7 @@ int set_fir_func(struct processing_module *mod, enum sof_ipc_frame fmt)
 	struct comp_data *cd = module_get_private_data(mod);
 	unsigned int valid_bit_depth = mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth;
 
-	comp_dbg(mod->dev, "set_fir_func(): valid_bit_depth %d", valid_bit_depth);
+	comp_dbg(mod->dev, "valid_bit_depth %d", valid_bit_depth);
 	switch (valid_bit_depth) {
 #if CONFIG_FORMAT_S16LE
 	case IPC4_DEPTH_16BIT:

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -69,7 +69,7 @@ static int eq_iir_init(struct processing_module *mod)
 	/* component model data handler */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "eq_iir_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -79,7 +79,7 @@ static int eq_iir_init(struct processing_module *mod)
 	 */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "eq_iir_init(): comp_init_data_blob() failed with error: %d", ret);
+		comp_err(dev, "comp_init_data_blob() failed with error: %d", ret);
 		comp_data_blob_handler_free(cd->model_handler);
 		goto err;
 	}

--- a/src/audio/eq_iir/eq_iir_generic.c
+++ b/src/audio/eq_iir/eq_iir_generic.c
@@ -195,7 +195,7 @@ static int eq_iir_init_coef(struct processing_module *mod, int nch)
 	int j;
 	int s;
 
-	comp_info(mod->dev, "eq_iir_init_coef(): %u responses, %u channels, stream %d channels",
+	comp_info(mod->dev, "%u responses, %u channels, stream %d channels",
 		  config->number_of_responses, config->channels_in_config, nch);
 
 	/* Sanity checks */

--- a/src/audio/eq_iir/eq_iir_ipc3.c
+++ b/src/audio/eq_iir/eq_iir_ipc3.c
@@ -291,7 +291,7 @@ static int eq_iir_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, buffer_flag, params);
 	if (ret < 0) {
-		comp_err(dev, "eq_iir_verify_params(): comp_verify_params() failed.");
+		comp_err(dev, "comp_verify_params() failed.");
 		return ret;
 	}
 

--- a/src/audio/eq_iir/eq_iir_ipc4.c
+++ b/src/audio/eq_iir/eq_iir_ipc4.c
@@ -57,7 +57,7 @@ static eq_iir_func eq_iir_find_func(struct processing_module *mod)
 {
 	unsigned int valid_bit_depth = mod->priv.cfg.base_cfg.audio_fmt.valid_bit_depth;
 
-	comp_dbg(mod->dev, "eq_iir_find_func(): valid_bit_depth %d", valid_bit_depth);
+	comp_dbg(mod->dev, "valid_bit_depth %d", valid_bit_depth);
 	switch (valid_bit_depth) {
 #if CONFIG_FORMAT_S16LE
 	case IPC4_DEPTH_16BIT:

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -267,7 +267,7 @@ static int ctc_init(struct processing_module *mod)
 	/* Create private component data */
 	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(*cd));
 	if (!cd) {
-		comp_err(dev, "ctc_init(): Failed to create component data");
+		comp_err(dev, "Failed to create component data");
 		ctc_free(mod);
 		return -ENOMEM;
 	}
@@ -279,27 +279,27 @@ static int ctc_init(struct processing_module *mod)
 
 	cd->input = rballoc(SOF_MEM_FLAG_USER, buf_size);
 	if (!cd->input) {
-		comp_err(dev, "ctc_init(): Failed to allocate input buffer");
+		comp_err(dev, "Failed to allocate input buffer");
 		ctc_free(mod);
 		return -ENOMEM;
 	}
 	cd->output = rballoc(SOF_MEM_FLAG_USER, buf_size);
 	if (!cd->output) {
-		comp_err(dev, "ctc_init(): Failed to allocate output buffer");
+		comp_err(dev, "Failed to allocate output buffer");
 		ctc_free(mod);
 		return -ENOMEM;
 	}
 
 	cd->tuning_handler = comp_data_blob_handler_new(dev);
 	if (!cd->tuning_handler) {
-		comp_err(dev, "ctc_init(): Failed to create tuning handler");
+		comp_err(dev, "Failed to create tuning handler");
 		ctc_free(mod);
 		return -ENOMEM;
 	}
 
 	cd->enabled = true;
 
-	comp_dbg(dev, "ctc_init(): Ready");
+	comp_dbg(dev, "Ready");
 
 	return 0;
 }
@@ -321,16 +321,16 @@ static int google_ctc_audio_processing_reconfigure(struct processing_module *mod
 	}
 
 	if (!config) {
-		comp_err(dev, "google_ctc_audio_processing_reconfigure(): Tuning config not set");
+		comp_err(dev, "Tuning config not set");
 		return -EINVAL;
 	}
 
-	comp_info(dev, "google_ctc_audio_processing_reconfigure(): New tuning config %p (%zu bytes)",
+	comp_info(dev, "New tuning config %p (%zu bytes)",
 		  config, size);
 
 	cd->reconfigure = false;
 	comp_info(dev,
-		  "google_ctc_audio_processing_reconfigure(): Applying config of size %zu bytes",
+		  "Applying config of size %zu bytes",
 		  size);
 	ret = GoogleCtcAudioProcessingReconfigure(cd->state, config, size);
 	if (ret) {
@@ -391,7 +391,7 @@ static int ctc_prepare(struct processing_module *mod,
 	config = comp_get_data_blob(cd->tuning_handler, &config_size, NULL);
 
 	if (config_size != CTC_BLOB_CONFIG_SIZE) {
-		comp_info(mod->dev, "ctc_prepare(): config_size not expected: %d", config_size);
+		comp_info(mod->dev, "config_size not expected: %d", config_size);
 		config = NULL;
 		config_size = 0;
 	}

--- a/src/audio/google/google_ctc_audio_processing_ipc3.c
+++ b/src/audio/google/google_ctc_audio_processing_ipc3.c
@@ -40,13 +40,13 @@ int ctc_set_config(struct processing_module *mod, uint32_t param_id,
 			config = comp_get_data_blob(cd->tuning_handler, &size, NULL);
 			if (size != CTC_BLOB_CONFIG_SIZE) {
 				comp_err(mod->dev,
-					 "ctc_set_config(): Invalid config size = %d",
+					 "Invalid config size = %d",
 					 size);
 				return -EINVAL;
 			}
 			if (config->size != CTC_BLOB_CONFIG_SIZE) {
 				comp_err(mod->dev,
-					 "ctc_set_config(): Invalid config->size = %d",
+					 "Invalid config->size = %d",
 					 config->size);
 				return -EINVAL;
 			}
@@ -61,12 +61,12 @@ int ctc_set_config(struct processing_module *mod, uint32_t param_id,
 			return 0;
 		}
 		comp_err(mod->dev,
-			 "ctc_set_config(): Illegal num_elems = %d",
+			 "Illegal num_elems = %d",
 			 cdata->num_elems);
 		return -EINVAL;
 	default:
 		comp_err(mod->dev,
-			 "ctc_set_config(): Only binary and switch controls supported %d",
+			 "Only binary and switch controls supported %d",
 			 cdata->cmd);
 		return -EINVAL;
 	}
@@ -79,7 +79,7 @@ int ctc_get_config(struct processing_module *mod,
 	struct sof_ipc_ctrl_data *cdata = (struct sof_ipc_ctrl_data *)fragment;
 	struct google_ctc_audio_processing_comp_data *cd = module_get_private_data(mod);
 
-	comp_info(mod->dev, "ctc_get_config(): %u", cdata->cmd);
+	comp_info(mod->dev, "%u", cdata->cmd);
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:

--- a/src/audio/google/google_ctc_audio_processing_ipc4.c
+++ b/src/audio/google/google_ctc_audio_processing_ipc4.c
@@ -37,15 +37,15 @@ int ctc_set_config(struct processing_module *mod, uint32_t param_id,
 	case SOF_IPC4_SWITCH_CONTROL_PARAM_ID:
 		if (ctl->id == 0 && ctl->num_elems == 1) {
 			cd->enabled = ctl->chanv[0].value;
-			comp_info(mod->dev, "ctc_set_config(): enabled = %d", cd->enabled);
+			comp_info(mod->dev, "enabled = %d", cd->enabled);
 			return 0;
 		}
-		comp_err(mod->dev, "ctc_set_config(): Illegal control id = %d, num_elems = %d",
+		comp_err(mod->dev, "Illegal control id = %d, num_elems = %d",
 			 ctl->id, ctl->num_elems);
 		return -EINVAL;
 	case SOF_IPC4_ENUM_CONTROL_PARAM_ID:
 	default:
-		comp_err(mod->dev, "ctc_set_config(): Only binary and switch controls supported");
+		comp_err(mod->dev, "Only binary and switch controls supported");
 		return -EINVAL;
 	}
 
@@ -58,13 +58,13 @@ int ctc_set_config(struct processing_module *mod, uint32_t param_id,
 		config = comp_get_data_blob(cd->tuning_handler, &size, NULL);
 		if (size != CTC_BLOB_CONFIG_SIZE) {
 			comp_err(mod->dev,
-				 "ctc_set_config(): Invalid config size = %d",
+				 "Invalid config size = %d",
 				 size);
 			return -EINVAL;
 		}
 		if (config->size != CTC_BLOB_CONFIG_SIZE) {
 			comp_err(mod->dev,
-				 "ctc_set_config(): Invalid config->size = %d",
+				 "Invalid config->size = %d",
 				 config->size);
 			return -EINVAL;
 		}
@@ -81,7 +81,7 @@ int ctc_get_config(struct processing_module *mod,
 	struct sof_ipc_ctrl_data *cdata = (struct sof_ipc_ctrl_data *)fragment;
 	struct google_ctc_audio_processing_comp_data *cd = module_get_private_data(mod);
 
-	comp_info(mod->dev, "ctc_get_config(): %u", cdata->cmd);
+	comp_info(mod->dev, "%u", cdata->cmd);
 
 	return comp_data_blob_get_cmd(cd->tuning_handler, cdata, fragment_size);
 }

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -115,19 +115,19 @@ static struct comp_dev *ghd_create(const struct comp_driver *drv,
 
 	cd->msg = ipc_msg_init(cd->event.rhdr.hdr.cmd, cd->event.rhdr.hdr.size);
 	if (!cd->msg) {
-		comp_err(dev, "ghd_create(): ipc_msg_init failed");
+		comp_err(dev, "ipc_msg_init failed");
 		goto cd_fail;
 	}
 
 	/* Create component model data handler */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "ghd_create(): comp_data_blob_handler_new failed");
+		comp_err(dev, "comp_data_blob_handler_new failed");
 		goto cd_fail;
 	}
 
 	dev->state = COMP_STATE_READY;
-	comp_dbg(dev, "ghd_create(): Ready");
+	comp_dbg(dev, "Ready");
 	return dev;
 
 cd_fail:
@@ -164,7 +164,7 @@ static int ghd_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "ghd_params(): comp_verify_params failed.");
+		comp_err(dev, "comp_verify_params failed.");
 		return -EINVAL;
 	}
 
@@ -172,13 +172,13 @@ static int ghd_params(struct comp_dev *dev,
 	sourceb = comp_dev_get_first_data_producer(dev);
 
 	if (audio_stream_get_channels(sourceb->stream) != 1) {
-		comp_err(dev, "ghd_params(): Only single-channel supported");
+		comp_err(dev, "Only single-channel supported");
 		ret = -EINVAL;
 	} else if (audio_stream_get_frm_fmt(&sourceb->stream) != SOF_IPC_FRAME_S16_LE) {
-		comp_err(dev, "ghd_params(): Only S16_LE supported");
+		comp_err(dev, "Only S16_LE supported");
 		ret = -EINVAL;
 	} else if (sourceb->stream.rate != KPB_SAMPLNG_FREQUENCY) {
-		comp_err(dev, "ghd_params(): Only 16KHz supported");
+		comp_err(dev, "Only 16KHz supported");
 		ret = -EINVAL;
 	}
 
@@ -229,11 +229,11 @@ static int ghd_ctrl_set_bin_data(struct comp_dev *dev,
 	switch (cdata->data->type) {
 	case GOOGLE_HOTWORD_DETECT_MODEL:
 		ret = comp_data_blob_set_cmd(cd->model_handler, cdata);
-		comp_dbg(dev, "ghd_ctrl_set_bin_data(): comp_data_blob_set_cmd=%d",
+		comp_dbg(dev, "comp_data_blob_set_cmd=%d",
 			 ret);
 		return ret;
 	default:
-		comp_err(dev, "ghd_ctrl_set_bin_data(): Unknown cdata->data->type %d",
+		comp_err(dev, "Unknown cdata->data->type %d",
 			 cdata->data->type);
 		return -EINVAL;
 	}
@@ -246,7 +246,7 @@ static int ghd_ctrl_set_data(struct comp_dev *dev,
 	case SOF_CTRL_CMD_BINARY:
 		return ghd_ctrl_set_bin_data(dev, cdata);
 	default:
-		comp_err(dev, "ghd_ctrl_set_data(): Only binary controls supported %d",
+		comp_err(dev, "Only binary controls supported %d",
 			 cdata->cmd);
 		return -EINVAL;
 	}
@@ -264,11 +264,11 @@ static int ghd_ctrl_get_bin_data(struct comp_dev *dev,
 		ret = comp_data_blob_get_cmd(cd->model_handler,
 					     cdata,
 					     max_data_size);
-		comp_dbg(dev, "ghd_ctrl_get_bin_data(): comp_data_blob_get_cmd=%d, size=%d",
+		comp_dbg(dev, "comp_data_blob_get_cmd=%d, size=%d",
 			 ret, max_data_size);
 		return ret;
 	default:
-		comp_err(dev, "ghd_ctrl_get_bin_data(): Unknown cdata->data->type %d",
+		comp_err(dev, "Unknown cdata->data->type %d",
 			 cdata->data->type);
 		return -EINVAL;
 	}
@@ -282,7 +282,7 @@ static int ghd_ctrl_get_data(struct comp_dev *dev,
 	case SOF_CTRL_CMD_BINARY:
 		return ghd_ctrl_get_bin_data(dev, cdata, max_data_size);
 	default:
-		comp_err(dev, "ghd_ctrl_get_data(): Only binary controls supported %d",
+		comp_err(dev, "Only binary controls supported %d",
 			 cdata->cmd);
 		return -EINVAL;
 	}
@@ -293,7 +293,7 @@ static int ghd_cmd(struct comp_dev *dev, int cmd, void *data,
 {
 	struct sof_ipc_ctrl_data *cdata = data;
 
-	comp_dbg(dev, "ghd_cmd(): %d", cmd);
+	comp_dbg(dev, "%d", cmd);
 
 	switch (cmd) {
 	case COMP_CMD_SET_DATA:
@@ -301,7 +301,7 @@ static int ghd_cmd(struct comp_dev *dev, int cmd, void *data,
 	case COMP_CMD_GET_DATA:
 		return ghd_ctrl_get_data(dev, cdata, max_data_size);
 	default:
-		comp_err(dev, "ghd_cmd(): Unknown cmd %d", cmd);
+		comp_err(dev, "Unknown cmd %d", cmd);
 		return -EINVAL;
 	}
 }
@@ -311,7 +311,7 @@ static int ghd_trigger(struct comp_dev *dev, int cmd)
 {
 	struct comp_data *cd = comp_get_drvdata(dev);
 
-	comp_dbg(dev, "ghd_trigger(): %d", cmd);
+	comp_dbg(dev, "%d", cmd);
 
 	if (cmd == COMP_TRIGGER_START || cmd == COMP_TRIGGER_RELEASE) {
 		cd->detected = 0;
@@ -382,7 +382,7 @@ static int ghd_copy(struct comp_dev *dev)
 
 	/* Check for new model */
 	if (comp_is_new_data_blob_available(cd->model_handler)) {
-		comp_dbg(dev, "ghd_copy(): Switch to new model");
+		comp_dbg(dev, "Switch to new model");
 		ret = ghd_setup_model(dev);
 		if (ret)
 			return ret;

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -269,11 +269,11 @@ static int google_rtc_audio_processing_reconfigure(struct processing_module *mod
 	}
 
 	if (!config) {
-		comp_err(dev, "google_rtc_audio_processing_reconfigure(): Tuning config not set");
+		comp_err(dev, "Tuning config not set");
 		return -EINVAL;
 	}
 
-	comp_info(dev, "google_rtc_audio_processing_reconfigure(): New tuning config %p (%zu bytes)",
+	comp_info(dev, "New tuning config %p (%zu bytes)",
 		  config, size);
 
 	cd->reconfigure = false;
@@ -305,7 +305,7 @@ static int google_rtc_audio_processing_reconfigure(struct processing_module *mod
 
 	if (google_rtc_audio_processing_config_present) {
 		comp_info(dev,
-			  "google_rtc_audio_processing_reconfigure(): Applying config of size %zu bytes",
+			  "Applying config of size %zu bytes",
 			  google_rtc_audio_processing_config_size);
 
 		ret = GoogleRtcAudioProcessingReconfigure(cd->state,
@@ -331,7 +331,7 @@ static int google_rtc_audio_processing_reconfigure(struct processing_module *mod
 			cd->num_capture_channels = num_capture_output_channels;
 		}
 		comp_info(dev,
-			  "google_rtc_audio_processing_reconfigure(): Applying num capture channels %d",
+			  "Applying num capture channels %d",
 			  cd->num_capture_channels);
 
 
@@ -358,7 +358,7 @@ static int google_rtc_audio_processing_reconfigure(struct processing_module *mod
 
 			/* Logging of linear headroom, using integer workaround to the broken printout of floats */
 			comp_info(dev,
-				  "google_rtc_audio_processing_reconfigure(): Applying capture linear headroom: %d.%d",
+				  "Applying capture linear headroom: %d.%d",
 				  (int)mic_gain, (int)(100 * mic_gain) - 100 * ((int)mic_gain));
 		}
 		if (aec_reference_delay_present) {
@@ -366,7 +366,7 @@ static int google_rtc_audio_processing_reconfigure(struct processing_module *mod
 
 			/* Logging of delay, using integer workaround to the broken printout of floats */
 			comp_info(dev,
-				  "google_rtc_audio_processing_reconfigure(): Applying aec reference delay: %d.%d",
+				  "Applying aec reference delay: %d.%d",
 				  (int)aec_reference_delay,
 				  (int)(100 * aec_reference_delay) -
 				  100 * ((int)aec_reference_delay));
@@ -414,7 +414,7 @@ static int google_rtc_audio_processing_cmd_set_data(struct processing_module *mo
 		return 0;
 	default:
 		comp_err(mod->dev,
-			 "google_rtc_audio_processing_ctrl_set_data(): Only binary controls supported %d",
+			 "Only binary controls supported %d",
 			 cdata->cmd);
 		return -EINVAL;
 	}
@@ -426,14 +426,14 @@ static int google_rtc_audio_processing_cmd_get_data(struct processing_module *mo
 {
 	struct google_rtc_audio_processing_comp_data *cd = module_get_private_data(mod);
 
-	comp_info(mod->dev, "google_rtc_audio_processing_ctrl_get_data(): %u", cdata->cmd);
+	comp_info(mod->dev, "%u", cdata->cmd);
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
 		return comp_data_blob_get_cmd(cd->tuning_handler, cdata, max_data_size);
 	default:
 		comp_err(mod->dev,
-			 "google_rtc_audio_processing_ctrl_get_data(): Only binary controls supported %d",
+			 "Only binary controls supported %d",
 			 cdata->cmd);
 		return -EINVAL;
 	}
@@ -454,7 +454,7 @@ static int google_rtc_audio_processing_set_config(struct processing_module *mod,
 	switch (param_id) {
 	case SOF_IPC4_SWITCH_CONTROL_PARAM_ID:
 	case SOF_IPC4_ENUM_CONTROL_PARAM_ID:
-		comp_err(mod->dev, "google_rtc_audio_processing_ctrl_set_data(): Only binary controls supported");
+		comp_err(mod->dev, "Only binary controls supported");
 		return -EINVAL;
 	}
 
@@ -493,7 +493,7 @@ static int google_rtc_audio_processing_get_config(struct processing_module *mod,
 						  uint8_t *fragment, size_t fragment_size)
 {
 #if CONFIG_IPC_MAJOR_4
-	comp_err(mod->dev, "google_rtc_audio_processing_ctrl_get_config(): Not supported");
+	comp_err(mod->dev, "Not supported");
 	return -EINVAL;
 #elif CONFIG_IPC_MAJOR_3
 	struct sof_ipc_ctrl_data *cdata = (struct sof_ipc_ctrl_data *)fragment;
@@ -575,11 +575,11 @@ static int google_rtc_audio_processing_init(struct processing_module *mod)
 	/* Mic and reference, needed for audio stream type copy module client */
 	mod->max_sources = 2;
 
-	comp_dbg(dev, "google_rtc_audio_processing_init(): Ready");
+	comp_dbg(dev, "Ready");
 	return 0;
 
 fail:
-	comp_err(dev, "google_rtc_audio_processing_init(): Failed");
+	comp_err(dev, "Failed");
 	if (cd) {
 		if (cd->state) {
 			GoogleRtcAudioProcessingFree(cd->state);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -81,14 +81,14 @@ static int host_dma_set_config_and_copy(struct host_data *hd, struct comp_dev *d
 	/* reconfigure transfer */
 	ret = dma_set_config_legacy(hd->chan, &hd->config);
 	if (ret < 0) {
-		comp_err(dev, "host_dma_set_config_and_copy(): dma_set_config() failed, ret = %d",
+		comp_err(dev, "dma_set_config() failed, ret = %d",
 			 ret);
 		return ret;
 	}
 
 	ret = dma_copy_legacy(hd->chan, bytes, DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (ret < 0) {
-		comp_err(dev, "host_dma_set_config_and_copy(): dma_copy() failed, ret = %d",
+		comp_err(dev, "dma_copy() failed, ret = %d",
 			 ret);
 		return ret;
 	}
@@ -133,7 +133,7 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 	copy_bytes = host_get_copy_bytes_one_shot(hd, dev);
 	if (!copy_bytes) {
-		comp_info(dev, "host_copy_one_shot(): no bytes to copy");
+		comp_info(dev, "no bytes to copy");
 		return ret;
 	}
 
@@ -201,20 +201,20 @@ static int host_copy_one_shot(struct host_data *hd, struct comp_dev *dev, copy_c
 
 	copy_bytes = host_get_copy_bytes_one_shot(hd, dev);
 	if (!copy_bytes) {
-		comp_info(dev, "host_copy_one_shot(): no bytes to copy");
+		comp_info(dev, "no bytes to copy");
 		return ret;
 	}
 
 	/* reconfigure transfer */
 	ret = dma_set_config_legacy(hd->chan, &hd->config);
 	if (ret < 0) {
-		comp_err(dev, "host_copy_one_shot(): dma_set_config() failed, ret = %u", ret);
+		comp_err(dev, "dma_set_config() failed, ret = %u", ret);
 		return ret;
 	}
 
 	ret = dma_copy_legacy(hd->chan, copy_bytes, DMA_COPY_ONE_SHOT);
 	if (ret < 0) {
-		comp_err(dev, "host_copy_one_shot(): dma_copy() failed, ret = %u", ret);
+		comp_err(dev, "dma_copy() failed, ret = %u", ret);
 		return ret;
 	}
 
@@ -369,7 +369,7 @@ static uint32_t host_get_copy_bytes_normal(struct host_data *hd, struct comp_dev
 	/* get data sizes from DMA */
 	ret = dma_get_data_size_legacy(hd->chan, &avail_bytes, &free_bytes);
 	if (ret < 0) {
-		comp_err(dev, "host_get_copy_bytes_normal(): dma_get_data_size() failed, ret = %u",
+		comp_err(dev, "dma_get_data_size() failed, ret = %u",
 			 ret);
 		/* return 0 copy_bytes in case of error to skip DMA copy */
 		return 0;
@@ -422,7 +422,7 @@ static int host_copy_normal(struct host_data *hd, struct comp_dev *dev, copy_cal
 
 	ret = dma_copy_legacy(hd->chan, copy_bytes, flags);
 	if (ret < 0)
-		comp_err(dev, "host_copy_normal(): dma_copy() failed, ret = %u", ret);
+		comp_err(dev, "dma_copy() failed, ret = %u", ret);
 
 	return ret;
 }
@@ -445,7 +445,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		err = dma_sg_alloc(&hd->config.elem_array, SOF_MEM_FLAG_USER,
 				   dir, 1, 0, 0, 0);
 		if (err < 0) {
-			comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
+			comp_err(dev, "dma_sg_alloc() failed");
 			return err;
 		}
 	} else {
@@ -456,7 +456,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 			   buffer_bytes,
 			   (uintptr_t)(audio_stream_get_addr(&hd->dma_buffer->stream)), 0);
 	if (err < 0) {
-		comp_err(dev, "create_local_elems(): dma_sg_alloc() failed");
+		comp_err(dev, "dma_sg_alloc() failed");
 		return err;
 	}
 
@@ -484,7 +484,7 @@ int host_common_trigger(struct host_data *hd, struct comp_dev *dev, int cmd)
 		return 0;
 
 	if (!hd->chan) {
-		comp_err(dev, "host_trigger(): no dma channel configured");
+		comp_err(dev, "no dma channel configured");
 		return -EINVAL;
 	}
 
@@ -492,14 +492,14 @@ int host_common_trigger(struct host_data *hd, struct comp_dev *dev, int cmd)
 	case COMP_TRIGGER_START:
 		ret = dma_start_legacy(hd->chan);
 		if (ret < 0)
-			comp_err(dev, "host_trigger(): dma_start() failed, ret = %u",
+			comp_err(dev, "dma_start() failed, ret = %u",
 				 ret);
 		break;
 	case COMP_TRIGGER_STOP:
 	case COMP_TRIGGER_XRUN:
 		ret = dma_stop_legacy(hd->chan);
 		if (ret < 0)
-			comp_err(dev, "host_trigger(): dma stop failed: %d",
+			comp_err(dev, "dma stop failed: %d",
 				 ret);
 		break;
 	default:
@@ -539,7 +539,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 
 	hd->dma = dma_get(dir, 0, DMA_DEV_HOST, DMA_ACCESS_SHARED);
 	if (!hd->dma) {
-		comp_err(dev, "host_common_new(): dma_get() returned NULL");
+		comp_err(dev, "dma_get() returned NULL");
 		return -ENODEV;
 	}
 
@@ -552,7 +552,7 @@ int host_common_new(struct host_data *hd, struct comp_dev *dev,
 
 	hd->msg = ipc_msg_init(hd->posn.rhdr.hdr.cmd, hd->posn.rhdr.hdr.size);
 	if (!hd->msg) {
-		comp_err(dev, "host_common_new(): ipc_msg_init failed");
+		comp_err(dev, "ipc_msg_init failed");
 		dma_put(hd->dma);
 		return -ENOMEM;
 	}
@@ -659,7 +659,7 @@ static int host_verify_params(struct comp_dev *dev,
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "host_verify_params(): comp_verify_params() failed");
+		comp_err(dev, "comp_verify_params() failed");
 		return ret;
 	}
 
@@ -689,7 +689,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	err = dma_get_attribute_legacy(hd->dma, DMA_ATTR_BUFFER_ADDRESS_ALIGNMENT,
 				       &addr_align);
 	if (err < 0) {
-		comp_err(dev, "host_params(): could not get dma buffer address alignment, err = %d",
+		comp_err(dev, "could not get dma buffer address alignment, err = %d",
 			 err);
 		return err;
 	}
@@ -697,7 +697,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	/* retrieve DMA buffer size alignment */
 	err = dma_get_attribute_legacy(hd->dma, DMA_ATTR_BUFFER_ALIGNMENT, &align);
 	if (err < 0 || !align) {
-		comp_err(dev, "host_params(): could not get valid dma buffer alignment, err = %d, align = %u",
+		comp_err(dev, "could not get valid dma buffer alignment, err = %d, align = %u",
 			 err, align);
 		return -EINVAL;
 	}
@@ -706,7 +706,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	err = dma_get_attribute_legacy(hd->dma, DMA_ATTR_BUFFER_PERIOD_COUNT,
 				       &period_count);
 	if (err < 0 || !period_count) {
-		comp_err(dev, "host_params(): could not get valid dma buffer period count, err = %d, period_count = %u",
+		comp_err(dev, "could not get valid dma buffer period count, err = %d, period_count = %u",
 			 err, period_count);
 		return -EINVAL;
 	}
@@ -720,7 +720,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		audio_stream_frame_bytes(&hd->local_buffer->stream);
 
 	if (!period_bytes) {
-		comp_err(dev, "host_params(): invalid period_bytes");
+		comp_err(dev, "invalid period_bytes");
 		err = -EINVAL;
 		goto out;
 	}
@@ -754,7 +754,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	if (hd->dma_buffer) {
 		err = buffer_set_size(hd->dma_buffer, buffer_size, addr_align);
 		if (err < 0) {
-			comp_err(dev, "host_params(): buffer_set_size() failed, buffer_size = %u",
+			comp_err(dev, "buffer_set_size() failed, buffer_size = %u",
 				 buffer_size);
 			goto out;
 		}
@@ -762,7 +762,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
 					      addr_align, false);
 		if (!hd->dma_buffer) {
-			comp_err(dev, "host_params(): failed to alloc dma buffer");
+			comp_err(dev, "failed to alloc dma buffer");
 			err = -ENOMEM;
 			goto out;
 		}
@@ -791,14 +791,14 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	 */
 	hd->chan = dma_channel_get_legacy(hd->dma, hd->stream_tag);
 	if (!hd->chan) {
-		comp_err(dev, "host_params(): hd->chan is NULL");
+		comp_err(dev, "hd->chan is NULL");
 		err = -ENODEV;
 		goto out;
 	}
 
 	err = dma_set_config_legacy(hd->chan, &hd->config);
 	if (err < 0) {
-		comp_err(dev, "host_params(): dma_set_config() failed");
+		comp_err(dev, "dma_set_config() failed");
 		dma_channel_put_legacy(hd->chan);
 		hd->chan = NULL;
 		goto out;
@@ -808,7 +808,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 				       &hd->dma_copy_align);
 
 	if (err < 0) {
-		comp_err(dev, "host_params(): dma_get_attribute()");
+		comp_err(dev, "dma_get_attribute()");
 
 		goto out;
 	}
@@ -847,7 +847,7 @@ static int host_params(struct comp_dev *dev,
 
 	err = host_verify_params(dev, params);
 	if (err < 0) {
-		comp_err(dev, "host_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return err;
 	}
 

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -428,14 +428,14 @@ static int igo_nr_init(struct processing_module *mod)
 	md->private = cd;
 	ret = IgoLibGetInfo(&cd->igo_lib_info);
 	if (ret != IGO_RET_OK) {
-		comp_err(dev, "igo_nr_init(): IgoLibGetInfo() Failed.");
+		comp_err(dev, "IgoLibGetInfo() Failed.");
 		ret = -EINVAL;
 		goto cd_fail;
 	}
 
 	cd->p_handle = rballoc(SOF_MEM_FLAG_USER, cd->igo_lib_info.handle_size);
 	if (!cd->p_handle) {
-		comp_err(dev, "igo_nr_init(): igo_handle memory rballoc error for size %d",
+		comp_err(dev, "igo_handle memory rballoc error for size %d",
 			 cd->igo_lib_info.handle_size);
 		ret = -ENOMEM;
 		goto cd_fail;
@@ -444,7 +444,7 @@ static int igo_nr_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "igo_nr_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail2;
 	}
@@ -452,7 +452,7 @@ static int igo_nr_init(struct processing_module *mod)
 	/* Get configuration data */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "igo_nr_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		ret = -ENOMEM;
 		goto cd_fail3;
 	}

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -96,7 +96,7 @@ static int mfcc_init(struct processing_module *mod)
 	md->private = cd;
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "mfcc_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -104,7 +104,7 @@ static int mfcc_init(struct processing_module *mod)
 	/* Get configuration data */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->init_data);
 	if (ret < 0) {
-		comp_err(mod->dev, "mfcc_init(): comp_init_data_blob() failed.");
+		comp_err(mod->dev, "comp_init_data_blob() failed.");
 		goto err_init;
 	}
 
@@ -207,7 +207,7 @@ static int mfcc_prepare(struct processing_module *mod,
 	comp_info(dev, "mfcc_prepare(), source_format = %d, sink_format = %d",
 		  source_format, sink_format);
 	if (audio_stream_get_size(&sinkb->stream) < sink_period_bytes) {
-		comp_err(dev, "mfcc_prepare(): sink buffer size %d is insufficient < %d",
+		comp_err(dev, "sink buffer size %d is insufficient < %d",
 			 audio_stream_get_size(&sinkb->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;

--- a/src/audio/mfcc/mfcc_setup.c
+++ b/src/audio/mfcc/mfcc_setup.c
@@ -112,19 +112,19 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 
 	/* Check size */
 	if (config->size != sizeof(struct sof_mfcc_config)) {
-		comp_err(dev, "mfcc_setup(): Illegal configuration size %d.", config->size);
+		comp_err(dev, "Illegal configuration size %d.", config->size);
 		return -EINVAL;
 	}
 
 	/* Check currently hard-coded features to match configuration request */
 	if (!config->round_to_power_of_two || !config->snip_edges ||
 	    config->subtract_mean || config->use_energy) {
-		comp_err(dev, "mfcc_setup(): Can't change currently hard-coded features");
+		comp_err(dev, "Can't change currently hard-coded features");
 		return -EINVAL;
 	}
 
 	if (config->sample_frequency != sample_rate) {
-		comp_err(dev, "mfcc_setup(): Config sample_frequency does not match stream");
+		comp_err(dev, "Config sample_frequency does not match stream");
 		return -EINVAL;
 	}
 
@@ -133,14 +133,14 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	state->low_freq = config->low_freq;
 	state->high_freq = (config->high_freq == 0) ? (sample_rate >> 1) : config->high_freq;
 	if (state->low_freq > state->high_freq) {
-		comp_err(dev, "mfcc_setup(): Config high_freq must be larger than low_freq");
+		comp_err(dev, "Config high_freq must be larger than low_freq");
 		return -EINVAL;
 	}
 
 	comp_info(dev, "mfcc_setup(), source_channel = %d, stream_channels = %d",
 		  config->channel, channels);
 	if (config->channel >= channels) {
-		comp_err(dev, "mfcc_setup(): Illegal channel");
+		comp_err(dev, "Illegal channel");
 		return -EINVAL;
 	}
 
@@ -174,7 +174,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	state->buffers = rzalloc(SOF_MEM_FLAG_USER,
 				 state->sample_buffers_size);
 	if (!state->buffers) {
-		comp_err(dev, "mfcc_setup(): Failed buffer allocate");
+		comp_err(dev, "Failed buffer allocate");
 		ret = -ENOMEM;
 		goto exit;
 	}
@@ -191,14 +191,14 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 #endif
 	fft->fft_buf = rzalloc(SOF_MEM_FLAG_USER, fft->fft_buffer_size);
 	if (!fft->fft_buf) {
-		comp_err(dev, "mfcc_setup(): Failed FFT buffer allocate");
+		comp_err(dev, "Failed FFT buffer allocate");
 		ret = -ENOMEM;
 		goto free_buffers;
 	}
 
 	fft->fft_out = rzalloc(SOF_MEM_FLAG_USER, fft->fft_buffer_size);
 	if (!fft->fft_out) {
-		comp_err(dev, "mfcc_setup(): Failed FFT output allocate");
+		comp_err(dev, "Failed FFT output allocate");
 		ret = -ENOMEM;
 		goto free_fft_buf;
 	}
@@ -209,7 +209,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	fft->fft_plan = fft_plan_new(fft->fft_buf, fft->fft_out, fft->fft_padded_size,
 				     MFCC_FFT_BITS);
 	if (!fft->fft_plan) {
-		comp_err(dev, "mfcc_setup(): Failed FFT init");
+		comp_err(dev, "Failed FFT init");
 		ret = -EINVAL;
 		goto free_fft_out;
 	}
@@ -222,7 +222,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	/* Setup window */
 	ret = mfcc_get_window(state, config->window);
 	if (ret < 0) {
-		comp_err(dev, "mfcc_setup(): Failed Window function");
+		comp_err(dev, "Failed Window function");
 		goto free_fft_out;
 	}
 
@@ -244,7 +244,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	fb->scratch_length2 = fft->fft_buffer_size / sizeof(int16_t);
 	ret = psy_get_mel_filterbank(fb);
 	if (ret < 0) {
-		comp_err(dev, "mfcc_setup(): Failed Mel filterbank");
+		comp_err(dev, "Failed Mel filterbank");
 		goto free_fft_out;
 	}
 
@@ -255,7 +255,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	dct->ortho = true;
 	ret = dct_initialize_16(dct);
 	if (ret < 0) {
-		comp_err(dev, "mfcc_setup(): Failed DCT init");
+		comp_err(dev, "Failed DCT init");
 		goto free_melfb_data;
 	}
 
@@ -263,7 +263,7 @@ int mfcc_setup(struct processing_module *mod, int max_frames, int sample_rate, i
 	state->lifter.cepstral_lifter = config->cepstral_lifter; /* Q7.9 max 64.0*/
 	ret = mfcc_get_cepstral_lifter(&state->lifter);
 	if (ret < 0) {
-		comp_err(dev, "mfcc_setup(): Failed cepstral lifter");
+		comp_err(dev, "Failed cepstral lifter");
 		goto free_dct_matrix;
 	}
 

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -306,7 +306,7 @@ static int mixin_process(struct processing_module *mod,
 	sinks_free_frames = INT32_MAX;
 
 	if (num_of_sinks > MIXIN_MAX_SINKS) {
-		comp_err(dev, "mixin_process(): Invalid output sink count %d",
+		comp_err(dev, "Invalid output sink count %d",
 			 num_of_sinks);
 		return -EINVAL;
 	}
@@ -673,7 +673,7 @@ static int mixin_params(struct processing_module *mod)
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "mixin_params(): comp_verify_params() failed!");
+		comp_err(dev, "comp_verify_params() failed!");
 		return -EINVAL;
 	}
 
@@ -738,7 +738,7 @@ static int mixout_params(struct processing_module *mod)
 
 	ret = comp_verify_params(dev, 0, params);
 	if (ret < 0) {
-		comp_err(dev, "mixout_params(): comp_verify_params() failed!");
+		comp_err(dev, "comp_verify_params() failed!");
 		return -EINVAL;
 	}
 
@@ -910,14 +910,14 @@ static int mixin_set_config(struct processing_module *mod, uint32_t config_id,
 	if (sizeof(struct ipc4_mixer_mode_config) +
 	    (cfg->mixer_mode_config_count - 1) * sizeof(struct ipc4_mixer_mode_sink_config) >
 	    data_offset_size) {
-		comp_err(dev, "mixin_set_config(): unexpected data size: %u", data_offset_size);
+		comp_err(dev, "unexpected data size: %u", data_offset_size);
 		return -EINVAL;
 	}
 
 	for (i = 0; i < cfg->mixer_mode_config_count; i++) {
 		sink_index = cfg->mixer_mode_sink_configs[i].output_queue_id;
 		if (sink_index >= MIXIN_MAX_SINKS) {
-			comp_err(dev, "mixin_set_config(): invalid sink index: %u", sink_index);
+			comp_err(dev, "invalid sink index: %u", sink_index);
 			return -EINVAL;
 		}
 
@@ -926,7 +926,7 @@ static int mixin_set_config(struct processing_module *mod, uint32_t config_id,
 			gain = IPC4_MIXIN_UNITY_GAIN;
 		mixin_data->sink_config[sink_index].gain = gain;
 
-		comp_dbg(dev, "mixin_set_config(): gain 0x%x will be applied for sink %u",
+		comp_dbg(dev, "gain 0x%x will be applied for sink %u",
 			 gain, sink_index);
 
 		if (cfg->mixer_mode_sink_configs[i].mixer_mode ==
@@ -934,7 +934,7 @@ static int mixin_set_config(struct processing_module *mod, uint32_t config_id,
 			uint32_t channel_count =
 				cfg->mixer_mode_sink_configs[i].output_channel_count;
 			if (channel_count < 1 || channel_count > 8) {
-				comp_err(dev, "mixin_set_config(): Invalid output_channel_count %u for sink %u",
+				comp_err(dev, "Invalid output_channel_count %u for sink %u",
 					 channel_count, sink_index);
 				return -EINVAL;
 			}
@@ -943,7 +943,7 @@ static int mixin_set_config(struct processing_module *mod, uint32_t config_id,
 			mixin_data->sink_config[sink_index].output_channel_map =
 				cfg->mixer_mode_sink_configs[i].output_channel_map;
 
-			comp_dbg(dev, "mixin_set_config(): output_channel_count: %u, chmap: 0x%x for sink: %u",
+			comp_dbg(dev, "output_channel_count: %u, chmap: 0x%x for sink: %u",
 				 channel_count,
 				 mixin_data->sink_config[sink_index].output_channel_map,
 				 sink_index);

--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -117,7 +117,7 @@ static int cadence_codec_resolve_api(struct processing_module *mod)
 
 	/* For ipc4 protocol codec parameters has to be retrieved from configuration */
 	if (!codec->cfg.data) {
-		comp_err(dev, "cadence_codec_resolve_api(): could not find cadence config");
+		comp_err(dev, "could not find cadence config");
 		return -EINVAL;
 	}
 	param = codec->cfg.data;
@@ -133,7 +133,7 @@ static int cadence_codec_resolve_api(struct processing_module *mod)
 
 	/* Verify API assignment */
 	if (!api) {
-		comp_err(dev, "cadence_codec_resolve_api(): could not find API function for id %x",
+		comp_err(dev, "could not find API function for id %x",
 			 api_id);
 		return -EINVAL;
 	}
@@ -193,7 +193,7 @@ static int cadence_codec_resolve_api(struct processing_module *mod)
 
 	/* Verify API assignment */
 	if (!api) {
-		comp_err(dev, "cadence_codec_resolve_api(): could not find API function for id %x",
+		comp_err(dev, "could not find API function for id %x",
 			 api_id);
 		return -EINVAL;
 	}
@@ -237,11 +237,11 @@ static int cadence_codec_post_init(struct processing_module *mod)
 	/* Allocate space for codec object */
 	cd->self = rballoc(SOF_MEM_FLAG_USER, obj_size);
 	if (!cd->self) {
-		comp_err(dev, "cadence_codec_init(): failed to allocate space for lib object");
+		comp_err(dev, "failed to allocate space for lib object");
 		return -ENOMEM;
 	}
 
-	comp_dbg(dev, "cadence_codec_post_init(): allocated %d bytes for lib object", obj_size);
+	comp_dbg(dev, "allocated %d bytes for lib object", obj_size);
 
 	/* Set all params to their default values */
 	API_CALL(cd, XA_API_CMD_INIT, XA_CMD_TYPE_INIT_API_PRE_CONFIG_PARAMS,
@@ -270,7 +270,7 @@ static int cadence_codec_init(struct processing_module *mod)
 
 	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(struct cadence_codec_data));
 	if (!cd) {
-		comp_err(dev, "cadence_codec_init(): failed to allocate memory for cadence codec data");
+		comp_err(dev, "failed to allocate memory for cadence codec data");
 		return -ENOMEM;
 	}
 
@@ -287,7 +287,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		setup_cfg->data = rmalloc(SOF_MEM_FLAG_USER,
 					  cfg->param_size);
 		if (!setup_cfg->data) {
-			comp_err(dev, "cadence_codec_init(): failed to alloc setup config");
+			comp_err(dev, "failed to alloc setup config");
 			ret = -ENOMEM;
 			goto free;
 		}
@@ -296,7 +296,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		codec->cfg.data = rmalloc(SOF_MEM_FLAG_USER,
 					  cfg->param_size);
 		if (!codec->cfg.data) {
-			comp_err(dev, "cadence_codec_init(): failed to alloc runtime setup config");
+			comp_err(dev, "failed to alloc runtime setup config");
 			ret = -ENOMEM;
 			goto free_cfg;
 		}
@@ -305,7 +305,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		ret = memcpy_s(codec->cfg.data, codec->cfg.size,
 			       cfg->param, cfg->param_size);
 		if (ret) {
-			comp_err(dev, "cadence_codec_init(): failed to init runtime config %d",
+			comp_err(dev, "failed to init runtime config %d",
 				 ret);
 			goto free_cfg2;
 		}
@@ -315,7 +315,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		ret = memcpy_s(setup_cfg->data, setup_cfg->size,
 			       cfg->param, cfg->param_size);
 		if (ret) {
-			comp_err(dev, "cadence_codec_init(): failed to copy setup config %d", ret);
+			comp_err(dev, "failed to copy setup config %d", ret);
 			goto free_cfg2;
 		}
 		setup_cfg->avail = true;
@@ -347,7 +347,7 @@ static int cadence_codec_init(struct processing_module *mod)
 
 	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(struct cadence_codec_data));
 	if (!cd) {
-		comp_err(dev, "cadence_codec_init(): failed to allocate memory for cadence codec data");
+		comp_err(dev, "failed to allocate memory for cadence codec data");
 		return -ENOMEM;
 	}
 
@@ -362,7 +362,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		setup_cfg->data = rmalloc(SOF_MEM_FLAG_USER,
 					  codec->cfg.size);
 		if (!setup_cfg->data) {
-			comp_err(dev, "cadence_codec_init(): failed to alloc setup config");
+			comp_err(dev, "failed to alloc setup config");
 			ret = -ENOMEM;
 			goto free;
 		}
@@ -372,7 +372,7 @@ static int cadence_codec_init(struct processing_module *mod)
 		ret = memcpy_s(setup_cfg->data, setup_cfg->size,
 			       codec->cfg.init_data, setup_cfg->size);
 		if (ret) {
-			comp_err(dev, "cadence_codec_init(): failed to copy setup config %d", ret);
+			comp_err(dev, "failed to copy setup config %d", ret);
 			goto free_cfg;
 		}
 		setup_cfg->avail = true;
@@ -447,12 +447,12 @@ static int cadence_codec_apply_config(struct processing_module *mod)
 			 param->data, ret);
 		if (ret != LIB_NO_ERROR) {
 			if (LIB_IS_FATAL_ERROR(ret)) {
-				comp_err(dev, "cadence_codec_apply_config(): failed to apply parameter: %d value: %d error: %#x",
+				comp_err(dev, "failed to apply parameter: %d value: %d error: %#x",
 					 param->id, *(int32_t *)param->data, ret);
 
 				return ret;
 			}
-			comp_warn(dev, "cadence_codec_apply_config(): applied parameter %d value %d with return code: %#x",
+			comp_warn(dev, "applied parameter %d value %d with return code: %#x",
 				  param->id, *(int32_t *)param->data, ret);
 		}
 		/* Obtain next parameter, it starts right after the preceding one */
@@ -694,7 +694,7 @@ static int cadence_codec_prepare(struct processing_module *mod,
 		return -ENOMEM;
 	}
 
-	comp_dbg(dev, "cadence_codec_prepare(): allocated %d bytes for memtabs", mem_tabs_size);
+	comp_dbg(dev, "allocated %d bytes for memtabs", mem_tabs_size);
 
 	API_CALL(cd, XA_API_CMD_SET_MEMTABS_PTR, 0, cd->mem_tabs, ret);
 	if (ret != LIB_NO_ERROR) {
@@ -757,7 +757,7 @@ cadence_codec_process(struct processing_module *mod,
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
 	if (input_buffers[0].size < codec->mpd.in_buff_size) {
-		comp_dbg(dev, "cadence_codec_process(): not enough data to process");
+		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
 
@@ -896,12 +896,12 @@ cadence_codec_set_configuration(struct processing_module *mod, uint32_t config_i
 	/* whole configuration received, apply it now */
 	ret = cadence_codec_apply_config(mod);
 	if (ret) {
-		comp_err(dev, "cadence_codec_set_configuration(): error %x: runtime config apply failed",
+		comp_err(dev, "error %x: runtime config apply failed",
 			 ret);
 		return ret;
 	}
 
-	comp_dbg(dev, "cadence_codec_set_configuration(): config applied");
+	comp_dbg(dev, "config applied");
 
 	return 0;
 }

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -28,7 +28,7 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 	comp_dbg(dev, "module_load_config() start");
 
 	if (!cfg || !size) {
-		comp_err(dev, "module_load_config(): wrong input params! dev %zx, cfg %zx size %zu",
+		comp_err(dev, "wrong input params! dev %zx, cfg %zx size %zu",
 			 (size_t)dev, (size_t)cfg, size);
 		return -EINVAL;
 	}
@@ -46,7 +46,7 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 		dst->data = rballoc(SOF_MEM_FLAG_USER, size);
 	}
 	if (!dst->data) {
-		comp_err(dev, "module_load_config(): failed to allocate space for setup config.");
+		comp_err(dev, "failed to allocate space for setup config.");
 		return -ENOMEM;
 	}
 
@@ -77,7 +77,7 @@ int module_init(struct processing_module *mod)
 		return -EPERM;
 #endif
 	if (!interface) {
-		comp_err(dev, "module_init(): module interface not defined for comp id %d",
+		comp_err(dev, "module interface not defined for comp id %d",
 			 dev_comp_id(dev));
 		return -EIO;
 	}
@@ -86,7 +86,7 @@ int module_init(struct processing_module *mod)
 	if (!interface->init ||
 	    (!!interface->process + !!interface->process_audio_stream +
 	     !!interface->process_raw_data < 1)) {
-		comp_err(dev, "module_init(): comp %d is missing mandatory interfaces",
+		comp_err(dev, "comp %d is missing mandatory interfaces",
 			 dev_comp_id(dev));
 		return -EIO;
 	}
@@ -283,7 +283,7 @@ int module_process_legacy(struct processing_module *mod,
 	struct module_data *md = &mod->priv;
 
 	if (md->state != MODULE_IDLE) {
-		comp_err(dev, "module_process(): wrong state of comp_id %x, state %d",
+		comp_err(dev, "wrong state of comp_id %x, state %d",
 			 dev_comp_id(dev), md->state);
 		return -EPERM;
 	}
@@ -329,7 +329,7 @@ int module_process_sink_src(struct processing_module *mod,
 #if CONFIG_IPC_MAJOR_3
 	struct module_data *md = &mod->priv;
 	if (md->state != MODULE_IDLE) {
-		comp_err(dev, "module_process(): wrong state of comp_id %x, state %d",
+		comp_err(dev, "wrong state of comp_id %x, state %d",
 			 dev_comp_id(dev), md->state);
 		return -EPERM;
 	}
@@ -426,7 +426,7 @@ int module_free(struct processing_module *mod)
 	if (ops->free) {
 		ret = ops->free(mod);
 		if (ret)
-			comp_warn(mod->dev, "module_free(): error: %d for %d",
+			comp_warn(mod->dev, "error: %d for %d",
 				  ret, dev_comp_id(mod->dev));
 	}
 
@@ -489,7 +489,7 @@ int module_set_configuration(struct processing_module *mod,
 
 		/* Check that there is no previous request in progress */
 		if (md->runtime_params) {
-			comp_err(dev, "module_set_configuration(): error: busy with previous request");
+			comp_err(dev, "error: busy with previous request");
 			return -EBUSY;
 		}
 
@@ -497,7 +497,7 @@ int module_set_configuration(struct processing_module *mod,
 			return 0;
 
 		if (md->new_cfg_size > CONFIG_MODULE_MAX_BLOB_SIZE) {
-			comp_err(dev, "module_set_configuration(): error: blob size is too big cfg size %zu, allowed %d",
+			comp_err(dev, "error: blob size is too big cfg size %zu, allowed %d",
 				 md->new_cfg_size, CONFIG_MODULE_MAX_BLOB_SIZE);
 			return -EINVAL;
 		}
@@ -505,7 +505,7 @@ int module_set_configuration(struct processing_module *mod,
 		/* Allocate buffer for new params */
 		md->runtime_params = rballoc(SOF_MEM_FLAG_USER, md->new_cfg_size);
 		if (!md->runtime_params) {
-			comp_err(dev, "module_set_configuration(): space allocation for new params failed");
+			comp_err(dev, "space allocation for new params failed");
 			return -ENOMEM;
 		}
 
@@ -513,7 +513,7 @@ int module_set_configuration(struct processing_module *mod,
 		break;
 	default:
 		if (!md->runtime_params) {
-			comp_err(dev, "module_set_configuration(): error: no memory available for runtime params in consecutive load");
+			comp_err(dev, "error: no memory available for runtime params in consecutive load");
 			return -EIO;
 		}
 
@@ -526,7 +526,7 @@ int module_set_configuration(struct processing_module *mod,
 
 	ret = memcpy_s(dst, md->new_cfg_size - offset, fragment, fragment_size);
 	if (ret < 0) {
-		comp_err(dev, "module_set_configuration(): error: %d failed to copy fragment",
+		comp_err(dev, "error: %d failed to copy fragment",
 			 ret);
 		return ret;
 	}
@@ -538,9 +538,9 @@ int module_set_configuration(struct processing_module *mod,
 	/* config fully copied, now load it */
 	ret = module_load_config(dev, md->runtime_params, md->new_cfg_size);
 	if (ret)
-		comp_err(dev, "module_set_configuration(): error %d: config failed", ret);
+		comp_err(dev, "error %d: config failed", ret);
 	else
-		comp_dbg(dev, "module_set_configuration(): config load successful");
+		comp_dbg(dev, "config load successful");
 
 	md->new_cfg_size = 0;
 

--- a/src/audio/module_adapter/module/modules.c
+++ b/src/audio/module_adapter/module/modules.c
@@ -112,7 +112,7 @@ static int modules_free(struct processing_module *mod)
 	comp_info(dev, "modules_free()");
 	ret = iadk_wrapper_free(module_get_private_data(mod));
 	if (ret)
-		comp_err(dev, "modules_free(): iadk_wrapper_free failed with error: %d", ret);
+		comp_err(dev, "iadk_wrapper_free failed with error: %d", ret);
 
 	return ret;
 }

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -34,14 +34,14 @@ static int passthrough_codec_prepare(struct processing_module *mod,
 
 	codec->mpd.in_buff = rballoc(SOF_MEM_FLAG_USER, mod->period_bytes);
 	if (!codec->mpd.in_buff) {
-		comp_err(dev, "passthrough_codec_prepare(): Failed to alloc in_buff");
+		comp_err(dev, "Failed to alloc in_buff");
 		return -ENOMEM;
 	}
 	codec->mpd.in_buff_size = mod->period_bytes;
 
 	codec->mpd.out_buff = rballoc(SOF_MEM_FLAG_USER, mod->period_bytes);
 	if (!codec->mpd.out_buff) {
-		comp_err(dev, "passthrough_codec_prepare(): Failed to alloc out_buff");
+		comp_err(dev, "Failed to alloc out_buff");
 		rfree(codec->mpd.in_buff);
 		return -ENOMEM;
 	}
@@ -74,7 +74,7 @@ passthrough_codec_process(struct processing_module *mod,
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
 	if (input_buffers[0].size < codec->mpd.in_buff_size) {
-		comp_dbg(dev, "passthrough_codec_process(): not enough data to process");
+		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
 

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -495,7 +495,7 @@ static int waves_effect_save_config_blob_to_cache(struct processing_module *mod,
 			data, size);
 	if (ret) {
 		comp_err(dev,
-			"waves_effect_save_config_blob_to_cache(): failed to copy config blob %d",
+			"failed to copy config blob %d",
 			ret);
 		mod_free(mod, waves_codec->config_blob);
 		waves_codec->config_blob = NULL;
@@ -766,7 +766,7 @@ waves_codec_process(struct processing_module *mod,
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
 	if (input_buffers[0].size < codec->mpd.in_buff_size) {
-		comp_dbg(dev, "waves_codec_process(): not enough data to process");
+		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
 
@@ -887,12 +887,12 @@ waves_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 	/* whole configuration received, apply it now */
 	ret = waves_effect_apply_config(mod);
 	if (ret) {
-		comp_err(dev, "waves_codec_set_configuration(): error %x: runtime config apply failed",
+		comp_err(dev, "error %x: runtime config apply failed",
 			 ret);
 		return ret;
 	}
 
-	comp_dbg(dev, "waves_codec_set_configuration(): config applied");
+	comp_dbg(dev, "config applied");
 
 	return 0;
 }

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -230,7 +230,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	} else {
 		ret = comp_verify_params(dev, mod->verify_params_flags, mod->stream_params);
 		if (ret < 0) {
-			comp_err(dev, "module_adapter_params(): comp_verify_params() failed.");
+			comp_err(dev, "comp_verify_params() failed.");
 			return ret;
 		}
 	}
@@ -291,7 +291,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 		return ret;
 
 	if (ret == COMP_STATUS_STATE_ALREADY_SET) {
-		comp_warn(dev, "module_adapter_prepare(): module has already been prepared");
+		comp_warn(dev, "module has already been prepared");
 		return PPL_STATUS_PATH_STOP;
 	}
 
@@ -307,7 +307,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	sink = comp_dev_get_first_data_consumer(dev);
 
 	mod->period_bytes = audio_stream_period_bytes(&sink->stream, dev->frames);
-	comp_dbg(dev, "module_adapter_prepare(): got period_bytes = %u", mod->period_bytes);
+	comp_dbg(dev, "got period_bytes = %u", mod->period_bytes);
 
 	/* no more to do for sink/source mode */
 	if (IS_PROCESSING_MODE_SINK_SOURCE(mod))
@@ -324,19 +324,19 @@ int module_adapter_prepare(struct comp_dev *dev)
 		mod->num_of_sinks++;
 
 	if (!mod->num_of_sources && !mod->num_of_sinks) {
-		comp_err(dev, "module_adapter_prepare(): no source and sink buffers connected!");
+		comp_err(dev, "no source and sink buffers connected!");
 		return -EINVAL;
 	}
 	if (mod->num_of_sources > CONFIG_MODULE_MAX_CONNECTIONS ||
 	    mod->num_of_sinks > CONFIG_MODULE_MAX_CONNECTIONS) {
-		comp_err(dev, "module_adapter_prepare(): too many connected sinks %d or sources %d!",
+		comp_err(dev, "too many connected sinks %d or sources %d!",
 			 mod->num_of_sinks, mod->num_of_sources);
 		return -EINVAL;
 	}
 
 	/* check processing mode */
 	if (IS_PROCESSING_MODE_AUDIO_STREAM(mod) && mod->max_sources > 1 && mod->max_sinks > 1) {
-		comp_err(dev, "module_adapter_prepare(): Invalid use of simple_copy");
+		comp_err(dev, "Invalid use of simple_copy");
 		return -EINVAL;
 	}
 
@@ -348,7 +348,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 			rzalloc(SOF_MEM_FLAG_USER,
 				sizeof(*mod->input_buffers) * mod->max_sources);
 		if (!mod->input_buffers) {
-			comp_err(dev, "module_adapter_prepare(): failed to allocate input buffers");
+			comp_err(dev, "failed to allocate input buffers");
 			return -ENOMEM;
 		}
 	} else {
@@ -361,7 +361,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 			rzalloc(SOF_MEM_FLAG_USER,
 				sizeof(*mod->output_buffers) * mod->max_sinks);
 		if (!mod->output_buffers) {
-			comp_err(dev, "module_adapter_prepare(): failed to allocate output buffers");
+			comp_err(dev, "failed to allocate output buffers");
 			ret = -ENOMEM;
 			goto in_out_free;
 		}
@@ -427,7 +427,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 
 		mod->input_buffers[i].data = rballoc(SOF_MEM_FLAG_USER, size);
 		if (!mod->input_buffers[i].data) {
-			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc input buffer data");
+			comp_err(mod->dev, "Failed to alloc input buffer data");
 			ret = -ENOMEM;
 			goto in_data_free;
 		}
@@ -439,7 +439,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 	list_for_item(blist, &dev->bsink_list) {
 		mod->output_buffers[i].data = rballoc(SOF_MEM_FLAG_USER, md->mpd.out_buff_size);
 		if (!mod->output_buffers[i].data) {
-			comp_err(mod->dev, "module_adapter_prepare(): Failed to alloc output buffer data");
+			comp_err(mod->dev, "Failed to alloc output buffer data");
 			ret = -ENOMEM;
 			goto out_data_free;
 		}
@@ -455,7 +455,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 			uint32_t flags;
 
 			if (!buffer) {
-				comp_err(dev, "module_adapter_prepare(): failed to allocate local buffer");
+				comp_err(dev, "failed to allocate local buffer");
 				ret = -ENOMEM;
 				goto free;
 			}
@@ -474,7 +474,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 
 			ret = buffer_set_size(buffer, buff_size, 0);
 			if (ret < 0) {
-				comp_err(dev, "module_adapter_prepare(): buffer_set_size() failed, buff_size = %u",
+				comp_err(dev, "buffer_set_size() failed, buff_size = %u",
 					 buff_size);
 				goto free;
 			}
@@ -526,7 +526,7 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 
 	ret = comp_verify_params(dev, mod->verify_params_flags, params);
 	if (ret < 0) {
-		comp_err(dev, "module_adapter_params(): comp_verify_params() failed.");
+		comp_err(dev, "comp_verify_params() failed.");
 		return ret;
 	}
 
@@ -650,11 +650,11 @@ static void module_copy_samples(struct comp_dev *dev, struct comp_buffer *src_bu
 			return;
 		}
 
-		comp_dbg(dev, "module_copy_samples(): deep buffering has ended after gathering %d bytes of processed data",
+		comp_dbg(dev, "deep buffering has ended after gathering %d bytes of processed data",
 			 audio_stream_get_avail_bytes(&src_buffer->stream));
 		mod->deep_buff_bytes = 0;
 	} else if (!produced) {
-		comp_dbg(dev, "module_copy_samples(): nothing processed in this call");
+		comp_dbg(dev, "nothing processed in this call");
 		/*
 		 * No data produced anything in this period but there still be data in the buffer
 		 * to copy to sink
@@ -1039,7 +1039,7 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 	int ret;
 	int i = 0;
 
-	comp_dbg(dev, "module_adapter_sink_source_copy(): start");
+	comp_dbg(dev, "start");
 
 	/* reset number of processed bytes */
 	for (i = 0; i < mod->num_of_sources; i++)
@@ -1062,7 +1062,7 @@ static int module_adapter_sink_source_copy(struct comp_dev *dev)
 	for (i = 0; i < mod->num_of_sinks; i++)
 		mod->total_data_produced += sink_get_num_of_processed_bytes(mod->sinks[i]);
 
-	comp_dbg(dev, "module_adapter_sink_source_copy(): done");
+	comp_dbg(dev, "done");
 
 	return ret;
 }
@@ -1077,7 +1077,7 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 	uint32_t min_free_frames = UINT_MAX;
 	int ret, i = 0;
 
-	comp_dbg(dev, "module_adapter_raw_data_type_copy(): start");
+	comp_dbg(dev, "start");
 
 	list_for_item(blist, &mod->raw_data_buffers_list) {
 		sink = container_of(blist, struct comp_buffer, buffers_list);
@@ -1139,7 +1139,7 @@ static int module_adapter_raw_data_type_copy(struct comp_dev *dev)
 
 	module_adapter_process_output(dev);
 
-	comp_dbg(dev, "module_adapter_raw_data_type_copy(): done");
+	comp_dbg(dev, "done");
 
 	return 0;
 
@@ -1152,13 +1152,13 @@ out:
 		mod->input_buffers[i].size = 0;
 		mod->input_buffers[i].consumed = 0;
 	}
-	comp_dbg(dev, "module_adapter_raw_data_type_copy(): error %x", ret);
+	comp_dbg(dev, "error %x", ret);
 	return ret;
 }
 
 int module_adapter_copy(struct comp_dev *dev)
 {
-	comp_dbg(dev, "module_adapter_copy(): start");
+	comp_dbg(dev, "start");
 
 	struct processing_module *mod = comp_mod(dev);
 
@@ -1176,7 +1176,7 @@ int module_adapter_copy(struct comp_dev *dev)
 
 	}
 
-	comp_err(dev, "module_adapter_copy(): unknown processing_data_type");
+	comp_err(dev, "unknown processing_data_type");
 	return -EINVAL;
 }
 EXPORT_SYMBOL(module_adapter_copy);
@@ -1186,7 +1186,7 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 	struct processing_module *mod = comp_mod(dev);
 	const struct module_interface *const interface = mod->dev->drv->adapter_ops;
 
-	comp_dbg(dev, "module_adapter_trigger(): cmd %d", cmd);
+	comp_dbg(dev, "cmd %d", cmd);
 
 	/* handle host/DAI gateway modules separately */
 	if (dev->ipc_config.type == SOF_COMP_HOST || dev->ipc_config.type == SOF_COMP_DAI)
@@ -1213,12 +1213,12 @@ int module_adapter_reset(struct comp_dev *dev)
 	struct processing_module *mod = comp_mod(dev);
 	struct list_item *blist;
 
-	comp_dbg(dev, "module_adapter_reset(): resetting");
+	comp_dbg(dev, "resetting");
 
 	ret = module_reset(mod);
 	if (ret) {
 		if (ret != PPL_STATUS_PATH_STOP)
-			comp_err(dev, "module_adapter_reset(): failed with error: %d", ret);
+			comp_err(dev, "failed with error: %d", ret);
 		return ret;
 	}
 
@@ -1249,7 +1249,7 @@ int module_adapter_reset(struct comp_dev *dev)
 	rfree(mod->stream_params);
 	mod->stream_params = NULL;
 
-	comp_dbg(dev, "module_adapter_reset(): done");
+	comp_dbg(dev, "done");
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);
 }
@@ -1261,11 +1261,11 @@ void module_adapter_free(struct comp_dev *dev)
 	struct processing_module *mod = comp_mod(dev);
 	struct list_item *blist, *_blist;
 
-	comp_dbg(dev, "module_adapter_free(): start");
+	comp_dbg(dev, "start");
 
 	ret = module_free(mod);
 	if (ret)
-		comp_err(dev, "module_adapter_free(): failed with error: %d", ret);
+		comp_err(dev, "failed with error: %d", ret);
 
 	list_for_item_safe(blist, _blist, &mod->raw_data_buffers_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,

--- a/src/audio/module_adapter/module_adapter_ipc3.c
+++ b/src/audio/module_adapter/module_adapter_ipc3.c
@@ -186,7 +186,7 @@ static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ct
 	uint32_t data_offset_size;
 	static uint32_t size;
 
-	comp_dbg(dev, "module_adapter_set_params(): num_of_elem %d, elem remain %d msg_index %u",
+	comp_dbg(dev, "num_of_elem %d, elem remain %d msg_index %u",
 		 cdata->num_elems, cdata->elems_remaining, cdata->msg_index);
 
 	/* set the fragment position, data offset and config data size */
@@ -216,7 +216,7 @@ static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ct
 							    (const uint8_t *)cdata,
 							    cdata->num_elems, NULL, 0);
 
-		comp_warn(dev, "module_adapter_get_set_params(): no configuration op set for %d",
+		comp_warn(dev, "no configuration op set for %d",
 			  dev_comp_id(dev));
 		return 0;
 	}
@@ -225,7 +225,7 @@ static int module_adapter_get_set_params(struct comp_dev *dev, struct sof_ipc_ct
 		return interface->get_configuration(mod, pos, &data_offset_size,
 						    (uint8_t *)cdata, cdata->num_elems);
 
-	comp_err(dev, "module_adapter_get_set_params(): no configuration op get for %d",
+	comp_err(dev, "no configuration op get for %d",
 		 dev_comp_id(dev));
 	return -EIO; /* non-implemented error */
 }
@@ -241,13 +241,13 @@ static int module_adapter_ctrl_get_set_data(struct comp_dev *dev, struct sof_ipc
 
 	/* Check version from ABI header */
 	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		comp_err(dev, "module_adapter_ctrl_set_data(): ABI mismatch!");
+		comp_err(dev, "ABI mismatch!");
 		return -EINVAL;
 	}
 
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_ENUM:
-		comp_err(dev, "module_adapter_ctrl_set_data(): set enum is not implemented");
+		comp_err(dev, "set enum is not implemented");
 		ret = -EIO;
 		break;
 	case SOF_CTRL_CMD_BINARY:

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -200,7 +200,7 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 		fragment_size = md->new_cfg_size - data_offset_size;
 		break;
 	default:
-		comp_err(dev, "module_set_large_config(): invalid fragment position");
+		comp_err(dev, "invalid fragment position");
 		return -EINVAL;
 	}
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -260,7 +260,7 @@ static int multiband_drc_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "multiband_drc_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail;
 	}
@@ -268,7 +268,7 @@ static int multiband_drc_init(struct processing_module *mod)
 	/* Get configuration data and reset DRC state */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "multiband_drc_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto cd_fail;
 	}
 	multiband_drc_reset_state(&cd->state);

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -89,7 +89,7 @@ static int mux_demux_common_init(struct processing_module *mod, enum sof_comp_ty
 	comp_dbg(dev, "mux_init()");
 
 	if (cfg->size > MUX_BLOB_MAX_SIZE) {
-		comp_err(dev, "mux_init(): blob size %zu exceeds %zu",
+		comp_err(dev, "blob size %zu exceeds %zu",
 			 cfg->size, MUX_BLOB_MAX_SIZE);
 		return -EINVAL;
 	}
@@ -101,7 +101,7 @@ static int mux_demux_common_init(struct processing_module *mod, enum sof_comp_ty
 
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "mux_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -109,7 +109,7 @@ static int mux_demux_common_init(struct processing_module *mod, enum sof_comp_ty
 	module_data->private = cd;
 	ret = comp_init_data_blob(cd->model_handler, cfg->size, cfg->init_data);
 	if (ret < 0) {
-		comp_err(dev, "mux_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto err_init;
 	}
 
@@ -152,7 +152,7 @@ static int get_stream_index(struct comp_dev *dev, struct comp_data *cd, uint32_t
 		if (cd->config.streams[idx].pipeline_id == pipe_id)
 			return idx;
 
-	comp_err(dev, "get_stream_index(): couldn't find configuration for connected pipeline %u",
+	comp_err(dev, "couldn't find configuration for connected pipeline %u",
 		 pipe_id);
 	return -EINVAL;
 }
@@ -199,7 +199,7 @@ static struct mux_look_up *get_lookup_table(struct comp_dev *dev, struct comp_da
 		if (cd->config.streams[i].pipeline_id == pipe_id)
 			return &cd->lookup[i];
 
-	comp_err(dev, "get_lookup_table(): couldn't find configuration for connected pipeline %u",
+	comp_err(dev, "couldn't find configuration for connected pipeline %u",
 		 pipe_id);
 	return 0;
 }
@@ -400,7 +400,7 @@ static int mux_prepare(struct processing_module *mod,
 
 	config = comp_get_data_blob(cd->model_handler, &blob_size, NULL);
 	if (blob_size > MUX_BLOB_MAX_SIZE) {
-		comp_err(dev, "mux_prepare(): illegal blob size %zu", blob_size);
+		comp_err(dev, "illegal blob size %zu", blob_size);
 		return -EINVAL;
 	}
 
@@ -416,7 +416,7 @@ static int mux_prepare(struct processing_module *mod,
 		cd->demux = demux_get_processing_function(mod);
 
 	if (!cd->mux && !cd->demux) {
-		comp_err(dev, "mux_prepare(): Invalid configuration, couldn't find suitable processing function.");
+		comp_err(dev, "Invalid configuration, couldn't find suitable processing function.");
 		return -EINVAL;
 	}
 

--- a/src/audio/mux/mux_ipc3.c
+++ b/src/audio/mux/mux_ipc3.c
@@ -42,7 +42,7 @@ static int mux_set_values(struct processing_module *mod)
 
 	/* check if number of streams configured doesn't exceed maximum */
 	if (cfg->num_streams > MUX_MAX_STREAMS) {
-		comp_err(dev, "mux_set_values(): configured number of streams (%u) exceeds maximum = "
+		comp_err(dev, "configured number of streams (%u) exceeds maximum = "
 			    STRINGIFY(MUX_MAX_STREAMS), cfg->num_streams);
 		return -EINVAL;
 	}
@@ -52,7 +52,7 @@ static int mux_set_values(struct processing_module *mod)
 		for (j = i + 1; j < cfg->num_streams; j++) {
 			if (cfg->streams[i].pipeline_id ==
 				cfg->streams[j].pipeline_id) {
-				comp_err(dev, "mux_set_values(): multiple configured streams have same pipeline ID = %u",
+				comp_err(dev, "multiple configured streams have same pipeline ID = %u",
 					 cfg->streams[i].pipeline_id);
 				return -EINVAL;
 			}
@@ -62,7 +62,7 @@ static int mux_set_values(struct processing_module *mod)
 	for (i = 0; i < cfg->num_streams; i++) {
 		for (j = 0 ; j < PLATFORM_MAX_CHANNELS; j++) {
 			if (popcount(cfg->streams[i].mask[j]) > 1) {
-				comp_err(dev, "mux_set_values(): mux component is not able to mix channels");
+				comp_err(dev, "mux component is not able to mix channels");
 				return -EINVAL;
 			}
 		}
@@ -70,7 +70,7 @@ static int mux_set_values(struct processing_module *mod)
 
 	if (cd->comp_type == SOF_COMP_MUX) {
 		if (mux_mix_check(cfg))
-			comp_err(dev, "mux_set_values(): mux component is not able to mix channels");
+			comp_err(dev, "mux component is not able to mix channels");
 	}
 
 	for (i = 0; i < cfg->num_streams; i++) {

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -57,7 +57,7 @@ static int build_config(struct processing_module *mod)
 
 	/* validation of matrix mixing */
 	if (mux_mix_check(&cd->config)) {
-		comp_err(dev, "build_config(): mux component is not able to mix channels");
+		comp_err(dev, "mux component is not able to mix channels");
 		return -EINVAL;
 	}
 	return 0;

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -122,7 +122,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	/* allocate new pipeline */
 	p = rzalloc(SOF_MEM_FLAG_USER, sizeof(*p));
 	if (!p) {
-		pipe_cl_err("pipeline_new(): Out of Memory");
+		pipe_cl_err("Out of Memory");
 		return NULL;
 	}
 
@@ -135,13 +135,13 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	ret = memcpy_s(&p->tctx, sizeof(struct tr_ctx), &pipe_tr,
 		       sizeof(struct tr_ctx));
 	if (ret < 0) {
-		pipe_err(p, "pipeline_new(): failed to copy trace settings");
+		pipe_err(p, "failed to copy trace settings");
 		goto free;
 	}
 
 	ret = pipeline_posn_offset_get(&p->posn_offset);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_new(): pipeline_posn_offset_get failed %d",
+		pipe_err(p, "pipeline_posn_offset_get failed %d",
 			 ret);
 		goto free;
 	}
@@ -152,7 +152,7 @@ struct pipeline *pipeline_new(uint32_t pipeline_id, uint32_t priority, uint32_t 
 	if (posn.rhdr.hdr.size) {
 		p->msg = ipc_msg_init(posn.rhdr.hdr.cmd, posn.rhdr.hdr.size);
 		if (!p->msg) {
-			pipe_err(p, "pipeline_new(): ipc_msg_init failed");
+			pipe_err(p, "ipc_msg_init failed");
 			goto free;
 		}
 	}
@@ -293,7 +293,7 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 
 	/* check whether pipeline is already completed */
 	if (p->status != COMP_STATE_INIT) {
-		pipe_err(p, "pipeline_complete(): Pipeline already completed");
+		pipe_err(p, "Pipeline already completed");
 		return -EINVAL;
 	}
 
@@ -329,7 +329,7 @@ static int pipeline_comp_reset(struct comp_dev *current,
 		 dev_comp_id(current), dir);
 
 	if (!p->source_comp) {
-		pipe_err(p, "pipeline_comp_reset(): source_comp is NULL");
+		pipe_err(p, "source_comp is NULL");
 		return -EINVAL;
 	}
 
@@ -354,10 +354,10 @@ static int pipeline_comp_reset(struct comp_dev *current,
 	 * 2. trigger functon skipped due to error of other component's trigger function
 	 */
 	if (current->state == COMP_STATE_ACTIVE) {
-		pipe_warn(current->pipeline, "pipeline_comp_reset(): component is in active state, try to stop it");
+		pipe_warn(current->pipeline, "component is in active state, try to stop it");
 		err = comp_trigger(current, COMP_TRIGGER_STOP);
 		if (err)
-			pipe_err(current->pipeline, "pipeline_comp_reset(): failed to recover");
+			pipe_err(current->pipeline, "failed to recover");
 	}
 
 	err = comp_reset(current);
@@ -387,7 +387,7 @@ int pipeline_reset(struct pipeline *p, struct comp_dev *host)
 
 	ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_reset(): ret = %d, host->comp.id = 0x%x",
+		pipe_err(p, "ret = %d, host->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 	} else {
 		 /* pipeline is reset to default state */

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -60,7 +60,7 @@ static int pipeline_comp_params_neg(struct comp_dev *current,
 			 * drop an error and reject the .params() command.
 			 */
 			pipe_err(current->pipeline,
-				 "pipeline_comp_params_neg(): params conflict with existing active pipeline!");
+				 "params conflict with existing active pipeline!");
 			err = -EINVAL;
 		}
 	}
@@ -144,7 +144,7 @@ static int pipeline_comp_hw_params(struct comp_dev *current,
 					     &ppl_data->params->params, dir);
 		if (ret < 0) {
 			pipe_err(current->pipeline,
-				 "pipeline_comp_hw_params(): failed getting DAI parameters: %d",
+				 "failed getting DAI parameters: %d",
 				 ret);
 			return ret;
 		}
@@ -170,7 +170,7 @@ static int pipeline_comp_hw_params_buf(struct comp_dev *current,
 					BUFFER_UPDATE_IF_UNSET);
 		if (ret < 0)
 			pipe_err(current->pipeline,
-				 "pipeline_comp_hw_params(): buffer_set_params(): %d", ret);
+				 "buffer_set_params(): %d", ret);
 	}
 
 	return ret;
@@ -226,14 +226,14 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = hw_param_ctx.comp_func(host, NULL, &hw_param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = 0x%x",
+		pipe_err(p, "ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 		return ret;
 	}
 
 	ret = buf_param_ctx.comp_func(host, NULL, &buf_param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, dev->comp.id = 0x%x",
+		pipe_err(p, "ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 		return ret;
 	}
@@ -244,7 +244,7 @@ int pipeline_params(struct pipeline *p, struct comp_dev *host,
 
 	ret = param_ctx.comp_func(host, NULL, &param_ctx, dir);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_params(): ret = %d, host->comp.id = 0x%x",
+		pipe_err(p, "ret = %d, host->comp.id = 0x%x",
 			 ret, dev_comp_id(host));
 	}
 
@@ -312,7 +312,7 @@ int pipeline_prepare(struct pipeline *p, struct comp_dev *dev)
 
 	ret = walk_ctx.comp_func(dev, NULL, &walk_ctx, dev->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_prepare(): ret = %d, dev->comp.id = 0x%x",
+		pipe_err(p, "ret = %d, dev->comp.id = 0x%x",
 			 ret, dev_comp_id(dev));
 		return ret;
 	}

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -100,7 +100,7 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 
 	err = pipeline_trigger_run(p, host, cmd);
 	if (err < 0) {
-		pipe_err(p, "pipeline_task_cmd(): failed to trigger components: %d", err);
+		pipe_err(p, "failed to trigger components: %d", err);
 		reply->error = err;
 		err = SOF_TASK_STATE_COMPLETED;
 	} else {
@@ -225,7 +225,7 @@ static enum task_state pipeline_task(void *arg)
 		/* try to recover */
 		err = pipeline_xrun_recover(p);
 		if (err < 0) {
-			pipe_err(p, "pipeline_task(): xrun recovery failed! pipeline is stopped.");
+			pipe_err(p, "xrun recovery failed! pipeline is stopped.");
 			/* failed - host will stop this pipeline */
 			return SOF_TASK_STATE_COMPLETED;
 		}
@@ -359,7 +359,7 @@ int pipeline_comp_ll_task_init(struct pipeline *p)
 
 		p->pipe_task = pipeline_task_init(p, type);
 		if (!p->pipe_task) {
-			pipe_err(p, "pipeline_comp_task_init(): task init failed");
+			pipe_err(p, "task init failed");
 			return -ENOMEM;
 		}
 	}

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -183,7 +183,7 @@ int pipeline_copy(struct pipeline *p)
 
 	ret = walk_ctx.comp_func(start, NULL, &walk_ctx, dir);
 	if (ret < 0)
-		pipe_err(p, "pipeline_copy(): ret = %d, start->comp.id = %u, dir = %u",
+		pipe_err(p, "ret = %d, start->comp.id = %u, dir = %u",
 			 ret, dev_comp_id(start), dir);
 
 	return ret;
@@ -267,7 +267,7 @@ static int pipeline_trigger_list(struct pipeline *p, struct comp_dev *host, int 
 
 	ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_trigger_list(): ret = %d, host->comp.id = %u, cmd = %d",
+		pipe_err(p, "ret = %d, host->comp.id = %u, cmd = %d",
 			 ret, dev_comp_id(host), cmd);
 	} else {
 		if (cmd == COMP_TRIGGER_PRE_START) {
@@ -595,7 +595,7 @@ int pipeline_trigger_run(struct pipeline *p, struct comp_dev *host, int cmd)
 
 	ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_trigger_run(): ret = %d, host->comp.id = %u, cmd = %d",
+		pipe_err(p, "ret = %d, host->comp.id = %u, cmd = %d",
 			 ret, dev_comp_id(host), cmd);
 		goto out;
 	}
@@ -624,7 +624,7 @@ int pipeline_trigger_run(struct pipeline *p, struct comp_dev *host, int cmd)
 
 		ret = walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction);
 		if (ret < 0)
-			pipe_err(p, "pipeline_trigger_run(): ret = %d, host->comp.id = %u, cmd = %d",
+			pipe_err(p, "ret = %d, host->comp.id = %u, cmd = %d",
 				 ret, dev_comp_id(host), cmd);
 		else if (ret == PPL_STATUS_PATH_STOP)
 			ret = 0;
@@ -658,7 +658,7 @@ void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 		dai = pipeline_get_dai_comp(host->pipeline->pipeline_id, PPL_DIR_UPSTREAM);
 
 	if (!dai) {
-		pipe_dbg(p, "pipeline_get_timestamp(): DAI position update failed");
+		pipe_dbg(p, "DAI position update failed");
 		return;
 	}
 

--- a/src/audio/pipeline/pipeline-xrun.c
+++ b/src/audio/pipeline/pipeline-xrun.c
@@ -68,7 +68,7 @@ int pipeline_xrun_recover(struct pipeline *p)
 	/* prepare the pipeline */
 	ret = pipeline_prepare(p, p->source_comp);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_xrun_recover(): pipeline_prepare() failed, ret = %d",
+		pipe_err(p, "pipeline_prepare() failed, ret = %d",
 			 ret);
 		return ret;
 	}
@@ -79,7 +79,7 @@ int pipeline_xrun_recover(struct pipeline *p)
 	/* restart pipeline comps */
 	ret = pipeline_trigger(p, p->source_comp, COMP_TRIGGER_START);
 	if (ret < 0) {
-		pipe_err(p, "pipeline_xrun_recover(): pipeline_trigger() failed, ret = %d",
+		pipe_err(p, "pipeline_trigger() failed, ret = %d",
 			 ret);
 		return ret;
 	}
@@ -159,7 +159,7 @@ void pipeline_xrun(struct pipeline *p, struct comp_dev *dev,
 	/* notify all pipeline comps we are in XRUN, and stop copying */
 	ret = pipeline_trigger(p, p->source_comp, COMP_TRIGGER_XRUN);
 	if (ret < 0)
-		pipe_err(p, "pipeline_xrun(): Pipelines notification about XRUN failed, ret = %d",
+		pipe_err(p, "Pipelines notification about XRUN failed, ret = %d",
 			 ret);
 
 	memset(&posn, 0, sizeof(posn));

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -252,14 +252,14 @@ static int rtnr_init(struct processing_module *mod)
 	/* Handler for component data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "rtnr_new(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail;
 	}
 
 	ret = comp_init_data_blob(cd->model_handler, bs, ipc_rtnr->data);
 	if (ret < 0) {
-		comp_err(dev, "rtnr_init(): comp_init_data_blob() failed with error: %d", ret);
+		comp_err(dev, "comp_init_data_blob() failed with error: %d", ret);
 		goto cd_fail;
 	}
 
@@ -268,11 +268,11 @@ static int rtnr_init(struct processing_module *mod)
 
 	cd->rtk_agl = RTKMA_API_Context_Create(cd->process_sample_rate);
 	if (cd->rtk_agl == 0) {
-		comp_err(dev, "rtnr_new(): RTKMA_API_Context_Create failed.");
+		comp_err(dev, "RTKMA_API_Context_Create failed.");
 		ret = -EINVAL;
 		goto cd_fail;
 	}
-	comp_info(dev, "rtnr_new(): RTKMA_API_Context_Create succeeded.");
+	comp_info(dev, "RTKMA_API_Context_Create succeeded.");
 
 	/* comp_is_new_data_blob_available always returns false for the first
 	 * control write with non-empty config. The first non-empty write may
@@ -395,7 +395,7 @@ static int rtnr_get_comp_data(struct processing_module *mod, struct sof_ipc_ctrl
 			       max_data_size,
 			       config,
 			       size);
-		comp_info(mod->dev, "rtnr_get_comp_data(): size= %d, ret = %d",
+		comp_info(mod->dev, "size= %d, ret = %d",
 			  size, ret);
 		if (ret)
 			return ret;
@@ -415,18 +415,18 @@ static int rtnr_get_bin_data(struct processing_module *mod, struct sof_ipc_ctrl_
 	if (!dev)
 		return -ENODEV;
 
-	comp_err(dev, "rtnr_get_bin_data(): type = %u, index = %u, size = %d",
+	comp_err(dev, "type = %u, index = %u, size = %d",
 		 cdata->data->type, cdata->msg_index, cdata->num_elems);
 
 	switch (cdata->data->type) {
 	case SOF_RTNR_CONFIG:
-		comp_err(dev, "rtnr_get_bin_data(): SOF_RTNR_CONFIG");
+		comp_err(dev, "SOF_RTNR_CONFIG");
 		return rtnr_get_comp_config(mod, cdata, max_data_size);
 	case SOF_RTNR_DATA:
-		comp_err(dev, "rtnr_get_bin_data(): SOF_RTNR_DATA");
+		comp_err(dev, "SOF_RTNR_DATA");
 		return rtnr_get_comp_data(mod, cdata, max_data_size);
 	default:
-		comp_err(dev, "rtnr_get_bin_data(): unknown binary data type");
+		comp_err(dev, "unknown binary data type");
 		return -EINVAL;
 	}
 }
@@ -502,11 +502,11 @@ static int rtnr_reconfigure(struct processing_module *mod)
 	}
 
 	if (!config) {
-		comp_err(dev, "rtnr_reconfigure(): Config not set");
+		comp_err(dev, "Config not set");
 		return -EINVAL;
 	}
 
-	comp_info(dev, "rtnr_reconfigure(): New data applied %p (%zu bytes)",
+	comp_info(dev, "New data applied %p (%zu bytes)",
 		  config, size);
 
 	cd->reconfigure = false;
@@ -530,7 +530,7 @@ static int rtnr_set_config_bytes(struct processing_module *mod,
 	 * the whole config data is received.
 	 */
 	if (size < sizeof(cd->config)) {
-		comp_err(dev, "rtnr_set_config_data(): invalid size %u",
+		comp_err(dev, "invalid size %u",
 			 size);
 		return -EINVAL;
 	}
@@ -541,7 +541,7 @@ static int rtnr_set_config_bytes(struct processing_module *mod,
 		       sizeof(cd->config));
 
 	comp_info(dev,
-		  "rtnr_set_config_data(): sample_rate = %u, enabled=%d",
+		  "sample_rate = %u, enabled=%d",
 		  cd->config.params.sample_rate,
 		  cd->config.params.enabled);
 
@@ -566,10 +566,10 @@ static int32_t rtnr_set_value(struct processing_module *mod, void *ctl_data)
 	}
 
 	if (val) {
-		comp_info(dev, "rtnr_set_value(): enabled");
+		comp_info(dev, "enabled");
 		cd->process_enable = true;
 	} else {
-		comp_info(dev, "rtnr_set_value(): passthrough");
+		comp_info(dev, "passthrough");
 		cd->process_enable = false;
 	}
 
@@ -591,7 +591,7 @@ static int rtnr_set_config(struct processing_module *mod, uint32_t param_id,
 	switch (cdata->cmd) {
 	case SOF_CTRL_CMD_BINARY:
 		if (dev->state < COMP_STATE_READY) {
-			comp_err(dev, "rtnr_set_config(): driver in init!");
+			comp_err(dev, "driver in init!");
 			return -EBUSY;
 		}
 
@@ -621,7 +621,7 @@ static int rtnr_set_config(struct processing_module *mod, uint32_t param_id,
 			return 0;
 		}
 
-		comp_err(dev, "rtnr_set_config(): unknown binary data type");
+		comp_err(dev, "unknown binary data type");
 		return -EINVAL;
 
 	case SOF_CTRL_CMD_SWITCH:
@@ -642,7 +642,7 @@ static int rtnr_set_config(struct processing_module *mod, uint32_t param_id,
 	case SOF_RTNR_CONFIG:
 		comp_dbg(dev, "rtnr_set_config(), SOF_RTNR_CONFIG");
 		if (dev->state < COMP_STATE_READY) {
-			comp_err(dev, "rtnr_set_config(): driver in init!");
+			comp_err(dev, "driver in init!");
 			return -EBUSY;
 		}
 
@@ -650,7 +650,7 @@ static int rtnr_set_config(struct processing_module *mod, uint32_t param_id,
 	case SOF_RTNR_DATA:
 		comp_dbg(dev, "rtnr_set_config(), SOF_RTNR_DATA");
 		if (dev->state < COMP_STATE_READY) {
-			comp_err(dev, "rtnr_set_config(): driver in init!");
+			comp_err(dev, "driver in init!");
 			return -EBUSY;
 		}
 
@@ -815,7 +815,7 @@ static int rtnr_prepare(struct processing_module *mod,
 	/* Check config */
 	ret = rtnr_check_config_validity(mod);
 	if (ret < 0) {
-		comp_err(dev, "rtnr_prepare(): rtnr_check_config_validity() failed.");
+		comp_err(dev, "rtnr_check_config_validity() failed.");
 		goto err;
 	}
 
@@ -832,7 +832,7 @@ static int rtnr_prepare(struct processing_module *mod,
 	comp_info(dev, "rtnr_prepare(), sink_format=%d", cd->sink_format);
 	cd->rtnr_func = rtnr_find_func(cd->sink_format);
 	if (!cd->rtnr_func) {
-		comp_err(dev, "rtnr_prepare(): No suitable processing function found.");
+		comp_err(dev, "No suitable processing function found.");
 		ret = -EINVAL;
 		goto err;
 	}

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -68,7 +68,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		buffer = comp_dev_get_first_data_consumer(dev);
 		if (cd->config.in_channels_count &&
 		    cd->config.in_channels_count != params->channels) {
-			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
+			comp_err(dev, "src in_channels_count does not match pcm channels");
 			return -EINVAL;
 		}
 		in_channels = cd->config.in_channels_count;
@@ -86,7 +86,7 @@ static int selector_verify_params(struct comp_dev *dev,
 		buffer = comp_dev_get_first_data_producer(dev);
 		if (cd->config.out_channels_count &&
 		    cd->config.out_channels_count != params->channels) {
-			comp_err(dev, "selector_verify_params(): src in_channels_count does not match pcm channels");
+			comp_err(dev, "src in_channels_count does not match pcm channels");
 			return -EINVAL;
 		}
 		out_channels = cd->config.out_channels_count;
@@ -113,7 +113,7 @@ static int selector_verify_params(struct comp_dev *dev,
 	case SEL_SOURCE_4CH:
 		break;
 	default:
-		comp_err(dev, "selector_verify_params(): in_channels = %u", in_channels);
+		comp_err(dev, "in_channels = %u", in_channels);
 		return -EINVAL;
 	}
 
@@ -125,19 +125,19 @@ static int selector_verify_params(struct comp_dev *dev,
 	case SEL_SINK_4CH:
 		/* verify proper channels for passthrough mode */
 		if (in_channels != out_channels) {
-			comp_err(dev, "selector_verify_params(): in_channels = %u, out_channels = %u"
+			comp_err(dev, "in_channels = %u, out_channels = %u"
 				 , in_channels, out_channels);
 			return -EINVAL;
 		}
 		break;
 	default:
-		comp_err(dev, "selector_verify_params(): out_channels = %u"
+		comp_err(dev, "out_channels = %u"
 			 , out_channels);
 		return -EINVAL;
 	}
 
 	if (cd->config.sel_channel > (params->channels - 1)) {
-		comp_err(dev, "selector_verify_params(): ch_idx = %u"
+		comp_err(dev, "ch_idx = %u"
 			 , cd->config.sel_channel);
 		return -EINVAL;
 	}
@@ -211,7 +211,7 @@ static int selector_params(struct comp_dev *dev,
 
 	err = selector_verify_params(dev, params);
 	if (err < 0) {
-		comp_err(dev, "selector_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return -EINVAL;
 	}
 
@@ -244,7 +244,7 @@ static int selector_ctrl_set_data(struct comp_dev *dev,
 		cd->config.sel_channel = cfg->sel_channel;
 		break;
 	default:
-		comp_err(dev, "selector_ctrl_set_cmd(): invalid cdata->cmd = %u",
+		comp_err(dev, "invalid cdata->cmd = %u",
 			 cdata->cmd);
 		ret = -EINVAL;
 		break;
@@ -284,7 +284,7 @@ static int selector_ctrl_get_data(struct comp_dev *dev,
 		break;
 
 	default:
-		comp_err(dev, "selector_ctrl_get_data(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -322,7 +322,7 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 		comp_dbg(dev, "selector_cmd(), COMP_CMD_GET_VALUE");
 		break;
 	default:
-		comp_err(dev, "selector_cmd(): invalid command");
+		comp_err(dev, "invalid command");
 		ret = -EINVAL;
 	}
 
@@ -444,15 +444,15 @@ static int selector_prepare(struct comp_dev *dev)
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
-	comp_dbg(dev, "selector_prepare(): sourceb->schannels = %u",
+	comp_dbg(dev, "sourceb->schannels = %u",
 		 audio_stream_get_channels(&sourceb->stream));
-	comp_dbg(dev, "selector_prepare(): sinkb->channels = %u",
+	comp_dbg(dev, "sinkb->channels = %u",
 		 audio_stream_get_channels(&sinkb->stream));
 
 	sink_size = audio_stream_get_size(&sinkb->stream);
 
 	if (sink_size < cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare(): sink buffer size %zu is insufficient < %d",
+		comp_err(dev, "sink buffer size %zu is insufficient < %d",
 			 sink_size, cd->sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
@@ -460,14 +460,14 @@ static int selector_prepare(struct comp_dev *dev)
 
 	/* validate */
 	if (cd->sink_period_bytes == 0) {
-		comp_err(dev, "selector_prepare(): cd->sink_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "cd->sink_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		ret = -EINVAL;
 		goto err;
 	}
 
 	if (cd->source_period_bytes == 0) {
-		comp_err(dev, "selector_prepare(): cd->source_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "cd->source_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		ret = -EINVAL;
 		goto err;
@@ -475,7 +475,7 @@ static int selector_prepare(struct comp_dev *dev)
 
 	cd->sel_func = sel_get_processing_function(dev);
 	if (!cd->sel_func) {
-		comp_err(dev, "selector_prepare(): invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
+		comp_err(dev, "invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
 			 cd->source_format, cd->sink_format,
 			 cd->config.out_channels_count);
 		ret = -EINVAL;
@@ -603,13 +603,13 @@ static int selector_init(struct processing_module *mod)
 
 		if (init_cfg_ext->base_cfg_ext.nb_input_pins != SEL_NUM_IN_PIN_FMTS ||
 		    init_cfg_ext->base_cfg_ext.nb_output_pins != SEL_NUM_OUT_PIN_FMTS) {
-			comp_err(mod->dev, "selector_init(): Invalid pin configuration");
+			comp_err(mod->dev, "Invalid pin configuration");
 			return -EINVAL;
 		}
 	} else if (cfg->size == base_cfg_size + bs[1]) {
 		payload_fmt = IPC4_SEL_INIT_PAYLOAD_BASE_WITH_OUT_FMT;
 	} else {
-		comp_err(mod->dev, "selector_init(): Invalid configuration size");
+		comp_err(mod->dev, "Invalid configuration size");
 		return -EINVAL;
 	}
 
@@ -696,13 +696,13 @@ static int selector_verify_params(struct processing_module *mod,
 
 	/* verify input channels */
 	if (in_channels == 0 || in_channels > SEL_SOURCE_CHANNELS_MAX) {
-		comp_err(dev, "selector_verify_params(): in_channels = %u", in_channels);
+		comp_err(dev, "in_channels = %u", in_channels);
 		return -EINVAL;
 	}
 
 	/* verify output channels */
 	if (out_channels == 0 || out_channels > SEL_SINK_CHANNELS_MAX) {
-		comp_err(dev, "selector_verify_params(): out_channels = %u", out_channels);
+		comp_err(dev, "out_channels = %u", out_channels);
 		return -EINVAL;
 	}
 
@@ -756,7 +756,7 @@ static int selector_params(struct processing_module *mod)
 
 	err = selector_verify_params(mod, params);
 	if (err < 0) {
-		comp_err(mod->dev, "selector_params(): pcm params verification failed.");
+		comp_err(mod->dev, "pcm params verification failed.");
 		return -EINVAL;
 	}
 
@@ -855,7 +855,7 @@ static int selector_prepare(struct processing_module *mod,
 	 * proper number of channels [1] for selector to actually
 	 * reduce channel count between source and sink
 	 */
-	comp_info(dev, "selector_prepare(): source sink channel = %u %u",
+	comp_info(dev, "source sink channel = %u %u",
 		  audio_stream_get_channels(&sourceb->stream),
 		  audio_stream_get_channels(&sinkb->stream));
 
@@ -865,27 +865,27 @@ static int selector_prepare(struct processing_module *mod,
 	md->mpd.out_buff_size = cd->sink_period_bytes;
 
 	if (sink_size < cd->sink_period_bytes) {
-		comp_err(dev, "selector_prepare(): sink buffer size %d is insufficient < %d",
+		comp_err(dev, "sink buffer size %d is insufficient < %d",
 			 sink_size, cd->sink_period_bytes);
 		return -ENOMEM;
 	}
 
 	/* validate */
 	if (cd->sink_period_bytes == 0) {
-		comp_err(dev, "selector_prepare(): cd->sink_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "cd->sink_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		return -EINVAL;
 	}
 
 	if (cd->source_period_bytes == 0) {
-		comp_err(dev, "selector_prepare(): cd->source_period_bytes = 0, dev->frames = %u",
+		comp_err(dev, "cd->source_period_bytes = 0, dev->frames = %u",
 			 dev->frames);
 		return -EINVAL;
 	}
 
 	cd->sel_func = sel_get_processing_function(mod);
 	if (!cd->sel_func) {
-		comp_err(dev, "selector_prepare(): invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
+		comp_err(dev, "invalid cd->sel_func, cd->source_format = %u, cd->sink_format = %u, cd->out_channels_count = %u",
 			 cd->source_format, cd->sink_format,
 			 cd->config.out_channels_count);
 		return -EINVAL;

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -164,7 +164,7 @@ static int smart_amp_alloc_data_buffers(struct comp_dev *dev,
 		goto error;
 	total_size += size;
 
-	comp_dbg(dev, "smart_amp_alloc(): used data buffer %zu bytes", total_size);
+	comp_dbg(dev, "used data buffer %zu bytes", total_size);
 	return 0;
 
 error:
@@ -202,7 +202,7 @@ static struct comp_dev *smart_amp_new(const struct comp_driver *drv,
 	bs = ipc_sa->size;
 
 	if (bs > 0 && bs < sizeof(struct sof_smart_amp_config)) {
-		comp_err(dev, "smart_amp_new(): failed to apply config");
+		comp_err(dev, "failed to apply config");
 		goto error;
 	}
 
@@ -211,47 +211,47 @@ static struct comp_dev *smart_amp_new(const struct comp_driver *drv,
 	/* allocate inner model data struct */
 	sad->mod_data = mod_data_create(dev);
 	if (!sad->mod_data) {
-		comp_err(dev, "smart_amp_new(): failed to allocate nner model data");
+		comp_err(dev, "failed to allocate nner model data");
 		goto error;
 	}
 
 	/* allocate stream buffers for mod */
 	ret = smart_amp_alloc_data_buffers(dev, sad);
 	if (ret) {
-		comp_err(dev, "smart_amp_new(): failed to allocate data buffers, ret:%d", ret);
+		comp_err(dev, "failed to allocate data buffers, ret:%d", ret);
 		goto error;
 	}
 
 	/* (before init) allocate mem block for mod private data usage */
 	ret = smart_amp_alloc_mod_memblk(sad, MOD_MEMBLK_PRIVATE);
 	if (ret < 0) {
-		comp_err(dev, "smart_amp_new(): failed to allocate mod private, ret:%d", ret);
+		comp_err(dev, "failed to allocate mod private, ret:%d", ret);
 		goto error;
 	}
-	comp_dbg(dev, "smart_amp_new(): used mod private buffer %d bytes", ret);
+	comp_dbg(dev, "used mod private buffer %d bytes", ret);
 
 	/* init model */
 	ret = sad->mod_data->mod_ops->init(sad->mod_data);
 	if (ret) {
-		comp_err(dev, "smart_amp_new(): failed to init inner model, ret:%d", ret);
+		comp_err(dev, "failed to init inner model, ret:%d", ret);
 		goto error;
 	}
 
 	/* (after init) allocate mem block for mod audio frame data usage */
 	ret = smart_amp_alloc_mod_memblk(sad, MOD_MEMBLK_FRAME);
 	if (ret < 0) {
-		comp_err(dev, "smart_amp_new(): failed to allocate mod buffer, ret:%d", ret);
+		comp_err(dev, "failed to allocate mod buffer, ret:%d", ret);
 		goto error;
 	}
-	comp_dbg(dev, "smart_amp_new(): used mod data buffer %d bytes", ret);
+	comp_dbg(dev, "used mod data buffer %d bytes", ret);
 
 	/* (after init) allocate mem block for mod parameter blob usage */
 	ret = smart_amp_alloc_mod_memblk(sad, MOD_MEMBLK_PARAM);
 	if (ret < 0) {
-		comp_err(dev, "smart_amp_new(): failed to allocate mod config, ret:%d", ret);
+		comp_err(dev, "failed to allocate mod config, ret:%d", ret);
 		goto error;
 	}
-	comp_dbg(dev, "smart_amp_new(): used mod config buffer %d bytes", ret);
+	comp_dbg(dev, "used mod config buffer %d bytes", ret);
 
 	dev->state = COMP_STATE_READY;
 
@@ -280,7 +280,7 @@ static int smart_amp_set_config(struct comp_dev *dev,
 		 bs, sizeof(struct sof_smart_amp_config));
 
 	if (bs != sizeof(struct sof_smart_amp_config)) {
-		comp_err(dev, "smart_amp_set_config(): invalid blob size, actual blob size = %zu, expected blob size = %zu",
+		comp_err(dev, "invalid blob size, actual blob size = %zu, expected blob size = %zu",
 			 bs, sizeof(struct sof_smart_amp_config));
 		return -EINVAL;
 	}
@@ -335,12 +335,12 @@ static int smart_amp_ctrl_get_bin_data(struct comp_dev *dev,
 	case SOF_SMART_AMP_MODEL:
 		ret = mod->mod_ops->get_config(mod, cdata, size);
 		if (ret < 0) {
-			comp_err(dev, "smart_amp_ctrl_get_bin_data(): failed to read inner model!");
+			comp_err(dev, "failed to read inner model!");
 			return ret;
 		}
 		break;
 	default:
-		comp_err(dev, "smart_amp_ctrl_get_bin_data(): unknown binary data type");
+		comp_err(dev, "unknown binary data type");
 		break;
 	}
 
@@ -359,7 +359,7 @@ static int smart_amp_ctrl_get_data(struct comp_dev *dev,
 		ret = smart_amp_ctrl_get_bin_data(dev, cdata, size);
 		break;
 	default:
-		comp_err(dev, "smart_amp_ctrl_get_data(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -377,7 +377,7 @@ static int smart_amp_ctrl_set_bin_data(struct comp_dev *dev,
 	mod = sad->mod_data;
 
 	if (dev->state < COMP_STATE_READY) {
-		comp_err(dev, "smart_amp_ctrl_set_bin_data(): driver in init!");
+		comp_err(dev, "driver in init!");
 		return -EBUSY;
 	}
 
@@ -388,12 +388,12 @@ static int smart_amp_ctrl_set_bin_data(struct comp_dev *dev,
 	case SOF_SMART_AMP_MODEL:
 		ret = mod->mod_ops->set_config(mod, cdata);
 		if (ret < 0) {
-			comp_err(dev, "smart_amp_ctrl_set_bin_data(): failed to write inner model!");
+			comp_err(dev, "failed to write inner model!");
 			return ret;
 		}
 		break;
 	default:
-		comp_err(dev, "smart_amp_ctrl_set_bin_data(): unknown binary data type");
+		comp_err(dev, "unknown binary data type");
 		break;
 	}
 
@@ -407,7 +407,7 @@ static int smart_amp_ctrl_set_data(struct comp_dev *dev,
 
 	/* Check version from ABI header */
 	if (SOF_ABI_VERSION_INCOMPATIBLE(SOF_ABI_VERSION, cdata->data->abi)) {
-		comp_err(dev, "smart_amp_ctrl_set_data(): invalid version");
+		comp_err(dev, "invalid version");
 		return -EINVAL;
 	}
 
@@ -417,7 +417,7 @@ static int smart_amp_ctrl_set_data(struct comp_dev *dev,
 		ret = smart_amp_ctrl_set_bin_data(dev, cdata);
 		break;
 	default:
-		comp_err(dev, "smart_amp_ctrl_set_data(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		ret = -EINVAL;
 		break;
 	}
@@ -431,7 +431,7 @@ static int smart_amp_cmd(struct comp_dev *dev, int cmd, void *data,
 {
 	struct sof_ipc_ctrl_data *cdata = ASSUME_ALIGNED(data, 4);
 
-	comp_dbg(dev, "smart_amp_cmd(): cmd: %d", cmd);
+	comp_dbg(dev, "cmd: %d", cmd);
 
 	switch (cmd) {
 	case COMP_CMD_SET_DATA:
@@ -483,7 +483,7 @@ static int smart_amp_params(struct comp_dev *dev,
 
 	err = smart_amp_verify_params(dev, params);
 	if (err < 0) {
-		comp_err(dev, "smart_amp_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return -EINVAL;
 	}
 
@@ -529,12 +529,12 @@ static int smart_amp_ff_process(struct comp_dev *dev,
 	sad->out_mod.produced = 0;
 
 	if (frames == 0) {
-		comp_warn(dev, "smart_amp_copy(): feed forward frame size zero warning.");
+		comp_warn(dev, "feed forward frame size zero warning.");
 		return 0;
 	}
 
 	if (frames > SMART_AMP_FF_BUF_DB_SZ) {
-		comp_err(dev, "smart_amp_copy(): feed forward frame size overflow: %u", frames);
+		comp_err(dev, "feed forward frame size overflow: %u", frames);
 		sad->ff_mod.consumed = frames;
 		return -EINVAL;
 	}
@@ -543,7 +543,7 @@ static int smart_amp_ff_process(struct comp_dev *dev,
 
 	ret = mod->mod_ops->ff_proc(mod, frames, &sad->ff_mod, &sad->out_mod);
 	if (ret) {
-		comp_err(dev, "smart_amp_copy(): feed forward inner model process error");
+		comp_err(dev, "feed forward inner model process error");
 		return ret;
 	}
 
@@ -563,12 +563,12 @@ static int smart_amp_fb_process(struct comp_dev *dev,
 	sad->fb_mod.consumed = 0;
 
 	if (frames == 0) {
-		comp_warn(dev, "smart_amp_copy(): feedback frame size zero warning.");
+		comp_warn(dev, "feedback frame size zero warning.");
 		return 0;
 	}
 
 	if (frames > SMART_AMP_FB_BUF_DB_SZ) {
-		comp_err(dev, "smart_amp_copy(): feedback frame size overflow: %u", frames);
+		comp_err(dev, "feedback frame size overflow: %u", frames);
 		sad->fb_mod.consumed = frames;
 		return -EINVAL;
 	}
@@ -577,7 +577,7 @@ static int smart_amp_fb_process(struct comp_dev *dev,
 
 	ret = mod->mod_ops->fb_proc(mod, frames, &sad->fb_mod);
 	if (ret) {
-		comp_err(dev, "smart_amp_copy(): feedback inner model process error");
+		comp_err(dev, "feedback inner model process error");
 		return ret;
 	}
 
@@ -618,7 +618,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 			feedback_bytes = avail_feedback_frames *
 				audio_stream_frame_bytes(&feedback_buf->stream);
 
-			comp_dbg(dev, "smart_amp_copy(): processing %u feedback frames (avail_passthrough_frames: %u)",
+			comp_dbg(dev, "processing %u feedback frames (avail_passthrough_frames: %u)",
 				 avail_feedback_frames, avail_passthrough_frames);
 
 			/* perform buffer writeback after source_buf process */
@@ -627,7 +627,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 					     avail_feedback_frames,
 					     sad->config.feedback_ch_map);
 
-			comp_dbg(dev, "smart_amp_copy(): consumed %u feedback frames",
+			comp_dbg(dev, "consumed %u feedback frames",
 				 sad->fb_mod.consumed);
 			if (sad->fb_mod.consumed < avail_feedback_frames) {
 				feedback_bytes = sad->fb_mod.consumed *
@@ -645,7 +645,7 @@ static int smart_amp_copy(struct comp_dev *dev)
 	smart_amp_ff_process(dev, &source_buf->stream, &sink_buf->stream,
 			     avail_frames, sad->config.source_ch_map);
 
-	comp_dbg(dev, "smart_amp_copy(): processing %u feed forward frames (consumed: %u, produced: %u)",
+	comp_dbg(dev, "processing %u feed forward frames (consumed: %u, produced: %u)",
 		 avail_frames, sad->ff_mod.consumed, sad->out_mod.produced);
 	if (sad->ff_mod.consumed < avail_frames)
 		source_bytes = sad->ff_mod.consumed * audio_stream_frame_bytes(&source_buf->stream);
@@ -702,7 +702,7 @@ static int smart_amp_resolve_mod_fmt(struct comp_dev *dev, uint32_t least_req_de
 	/* get supported formats from mod */
 	ret = mod->mod_ops->get_supported_fmts(mod, &mod_fmts, &num_mod_fmts);
 	if (ret) {
-		comp_err(dev, "smart_amp_resolve_mod_fmt(): failed to get supported formats");
+		comp_err(dev, "failed to get supported formats");
 		return ret;
 	}
 
@@ -710,12 +710,12 @@ static int smart_amp_resolve_mod_fmt(struct comp_dev *dev, uint32_t least_req_de
 		if (get_sample_bitdepth(mod_fmts[i]) >= least_req_depth &&
 		    is_supported_fmt(mod_fmts[i])) {
 			/* set frame format to inner model */
-			comp_dbg(dev, "smart_amp_resolve_mod_fmt(): set mod format to %u",
+			comp_dbg(dev, "set mod format to %u",
 				 mod_fmts[i]);
 			ret = mod->mod_ops->set_fmt(mod, mod_fmts[i]);
 			if (ret) {
 				comp_err(dev,
-					 "smart_amp_resolve_mod_fmt(): failed setting format %u",
+					 "failed setting format %u",
 					 mod_fmts[i]);
 				return ret;
 			}
@@ -724,7 +724,7 @@ static int smart_amp_resolve_mod_fmt(struct comp_dev *dev, uint32_t least_req_de
 		}
 	}
 
-	comp_err(dev, "smart_amp_resolve_mod_fmt(): failed to resolve the frame format for mod");
+	comp_err(dev, "failed to resolve the frame format for mod");
 	return -EINVAL;
 }
 
@@ -798,15 +798,15 @@ static int smart_amp_prepare(struct comp_dev *dev)
 	sad->out_mod.frame_fmt = resolved_mod_fmt;
 	sad->ff_get_frame = smart_amp_get_src_func(ff_src_fmt, sad->ff_mod.frame_fmt);
 	sad->ff_set_frame = smart_amp_get_sink_func(ff_src_fmt, sad->out_mod.frame_fmt);
-	comp_dbg(dev, "smart_amp_prepare(): ff mod buffer channels:%u fmt_conv:%u -> %u",
+	comp_dbg(dev, "ff mod buffer channels:%u fmt_conv:%u -> %u",
 		 sad->ff_mod.channels, ff_src_fmt, sad->ff_mod.frame_fmt);
-	comp_dbg(dev, "smart_amp_prepare(): output mod buffer channels:%u fmt_conv:%u -> %u",
+	comp_dbg(dev, "output mod buffer channels:%u fmt_conv:%u -> %u",
 		 sad->out_mod.channels, sad->out_mod.frame_fmt, ff_src_fmt);
 
 	if (sad->feedback_buf) {
 		sad->fb_mod.frame_fmt = resolved_mod_fmt;
 		sad->fb_get_frame = smart_amp_get_src_func(fb_src_fmt, sad->fb_mod.frame_fmt);
-		comp_dbg(dev, "smart_amp_prepare(): fb mod buffer channels:%u fmt_conv:%u -> %u",
+		comp_dbg(dev, "fb mod buffer channels:%u fmt_conv:%u -> %u",
 			 sad->fb_mod.channels, fb_src_fmt, sad->fb_mod.frame_fmt);
 	}
 	return 0;

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -61,7 +61,7 @@ static int src_buffer_lengths(struct comp_dev *dev, struct comp_data *cd, int nc
 
 	if (nch > PLATFORM_MAX_CHANNELS) {
 		/* TODO: should be device, not class */
-		comp_err(dev, "src_buffer_lengths(): nch = %u > PLATFORM_MAX_CHANNELS",
+		comp_err(dev, "nch = %u > PLATFORM_MAX_CHANNELS",
 			 nch);
 		return -EINVAL;
 	}
@@ -73,7 +73,7 @@ static int src_buffer_lengths(struct comp_dev *dev, struct comp_data *cd, int nc
 
 	/* Check from stage1 parameter for a deleted in/out rate combination.*/
 	if (stage1->filter_length < 1) {
-		comp_err(dev, "src_buffer_lengths(): Non-supported combination sfs_in = %d, fs_out = %d",
+		comp_err(dev, "Non-supported combination sfs_in = %d, fs_out = %d",
 			 fs_in, fs_out);
 		return -EINVAL;
 	}
@@ -410,13 +410,13 @@ static int src_verify_params(struct processing_module *mod)
 	if (dev->direction == SOF_IPC_STREAM_PLAYBACK) {
 		ret = src_stream_pcm_sink_rate_check(cd->ipc_config, params);
 		if (ret < 0) {
-			comp_err(dev, "src_verify_params(): sink stream rate does not match rate fetched from ipc.");
+			comp_err(dev, "sink stream rate does not match rate fetched from ipc.");
 			return ret;
 		}
 	} else {
 		ret = src_stream_pcm_source_rate_check(cd->ipc_config, params);
 		if (ret < 0) {
-			comp_err(dev, "src_verify_params(): source stream rate does not match rate fetched from ipc.");
+			comp_err(dev, "source stream rate does not match rate fetched from ipc.");
 			return ret;
 		}
 	}
@@ -425,7 +425,7 @@ static int src_verify_params(struct processing_module *mod)
 	 */
 	ret = comp_verify_params(dev, BUFF_PARAMS_RATE, params);
 	if (ret < 0)
-		comp_err(dev, "src_verify_params(): comp_verify_params() failed.");
+		comp_err(dev, "comp_verify_params() failed.");
 
 	return ret;
 }
@@ -489,13 +489,13 @@ int src_params_general(struct processing_module *mod,
 
 	err = src_set_params(mod, sink);
 	if (err < 0) {
-		comp_err(dev, "src_params(): set params failed.");
+		comp_err(dev, "set params failed.");
 		return err;
 	}
 
 	err = src_verify_params(mod);
 	if (err < 0) {
-		comp_err(dev, "src_params(): pcm params verification failed.");
+		comp_err(dev, "pcm params verification failed.");
 		return err;
 	}
 
@@ -514,7 +514,7 @@ int src_params_general(struct processing_module *mod,
 	/* Allocate needed memory for delay lines */
 	err = src_buffer_lengths(dev, cd, cd->channels_count);
 	if (err < 0) {
-		comp_err(dev, "src_params(): src_buffer_lengths() failed");
+		comp_err(dev, "src_buffer_lengths() failed");
 		return err;
 	}
 
@@ -525,7 +525,7 @@ int src_params_general(struct processing_module *mod,
 	 */
 	delay_lines_size = ALIGN_UP(sizeof(int32_t) * cd->param.total, 8);
 	if (delay_lines_size == 0) {
-		comp_err(dev, "src_params(): delay_lines_size = 0");
+		comp_err(dev, "delay_lines_size = 0");
 
 		return  -EINVAL;
 	}
@@ -535,7 +535,7 @@ int src_params_general(struct processing_module *mod,
 
 	cd->delay_lines = mod_alloc(mod, delay_lines_size);
 	if (!cd->delay_lines) {
-		comp_err(dev, "src_params(): failed to alloc cd->delay_lines, delay_lines_size = %zu",
+		comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
 			 delay_lines_size);
 		return  -EINVAL;
 	}
@@ -586,7 +586,7 @@ int src_param_set(struct comp_dev *dev, struct comp_data *cd)
 
 	/* Check that both in and out rates are supported */
 	if (a->idx_in < 0 || a->idx_out < 0) {
-		comp_err(dev, "src_buffer_lengths(): rates not supported, fs_in: %u, fs_out: %u",
+		comp_err(dev, "rates not supported, fs_in: %u, fs_out: %u",
 			 fs_in, fs_out);
 		return -EINVAL;
 	}

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -113,7 +113,7 @@ int src_prepare_general(struct processing_module *mod,
 
 	/* SRC supports S16_LE, S24_4LE and S32_LE formats */
 	if (source_format != sink_format) {
-		comp_err(dev, "src_prepare(): Source fmt %d and sink fmt %d are different.",
+		comp_err(dev, "Source fmt %d and sink fmt %d are different.",
 			 source_format, sink_format);
 		ret = -EINVAL;
 		goto out;
@@ -139,7 +139,7 @@ int src_prepare_general(struct processing_module *mod,
 		break;
 #endif /* CONFIG_FORMAT_S32LE */
 	default:
-		comp_err(dev, "src_prepare(): invalid format %d", source_format);
+		comp_err(dev, "invalid format %d", source_format);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -161,20 +161,20 @@ int src_init(struct processing_module *mod)
 	comp_dbg(dev, "src_init()");
 
 	if (dev->ipc_config.type != SOF_COMP_SRC) {
-		comp_err(dev, "src_init(): Wrong IPC config type %u",
+		comp_err(dev, "Wrong IPC config type %u",
 			 dev->ipc_config.type);
 		return -EINVAL;
 	}
 
 	if (!cfg->init_data || cfg->size != sizeof(cd->ipc_config)) {
-		comp_err(dev, "src_init(): Missing or bad size (%zu) init data",
+		comp_err(dev, "Missing or bad size (%zu) init data",
 			 cfg->size);
 		return -EINVAL;
 	}
 
 	/* validate init data - either SRC sink or source rate must be set */
 	if (src_rate_check(cfg->init_data) < 0) {
-		comp_err(dev, "src_init(): SRC sink and source rate are not set");
+		comp_err(dev, "SRC sink and source rate are not set");
 		return -EINVAL;
 	}
 

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -173,7 +173,7 @@ int src_prepare_general(struct processing_module *mod,
 		break;
 #endif /* CONFIG_FORMAT_S32LE */
 	default:
-		comp_err(dev, "src_prepare(): Invalid depth %d",
+		comp_err(dev, "Invalid depth %d",
 			 cd->ipc_config.base.audio_fmt.depth);
 		ret = -EINVAL;
 		goto out;
@@ -198,14 +198,14 @@ __cold int src_init(struct processing_module *mod)
 	comp_dbg(dev, "src_init()");
 
 	if (!cfg->init_data || cfg->size != sizeof(cd->ipc_config)) {
-		comp_err(dev, "src_init(): Missing or bad size (%u) init data",
+		comp_err(dev, "Missing or bad size (%u) init data",
 			 cfg->size);
 		return -EINVAL;
 	}
 
 	/* validate init data - either SRC sink or source rate must be set */
 	if (src_rate_check(cfg->init_data) < 0) {
-		comp_err(dev, "src_init(): SRC sink and source rate are not set");
+		comp_err(dev, "SRC sink and source rate are not set");
 		return -EINVAL;
 	}
 
@@ -238,7 +238,7 @@ __cold int src_init(struct processing_module *mod)
 		cd->sample_container_bytes = sizeof(int32_t);
 		break;
 	default:
-		comp_err(dev, "src_init(): Illegal sample depth %d",
+		comp_err(dev, "Illegal sample depth %d",
 			 cd->ipc_config.base.audio_fmt.depth);
 		return -EINVAL;
 	}

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -576,7 +576,7 @@ static int tdfb_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "tdfb_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -584,7 +584,7 @@ static int tdfb_init(struct processing_module *mod)
 	/* Get configuration data and reset FIR filters */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "tdfb_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto err;
 	}
 

--- a/src/audio/tensorflow/tflm-classify.c
+++ b/src/audio/tensorflow/tflm-classify.c
@@ -70,7 +70,7 @@ __cold static int tflm_init(struct processing_module *mod)
 	/* Handler for configuration data */
 	cd->model_handler = comp_data_blob_handler_new(dev);
 	if (!cd->model_handler) {
-		comp_err(dev, "tflm_init(): comp_data_blob_handler_new() failed.");
+		comp_err(dev, "comp_data_blob_handler_new() failed.");
 		ret = -ENOMEM;
 		goto cd_fail;
 	}
@@ -78,7 +78,7 @@ __cold static int tflm_init(struct processing_module *mod)
 	/* Get configuration data and reset DRC state */
 	ret = comp_init_data_blob(cd->model_handler, bs, cfg->data);
 	if (ret < 0) {
-		comp_err(dev, "tflm_init(): comp_init_data_blob() failed.");
+		comp_err(dev, "comp_init_data_blob() failed.");
 		goto cd_fail;
 	}
 
@@ -197,7 +197,7 @@ static int tflm_process(struct processing_module *mod,
 		cd->tfc.audio_data_size = TFLM_FEATURE_ELEM_COUNT;
 		ret = TF_ProcessClassify(&cd->tfc);
 		if (!ret) {
-			comp_err(dev, "tflm_process(): classify failed %s.",
+			comp_err(dev, "classify failed %s.",
 				 cd->tfc.error);
 			return ret;
 		}

--- a/src/audio/tone.c
+++ b/src/audio/tone.c
@@ -462,7 +462,7 @@ static int tone_cmd_get_value(struct comp_dev *dev,
 	comp_info(dev, "tone_cmd_get_value()");
 
 	if (cdata->type != SOF_CTRL_TYPE_VALUE_CHAN_GET) {
-		comp_err(dev, "tone_cmd_get_value(): wrong cdata->type: %u",
+		comp_err(dev, "wrong cdata->type: %u",
 			 cdata->type);
 		return -EINVAL;
 	}
@@ -487,7 +487,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 	bool val;
 
 	if (cdata->type != SOF_CTRL_TYPE_VALUE_CHAN_SET) {
-		comp_err(dev, "tone_cmd_set_value(): wrong cdata->type: %u",
+		comp_err(dev, "wrong cdata->type: %u",
 			 cdata->type);
 		return -EINVAL;
 	}
@@ -500,7 +500,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 			comp_info(dev, "tone_cmd_set_value(), SOF_CTRL_CMD_SWITCH, ch = %u, val = %u",
 				  ch, val);
 			if (ch >= PLATFORM_MAX_CHANNELS) {
-				comp_err(dev, "tone_cmd_set_value(): ch >= PLATFORM_MAX_CHANNELS");
+				comp_err(dev, "ch >= PLATFORM_MAX_CHANNELS");
 				return -EINVAL;
 			}
 
@@ -510,7 +510,7 @@ static int tone_cmd_set_value(struct comp_dev *dev,
 				tonegen_mute(&cd->sg[ch]);
 		}
 	} else {
-		comp_err(dev, "tone_cmd_set_value(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -529,7 +529,7 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 	comp_info(dev, "tone_cmd_set_data()");
 
 	if (cdata->type != SOF_CTRL_TYPE_VALUE_COMP_SET) {
-		comp_err(dev, "tone_cmd_set_data(): wrong cdata->type: %u",
+		comp_err(dev, "wrong cdata->type: %u",
 			 cdata->type);
 		return -EINVAL;
 	}
@@ -579,13 +579,13 @@ static int tone_cmd_set_data(struct comp_dev *dev,
 				tonegen_set_linramp(&cd->sg[ch], val);
 				break;
 			default:
-				comp_err(dev, "tone_cmd_set_data(): invalid cdata->index");
+				comp_err(dev, "invalid cdata->index");
 				return -EINVAL;
 			}
 		}
 		break;
 	default:
-		comp_err(dev, "tone_cmd_set_data(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		return -EINVAL;
 	}
 

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -100,7 +100,7 @@ static int set_downmix_coefficients(struct processing_module *mod,
 		cd->downmix_coefficients = k_scaled_lo_ro_downmix32bit;
 		break;
 	default:
-		comp_err(dev, "set_downmix_coefficients(): invalid channel config.");
+		comp_err(dev, "invalid channel config.");
 		return -EINVAL;
 	}
 
@@ -128,7 +128,7 @@ static up_down_mixer_routine select_mix_out_stereo(struct comp_dev *dev,
 			return downmix16bit_5_1;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_stereo(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			/*
 			 * This is a strange situation. We will allow to process it
 			 * in the release code (hoping for the best) with downmix16bit,
@@ -161,7 +161,7 @@ static up_down_mixer_routine select_mix_out_stereo(struct comp_dev *dev,
 			return downmix32bit_7_1;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_stereo(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			/*
 			 * This is a strange situation. We will allow to process it
 			 * in the release code (hoping for the best) with downmix32bit,
@@ -185,7 +185,7 @@ static up_down_mixer_routine select_mix_out_mono(struct comp_dev *dev,
 			return downmix16bit_4ch_mono;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_mono(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			/*
 			 * This is a strange situation. We will allow to process it
 			 * in the release code (hoping for the best) with downmix16bit,
@@ -212,7 +212,7 @@ static up_down_mixer_routine select_mix_out_mono(struct comp_dev *dev,
 			return downmix32bit_7_1_mono;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_mono(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			/*
 			 * This is a strange situation. We will allow to process it
 			 * in the release code (hoping for the best) with downmix32bit,
@@ -234,7 +234,7 @@ static up_down_mixer_routine select_mix_out_5_1(struct comp_dev *dev,
 			return upmix16bit_2_0_to_5_1;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_5_1(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			return NULL;
 		}
 	} else {
@@ -251,7 +251,7 @@ static up_down_mixer_routine select_mix_out_5_1(struct comp_dev *dev,
 			return downmix32bit_7_1_to_5_1;
 		case IPC4_CHANNEL_CONFIG_INVALID:
 		default:
-			comp_err(dev, "select_mix_out_5_1(): invalid channel config.");
+			comp_err(dev, "invalid channel config.");
 			return NULL;
 		}
 	}
@@ -379,13 +379,13 @@ static int up_down_mixer_init(struct processing_module *mod)
 			       up_down_mixer->out_channel_config, up_down_mixer->coefficients);
 		break;
 	default:
-		comp_err(dev, "up_down_mixer_init(): unsupported coefficient type");
+		comp_err(dev, "unsupported coefficient type");
 		ret = -EINVAL;
 		break;
 	}
 
 	if (ret < 0) {
-		comp_err(dev, "up_down_mixer_init(): failed to initialize up_down_mix");
+		comp_err(dev, "failed to initialize up_down_mix");
 		goto err;
 	}
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -690,7 +690,7 @@ static int volume_prepare(struct processing_module *mod,
 						      dev->frames);
 
 	if (audio_stream_get_size(&sinkb->stream) < sink_period_bytes) {
-		comp_err(dev, "volume_prepare(): sink buffer size %d is insufficient < %d",
+		comp_err(dev, "sink buffer size %d is insufficient < %d",
 			 audio_stream_get_size(&sinkb->stream), sink_period_bytes);
 		ret = -ENOMEM;
 		goto err;
@@ -699,7 +699,7 @@ static int volume_prepare(struct processing_module *mod,
 	set_volume_process(cd, dev, false);
 
 	if (!cd->scale_vol) {
-		comp_err(dev, "volume_prepare(): invalid cd->scale_vol");
+		comp_err(dev, "invalid cd->scale_vol");
 
 		ret = -EINVAL;
 		goto err;
@@ -707,7 +707,7 @@ static int volume_prepare(struct processing_module *mod,
 
 	cd->zc_get = vol_get_zc_function(dev, sinkb);
 	if (!cd->zc_get) {
-		comp_err(dev, "volume_prepare(): invalid cd->zc_get");
+		comp_err(dev, "invalid cd->zc_get");
 		ret = -EINVAL;
 		goto err;
 	}

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -264,7 +264,7 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 		case IPC4_DEPTH_32BIT:
 			return volume_func_map[2].passthrough_func;
 		default:
-			comp_err(dev, "vol_get_processing_function(): unsupported depth %d",
+			comp_err(dev, "unsupported depth %d",
 				 mod->priv.cfg.base_cfg.audio_fmt.depth);
 			return NULL;
 		}
@@ -277,7 +277,7 @@ static inline vol_scale_func vol_get_processing_function(struct comp_dev *dev,
 		case IPC4_DEPTH_32BIT:
 			return volume_func_map[2].func;
 		default:
-			comp_err(dev, "vol_get_processing_function(): unsupported depth %d",
+			comp_err(dev, "unsupported depth %d",
 				 mod->priv.cfg.base_cfg.audio_fmt.depth);
 			return NULL;
 		}

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -76,7 +76,7 @@ int volume_init(struct processing_module *mod)
 	int i;
 
 	if (!vol || cfg->size != sizeof(*vol)) {
-		comp_err(dev, "volume_init(): No configuration data or bad data size %zu",
+		comp_err(dev, "No configuration data or bad data size %zu",
 			 cfg->size);
 		return -EINVAL;
 	}
@@ -92,7 +92,7 @@ int volume_init(struct processing_module *mod)
 	cd->vol = rmalloc(SOF_MEM_FLAG_USER, vol_size);
 	if (!cd->vol) {
 		rfree(cd);
-		comp_err(dev, "volume_init(): Failed to allocate %zu", vol_size);
+		comp_err(dev, "Failed to allocate %zu", vol_size);
 		return -ENOMEM;
 	}
 
@@ -108,7 +108,7 @@ int volume_init(struct processing_module *mod)
 		if (vol->min_value < VOL_MIN) {
 			/* Use VOL_MIN instead, no need to stop new(). */
 			cd->vol_min = VOL_MIN;
-			comp_err(dev, "volume_new(): vol->min_value was limited to VOL_MIN.");
+			comp_err(dev, "vol->min_value was limited to VOL_MIN.");
 		} else {
 			cd->vol_min = vol->min_value;
 		}
@@ -116,7 +116,7 @@ int volume_init(struct processing_module *mod)
 		if (vol->max_value > VOL_MAX) {
 			/* Use VOL_MAX instead, no need to stop new(). */
 			cd->vol_max = VOL_MAX;
-			comp_err(dev, "volume_new(): vol->max_value was limited to VOL_MAX.");
+			comp_err(dev, "vol->max_value was limited to VOL_MAX.");
 		} else {
 			cd->vol_max = vol->max_value;
 		}
@@ -157,7 +157,7 @@ int volume_init(struct processing_module *mod)
 		cd->initial_ramp = vol->initial_ramp;
 		break;
 	default:
-		comp_err(dev, "volume_new(): invalid ramp type %d", vol->ramp);
+		comp_err(dev, "invalid ramp type %d", vol->ramp);
 		rfree(cd);
 		rfree(cd->vol);
 		return -EINVAL;
@@ -189,7 +189,7 @@ int volume_set_config(struct processing_module *mod, uint32_t config_id,
 
 	/* validate */
 	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
-		comp_err(dev, "volume_set_config(): invalid cdata->num_elems");
+		comp_err(dev, "invalid cdata->num_elems");
 		return -EINVAL;
 	}
 
@@ -246,7 +246,7 @@ int volume_set_config(struct processing_module *mod, uint32_t config_id,
 		break;
 
 	default:
-		comp_err(dev, "volume_set_config(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		return -EINVAL;
 	}
 
@@ -266,7 +266,7 @@ int volume_get_config(struct processing_module *mod,
 
 	/* validate */
 	if (cdata->num_elems == 0 || cdata->num_elems > SOF_IPC_MAX_CHANNELS) {
-		comp_err(dev, "volume_get_config(): invalid cdata->num_elems %u",
+		comp_err(dev, "invalid cdata->num_elems %u",
 			 cdata->num_elems);
 		return -EINVAL;
 	}
@@ -291,7 +291,7 @@ int volume_get_config(struct processing_module *mod,
 		}
 		break;
 	default:
-		comp_err(dev, "volume_get_config(): invalid cdata->cmd");
+		comp_err(dev, "invalid cdata->cmd");
 		return -EINVAL;
 	}
 

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -124,7 +124,7 @@ int volume_init(struct processing_module *mod)
 	}
 	channels_count = mod->priv.cfg.base_cfg.audio_fmt.channels_count;
 	if (channels_count > SOF_IPC_MAX_CHANNELS || !channels_count) {
-		comp_err(dev, "volume_init(): Invalid channels count %u", channels_count);
+		comp_err(dev, "Invalid channels count %u", channels_count);
 		return -EINVAL;
 	}
 
@@ -139,7 +139,7 @@ int volume_init(struct processing_module *mod)
 	cd->vol = rmalloc(SOF_MEM_FLAG_USER, vol_size);
 	if (!cd->vol) {
 		rfree(cd);
-		comp_err(dev, "volume_init(): Failed to allocate %d", vol_size);
+		comp_err(dev, "Failed to allocate %d", vol_size);
 		return -ENOMEM;
 	}
 
@@ -150,7 +150,7 @@ int volume_init(struct processing_module *mod)
 	if (!cd->peak_vol) {
 		rfree(cd->vol);
 		rfree(cd);
-		comp_err(dev, "volume_init(): Failed to allocate %d for peak_vol", vol_size);
+		comp_err(dev, "Failed to allocate %d for peak_vol", vol_size);
 		return -ENOMEM;
 	}
 

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -343,7 +343,7 @@ static void idc_process_async_msg(uint32_t slot)
 #if CONFIG_AMS
 	process_incoming_message(slot);
 #else
-	tr_err(&idc_tr, "idc_cmd(): AMS not enabled");
+	tr_err(&idc_tr, "AMS not enabled");
 #endif
 }
 
@@ -430,7 +430,7 @@ void idc_cmd(struct idc_msg *msg)
 		idc_process_async_msg(IDC_HEADER_TO_AMS_SLOT_MASK(msg->header));
 		break;
 	default:
-		tr_err(&idc_tr, "idc_cmd(): invalid msg->header = %u",
+		tr_err(&idc_tr, "invalid msg->header = %u",
 		       msg->header);
 	}
 
@@ -442,7 +442,7 @@ int idc_init(void)
 {
 	struct idc **idc = idc_get();
 
-	tr_dbg(&idc_tr, "idc_init()");
+	tr_dbg(&idc_tr, "entry");
 
 	/* initialize idc data */
 	(*idc)->payload = platform_shared_get(static_payload, sizeof(static_payload));
@@ -469,7 +469,7 @@ int idc_restore(void)
 {
 	struct idc **idc __unused = idc_get();
 
-	tr_info(&idc_tr, "idc_restore()");
+	tr_info(&idc_tr, "entry");
 
 	/* idc_restore() is invoked during D0->D0ix/D0ix->D0 flow. In that
 	 * case basic core structures e.g. idc struct should be already

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -46,7 +46,7 @@ static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,
 	}
 
 	/* host offset in beyond end of SG buffer */
-	tr_err(&dmacpy_tr, "sg_get_elem_at(): host offset in beyond end of SG buffer");
+	tr_err(&dmacpy_tr, "host offset in beyond end of SG buffer");
 	return NULL;
 }
 #endif
@@ -165,7 +165,7 @@ int dma_copy_new(struct dma_copy *dc)
 	cap = 0;
 	dc->dmac = dma_get(dir, cap, dev, DMA_ACCESS_SHARED);
 	if (!dc->dmac) {
-		tr_err(&dmacpy_tr, "dma_copy_new(): dc->dmac = NULL");
+		tr_err(&dmacpy_tr, "dc->dmac = NULL");
 		return -ENODEV;
 	}
 
@@ -173,7 +173,7 @@ int dma_copy_new(struct dma_copy *dc)
 	/* get DMA channel from DMAC0 */
 	dc->chan = dma_channel_get_legacy(dc->dmac, CONFIG_TRACE_CHANNEL);
 	if (!dc->chan) {
-		tr_err(&dmacpy_tr, "dma_copy_new(): dc->chan is NULL");
+		tr_err(&dmacpy_tr, "dc->chan is NULL");
 		return -ENODEV;
 	}
 #endif
@@ -186,7 +186,7 @@ int dma_copy_set_stream_tag(struct dma_copy *dc, uint32_t stream_tag)
 	/* get DMA channel from DMAC */
 	dc->chan = dma_channel_get_legacy(dc->dmac, stream_tag - 1);
 	if (!dc->chan) {
-		tr_err(&dmacpy_tr, "dma_copy_set_stream_tag(): dc->chan is NULL");
+		tr_err(&dmacpy_tr, "dc->chan is NULL");
 		return -EINVAL;
 	}
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -51,7 +51,7 @@ int ipc_process_on_core(uint32_t core, bool blocking)
 
 	/* check if requested core is enabled */
 	if (!cpu_is_core_enabled(core)) {
-		tr_err(&ipc_tr, "ipc_process_on_core(): core #%d is disabled", core);
+		tr_err(&ipc_tr, "core #%d is disabled", core);
 		return -EACCES;
 	}
 
@@ -290,7 +290,7 @@ __cold int ipc_init(struct sof *sof)
 {
 	assert_can_be_cold();
 
-	tr_dbg(&ipc_tr, "ipc_init()");
+	tr_dbg(&ipc_tr, "entry");
 
 	/* init ipc data */
 	sof->ipc = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, sizeof(*sof->ipc));

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -140,7 +140,7 @@ int comp_verify_params(struct comp_dev *dev, uint32_t flag,
 	int dir = dev->direction;
 
 	if (!params) {
-		comp_err(dev, "comp_verify_params(): !params");
+		comp_err(dev, "!params");
 		return -EINVAL;
 	}
 
@@ -263,14 +263,14 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id)
 	/* find the scheduling component */
 	icd = ipc_get_comp_by_id(ipc, p->sched_id);
 	if (!icd) {
-		tr_warn(&ipc_tr, "ipc_pipeline_complete(): no scheduling component specified, use comp 0x%x",
+		tr_warn(&ipc_tr, "no scheduling component specified, use comp 0x%x",
 			ipc_ppl_sink->id);
 
 		icd = ipc_ppl_sink;
 	}
 
 	if (icd->core != ipc_pipe->core) {
-		tr_err(&ipc_tr, "ipc_pipeline_complete(): icd->core (%d) != ipc_pipe->core (%d) for pipeline scheduling component icd->id 0x%x",
+		tr_err(&ipc_tr, "icd->core (%d) != ipc_pipe->core (%d) for pipeline scheduling component icd->id 0x%x",
 		       icd->core, ipc_pipe->core, icd->id);
 		return -EINVAL;
 	}
@@ -298,7 +298,7 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	/* check whether component exists */
 	icd = ipc_get_comp_by_id(ipc, comp_id);
 	if (!icd) {
-		tr_err(&ipc_tr, "ipc_comp_free(): comp id: 0x%x is not found",
+		tr_err(&ipc_tr, "comp id: 0x%x is not found",
 		       comp_id);
 		return -ENODEV;
 	}
@@ -309,7 +309,7 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check state */
 	if (icd->cd->state != COMP_STATE_READY) {
-		tr_err(&ipc_tr, "ipc_comp_free(): comp id: 0x%x state is %d cannot be freed",
+		tr_err(&ipc_tr, "comp id: 0x%x state is %d cannot be freed",
 		       comp_id, icd->cd->state);
 		return -EINVAL;
 	}
@@ -328,7 +328,7 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 		 * leak on error.  Bug-free host drivers won't do
 		 * this, this was found via fuzzing.
 		 */
-		tr_err(&ipc_tr, "ipc_comp_free(): uninitialized buffer lists on comp 0x%x\n",
+		tr_err(&ipc_tr, "uninitialized buffer lists on comp 0x%x\n",
 		       icd->id);
 		return -EINVAL;
 	}

--- a/src/ipc/ipc3/dai.c
+++ b/src/ipc/ipc3/dai.c
@@ -104,7 +104,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		comp_err(dev, "dai_config_dma_channel(): Unknown dai type %d",
+		comp_err(dev, "Unknown dai type %d",
 			 config->type);
 		channel = SOF_DMA_CHAN_INVALID;
 		break;
@@ -119,7 +119,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 	struct sof_ipc_dai_config *config = ipc_from_dai_config(dd->dai_spec_config);
 
 	if (!config) {
-		comp_err(dev, "dai_data_config(): no config set for dai %d type %d",
+		comp_err(dev, "no config set for dai %d type %d",
 			 dai->dai_index, dai->type);
 		return -EINVAL;
 	}
@@ -129,14 +129,14 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_data_config(): Component is in active state.");
+		comp_info(dev, "Component is in active state.");
 		return 0;
 	}
 
 	/* validate direction */
 	if (dai->direction != SOF_IPC_STREAM_PLAYBACK &&
 	    dai->direction != SOF_IPC_STREAM_CAPTURE) {
-		comp_err(dev, "dai_data_config(): no direction set for dai %d type %d",
+		comp_err(dev, "no direction set for dai %d type %d",
 			 dai->dai_index, dai->type);
 		return -EINVAL;
 	}
@@ -195,7 +195,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		comp_warn(dev, "dai_data_config(): Unknown dai type %d",
+		comp_warn(dev, "Unknown dai type %d",
 			  config->type);
 		break;
 	}
@@ -241,7 +241,7 @@ int ipc_comp_dai_config(struct ipc *ipc, struct ipc_config_dai *common_config,
 	}
 
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_comp_dai_config(): comp_dai_config() failed");
+		tr_err(&ipc_tr, "comp_dai_config() failed");
 		return ret;
 	}
 
@@ -281,7 +281,7 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");
+		comp_info(dev, "Component is in active state. Ignore resetting");
 		return;
 	}
 
@@ -315,7 +315,7 @@ int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai 
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config(): Component is in active state. Ignore config");
+		comp_info(dev, "Component is in active state. Ignore config");
 		return 0;
 	}
 
@@ -328,7 +328,7 @@ int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai 
 			dd->delayed_dma_stop = true;
 
 		if (dd->chan) {
-			comp_info(dev, "dai_config(): Configured. dma channel index %d, ignore...",
+			comp_info(dev, "Configured. dma channel index %d, ignore...",
 				  dd->chan->index);
 			return 0;
 		}
@@ -379,7 +379,7 @@ int dai_config(struct dai_data *dd, struct comp_dev *dev, struct ipc_config_dai 
 		dd->dai_spec_config = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 					      sizeof(struct sof_ipc_dai_config));
 		if (!dd->dai_spec_config) {
-			comp_err(dev, "dai_config(): No memory for dai_config.");
+			comp_err(dev, "No memory for dai_config.");
 			return -ENOMEM;
 		}
 	}

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -996,10 +996,10 @@ static inline int ipc_probe_init(uint32_t header)
 	struct sof_ipc_probe_dma_add_params *params = ipc_get()->comp_data;
 	int dma_provided = params->num_elems;
 
-	tr_dbg(&ipc_tr, "ipc_probe_init()");
+	tr_dbg(&ipc_tr, "entry");
 
 	if (dma_provided > 1 || dma_provided < 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_init(): Invalid amount of extraction DMAs specified = %d",
+		ipc_cmd_err(&ipc_tr, "Invalid amount of extraction DMAs specified = %d",
 			    dma_provided);
 		return -EINVAL;
 	}
@@ -1009,7 +1009,7 @@ static inline int ipc_probe_init(uint32_t header)
 
 static inline int ipc_probe_deinit(uint32_t header)
 {
-	tr_dbg(&ipc_tr, "ipc_probe_deinit()");
+	tr_dbg(&ipc_tr, "entry");
 
 	return probe_deinit();
 }
@@ -1019,17 +1019,17 @@ static inline int ipc_probe_dma_add(uint32_t header)
 	struct sof_ipc_probe_dma_add_params *params = ipc_get()->comp_data;
 	int dmas_count = params->num_elems;
 
-	tr_dbg(&ipc_tr, "ipc_probe_dma_add()");
+	tr_dbg(&ipc_tr, "entry");
 
 	if (dmas_count > CONFIG_PROBE_DMA_MAX) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_dma_add(): Invalid amount of injection DMAs specified = %d. Max is "
+		ipc_cmd_err(&ipc_tr, "Invalid amount of injection DMAs specified = %d. Max is "
 			    STRINGIFY(CONFIG_PROBE_DMA_MAX) ".",
 			    dmas_count);
 		return -EINVAL;
 	}
 
 	if (dmas_count <= 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_dma_add(): Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		ipc_cmd_err(&ipc_tr, "Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 			    dmas_count);
 		return -EINVAL;
 	}
@@ -1042,17 +1042,17 @@ static inline int ipc_probe_dma_remove(uint32_t header)
 	struct sof_ipc_probe_dma_remove_params *params = ipc_get()->comp_data;
 	int tags_count = params->num_elems;
 
-	tr_dbg(&ipc_tr, "ipc_probe_dma_remove()");
+	tr_dbg(&ipc_tr, "entry");
 
 	if (tags_count > CONFIG_PROBE_DMA_MAX) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_dma_remove(): Invalid amount of injection DMAs specified = %d. Max is "
+		ipc_cmd_err(&ipc_tr, "Invalid amount of injection DMAs specified = %d. Max is "
 			    STRINGIFY(CONFIG_PROBE_DMA_MAX) ".",
 			    tags_count);
 		return -EINVAL;
 	}
 
 	if (tags_count <= 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_dma_remove(): Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		ipc_cmd_err(&ipc_tr, "Inferred amount of incjection DMAs in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 			    tags_count);
 		return -EINVAL;
 	}
@@ -1065,17 +1065,17 @@ static inline int ipc_probe_point_add(uint32_t header)
 	struct sof_ipc_probe_point_add_params *params = ipc_get()->comp_data;
 	int probes_count = params->num_elems;
 
-	tr_dbg(&ipc_tr, "ipc_probe_point_add()");
+	tr_dbg(&ipc_tr, "entry");
 
 	if (probes_count > CONFIG_PROBE_POINTS_MAX) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_point_add(): Invalid amount of Probe Points specified = %d. Max is "
+		ipc_cmd_err(&ipc_tr, "Invalid amount of Probe Points specified = %d. Max is "
 			    STRINGIFY(CONFIG_PROBE_POINT_MAX) ".",
 			    probes_count);
 		return -EINVAL;
 	}
 
 	if (probes_count <= 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_point_add(): Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		ipc_cmd_err(&ipc_tr, "Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 			    probes_count);
 		return -EINVAL;
 	}
@@ -1088,17 +1088,17 @@ static inline int ipc_probe_point_remove(uint32_t header)
 	struct sof_ipc_probe_point_remove_params *params = ipc_get()->comp_data;
 	int probes_count = params->num_elems;
 
-	tr_dbg(&ipc_tr, "ipc_probe_point_remove()");
+	tr_dbg(&ipc_tr, "entry");
 
 	if (probes_count > CONFIG_PROBE_POINTS_MAX) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_point_remove(): Invalid amount of Probe Points specified = %d. Max is "
+		ipc_cmd_err(&ipc_tr, "Invalid amount of Probe Points specified = %d. Max is "
 			    STRINGIFY(CONFIG_PROBE_POINT_MAX) ".",
 			    probes_count);
 		return -EINVAL;
 	}
 
 	if (probes_count <= 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_point_remove(): Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
+		ipc_cmd_err(&ipc_tr, "Inferred amount of Probe Points in payload is %d. This could indicate corrupt size reported in header or invalid IPC payload.",
 			    probes_count);
 		return -EINVAL;
 	}
@@ -1111,7 +1111,7 @@ static int ipc_probe_info(uint32_t header)
 	struct sof_ipc_probe_info_params *params = ipc_get()->comp_data;
 	int ret;
 
-	tr_dbg(&ipc_tr, "ipc_probe_get_data()");
+	tr_dbg(&ipc_tr, "entry");
 
 	switch (cmd) {
 	case SOF_IPC_PROBE_DMA_INFO:
@@ -1121,13 +1121,13 @@ static int ipc_probe_info(uint32_t header)
 		ret = probe_point_info(params, SOF_IPC_MSG_MAX_SIZE);
 		break;
 	default:
-		ipc_cmd_err(&ipc_tr, "ipc_probe_info(): Invalid probe INFO command = %u",
+		ipc_cmd_err(&ipc_tr, "Invalid probe INFO command = %u",
 			    cmd);
 		ret = -EINVAL;
 	}
 
 	if (ret < 0) {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_info(): cmd %u failed", cmd);
+		ipc_cmd_err(&ipc_tr, "cmd %u failed", cmd);
 		return ret;
 	}
 
@@ -1138,7 +1138,7 @@ static int ipc_probe_info(uint32_t header)
 		mailbox_hostbox_write(0, params, params->rhdr.hdr.size);
 		ret = 1;
 	} else {
-		ipc_cmd_err(&ipc_tr, "ipc_probe_get_data(): probes module returned too much payload for cmd %u - returned %d bytes, max %d",
+		ipc_cmd_err(&ipc_tr, "probes module returned too much payload for cmd %u - returned %d bytes, max %d",
 			    cmd, params->rhdr.hdr.size,
 			    MIN(MAILBOX_HOSTBOX_SIZE, SOF_IPC_MSG_MAX_SIZE));
 		ret = -EINVAL;
@@ -1177,7 +1177,7 @@ static int ipc_glb_probe(uint32_t header)
 #else
 static inline int ipc_glb_probe(uint32_t header)
 {
-	ipc_cmd_err(&ipc_tr, "ipc_glb_probe(): Probes not enabled by Kconfig.");
+	ipc_cmd_err(&ipc_tr, "Probes not enabled by Kconfig.");
 
 	return -EINVAL;
 }

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -95,7 +95,7 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 		}
 
 		if (!drv)
-			tr_err(&comp_tr, "get_drv(): driver not found, comp->type = %u",
+			tr_err(&comp_tr, "driver not found, comp->type = %u",
 			       comp->type);
 
 		goto out;
@@ -142,7 +142,7 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 
 	if (!drv)
 		tr_err(&comp_tr,
-		       "get_drv(): the provided UUID (%8x%8x%8x%8x) doesn't match to any driver!",
+		       "the provided UUID (%8x%8x%8x%8x) doesn't match to any driver!",
 		       *(uint32_t *)(&comp_ext->uuid[0]),
 		       *(uint32_t *)(&comp_ext->uuid[4]),
 		       *(uint32_t *)(&comp_ext->uuid[8]),
@@ -363,13 +363,13 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 
 	/* build the component */
 	if (comp_specific_builder(comp, &spec) < 0) {
-		comp_cl_err(drv, "comp_new(): component type not recognized");
+		comp_cl_err(drv, "component type not recognized");
 		return NULL;
 	}
 	comp_common_builder(comp, &config);
 	cdev = drv->ops.create(drv, &config, &spec);
 	if (!cdev) {
-		comp_cl_err(drv, "comp_new(): unable to create the new component");
+		comp_cl_err(drv, "unable to create the new component");
 		return NULL;
 	}
 
@@ -389,7 +389,7 @@ int ipc_pipeline_new(struct ipc *ipc, ipc_pipe_new *_pipe_desc)
 	/* check whether the pipeline already exists */
 	ipc_pipe = ipc_get_pipeline_by_id(ipc, pipe_desc->comp_id);
 	if (ipc_pipe != NULL) {
-		tr_err(&ipc_tr, "ipc_pipeline_new(): pipeline already exists, pipe_desc->comp_id = %u",
+		tr_err(&ipc_tr, "pipeline already exists, pipe_desc->comp_id = %u",
 		       pipe_desc->comp_id);
 		return -EINVAL;
 	}
@@ -398,7 +398,7 @@ int ipc_pipeline_new(struct ipc *ipc, ipc_pipe_new *_pipe_desc)
 	pipe = pipeline_new(pipe_desc->pipeline_id, pipe_desc->priority,
 			    pipe_desc->comp_id);
 	if (!pipe) {
-		tr_err(&ipc_tr, "ipc_pipeline_new(): pipeline_new() failed");
+		tr_err(&ipc_tr, "pipeline_new() failed");
 		return -ENOMEM;
 	}
 
@@ -412,7 +412,7 @@ int ipc_pipeline_new(struct ipc *ipc, ipc_pipe_new *_pipe_desc)
 	/* set xrun time limit */
 	ret = pipeline_xrun_set_limit(pipe, pipe_desc->xrun_limit_usecs);
 	if (ret) {
-		tr_err(&ipc_tr, "ipc_pipeline_new(): pipeline_xrun_set_limit() failed");
+		tr_err(&ipc_tr, "pipeline_xrun_set_limit() failed");
 		pipeline_free(pipe);
 		return ret;
 	}
@@ -448,7 +448,7 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 
 	/* check type */
 	if (ipc_pipe->type != COMP_TYPE_PIPELINE) {
-		tr_err(&ipc_tr, "ipc_pipeline_free(): comp id: %d is not a PIPELINE",
+		tr_err(&ipc_tr, "comp id: %d is not a PIPELINE",
 		       comp_id);
 		return -EINVAL;
 	}
@@ -460,7 +460,7 @@ int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 	/* free buffer and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_pipeline_free(): pipeline_free() failed");
+		tr_err(&ipc_tr, "pipeline_free() failed");
 		return ret;
 	}
 	ipc_pipe->pipeline = NULL;
@@ -479,7 +479,7 @@ int ipc_buffer_new(struct ipc *ipc, const struct sof_ipc_buffer *desc)
 	/* check whether buffer already exists */
 	ibd = ipc_get_buffer_by_id(ipc, desc->comp.id);
 	if (ibd != NULL) {
-		tr_err(&ipc_tr, "ipc_buffer_new(): buffer already exists, desc->comp.id = %u",
+		tr_err(&ipc_tr, "buffer already exists, desc->comp.id = %u",
 		       desc->comp.id);
 		return -EINVAL;
 	}
@@ -487,7 +487,7 @@ int ipc_buffer_new(struct ipc *ipc, const struct sof_ipc_buffer *desc)
 	/* register buffer with pipeline */
 	buffer = buffer_new(desc, false);
 	if (!buffer) {
-		tr_err(&ipc_tr, "ipc_buffer_new(): buffer_new() failed");
+		tr_err(&ipc_tr, "buffer_new() failed");
 		return -ENOMEM;
 	}
 
@@ -574,7 +574,7 @@ int ipc_buffer_free(struct ipc *ipc, uint32_t buffer_id)
 
 		if (active_comp->state > COMP_STATE_READY &&
 		    core != ibd->core && core != cpu_get_id()) {
-			tr_dbg(&ipc_tr, "ipc_buffer_free(): comp id: %d run on sink core %u",
+			tr_dbg(&ipc_tr, "comp id: %d run on sink core %u",
 			       buffer_id, core);
 			ibd->core = core;
 			return ipc_process_on_core(core, false);
@@ -639,14 +639,14 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	/* check whether the components already exist */
 	icd_source = ipc_get_comp_dev(ipc, COMP_TYPE_ANY, connect->source_id);
 	if (!icd_source) {
-		tr_err(&ipc_tr, "ipc_comp_connect(): source component does not exist, source_id = %u sink_id = %u",
+		tr_err(&ipc_tr, "source component does not exist, source_id = %u sink_id = %u",
 		       connect->source_id, connect->sink_id);
 		return -EINVAL;
 	}
 
 	icd_sink = ipc_get_comp_dev(ipc, COMP_TYPE_ANY, connect->sink_id);
 	if (!icd_sink) {
-		tr_err(&ipc_tr, "ipc_comp_connect(): sink component does not exist, source_id = %d sink_id = %u",
+		tr_err(&ipc_tr, "sink component does not exist, source_id = %d sink_id = %u",
 		       connect->sink_id, connect->source_id);
 		return -EINVAL;
 	}
@@ -659,7 +659,7 @@ int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 		 icd_sink->type == COMP_TYPE_BUFFER)
 		return ipc_comp_to_buffer_connect(icd_source, icd_sink);
 	else {
-		tr_err(&ipc_tr, "ipc_comp_connect(): invalid source and sink types, connect->source_id = %u, connect->sink_id = %u",
+		tr_err(&ipc_tr, "invalid source and sink types, connect->source_id = %u, connect->sink_id = %u",
 		       connect->source_id, connect->sink_id);
 		return -EINVAL;
 	}
@@ -673,21 +673,21 @@ int ipc_comp_new(struct ipc *ipc, ipc_comp *_comp)
 
 	/* check core is valid */
 	if (comp->core >= CONFIG_CORE_COUNT) {
-		tr_err(&ipc_tr, "ipc_comp_new(): comp->core = %u", comp->core);
+		tr_err(&ipc_tr, "comp->core = %u", comp->core);
 		return -EINVAL;
 	}
 
 	/* check whether component already exists */
 	icd = ipc_get_comp_by_id(ipc, comp->id);
 	if (icd != NULL) {
-		tr_err(&ipc_tr, "ipc_comp_new(): comp->id = %u", comp->id);
+		tr_err(&ipc_tr, "comp->id = %u", comp->id);
 		return -EINVAL;
 	}
 
 	/* create component */
 	cd = comp_new(comp);
 	if (!cd) {
-		tr_err(&ipc_tr, "ipc_comp_new(): component cd = NULL");
+		tr_err(&ipc_tr, "component cd = NULL");
 		return -EINVAL;
 	}
 
@@ -695,7 +695,7 @@ int ipc_comp_new(struct ipc *ipc, ipc_comp *_comp)
 	icd = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 		      sizeof(struct ipc_comp_dev));
 	if (!icd) {
-		tr_err(&ipc_tr, "ipc_comp_new(): alloc failed");
+		tr_err(&ipc_tr, "alloc failed");
 		rfree(cd);
 		return -ENOMEM;
 	}

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -38,14 +38,14 @@ static int ipc_parse_page_descriptors(uint8_t *page_table,
 	if ((ring->size <= HOST_PAGE_SIZE * (ring->pages - 1)) ||
 	    (ring->size > HOST_PAGE_SIZE * ring->pages)) {
 		/* error buffer size */
-		tr_err(&ipc_tr, "ipc_parse_page_descriptors(): error buffer size");
+		tr_err(&ipc_tr, "error buffer size");
 		return -EINVAL;
 	}
 
 	elem_array->elems = rzalloc(SOF_MEM_FLAG_USER,
 				    sizeof(struct dma_sg_elem) * ring->pages);
 	if (!elem_array->elems) {
-		tr_err(&ipc_tr, "ipc_parse_page_descriptors(): There is no heap free with this block size: %zu",
+		tr_err(&ipc_tr, "There is no heap free with this block size: %zu",
 		       sizeof(struct dma_sg_elem) * ring->pages);
 		return -ENOMEM;
 	}
@@ -157,7 +157,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	/* get DMA channel from DMAC */
 	chan = dma_channel_get_legacy(dmac, 0);
 	if (!chan) {
-		tr_err(&ipc_tr, "ipc_get_page_descriptors(): chan is NULL");
+		tr_err(&ipc_tr, "chan is NULL");
 		return -ENODEV;
 	}
 
@@ -178,7 +178,7 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 	/* 20 bits for each page, round up to minimum DMA copy size */
 	ret = dma_get_attribute_legacy(dmac, DMA_ATTR_COPY_ALIGNMENT, &dma_copy_align);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_get_page_descriptors(): dma_get_attribute() failed");
+		tr_err(&ipc_tr, "dma_get_attribute() failed");
 		goto out;
 	}
 	elem.size = SOF_DIV_ROUND_UP(ring->pages * 20, 8);
@@ -188,14 +188,14 @@ static int ipc_get_page_descriptors(struct dma *dmac, uint8_t *page_table,
 
 	ret = dma_set_config_legacy(chan, &config);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_get_page_descriptors(): dma_set_config() failed");
+		tr_err(&ipc_tr, "dma_set_config() failed");
 		goto out;
 	}
 
 	/* start the copy of page table to DSP */
 	ret = dma_copy_legacy(chan, elem.size, DMA_COPY_ONE_SHOT | DMA_COPY_BLOCKING);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_get_page_descriptors(): dma_start() failed");
+		tr_err(&ipc_tr, "dma_start() failed");
 		goto out;
 	}
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -118,7 +118,7 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		comp_err(dev, "dai_config_dma_channel(): Unknown dai type %d", dai->type);
+		comp_err(dev, "Unknown dai type %d", dai->type);
 		channel = SOF_DMA_CHAN_INVALID;
 		break;
 	}
@@ -135,7 +135,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 #endif
 
 	if (!dai) {
-		comp_err(dev, "dai_data_config(): no dai!\n");
+		comp_err(dev, "no dai!\n");
 		return -EINVAL;
 	}
 
@@ -144,7 +144,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_data_config(): Component is in active state.");
+		comp_info(dev, "Component is in active state.");
 		return 0;
 	}
 
@@ -180,7 +180,7 @@ int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev)
 		break;
 	default:
 		/* other types of DAIs not handled for now */
-		comp_warn(dev, "dai_data_config(): Unknown dai type %d", dai->type);
+		comp_warn(dev, "Unknown dai type %d", dai->type);
 		return -EINVAL;
 	}
 
@@ -201,7 +201,7 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 {
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config(): Component is in active state. Ignore resetting");
+		comp_info(dev, "Component is in active state. Ignore resetting");
 		return;
 	}
 
@@ -351,12 +351,12 @@ __cold int dai_config(struct dai_data *dd, struct comp_dev *dev,
 
 	/* cannot configure DAI while active */
 	if (dev->state == COMP_STATE_ACTIVE) {
-		comp_info(dev, "dai_config(): Component is in active state. Ignore config");
+		comp_info(dev, "Component is in active state. Ignore config");
 		return 0;
 	}
 
 	if (dd->chan) {
-		comp_info(dev, "dai_config(): Configured. dma channel index %d, ignore...",
+		comp_info(dev, "Configured. dma channel index %d, ignore...",
 			  dd->chan->index);
 		return 0;
 	}
@@ -380,7 +380,7 @@ __cold int dai_config(struct dai_data *dd, struct comp_dev *dev,
 		size = sizeof(*copier_cfg);
 		dd->dai_spec_config = rzalloc(SOF_MEM_FLAG_USER, size);
 		if (!dd->dai_spec_config) {
-			comp_err(dev, "dai_config(): No memory for dai_config size %d", size);
+			comp_err(dev, "No memory for dai_config size %d", size);
 			return -ENOMEM;
 		}
 

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -371,14 +371,14 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 
 	ret = ipc_pipeline_module_free(ipc_pipe->pipeline->pipeline_id);
 	if (ret != IPC4_SUCCESS) {
-		tr_err(&ipc_tr, "ipc_pipeline_free(): module free () failed");
+		tr_err(&ipc_tr, "module free () failed");
 		return ret;
 	}
 
 	/* free buffer, delete all tasks and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "ipc_pipeline_free(): pipeline_free() failed");
+		tr_err(&ipc_tr, "pipeline_free() failed");
 		return IPC4_INVALID_RESOURCE_STATE;
 	}
 
@@ -986,7 +986,7 @@ __cold static const struct comp_driver *ipc4_get_drv(const void *uuid)
 	}
 
 	tr_warn(&comp_tr,
-		"get_drv(): the provided UUID (%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x) can't be found!",
+		"the provided UUID (%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x) can't be found!",
 		sof_uuid->a, sof_uuid->b, sof_uuid->c, sof_uuid->d[0], sof_uuid->d[1],
 		sof_uuid->d[2], sof_uuid->d[3], sof_uuid->d[4], sof_uuid->d[5], sof_uuid->d[6],
 		sof_uuid->d[7]);
@@ -1095,7 +1095,7 @@ __cold static int ipc4_add_comp_dev(struct comp_dev *dev)
 	icd = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 		      sizeof(struct ipc_comp_dev));
 	if (!icd) {
-		tr_err(&ipc_tr, "ipc_comp_new(): alloc failed");
+		tr_err(&ipc_tr, "alloc failed");
 		rfree(icd);
 		return IPC4_OUT_OF_MEMORY;
 	}

--- a/src/math/power.c
+++ b/src/math/power.c
@@ -56,7 +56,7 @@ int32_t power_int32(int32_t b, int32_t e)
 			multiplier = (int32_t)((1LL << 50) / (int64_t)b);
 		} else {
 			multiplier = INT32_MAX;
-			tr_err(&math_power_tr, "power_int32(): Divide by zero error.");
+			tr_err(&math_power_tr, "Divide by zero error.");
 		}
 	} else {
 		multiplier = b;

--- a/src/schedule/dma_multi_chan_domain.c
+++ b/src/schedule/dma_multi_chan_domain.c
@@ -86,7 +86,7 @@ static int dma_multi_chan_domain_irq_register(struct dma_domain_data *data,
 {
 	int ret;
 
-	tr_info(&ll_tr, "dma_multi_chan_domain_irq_register()");
+	tr_info(&ll_tr, "entry");
 
 	/* always go through dma_multi_chan_domain_irq_handler,
 	 * so we have different arg registered for every channel
@@ -125,7 +125,7 @@ static int dma_multi_chan_domain_register(struct ll_schedule_domain *domain,
 	int i;
 	int j;
 
-	tr_info(&ll_tr, "dma_multi_chan_domain_register()");
+	tr_info(&ll_tr, "entry");
 
 	/* check if task should be registered */
 	if (!pipe_task->registrable)
@@ -192,7 +192,7 @@ out:
  */
 static void dma_multi_chan_domain_irq_unregister(struct dma_domain_data *data)
 {
-	tr_info(&ll_tr, "dma_multi_chan_domain_irq_unregister()");
+	tr_info(&ll_tr, "entry");
 
 	interrupt_disable(data->irq, data);
 
@@ -217,7 +217,7 @@ static int dma_multi_chan_domain_unregister(struct ll_schedule_domain *domain,
 	int i;
 	int j;
 
-	tr_info(&ll_tr, "dma_multi_chan_domain_unregister()");
+	tr_info(&ll_tr, "entry");
 
 	/* check if task should be unregistered */
 	if (!task || !pipe_task->registrable)
@@ -365,19 +365,19 @@ struct ll_schedule_domain *dma_multi_chan_domain_init(struct dma *dma_array,
 	int i;
 	int j;
 
-	tr_info(&ll_tr, "dma_multi_chan_domain_init(): num_dma %d, clk %d, aggregated_irq %d",
+	tr_info(&ll_tr, "num_dma %d, clk %d, aggregated_irq %d",
 		num_dma, clk, aggregated_irq);
 
 	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk, true,
 			     &dma_multi_chan_domain_ops);
 	if (!domain) {
-		tr_err(&ll_tr, "dma_multi_chan_domain_init(): domain init failed");
+		tr_err(&ll_tr, "domain init failed");
 		return NULL;
 	}
 
 	dma_domain = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT, sizeof(*dma_domain));
 	if (!dma_domain) {
-		tr_err(&ll_tr, "dma_multi_chan_domain_init(): allocation failed");
+		tr_err(&ll_tr, "allocation failed");
 		rfree(domain);
 		return NULL;
 	}

--- a/src/schedule/dma_single_chan_domain.c
+++ b/src/schedule/dma_single_chan_domain.c
@@ -101,7 +101,7 @@ static struct dma_chan_data *dma_chan_min_period(struct dma_domain *dma_domain)
  */
 static void dma_domain_notify_change(struct dma_chan_data *channel)
 {
-	tr_info(&ll_tr, "dma_domain_notify_change()");
+	tr_info(&ll_tr, "entry");
 
 	notifier_event(channel, NOTIFIER_ID_DMA_DOMAIN_CHANGE,
 		       NOTIFIER_TARGET_CORE_ALL_MASK & ~BIT(cpu_get_id()),
@@ -124,7 +124,7 @@ static int dma_single_chan_domain_irq_register(struct dma_chan_data *channel,
 	int irq = dma_chan_irq(channel->dma, channel->index);
 	int ret;
 
-	tr_info(&ll_tr, "dma_single_chan_domain_irq_register()");
+	tr_info(&ll_tr, "entry");
 
 	data->irq = interrupt_get_irq(irq, dma_irq_name(channel->dma));
 	if (data->irq < 0) {
@@ -154,7 +154,7 @@ out:
  */
 static void dma_single_chan_domain_irq_unregister(struct dma_domain_data *data)
 {
-	tr_info(&ll_tr, "dma_single_chan_domain_irq_unregister()");
+	tr_info(&ll_tr, "entry");
 
 	interrupt_disable(data->irq, data->arg);
 	interrupt_unregister(data->irq, data->arg);
@@ -188,7 +188,7 @@ static int dma_single_chan_domain_register(struct ll_schedule_domain *domain,
 	bool register_needed = true;
 	int ret = 0;
 
-	tr_info(&ll_tr, "dma_single_chan_domain_register()");
+	tr_info(&ll_tr, "entry");
 
 	/* check if task should be registered */
 	if (!pipe_task->registrable)
@@ -206,7 +206,7 @@ static int dma_single_chan_domain_register(struct ll_schedule_domain *domain,
 		if (data->channel->period == channel->period)
 			goto out;
 
-		tr_info(&ll_tr, "dma_single_chan_domain_register(): lower period detected, registering again");
+		tr_info(&ll_tr, "lower period detected, registering again");
 
 		/* unregister from current channel */
 		dma_single_chan_domain_irq_unregister(data);
@@ -221,11 +221,11 @@ static int dma_single_chan_domain_register(struct ll_schedule_domain *domain,
 
 	if (channel->period <= UINT_MAX)
 		tr_info(&ll_tr,
-			"dma_single_chan_domain_register(): registering on channel with period %u",
+			"registering on channel with period %u",
 			(unsigned int)channel->period);
 	else
 		tr_info(&ll_tr,
-			"dma_single_chan_domain_register(): registering on channel with period > %u",
+			"registering on channel with period > %u",
 			UINT_MAX);
 
 	/* register for interrupt */
@@ -308,7 +308,7 @@ static void dma_domain_unregister_owner(struct ll_schedule_domain *domain,
 	struct dma *dmas = dma_domain->dma_array;
 	struct dma_chan_data *channel;
 
-	tr_info(&ll_tr, "dma_domain_unregister_owner()");
+	tr_info(&ll_tr, "entry");
 
 	/* transfers still scheduled on this channel */
 	if (data->channel->status == COMP_STATE_ACTIVE)
@@ -317,7 +317,7 @@ static void dma_domain_unregister_owner(struct ll_schedule_domain *domain,
 	channel = dma_chan_min_period(dma_domain);
 	if (channel && dma_chan_is_any_running(dmas, dma_domain->num_dma)) {
 		/* another channel is running */
-		tr_info(&ll_tr, "dma_domain_unregister_owner(): domain in use, change owner");
+		tr_info(&ll_tr, "domain in use, change owner");
 
 		/* change owner */
 		dma_domain->owner = channel->core;
@@ -369,7 +369,7 @@ static int dma_single_chan_domain_unregister(struct ll_schedule_domain *domain,
 	int core = cpu_get_id();
 	struct dma_domain_data *data = &dma_domain->data[core];
 
-	tr_info(&ll_tr, "dma_single_chan_domain_unregister()");
+	tr_info(&ll_tr, "entry");
 
 	/* check if task should be unregistered */
 	if (!task || !pipe_task->registrable)
@@ -505,7 +505,7 @@ static void dma_domain_changed(void *arg, enum notify_id type, void *data)
 	int core = cpu_get_id();
 	struct dma_domain_data *domain_data = &dma_domain->data[core];
 
-	tr_info(&ll_tr, "dma_domain_changed()");
+	tr_info(&ll_tr, "entry");
 
 	/* unregister from current DMA channel */
 	dma_single_chan_domain_irq_unregister(domain_data);
@@ -538,19 +538,19 @@ struct ll_schedule_domain *dma_single_chan_domain_init(struct dma *dma_array,
 	struct ll_schedule_domain *domain;
 	struct dma_domain *dma_domain;
 
-	tr_info(&ll_tr, "dma_single_chan_domain_init(): num_dma %d, clk %d",
+	tr_info(&ll_tr, "num_dma %d, clk %d",
 		num_dma, clk);
 
 	domain = domain_init(SOF_SCHEDULE_LL_DMA, clk, false,
 			     &dma_single_chan_domain_ops);
 	if (!domain) {
-		tr_err(&ll_tr, "dma_single_chan_domain_init(): domain init failed");
+		tr_err(&ll_tr, "domain init failed");
 		return NULL;
 	}
 
 	dma_domain = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT, sizeof(*dma_domain));
 	if (!dma_domain) {
-		tr_err(&ll_tr, "dma_single_chan_domain_init(): allocation failed");
+		tr_err(&ll_tr, "allocation failed");
 		rfree(domain);
 		return NULL;
 	}

--- a/src/schedule/ll_schedule.c
+++ b/src/schedule/ll_schedule.c
@@ -365,7 +365,7 @@ static int schedule_ll_domain_set(struct ll_schedule_data *sch,
 
 	ret = domain_register(domain, task, &schedule_ll_tasks_run, sch);
 	if (ret < 0) {
-		tr_err(&ll_tr, "schedule_ll_domain_set: cannot register domain %d",
+		tr_err(&ll_tr, "cannot register domain %d",
 		       ret);
 		goto done;
 	}
@@ -548,7 +548,7 @@ static int schedule_ll_task_common(struct ll_schedule_data *sch, struct task *ta
 				 */
 				if (pdata->period < reg_pdata->period) {
 					tr_err(&ll_tr,
-					       "schedule_ll_task(): registrable task has a period longer than current task");
+					       "registrable task has a period longer than current task");
 					ret = -EINVAL;
 					goto out;
 				}
@@ -625,7 +625,7 @@ int schedule_task_init_ll(struct task *task,
 			   sizeof(*ll_pdata));
 
 	if (!ll_pdata) {
-		tr_err(&ll_tr, "schedule_task_init_ll(): alloc failed");
+		tr_err(&ll_tr, "alloc failed");
 		return -ENOMEM;
 	}
 
@@ -714,7 +714,7 @@ static int reschedule_ll_task(void *data, struct task *task, uint64_t start)
 		}
 	}
 
-	tr_err(&ll_tr, "reschedule_ll_task(): task not found");
+	tr_err(&ll_tr, "task not found");
 
 out:
 
@@ -783,7 +783,7 @@ int scheduler_init_ll(struct ll_schedule_domain *domain)
 	/* initialize scheduler private data */
 	sch = rzalloc(SOF_MEM_FLAG_KERNEL, sizeof(*sch));
 	if (!sch) {
-		tr_err(&ll_tr, "scheduler_init_ll(): allocation failed");
+		tr_err(&ll_tr, "allocation failed");
 		return -ENOMEM;
 	}
 	list_init(&sch->tasks);

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -28,7 +28,7 @@ int schedule_task_init(struct task *task,
 		       void *data, uint16_t core, uint32_t flags)
 {
 	if (type >= SOF_SCHEDULE_COUNT) {
-		tr_err(&sch_tr, "schedule_task_init(): invalid task type");
+		tr_err(&sch_tr, "invalid task type");
 		return -EINVAL;
 	}
 
@@ -53,7 +53,7 @@ static void scheduler_register(struct schedule_data *scheduler)
 		*sch = rzalloc(SOF_MEM_FLAG_KERNEL,
 			       sizeof(**sch));
 		if (!*sch) {
-			tr_err(&sch_tr, "scheduler_register(): allocation failed");
+			tr_err(&sch_tr, "allocation failed");
 			return;
 		}
 		list_init(&(*sch)->list);
@@ -72,7 +72,7 @@ void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 
 	sch = rzalloc(SOF_MEM_FLAG_KERNEL, sizeof(*sch));
 	if (!sch) {
-		tr_err(&sch_tr, "scheduler_init(): allocation failed");
+		tr_err(&sch_tr, "allocation failed");
 		sof_panic(SOF_IPC_PANIC_IPC);
 	}
 	list_init(&sch->list);

--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -120,7 +120,7 @@ struct ll_schedule_domain *zephyr_dma_domain_init(struct dma *dma_array,
 			     true,
 			     &zephyr_dma_domain_ops);
 	if (!domain) {
-		tr_err(&ll_tr, "zephyr_dma_domain_init(): domain init failed");
+		tr_err(&ll_tr, "domain init failed");
 		return NULL;
 	}
 
@@ -128,7 +128,7 @@ struct ll_schedule_domain *zephyr_dma_domain_init(struct dma *dma_array,
 	zephyr_dma_domain = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 				    sizeof(*zephyr_dma_domain));
 	if (!zephyr_dma_domain) {
-		tr_err(&ll_tr, "zephyr_dma_domain_init(): allocation failed");
+		tr_err(&ll_tr, "allocation failed");
 		rfree(domain);
 		return NULL;
 	}
@@ -388,7 +388,7 @@ static int zephyr_dma_domain_register(struct ll_schedule_domain *domain,
 	dt = zephyr_dma_domain->domain_thread + core;
 	pipe_task = pipeline_task_get(task);
 
-	tr_info(&ll_tr, "zephyr_dma_domain_register()");
+	tr_info(&ll_tr, "entry");
 
 	/* don't even bother trying to register DMA IRQ for
 	 * non-registrable tasks.
@@ -561,7 +561,7 @@ static int zephyr_dma_domain_unregister(struct ll_schedule_domain *domain,
 	core = cpu_get_id();
 	dt = zephyr_dma_domain->domain_thread + core;
 
-	tr_info(&ll_tr, "zephyr_dma_domain_unregister()");
+	tr_info(&ll_tr, "entry");
 
 	/* unregister the DMA IRQ only for PPL tasks marked as "registrable"
 	 *

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -178,7 +178,7 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 	k_tid_t thread;
 	k_spinlock_key_t key;
 
-	tr_dbg(&ll_tr, "zephyr_domain_register()");
+	tr_dbg(&ll_tr, "entry");
 
 	/* domain work only needs registered once on each core */
 	if (dt->handler)
@@ -233,7 +233,7 @@ static int zephyr_domain_unregister(struct ll_schedule_domain *domain,
 	int core = cpu_get_id();
 	k_spinlock_key_t key;
 
-	tr_dbg(&ll_tr, "zephyr_domain_unregister()");
+	tr_dbg(&ll_tr, "entry");
 
 	/* tasks still registered on this core */
 	if (num_tasks)
@@ -307,14 +307,14 @@ struct ll_schedule_domain *zephyr_domain_init(int clk)
 	domain = domain_init(SOF_SCHEDULE_LL_TIMER, clk, false,
 			     &zephyr_domain_ops);
 	if (!domain) {
-		tr_err(&ll_tr, "zephyr_domain_init: domain init failed");
+		tr_err(&ll_tr, "domain init failed");
 		return NULL;
 	}
 
 	zephyr_domain = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT,
 				sizeof(*zephyr_domain));
 	if (!zephyr_domain) {
-		tr_err(&ll_tr, "zephyr_domain_init: domain allocation failed");
+		tr_err(&ll_tr, "domain allocation failed");
 		rfree(domain);
 		return NULL;
 	}

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -399,7 +399,7 @@ static int scheduler_dp_task_shedule(void *data, struct task *task, uint64_t sta
 	/* pin the thread to specific core */
 	ret = k_thread_cpu_pin(pdata->thread_id, task->core);
 	if (ret < 0) {
-		tr_err(&dp_tr, "zephyr_dp_task_init(): zephyr task pin to core failed");
+		tr_err(&dp_tr, "zephyr task pin to core failed");
 		goto err;
 	}
 
@@ -499,7 +499,7 @@ int scheduler_dp_task_init(struct task **task,
 	task_memory = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT,
 			      sizeof(*task_memory));
 	if (!task_memory) {
-		tr_err(&dp_tr, "zephyr_dp_task_init(): memory alloc failed");
+		tr_err(&dp_tr, "memory alloc failed");
 		return -ENOMEM;
 	}
 
@@ -508,7 +508,7 @@ int scheduler_dp_task_init(struct task **task,
 	p_stack = (__sparse_force void __sparse_cache *)
 		rballoc_align(SOF_MEM_FLAG_KERNEL, stack_size, Z_KERNEL_STACK_OBJ_ALIGN);
 	if (!p_stack) {
-		tr_err(&dp_tr, "zephyr_dp_task_init(): stack alloc failed");
+		tr_err(&dp_tr, "stack alloc failed");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -517,7 +517,7 @@ int scheduler_dp_task_init(struct task **task,
 	ret = schedule_task_init(&task_memory->task, uid, SOF_SCHEDULE_DP, 0, ops->run,
 				 mod, core, 0);
 	if (ret < 0) {
-		tr_err(&dp_tr, "zephyr_dp_task_init(): schedule_task_init failed");
+		tr_err(&dp_tr, "schedule_task_init failed");
 		goto err;
 	}
 

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -342,7 +342,7 @@ static int zephyr_ll_task_schedule_common(struct zephyr_ll *sch, struct task *ta
 
 	ret = domain_register(sch->ll_domain, task, &schedule_ll_callback, sch);
 	if (ret < 0)
-		tr_err(&ll_tr, "zephyr_ll_task_schedule: cannot register domain %d",
+		tr_err(&ll_tr, "cannot register domain %d",
 		       ret);
 
 	return 0;
@@ -386,8 +386,7 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 	zephyr_ll_assert_core(sch);
 
 	if (k_is_in_isr()) {
-		tr_err(&ll_tr,
-		       "zephyr_ll_task_free: cannot free tasks from interrupt context!");
+		tr_err(&ll_tr, "cannot free tasks from interrupt context!");
 		return -EDEADLK;
 	}
 
@@ -481,7 +480,7 @@ static void zephyr_ll_scheduler_free(void *data, uint32_t flags)
 	zephyr_ll_assert_core(sch);
 
 	if (sch->n_tasks)
-		tr_err(&ll_tr, "zephyr_ll_scheduler_free: %u tasks are still active!",
+		tr_err(&ll_tr, "%u tasks are still active!",
 		       sch->n_tasks);
 }
 
@@ -513,7 +512,7 @@ int zephyr_ll_task_init(struct task *task,
 	pdata = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT,
 			sizeof(*pdata));
 	if (!pdata) {
-		tr_err(&ll_tr, "zephyr_ll_task_init(): alloc failed");
+		tr_err(&ll_tr, "alloc failed");
 		return -ENOMEM;
 	}
 
@@ -534,7 +533,7 @@ int zephyr_ll_scheduler_init(struct ll_schedule_domain *domain)
 	/* initialize per-core scheduler private data */
 	sch = rzalloc(SOF_MEM_FLAG_KERNEL, sizeof(*sch));
 	if (!sch) {
-		tr_err(&ll_tr, "zephyr_ll_scheduler_init(): allocation failed");
+		tr_err(&ll_tr, "allocation failed");
 		return -ENOMEM;
 	}
 	list_init(&sch->tasks);

--- a/src/schedule/zephyr_twb_schedule.c
+++ b/src/schedule/zephyr_twb_schedule.c
@@ -395,7 +395,7 @@ int scheduler_twb_task_init(struct task **task,
 
 	twb_sch = scheduler_get_data(SOF_SCHEDULE_TWB);
 	if (!twb_sch) {
-		tr_err(&twb_tr, "scheduler_twb_task_init(): TWB not initialized");
+		tr_err(&twb_tr, "TWB not initialized");
 		return -EINVAL;
 	}
 
@@ -403,7 +403,7 @@ int scheduler_twb_task_init(struct task **task,
 	assert(cpu_get_id() == core);
 
 	if (thread_priority < 0) {
-		tr_err(&twb_tr, "scheduler_twb_task_init(): non preemptible priority");
+		tr_err(&twb_tr, "non preemptible priority");
 		return -EINVAL;
 	}
 
@@ -417,7 +417,7 @@ int scheduler_twb_task_init(struct task **task,
 	task_memory = rzalloc(SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT,
 			      sizeof(*task_memory));
 	if (!task_memory) {
-		tr_err(&twb_tr, "scheduler_twb_task_init(): memory alloc failed");
+		tr_err(&twb_tr, "memory alloc failed");
 		return -ENOMEM;
 	}
 
@@ -426,7 +426,7 @@ int scheduler_twb_task_init(struct task **task,
 	p_stack = (__sparse_force void __sparse_cache *)
 		rballoc_align(SOF_MEM_FLAG_KERNEL, stack_size, Z_KERNEL_STACK_OBJ_ALIGN);
 	if (!p_stack) {
-		tr_err(&twb_tr, "scheduler_twb_task_init(): stack alloc failed");
+		tr_err(&twb_tr, "stack alloc failed");
 		ret = -ENOMEM;
 		goto err;
 	}
@@ -437,7 +437,7 @@ int scheduler_twb_task_init(struct task **task,
 				    thread_priority, K_USER, K_FOREVER);
 	if (!thread_id)	{
 		ret = -EFAULT;
-		tr_err(&twb_tr, "scheduler_twb_task_init(): zephyr thread create failed");
+		tr_err(&twb_tr, "zephyr thread create failed");
 		goto err;
 	}
 
@@ -445,7 +445,7 @@ int scheduler_twb_task_init(struct task **task,
 	ret = k_thread_cpu_pin(thread_id, core);
 	if (ret < 0) {
 		ret = -EFAULT;
-		tr_err(&twb_tr, "scheduler_twb_task_init(): zephyr task pin to core %d failed", core);
+		tr_err(&twb_tr, "zephyr task pin to core %d failed", core);
 		goto err;
 	}
 
@@ -453,14 +453,14 @@ int scheduler_twb_task_init(struct task **task,
 	if (name) {
 		ret = k_thread_name_set(thread_id, name);
 		if (ret < 0)
-			tr_warn(&twb_tr, "scheduler_twb_task_init(): failed to set thread name");
+			tr_warn(&twb_tr, "failed to set thread name");
 	}
 
 	/* internal SOF task init */
 	ret = schedule_task_init(&task_memory->task, uid, SOF_SCHEDULE_TWB, thread_priority,
 				 ops->run, data, core, 0);
 	if (ret < 0) {
-		tr_err(&twb_tr, "scheduler_twb_task_init(): schedule_task_init failed");
+		tr_err(&twb_tr, "schedule_task_init failed");
 		goto err;
 	}
 


### PR DESCRIPTION
Zephyr adds function names to log entries automatically, remove excessive verbatim names globally