### PR TITLE
module_adapter: Fix memory leak

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1284,6 +1284,7 @@ void module_adapter_free(struct comp_dev *dev)
 	rfree(mod->priv.cfg.input_pins);
 #endif
 
+	rfree(mod->stream_params);
 	rfree(mod);
 	rfree(dev);
 }


### PR DESCRIPTION
The freeing of mod->stream_params was missing. This led to -ENOMEM error during stress test that creates pipeline -> creates copier -> deletes pipeline in cycles numerous times.