### PR TITLE
ipc3: Fix spinlock violation in PM context save on fuzzer

### DIFF
--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -672,7 +672,7 @@ static int ipc_pm_context_save(uint32_t header)
 	/* do platform specific suspending */
 	platform_context_save(sof_get());
 
-#if !defined(CONFIG_LIBRARY)
+#if !defined(CONFIG_LIBRARY) && !defined(CONFIG_ZEPHYR_POSIX)
 	/* TODO: check we are inactive - all streams are suspended */
 
 	/* TODO: mask ALL platform interrupts except DMA */


### PR DESCRIPTION
Fix spinlock validation assertion failure during fuzzing on native_sim builds with IPC3.

Recent Zephyr commit added spinlock validation that detects context switching while holding spinlocks. This revealed that `ipc_pm_context_save` calls `arch_irq_lock` before the EDF work queue yields, causing:

ASSERTION FAIL [arch_irq_unlocked(key) || ...] Context switching while holding lock!

The hardware PM operations (arch_irq_lock, platform_timer_stop, etc.) are not needed for POSIX simulation environments. Extend the existing guard to exclude these operations when CONFIG_ZEPHYR_POSIX is defined.

This preserves PM functionality while avoiding spinlock violations in native simulation builds.