### PR TITLE
Audio: Template Comp: Fix build for CONFIG_FORMAT_S24LE only

### DIFF
--- a/src/audio/template_comp/template-generic.c
+++ b/src/audio/template_comp/template-generic.c
@@ -96,7 +96,7 @@ static int template_comp_s16(const struct processing_module *mod,
 }
 #endif /* CONFIG_FORMAT_S16LE */
 
-#if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S32LE
+#if CONFIG_FORMAT_S32LE || CONFIG_FORMAT_S24LE
 /**
  * template_comp_s32() - Process S32_LE or S24_4LE format.
  * @mod: Pointer to module data.


### PR DESCRIPTION
The build of template-generic.c would fail if only S24_LE format would be enabled without S32_LE.