### PR TITLE
audio: chain_dma: fix link DMA reload logic for initial reload

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -243,7 +243,7 @@ static enum task_state chain_task_run(void *data)
 		if (!cd->first_data_received && host_avail_bytes > half_buff_size) {
 			ret = dma_reload(cd->chan_link->dma->z_dev,
 					 cd->chan_link->index, 0, 0,
-					 half_buff_size);
+					 MIN(host_avail_bytes, link_free_bytes));
 			if (ret < 0) {
 				tr_err(&chain_dma_tr,
 				       "dma_reload() link error, ret = %d", ret);


### PR DESCRIPTION
Current code waits until host DMA has more than half of the DMA buffer size worth of data available for transfer. The code however does not check whether link DMA has space for all available data yet and can cause the link DMA write pointer to wrap the read pointer. This will break the delay reporting and can lead to link xruns if the wrapped write pointer ends up too close to the link DMA read position (which is moved by DMA hardware in playback case).

Tested-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>