### PR TITLE
Audio: Volume: Fix a possible overflow in S24_LE format volume

### DIFF
--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -122,8 +122,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #endif
 
-			/* Shift and round for S24_LE */
-			out_sample = AE_SRAI32R(out_sample, 8);
+			/* Shift to S24_LE */
+			out_sample = AE_SRAI32(out_sample, 8);
 
 			/* Store the output sample */
 			AE_SA32X2_IP(out_sample, outu, out);

--- a/src/audio/volume/volume_hifi3_with_peakvol.c
+++ b/src/audio/volume/volume_hifi3_with_peakvol.c
@@ -91,8 +91,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 				out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #endif
 
-				/* Shift and round for S24_LE */
-				out_sample = AE_SRAI32R(out_sample, 8);
+				/* Shift to S24_LE */
+				out_sample = AE_SRAI32(out_sample, 8);
 				/* Store the output sample */
 				AE_S32_L_XP(out_sample, out, inc);
 			}

--- a/src/audio/volume/volume_hifi4.c
+++ b/src/audio/volume/volume_hifi4.c
@@ -122,8 +122,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #endif
 
-			/* Shift and round for S24_LE */
-			out_sample = AE_SRAI32R(out_sample, 8);
+			/* Shift to S24_LE */
+			out_sample = AE_SRAI32(out_sample, 8);
 
 			/* Store the output sample */
 			AE_SA32X2_IP(out_sample, outu, out);

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -120,8 +120,8 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct input_strea
 			out_sample = AE_MULFP32X2RS(volume, AE_SLAI32(in_sample, 8));
 #endif
 
-			/* Shift and round for S24_LE */
-			out_sample = AE_SRAI32R(out_sample, 8);
+			/* Shift to S24_LE */
+			out_sample = AE_SRAI32(out_sample, 8);
 
 			/* Store the output sample */
 			AE_SA32X2_IP(out_sample, outu, out);


### PR DESCRIPTION
The AE_SRAI32R() right shift with round could cause the value to go over S24_LE range by one if the gain would be over one or 0 dB (only possible in IPC3). The rounding shift is unnecessary because the gain product is already rounded in the multiply instruction. The SRAI32() instruction does just the shift.

Fixes: f3e34039db4b ("Audio: Volume: Add IPC4 native Q1.31 mode
       and optimize")