### PR TITLE
manifest: rimage: Update manifest module type with reference FW state

### DIFF
--- a/tools/rimage/src/include/rimage/sof/user/manifest.h
+++ b/tools/rimage/src/include/rimage/sof/user/manifest.h
@@ -42,7 +42,16 @@ struct sof_man_module_type {
 	uint32_t domain_dp:1;
 	uint32_t lib_code:1;
 	uint32_t init_config:4; /* SOF_MAN_MOD_INIT_CONFIG_ */
-	uint32_t rsvd_:20;
+	/* The init_config field overlaps with the following fields, so core_type was trimmed to
+	 * ensure proper placement of remaining fields.
+	 * uint32_t domain_rtos:1;
+	 * uint32_t core_type:8;
+	 */
+	uint32_t core_type:5;
+	uint32_t user_mode:1;
+	uint32_t large_param:1;
+	uint32_t stack_on_bss:1;
+	uint32_t rsvd_:12;
 };
 
 /* segment flags.type */


### PR DESCRIPTION
Update `sof_man_module_type` to match the layout defined in the reference firmware. This includes <s>reordering and</s> extending the structure with new fields such as `domain_rtos`, `core_type`, `user_mode`, `large_param`, and `stack_on_bss`.

<s>The previously added `init_config` field (https://github.com/thesofproject/sof/commit/15ea48177a2b4cb93eaa9858e90a4da89f9f84b1), which had been added earlier using reserved bits has been moved to the end of the structure to avoid layout conflicts and maintain compatibility with the reference FW.

This change is required for ABI alignment but will cause CI failures due to the need for a software rebuild.</s>