### PR TITLE
west.yml: update zephyr to 9f4bd38ef7d3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 8843fd9fe1800164fbb5221d95d1eba7d0699458
+      revision: 9f4bd38ef7d3b52a41e715f45c9a4b2d9caf3bc4
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 1400 commits.

Changes include:
- fa02e373be83 drivers: dai: dmic: do not call k_sleep() in PM callbacks
- d11474ce6463 samples: i2s_codec: Modify DMIC channel mapping
- b82c44ce2042 boards: intel_adsp: set correct stack size for ACE30_WCL
- 414ede30575f xtensa: jump to GDB upon exception
- soc/intel_adsp: soc_adsp_halt_cpu always fails when NUM_CPUS <= 1