### PR TITLE
Tools: Topology: SRC: Increase 48 kHz capture source buffer size

### DIFF
--- a/tools/topology/topology2/include/components/src_format_s32_convert_from_48k.conf
+++ b/tools/topology/topology2/include/components/src_format_s32_convert_from_48k.conf
@@ -39,5 +39,6 @@
 					in_rate                 48000
 					in_bit_depth            32
 					in_valid_bit_depth      32
+					ibs			512
 				}
 			]


### PR DESCRIPTION
This patch fixes the issue in nocodec topologies with 48 kHz to 11.025 kHz capture.