### PR TITLE
[CI TEST not for review] Audio: Copier: All memory allocations through module API

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -191,7 +191,7 @@ __cold static int copier_init(struct processing_module *mod)
 		switch (node_id.f.dma_type) {
 		case ipc4_hda_host_output_class:
 		case ipc4_hda_host_input_class:
-			ret = copier_host_create(dev, cd, copier, ipc_pipe->pipeline);
+			ret = copier_host_create(mod, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create host");
 				return ret;
@@ -271,7 +271,7 @@ __cold static int copier_free(struct processing_module *mod)
 	switch (dev->ipc_config.type) {
 	case SOF_COMP_HOST:
 		if (!cd->ipc_gtw)
-			copier_host_free(cd);
+			copier_host_free(mod);
 		else
 			/* handle gtw case */
 			copier_ipcgtw_free(cd);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -271,7 +271,7 @@ __cold static int copier_free(struct processing_module *mod)
 	switch (dev->ipc_config.type) {
 	case SOF_COMP_HOST:
 		if (!cd->ipc_gtw)
-			copier_host_free(mod);
+			copier_host_free(cd);
 		else
 			/* handle gtw case */
 			copier_ipcgtw_free(cd);

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -232,7 +232,7 @@ __cold static int copier_init(struct processing_module *mod)
 #if CONFIG_IPC4_GATEWAY
 		case ipc4_ipc_output_class:
 		case ipc4_ipc_input_class:
-			ret = copier_ipcgtw_create(dev, cd, copier, ipc_pipe->pipeline);
+			ret = copier_ipcgtw_create(mod, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create IPC gateway");
 				return ret;

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -15,7 +15,6 @@
 #include <sof/ipc/topology.h>
 #include <rtos/interrupt.h>
 #include <rtos/timer.h>
-#include <rtos/alloc.h>
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/memory.h>
@@ -82,13 +81,12 @@ static void mic_privacy_event(void *arg, enum notify_id type, void *data)
 	}
 }
 
-static int mic_privacy_configure(struct comp_dev *dev, struct copier_data *cd)
+static int mic_privacy_configure(struct processing_module *mod, struct copier_data *cd)
 {
 	struct mic_privacy_data *mic_priv_data;
 	int ret;
 
-	mic_priv_data = rzalloc(SOF_MEM_FLAG_USER,
-				sizeof(struct mic_privacy_data));
+	mic_priv_data = mod_zalloc(mod, sizeof(struct mic_privacy_data));
 	if (!mic_priv_data)
 		return -ENOMEM;
 
@@ -100,19 +98,15 @@ static int mic_privacy_configure(struct comp_dev *dev, struct copier_data *cd)
 	uint32_t zeroing_wait_time = (mic_privacy_get_dma_zeroing_wait_time() * 1000) /
 				     ADSP_RTC_FREQUENCY;
 
-	ret = copier_gain_set_params(dev, &mic_priv_data->mic_priv_gain_params,
+	ret = copier_gain_set_params(mod->dev, &mic_priv_data->mic_priv_gain_params,
 				     zeroing_wait_time, SOF_DAI_INTEL_NONE);
-	if (ret != 0) {
-		rfree(mic_priv_data);
+	if (ret != 0)
 		return ret;
-	}
 
 	cd->mic_priv = mic_priv_data;
 
 	ret = notifier_register(cd->mic_priv, NULL, NOTIFIER_ID_MIC_PRIVACY_STATE_CHANGE,
 				mic_privacy_event, 0);
-	if (ret != 0)
-		rfree(mic_priv_data);
 
 	return ret;
 }
@@ -123,8 +117,6 @@ static void mic_privacy_free(struct copier_data *cd)
 		mic_privacy_enable_dmic_irq(false);
 
 	notifier_unregister(cd->mic_priv, NULL, NOTIFIER_ID_MIC_PRIVACY_STATE_CHANGE);
-
-	rfree(cd->mic_priv);
 }
 #endif
 
@@ -144,7 +136,7 @@ __cold static int copier_init(struct processing_module *mod)
 
 	assert_can_be_cold();
 
-	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(*cd));
+	cd = mod_zalloc(mod, sizeof(*cd));
 	if (!cd)
 		return -ENOMEM;
 
@@ -154,10 +146,8 @@ __cold static int copier_init(struct processing_module *mod)
 	 * store it, it's only used during IPC processing, besides we haven't
 	 * allocated space for it, so don't "fix" this!
 	 */
-	if (memcpy_s(&cd->config, sizeof(cd->config), copier, sizeof(*copier)) < 0) {
-		ret = -EINVAL;
-		goto error_cd;
-	}
+	if (memcpy_s(&cd->config, sizeof(cd->config), copier, sizeof(*copier)) < 0)
+		return -EINVAL;
 
 	/* Allocate memory and store gateway_cfg in runtime. Gateway cfg has to
 	 * be kept even after copier is created e.g. during SET_PIPELINE_STATE
@@ -166,18 +156,15 @@ __cold static int copier_init(struct processing_module *mod)
 	 */
 	if (copier->gtw_cfg.config_length) {
 		gtw_cfg_size = copier->gtw_cfg.config_length << 2;
-		gtw_cfg = rmalloc(SOF_MEM_FLAG_USER,
-				  gtw_cfg_size);
-		if (!gtw_cfg) {
-			ret = -ENOMEM;
-			goto error_cd;
-		}
+		gtw_cfg = mod_alloc(mod, gtw_cfg_size);
+		if (!gtw_cfg)
+			return -ENOMEM;
 
 		ret = memcpy_s(gtw_cfg, gtw_cfg_size, &copier->gtw_cfg.config_data,
 			       gtw_cfg_size);
 		if (ret) {
 			comp_err(dev, "Unable to copy gateway config from copier blob");
-			goto error;
+			return ret;
 		}
 
 		cd->gtw_cfg = gtw_cfg;
@@ -191,8 +178,7 @@ __cold static int copier_init(struct processing_module *mod)
 					  IPC_COMP_IGNORE_REMOTE);
 	if (!ipc_pipe) {
 		comp_err(dev, "pipeline %d is not existed", config->pipeline_id);
-		ret = -EPIPE;
-		goto error;
+		return -EPIPE;
 	}
 
 	dev->pipeline = ipc_pipe->pipeline;
@@ -208,15 +194,15 @@ __cold static int copier_init(struct processing_module *mod)
 			ret = copier_host_create(dev, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create host");
-				goto error;
+				return ret;
 			}
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
 			if (cd->direction == SOF_IPC_STREAM_CAPTURE &&
 			    node_id.f.dma_type == ipc4_hda_host_output_class) {
-				ret = mic_privacy_configure(dev, cd);
+				ret = mic_privacy_configure(mod, cd);
 				if (ret < 0) {
 					comp_err(dev, "unable to configure mic privacy");
-					goto error;
+					return ret;
 				}
 			}
 #endif
@@ -231,14 +217,14 @@ __cold static int copier_init(struct processing_module *mod)
 			ret = copier_dai_create(dev, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create dai");
-				goto error;
+				return ret;
 			}
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
 			if (cd->direction == SOF_IPC_STREAM_CAPTURE) {
-				ret = mic_privacy_configure(dev, cd);
+				ret = mic_privacy_configure(mod, cd);
 				if (ret < 0) {
 					comp_err(dev, "unable to configure mic privacy");
-					goto error;
+					return ret;
 				}
 			}
 #endif
@@ -249,14 +235,13 @@ __cold static int copier_init(struct processing_module *mod)
 			ret = copier_ipcgtw_create(dev, cd, copier, ipc_pipe->pipeline);
 			if (ret < 0) {
 				comp_err(dev, "unable to create IPC gateway");
-				goto error;
+				return ret;
 			}
 			break;
 #endif
 		default:
 			comp_err(dev, "unsupported dma type %x", (uint32_t)node_id.f.dma_type);
-			ret = -EINVAL;
-			goto error;
+			return -EINVAL;
 		};
 
 		dev->direction_set = true;
@@ -270,11 +255,6 @@ __cold static int copier_init(struct processing_module *mod)
 	dev->direction = cd->direction;
 	dev->state = COMP_STATE_READY;
 	return 0;
-error:
-	rfree(gtw_cfg);
-error_cd:
-	rfree(cd);
-	return ret;
 }
 
 __cold static int copier_free(struct processing_module *mod)
@@ -302,10 +282,6 @@ __cold static int copier_free(struct processing_module *mod)
 	default:
 		break;
 	}
-
-	if (cd)
-		rfree(cd->gtw_cfg);
-	rfree(cd);
 
 	return 0;
 }

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -253,10 +253,8 @@ e_conv:
 	return ret;
 }
 
-__cold void copier_host_free(struct processing_module *mod)
+__cold void copier_host_free(struct copier_data *cd)
 {
-	struct copier_data *cd = module_get_private_data(mod);
-
 	assert_can_be_cold();
 
 #if CONFIG_HOST_DMA_STREAM_SYNCHRONIZATION

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -2,6 +2,7 @@
 //
 // Copyright 2023 Intel Corporation. All rights reserved.
 
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/component_ext.h>
 #include <sof/trace/trace.h>
 #include <sof/lib/memory.h>
@@ -207,15 +208,15 @@ void copier_ipcgtw_reset(struct comp_dev *dev)
 	}
 }
 
-__cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
+__cold int copier_ipcgtw_create(struct processing_module *mod, struct copier_data *cd,
 				const struct ipc4_copier_module_cfg *copier,
 				struct pipeline *pipeline)
 {
+	struct comp_dev *dev = mod->dev;
 	struct comp_ipc_config *config = &dev->ipc_config;
 	struct ipcgtw_data *ipcgtw_data;
 	const struct ipc4_copier_gateway_cfg *gtw_cfg;
 	const struct ipc4_ipc_gateway_config_blob *blob;
-	int ret;
 
 	assert_can_be_cold();
 
@@ -231,7 +232,7 @@ __cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	config->type = SOF_COMP_HOST;
 	cd->gtw_type = ipc4_gtw_host;
 
-	ipcgtw_data = rzalloc(SOF_MEM_FLAG_USER, sizeof(*ipcgtw_data));
+	ipcgtw_data = mod_zalloc(mod, sizeof(*ipcgtw_data));
 	if (!ipcgtw_data)
 		return -ENOMEM;
 
@@ -254,8 +255,7 @@ __cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	if (!cd->converter[IPC4_COPIER_GATEWAY_PIN]) {
 		comp_err(dev, "failed to get converter for IPC gateway, dir %d",
 			 cd->direction);
-		ret = -EINVAL;
-		goto e_ipcgtw;
+		return -EINVAL;
 	}
 
 	if (cd->direction == SOF_IPC_STREAM_PLAYBACK) {
@@ -271,10 +271,6 @@ __cold int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
 	cd->endpoint_num++;
 
 	return 0;
-
-e_ipcgtw:
-	rfree(ipcgtw_data);
-	return ret;
 }
 
 __cold void copier_ipcgtw_free(struct copier_data *cd)
@@ -282,5 +278,4 @@ __cold void copier_ipcgtw_free(struct copier_data *cd)
 	assert_can_be_cold();
 
 	list_item_del(&cd->ipcgtw_data->item);
-	rfree(cd->ipcgtw_data);
 }

--- a/src/audio/copier/host_copier.h
+++ b/src/audio/copier/host_copier.h
@@ -129,10 +129,10 @@ static inline int host_common_copy(struct host_data *hd, struct comp_dev *dev, c
 }
 void host_common_update(struct host_data *hd, struct comp_dev *dev, uint32_t bytes);
 void host_common_one_shot(struct host_data *hd, uint32_t bytes);
-int copier_host_create(struct comp_dev *dev, struct copier_data *cd,
+int copier_host_create(struct processing_module *mod, struct copier_data *cd,
 		       const struct ipc4_copier_module_cfg *copier_cfg,
 		       struct pipeline *pipeline);
-void copier_host_free(struct copier_data *cd);
+void copier_host_free(struct processing_module *mod);
 int copier_host_params(struct copier_data *cd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params);
 void copier_host_dma_cb(struct comp_dev *dev, size_t bytes);

--- a/src/audio/copier/host_copier.h
+++ b/src/audio/copier/host_copier.h
@@ -132,7 +132,7 @@ void host_common_one_shot(struct host_data *hd, uint32_t bytes);
 int copier_host_create(struct processing_module *mod, struct copier_data *cd,
 		       const struct ipc4_copier_module_cfg *copier_cfg,
 		       struct pipeline *pipeline);
-void copier_host_free(struct processing_module *mod);
+void copier_host_free(struct copier_data *cd);
 int copier_host_params(struct copier_data *cd, struct comp_dev *dev,
 		       struct sof_ipc_stream_params *params);
 void copier_host_dma_cb(struct comp_dev *dev, size_t bytes);

--- a/src/audio/copier/ipcgtw_copier.h
+++ b/src/audio/copier/ipcgtw_copier.h
@@ -95,7 +95,7 @@ struct ipc4_ipc_gateway_cmd_data_reply {
 int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 			  void *reply_payload, uint32_t *reply_payload_size);
 
-int copier_ipcgtw_create(struct comp_dev *dev, struct copier_data *cd,
+int copier_ipcgtw_create(struct processing_module *mod, struct copier_data *cd,
 			 const struct ipc4_copier_module_cfg *copier, struct pipeline *pipeline);
 
 #if CONFIG_IPC4_GATEWAY

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -182,7 +182,7 @@ void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t ali
 		return NULL;
 
 	if (!size) {
-		comp_err(mod->dev, "mod_alloc: requested allocation of 0 bytes.");
+		comp_err(mod->dev, "requested allocation of 0 bytes.");
 		container_put(mod, container);
 		return NULL;
 	}
@@ -194,8 +194,8 @@ void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t ali
 		ptr = rballoc(SOF_MEM_FLAG_USER, size);
 
 	if (!ptr) {
-		comp_err(mod->dev, "mod_alloc: failed to allocate memory for comp %x.",
-			 dev_comp_id(mod->dev));
+		comp_err(mod->dev, "Failed to alloc %d bytes %d alignment for comp %x.",
+			 size, alignment, dev_comp_id(mod->dev));
 		container_put(mod, container);
 		return NULL;
 	}

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -581,7 +581,7 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	buffer = ipc4_create_buffer(source, cross_core_bind, buf_size, bu->extension.r.src_queue,
 				    bu->extension.r.dst_queue);
 	if (!buffer) {
-		tr_err(&ipc_tr, "failed to allocate buffer to bind %d to %d", src_id, sink_id);
+		tr_err(&ipc_tr, "failed to allocate buffer to bind %#x to %#x", src_id, sink_id);
 		return IPC4_OUT_OF_MEMORY;
 	}
 
@@ -646,14 +646,14 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	ret = comp_buffer_connect(source, source->ipc_config.core, buffer,
 				  PPL_CONN_DIR_COMP_TO_BUFFER);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to connect src %d to internal buffer", src_id);
+		tr_err(&ipc_tr, "failed to connect src %#x to internal buffer", src_id);
 		goto free;
 	}
 
 	ret = comp_buffer_connect(sink, sink->ipc_config.core, buffer,
 				  PPL_CONN_DIR_BUFFER_TO_COMP);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to connect internal buffer to sink %d", sink_id);
+		tr_err(&ipc_tr, "failed to connect internal buffer to sink %#x", sink_id);
 		goto e_sink_connect;
 	}
 
@@ -1043,7 +1043,7 @@ __cold const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id)
 		mod = lib_manager_get_module_manifest(module_id);
 
 		if (!mod) {
-			tr_err(&comp_tr, "Error: Couldn't find loadable module with id %d.",
+			tr_err(&comp_tr, "Error: Couldn't find loadable module with id %#x.",
 			       module_id);
 			return NULL;
 		}


### PR DESCRIPTION
Allocate all memory through module API mod_alloc() and friends and remove all redundant rfree() calls from module unload functions and init error branches.

NOTE: copier_dai.c and copier_host.c still have their shared memory allocated through the old API. This is to be fixed once we have decided on how the shared memory allocations should work in user-space.