### PR TITLE
Audio: KPB, Mixin-Mixout: Fix missing HiFi3 header include

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -55,6 +55,10 @@
 #include <sof/lib/notifier.h>
 #endif
 
+#ifdef KPB_HIFI3
+#include <xtensa/tie/xt_hifi3.h>
+#endif
+
 static const struct comp_driver comp_kpb;
 
 LOG_MODULE_REGISTER(kpb, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/mixin_mixout/mixin_mixout_hifi3.c
+++ b/src/audio/mixin_mixout/mixin_mixout_hifi3.c
@@ -10,6 +10,8 @@
 
 #if SOF_USE_HIFI(3, MIXIN_MIXOUT) || SOF_USE_HIFI(4, MIXIN_MIXOUT)
 
+#include <xtensa/tie/xt_hifi3.h>
+
 #if CONFIG_FORMAT_S16LE
 static void mix_s16(struct cir_buf_ptr *sink, int32_t start_sample, int32_t mixed_samples,
 		    const struct cir_buf_ptr *source,


### PR DESCRIPTION
If build format.h as generic without intrinsics, these modules fail to build due to no header included for HiFi3.