### PR TITLE
cmocka: eq_iir and eq_fir: Fix test crash

### DIFF
--- a/test/cmocka/src/audio/eq_fir/eq_fir_process.c
+++ b/test/cmocka/src/audio/eq_fir/eq_fir_process.c
@@ -186,6 +186,7 @@ static int teardown(void **state)
 	test_free(mod->input_buffers);
 	test_free(mod->output_buffers);
 	test_free(mod->stream_params);
+	mod->stream_params = NULL;
 	test_free(td->params);
 	free_test_source(td->source);
 	free_test_sink(td->sink);

--- a/test/cmocka/src/audio/eq_iir/eq_iir_process.c
+++ b/test/cmocka/src/audio/eq_iir/eq_iir_process.c
@@ -185,6 +185,7 @@ static int teardown(void **state)
 	test_free(mod->input_buffers);
 	test_free(mod->output_buffers);
 	test_free(mod->stream_params);
+	mod->stream_params = NULL;
 	test_free(td->params);
 	free_test_source(td->source);
 	free_test_sink(td->sink);


### PR DESCRIPTION
Assign mod->stream_params to NULL aftere it is freed. If this is not done comp_free() tries to free it again couple of lines later, when it calls module_adapter_free(). Removing test_free(mod->stream_params) does not fix the issue because cmocka framework provided test_alloc() and test_free() are not equivalent to malloc() and free().