### PR TITLE
Audio: Template component: Add missing llext sources

### DIFF
--- a/src/audio/template_comp/llext/CMakeLists.txt
+++ b/src/audio/template_comp/llext/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 sof_llext_build("template_comp"
-	SOURCES ../template_comp.c
+	SOURCES	../template.c
+		../template-generic.c
+		../template-ipc4.c
 	LIB openmodules
 )


### PR DESCRIPTION
The build of template component as module fails because of wrong and missing file names for needed source files for build.