### PR TITLE
lib-manager: llext: remove entry point functions

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -320,10 +320,8 @@ static const struct module_interface aria_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(aria, &aria_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("ARIA", aria_llext_entry, 1, SOF_REG_UUID(aria), 8);
+	SOF_LLEXT_MODULE_MANIFEST("ARIA", &aria_interface, 1, SOF_REG_UUID(aria), 8);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -892,10 +892,8 @@ static const struct module_interface asrc_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(asrc, &asrc_interface);
-
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
-	SOF_LLEXT_MODULE_MANIFEST("ASRC", asrc_llext_entry, 1, SOF_REG_UUID(asrc4), 2),
+	SOF_LLEXT_MODULE_MANIFEST("ASRC", &asrc_interface, 1, SOF_REG_UUID(asrc4), 2),
 };
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -473,10 +473,8 @@ static const struct module_interface dts_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(dts, &dts_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("DTS", dts_llext_entry, 1, SOF_REG_UUID(dts), 40);
+	SOF_LLEXT_MODULE_MANIFEST("DTS", &dts_interface, 1, SOF_REG_UUID(dts), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -642,10 +642,8 @@ static const struct module_interface crossover_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(crossover, &crossover_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("XOVER", crossover_llext_entry, 1, SOF_REG_UUID(crossover), 40);
+	SOF_LLEXT_MODULE_MANIFEST("XOVER", &crossover_interface, 1, SOF_REG_UUID(crossover), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -265,10 +265,8 @@ static const struct module_interface dcblock_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(dcblock, &dcblock_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("DCBLOCK", dcblock_llext_entry, 1, SOF_REG_UUID(dcblock), 40);
+	SOF_LLEXT_MODULE_MANIFEST("DCBLOCK", &dcblock_interface, 1, SOF_REG_UUID(dcblock), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -424,10 +424,8 @@ static const struct module_interface drc_interface = {
 #include <module/module/api_ver.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(drc, &drc_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("DRC", drc_llext_entry, 1, SOF_REG_UUID(drc), 40);
+	SOF_LLEXT_MODULE_MANIFEST("DRC", &drc_interface, 1, SOF_REG_UUID(drc), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -490,10 +490,8 @@ static const struct module_interface eq_fir_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(eq_fir, &eq_fir_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("EQFIR", eq_fir_llext_entry, 1, SOF_REG_UUID(eq_fir), 40);
+	SOF_LLEXT_MODULE_MANIFEST("EQFIR", &eq_fir_interface, 1, SOF_REG_UUID(eq_fir), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -260,10 +260,8 @@ static const struct module_interface eq_iir_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(eq_iir, &eq_iir_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("EQIIR", eq_iir_llext_entry, 1, SOF_REG_UUID(eq_iir), 40);
+	SOF_LLEXT_MODULE_MANIFEST("EQIIR", &eq_iir_interface, 1, SOF_REG_UUID(eq_iir), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -466,10 +466,8 @@ static const struct module_interface google_ctc_audio_processing_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(google_ctc_audio_processing, &google_ctc_audio_processing_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("CTC", google_ctc_audio_processing_llext_entry,
+	SOF_LLEXT_MODULE_MANIFEST("CTC", &google_ctc_audio_processing_interface,
 				  1, SOF_REG_UUID(google_ctc_audio_processing), 40);
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -856,10 +856,8 @@ static const struct module_interface google_rtc_audio_processing_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(google_rtc_audio_processing, &google_rtc_audio_processing_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("RTC_AEC", google_rtc_audio_processing_llext_entry,
+	SOF_LLEXT_MODULE_MANIFEST("RTC_AEC", &google_rtc_audio_processing_interface,
 				  7, SOF_REG_UUID(google_rtc_audio_processing), 1);
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -895,10 +895,8 @@ static const struct module_interface igo_nr_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(igo_nr, &igo_nr_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("IGO_NR", igo_nr_llext_entry, 1, SOF_REG_UUID(igo_nr), 40);
+	SOF_LLEXT_MODULE_MANIFEST("IGO_NR", &igo_nr_interface, 1, SOF_REG_UUID(igo_nr), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -267,10 +267,8 @@ static const struct module_interface mfcc_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(mfcc, &mfcc_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("MFCC", mfcc_llext_entry, 1, SOF_REG_UUID(mfcc), 40);
+	SOF_LLEXT_MODULE_MANIFEST("MFCC", &mfcc_interface, 1, SOF_REG_UUID(mfcc), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -1020,13 +1020,10 @@ static const struct module_interface mixout_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(mixin, &mixin_interface);
-SOF_LLEXT_MOD_ENTRY(mixout, &mixout_interface);
-
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used =
 {
-	SOF_LLEXT_MODULE_MANIFEST("MIXIN", mixin_llext_entry, 1, SOF_REG_UUID(mixin), 30),
-	SOF_LLEXT_MODULE_MANIFEST("MIXOUT", mixout_llext_entry, 1, SOF_REG_UUID(mixout), 30),
+	SOF_LLEXT_MODULE_MANIFEST("MIXIN", &mixin_interface, 1, SOF_REG_UUID(mixin), 30),
+	SOF_LLEXT_MODULE_MANIFEST("MIXOUT", &mixout_interface, 1, SOF_REG_UUID(mixout), 30),
 };
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -913,10 +913,8 @@ static const struct module_interface waves_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(waves, &waves_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("WAVES", waves_llext_entry, 7, SOF_REG_UUID(waves), 8);
+	SOF_LLEXT_MODULE_MANIFEST("WAVES", &waves_interface, 7, SOF_REG_UUID(waves), 8);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -441,10 +441,8 @@ static const struct module_interface multiband_drc_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(multiband_drc, &multiband_drc_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("MB_DRC", multiband_drc_llext_entry, 1,
+	SOF_LLEXT_MODULE_MANIFEST("MB_DRC", &multiband_drc_interface, 1,
 				  SOF_REG_UUID(multiband_drc), 40);
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -479,19 +479,12 @@ static const struct module_interface demux_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(mux, &mux_interface);
-
-/*
- * The demux entry is removed because mtl.toml doesn't have an entry
- * for it. Once that is fixed, the manifest line below can be
- * re-activated:
- * SOF_LLEXT_MOD_ENTRY(demux, &demux_interface);
- */
-
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
-	SOF_LLEXT_MODULE_MANIFEST("MUX", mux_llext_entry, 1, SOF_REG_UUID(mux4), 15),
+	SOF_LLEXT_MODULE_MANIFEST("MUX", &mux_interface, 1, SOF_REG_UUID(mux4), 15),
 	/*
-	 * See comment above for a demux deactivation reason
+	 * The demux entry is removed because mtl.toml doesn't have an entry
+	 * for it. Once that is fixed, the manifest line below can be
+	 * re-activated:
 	 * SOF_LLEXT_MODULE_MANIFEST("DEMUX", demux_llext_entry, 1, SOF_REG_UUID(demux), 15),
 	 */
 };

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -880,10 +880,8 @@ static const struct module_interface rtnr_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(rtnr, &rtnr_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("RTNR", rtnr_llext_entry, 1, SOF_REG_UUID(rtnr), 40);
+	SOF_LLEXT_MODULE_MANIFEST("RTNR", &rtnr_interface, 1, SOF_REG_UUID(rtnr), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -930,11 +930,8 @@ static const struct module_interface selector_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(selector, &selector_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("MICSEL", selector_llext_entry, 1, SOF_REG_UUID(selector4),
-				  8);
+	SOF_LLEXT_MODULE_MANIFEST("MICSEL", &selector_interface, 1, SOF_REG_UUID(selector4), 8);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -91,18 +91,14 @@ static const struct module_interface src_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(src, &src_interface);
-
 #if CONFIG_COMP_SRC_LITE
 extern const struct module_interface src_lite_interface;
-SOF_LLEXT_MOD_ENTRY(src_lite, &src_lite_interface);
 #endif
 
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
-	SOF_LLEXT_MODULE_MANIFEST("SRC", src_llext_entry, 1, SOF_REG_UUID(src4), 1),
+	SOF_LLEXT_MODULE_MANIFEST("SRC", &src_interface, 1, SOF_REG_UUID(src4), 1),
 #if CONFIG_COMP_SRC_LITE
-	SOF_LLEXT_MODULE_MANIFEST("SRC_LITE", src_lite_llext_entry, 1, SOF_REG_UUID(src_lite),
-				  1),
+	SOF_LLEXT_MODULE_MANIFEST("SRC_LITE", &src_lite_interface, 1, SOF_REG_UUID(src_lite), 1),
 #endif
 };
 

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -833,10 +833,8 @@ static const struct module_interface tdfb_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(tdfb, &tdfb_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("TDFB", tdfb_llext_entry, 1, SOF_REG_UUID(tdfb), 40);
+	SOF_LLEXT_MODULE_MANIFEST("TDFB", &tdfb_interface, 1, SOF_REG_UUID(tdfb), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/template_comp/template.c
+++ b/src/audio/template_comp/template.c
@@ -197,10 +197,8 @@ static const struct module_interface template_comp_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(template_comp, &template_comp_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("TEMPLATE", template_comp_llext_entry, 1,
+	SOF_LLEXT_MODULE_MANIFEST("TEMPLATE", &template_comp_interface, 1,
 				  SOF_REG_UUID(template_comp), 40);
 
 SOF_LLEXT_BUILDINFO;

--- a/src/audio/tensorflow/tflm-classify.c
+++ b/src/audio/tensorflow/tflm-classify.c
@@ -243,10 +243,8 @@ SOF_MODULE_INIT(tflmcly, sys_comp_module_tflmcly_interface_init);
 #include <module/module/api_ver.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(tflmcly, &tflmcly_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("TFLMCLY", tflmcly_llext_entry, 1, SOF_REG_UUID(tflmcly), 40);
+	SOF_LLEXT_MODULE_MANIFEST("TFLMCLY", &tflmcly_interface, 1, SOF_REG_UUID(tflmcly), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -812,20 +812,12 @@ static const struct module_interface gain_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-#if CONFIG_COMP_PEAK_VOL
-SOF_LLEXT_MOD_ENTRY(peakvol, &volume_interface);
-#endif
-
-#if CONFIG_COMP_GAIN
-SOF_LLEXT_MOD_ENTRY(gain, &gain_interface);
-#endif
-
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
 #if CONFIG_COMP_PEAK_VOL
-	SOF_LLEXT_MODULE_MANIFEST("PEAKVOL", peakvol_llext_entry, 1, SOF_REG_UUID(volume4), 10),
+	SOF_LLEXT_MODULE_MANIFEST("PEAKVOL", &volume_interface, 1, SOF_REG_UUID(volume4), 10),
 #endif
 #if CONFIG_COMP_GAIN
-	SOF_LLEXT_MODULE_MANIFEST("GAIN", gain_llext_entry, 1, SOF_REG_UUID(gain), 40),
+	SOF_LLEXT_MODULE_MANIFEST("GAIN", &gain_interface, 1, SOF_REG_UUID(gain), 40),
 #endif
 };
 

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -243,10 +243,8 @@ static const struct module_interface tester_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(tester, &tester_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("TESTER", tester_llext_entry, 1, SOF_REG_UUID(tester), 40);
+	SOF_LLEXT_MODULE_MANIFEST("TESTER", &tester_interface, 1, SOF_REG_UUID(tester), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/include/module/module/llext.h
+++ b/src/include/module/module/llext.h
@@ -33,13 +33,6 @@
 	} \
 }
 
-#define SOF_LLEXT_MOD_ENTRY(name, interface) \
-static const struct module_interface *name##_llext_entry(void *mod_cfg, \
-					void *parent_ppl, void **mod_ptr) \
-{ \
-	return interface; \
-}
-
 #define SOF_LLEXT_BUILDINFO \
 static const struct sof_module_api_build_info buildinfo __section(".mod_buildinfo") __used = { \
 	.format = SOF_MODULE_API_BUILD_INFO_FORMAT, \

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1660,10 +1660,8 @@ static const struct module_interface probe_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(probe, &probe_interface);
-
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("PROBE", probe_llext_entry, 1, SOF_REG_UUID(probe4), 40);
+	SOF_LLEXT_MODULE_MANIFEST("PROBE", &probe_interface, 1, SOF_REG_UUID(probe4), 40);
 
 SOF_LLEXT_BUILDINFO;
 

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -381,10 +381,8 @@ static const struct module_interface smart_amp_test_interface = {
 #include <module/module/llext.h>
 #include <rimage/sof/user/manifest.h>
 
-SOF_LLEXT_MOD_ENTRY(smart_amp_test, &smart_amp_test_interface);
-
 static const struct sof_man_module_manifest mod_manifest[] __section(".module") __used = {
-	SOF_LLEXT_MODULE_MANIFEST("SMATEST", smart_amp_test_llext_entry, 1,
+	SOF_LLEXT_MODULE_MANIFEST("SMATEST", &smart_amp_test_interface, 1,
 				  SOF_REG_UUID(smart_amp_test), 1),
 };
 


### PR DESCRIPTION
The current library loading API prescribes that all modules should have entry functions whose only role in fact (in case of LLEXT at least) is returning an interface operations popinter. LLEXT modules don't need that, they can store that pointer directly in module manifest.

**Note:** this is a part of #10183 - would be good to merge it early independently