### PR TITLE
Module api: various fixes and developments

### DIFF
--- a/posix/include/rtos/alloc.h
+++ b/posix/include/rtos/alloc.h
@@ -61,7 +61,14 @@
  * Allocates memory block.
  * @param flags Flags, see SOF_MEM_FLAG_...
  * @param bytes Size in bytes.
+ * @param alignment	Alignment in bytes.
  * @return Pointer to the allocated memory or NULL if failed.
+ */
+void *rmalloc_align(uint32_t flags, size_t bytes,
+		    uint32_t alignment);
+
+/**
+ * Similar to rmalloc_align(), but no alignment can be specified.
  */
 void *rmalloc(uint32_t flags, size_t bytes);
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -168,7 +168,7 @@ static void container_put(struct processing_module *mod, struct module_resource 
  *
  * The allocated memory is automatically freed when the module is unloaded.
  */
-void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t alignment)
+void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment)
 {
 	struct module_resource *container = container_get(mod);
 	struct module_resources *res = &mod->priv.resources;
@@ -188,7 +188,7 @@ void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t ali
 	ptr = rmalloc_align(SOF_MEM_FLAG_USER, size, alignment);
 
 	if (!ptr) {
-		comp_err(mod->dev, "Failed to alloc %d bytes %d alignment for comp %x.",
+		comp_err(mod->dev, "Failed to alloc %zu bytes %zu alignment for comp %#x.",
 			 size, alignment, dev_comp_id(mod->dev));
 		container_put(mod, container);
 		return NULL;
@@ -216,7 +216,7 @@ EXPORT_SYMBOL(mod_alloc_align);
  * Like mod_alloc_align() but the alignment can not be specified. However,
  * rballoc() will always aligns the memory to PLATFORM_DCACHE_ALIGN.
  */
-void *mod_alloc(struct processing_module *mod, uint32_t size)
+void *mod_alloc(struct processing_module *mod, size_t size)
 {
 	return mod_alloc_align(mod, size, 0);
 }
@@ -230,7 +230,7 @@ EXPORT_SYMBOL(mod_alloc);
  *
  * Like mod_alloc() but the allocated memory is initialized to zero.
  */
-void *mod_zalloc(struct processing_module *mod, uint32_t size)
+void *mod_zalloc(struct processing_module *mod, size_t size)
 {
 	void *ret = mod_alloc(mod, size);
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -185,10 +185,7 @@ void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t ali
 	}
 
 	/* Allocate memory for module */
-	if (alignment)
-		ptr = rballoc_align(SOF_MEM_FLAG_USER, size, alignment);
-	else
-		ptr = rballoc(SOF_MEM_FLAG_USER, size);
+	ptr = rmalloc_align(SOF_MEM_FLAG_USER, size, alignment);
 
 	if (!ptr) {
 		comp_err(mod->dev, "failed to allocate memory.");

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -172,11 +172,13 @@ static void container_put(struct processing_module *mod, struct module_resource 
  */
 void *mod_balloc_align(struct processing_module *mod, size_t size, size_t alignment)
 {
-	struct module_resource *container = container_get(mod);
 	struct module_resources *res = &mod->priv.resources;
+	struct module_resource *container;
 	void *ptr;
 
 	MEM_API_CHECK_THREAD(res);
+
+	container = container_get(mod);
 	if (!container)
 		return NULL;
 
@@ -235,11 +237,13 @@ EXPORT_SYMBOL(mod_balloc);
  */
 void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment)
 {
-	struct module_resource *container = container_get(mod);
 	struct module_resources *res = &mod->priv.resources;
+	struct module_resource *container;
 	void *ptr;
 
 	MEM_API_CHECK_THREAD(res);
+
+	container = container_get(mod);
 	if (!container)
 		return NULL;
 
@@ -317,10 +321,12 @@ struct comp_data_blob_handler *
 mod_data_blob_handler_new(struct processing_module *mod)
 {
 	struct module_resources *res = &mod->priv.resources;
-	struct module_resource *container = container_get(mod);
 	struct comp_data_blob_handler *bhp;
+	struct module_resource *container;
 
 	MEM_API_CHECK_THREAD(res);
+
+	container = container_get(mod);
 	if (!container)
 		return NULL;
 
@@ -351,10 +357,12 @@ EXPORT_SYMBOL(mod_data_blob_handler_new);
 const void *mod_fast_get(struct processing_module *mod, const void * const dram_ptr, size_t size)
 {
 	struct module_resources *res = &mod->priv.resources;
-	struct module_resource *container = container_get(mod);
+	struct module_resource *container;
 	const void *ptr;
 
 	MEM_API_CHECK_THREAD(res);
+
+	container = container_get(mod);
 	if (!container)
 		return NULL;
 

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -262,25 +262,6 @@ void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignme
 EXPORT_SYMBOL(mod_alloc_align);
 
 /**
- * Allocates memory block for module and initializes it to zero.
- * @param mod	Pointer to module this memory block is allocated for.
- * @param bytes	Size in bytes.
- * @return Pointer to the allocated memory or NULL if failed.
- *
- * Like mod_alloc() but the allocated memory is initialized to zero.
- */
-void *mod_zalloc(struct processing_module *mod, size_t size)
-{
-	void *ret = mod_alloc(mod, size);
-
-	if (ret)
-		memset(ret, 0, size);
-
-	return ret;
-}
-EXPORT_SYMBOL(mod_zalloc);
-
-/**
  * Creates a blob handler and releases it when the module is unloaded
  * @param mod	Pointer to module this memory block is allocated for.
  * @return Pointer to the created data blob handler

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -212,21 +212,6 @@ void *mod_balloc_align(struct processing_module *mod, size_t size, size_t alignm
 EXPORT_SYMBOL(mod_balloc_align);
 
 /**
- * Allocates buffer memory block for module.
- * @param mod	Pointer to module this memory block is allocated for.
- * @param bytes	Size in bytes.
- * @return Pointer to the allocated memory or NULL if failed.
- *
- * Like mod_balloc_align() but the alignment can not be specified. However,
- * rballoc() always aligns the memory to PLATFORM_DCACHE_ALIGN.
- */
-void *mod_balloc(struct processing_module *mod, size_t size)
-{
-	return mod_balloc_align(mod, size, 0);
-}
-EXPORT_SYMBOL(mod_balloc);
-
-/**
  * Allocates aligned memory block for module.
  * @param mod		Pointer to the module this memory block is allocatd for.
  * @param bytes		Size in bytes.
@@ -275,20 +260,6 @@ void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignme
 	return ptr;
 }
 EXPORT_SYMBOL(mod_alloc_align);
-
-/**
- * Allocates memory block for module.
- * @param mod	Pointer to module this memory block is allocated for.
- * @param bytes	Size in bytes.
- * @return Pointer to the allocated memory or NULL if failed.
- *
- * Like mod_alloc_align() but the alignment can not be specified.
- */
-void *mod_alloc(struct processing_module *mod, size_t size)
-{
-	return mod_alloc_align(mod, size, 0);
-}
-EXPORT_SYMBOL(mod_alloc);
 
 /**
  * Allocates memory block for module and initializes it to zero.

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -188,7 +188,8 @@ void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t ali
 	ptr = rmalloc_align(SOF_MEM_FLAG_USER, size, alignment);
 
 	if (!ptr) {
-		comp_err(mod->dev, "failed to allocate memory.");
+		comp_err(mod->dev, "Failed to alloc %d bytes %d alignment for comp %x.",
+			 size, alignment, dev_comp_id(mod->dev));
 		container_put(mod, container);
 		return NULL;
 	}

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -188,6 +188,8 @@ struct module_processing_data {
 /*****************************************************************************/
 int module_load_config(struct comp_dev *dev, const void *cfg, size_t size);
 int module_init(struct processing_module *mod);
+void *mod_balloc_align(struct processing_module *mod, size_t size, size_t alignment);
+void *mod_balloc(struct processing_module *mod, size_t size);
 void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment);
 void *mod_alloc(struct processing_module *mod, size_t size);
 void *mod_zalloc(struct processing_module *mod, size_t size);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -200,7 +200,16 @@ static inline void *mod_alloc(struct processing_module *mod, size_t size)
 	return mod_alloc_align(mod, size, 0);
 }
 
-void *mod_zalloc(struct processing_module *mod, size_t size);
+static inline void *mod_zalloc(struct processing_module *mod, size_t size)
+{
+	void *ret = mod_alloc(mod, size);
+
+	if (ret)
+		memset(ret, 0, size);
+
+	return ret;
+}
+
 int mod_free(struct processing_module *mod, const void *ptr);
 #if CONFIG_COMP_BLOB
 struct comp_data_blob_handler *mod_data_blob_handler_new(struct processing_module *mod);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -188,9 +188,9 @@ struct module_processing_data {
 /*****************************************************************************/
 int module_load_config(struct comp_dev *dev, const void *cfg, size_t size);
 int module_init(struct processing_module *mod);
-void *mod_alloc_align(struct processing_module *mod, uint32_t size, uint32_t alignment);
-void *mod_alloc(struct processing_module *mod, uint32_t size);
-void *mod_zalloc(struct processing_module *mod, uint32_t size);
+void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment);
+void *mod_alloc(struct processing_module *mod, size_t size);
+void *mod_zalloc(struct processing_module *mod, size_t size);
 int mod_free(struct processing_module *mod, const void *ptr);
 #if CONFIG_COMP_BLOB
 struct comp_data_blob_handler *mod_data_blob_handler_new(struct processing_module *mod);

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -189,9 +189,17 @@ struct module_processing_data {
 int module_load_config(struct comp_dev *dev, const void *cfg, size_t size);
 int module_init(struct processing_module *mod);
 void *mod_balloc_align(struct processing_module *mod, size_t size, size_t alignment);
-void *mod_balloc(struct processing_module *mod, size_t size);
+static inline void *mod_balloc(struct processing_module *mod, size_t size)
+{
+	return mod_balloc_align(mod, size, 0);
+}
+
 void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment);
-void *mod_alloc(struct processing_module *mod, size_t size);
+static inline void *mod_alloc(struct processing_module *mod, size_t size)
+{
+	return mod_alloc_align(mod, size, 0);
+}
+
 void *mod_zalloc(struct processing_module *mod, size_t size);
 int mod_free(struct processing_module *mod, const void *ptr);
 #if CONFIG_COMP_BLOB

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -581,7 +581,7 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	buffer = ipc4_create_buffer(source, cross_core_bind, buf_size, bu->extension.r.src_queue,
 				    bu->extension.r.dst_queue);
 	if (!buffer) {
-		tr_err(&ipc_tr, "failed to allocate buffer to bind %d to %d", src_id, sink_id);
+		tr_err(&ipc_tr, "failed to allocate buffer to bind %#x to %#x", src_id, sink_id);
 		return IPC4_OUT_OF_MEMORY;
 	}
 
@@ -646,14 +646,14 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 	ret = comp_buffer_connect(source, source->ipc_config.core, buffer,
 				  PPL_CONN_DIR_COMP_TO_BUFFER);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to connect src %d to internal buffer", src_id);
+		tr_err(&ipc_tr, "failed to connect src %#x to internal buffer", src_id);
 		goto free;
 	}
 
 	ret = comp_buffer_connect(sink, sink->ipc_config.core, buffer,
 				  PPL_CONN_DIR_BUFFER_TO_COMP);
 	if (ret < 0) {
-		tr_err(&ipc_tr, "failed to connect internal buffer to sink %d", sink_id);
+		tr_err(&ipc_tr, "failed to connect internal buffer to sink %#x", sink_id);
 		goto e_sink_connect;
 	}
 
@@ -1043,7 +1043,7 @@ __cold const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id)
 		mod = lib_manager_get_module_manifest(module_id);
 
 		if (!mod) {
-			tr_err(&comp_tr, "Error: Couldn't find loadable module with id %d.",
+			tr_err(&comp_tr, "Error: Couldn't find loadable module with id %#x.",
 			       module_id);
 			return NULL;
 		}

--- a/src/platform/library/lib/alloc.c
+++ b/src/platform/library/lib/alloc.c
@@ -16,6 +16,11 @@
 
 /* testbench mem alloc definition */
 
+void *rmalloc_align(uint32_t flags, size_t bytes, uint32_t alignment)
+{
+	return malloc(bytes);
+}
+
 void *rmalloc(uint32_t flags, size_t bytes)
 {
 	return malloc(bytes);

--- a/test/cmocka/src/common_mocks.c
+++ b/test/cmocka/src/common_mocks.c
@@ -63,8 +63,24 @@ void WEAK *rbrealloc_align(void *ptr, uint32_t flags,
 {
 	(void)flags;
 	(void)old_bytes;
+	(void)alignment;
 
 	return realloc(ptr, bytes);
+}
+
+void WEAK *rmalloc_align(uint32_t flags, size_t bytes, uint32_t alignment)
+{
+	(void)flags;
+	(void)alignment;
+
+	return malloc(bytes);
+}
+
+void WEAK *rmalloc(uint32_t flags, size_t bytes)
+{
+	(void)flags;
+
+	return malloc(bytes);
 }
 
 void WEAK rfree(void *ptr)

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -52,8 +52,14 @@
  * Allocates memory block.
  * @param flags Flags, see SOF_MEM_FLAG_....
  * @param bytes Size in bytes.
+ * @param alignment	Alignment in bytes.
  * @return Pointer to the allocated memory or NULL if failed.
  *
+ */
+void *rmalloc_align(uint32_t flags, size_t bytes, uint32_t alignment);
+
+/**
+ * Similar to rmalloc_align(), but no alignment can be specified.
  */
 void *rmalloc(uint32_t flags, size_t bytes);
 


### PR DESCRIPTION
The message bellow is mostly obsolete. 

It appears that virtual heap is not  able to cope with all module allcations, so move away from using rballoc() and friends to avoid moving all the module allocations to virtual heap. Use rmalloc() friends in stead. To do this rmalloc() family needs to be extended with rmallloc_aling(). Adding new function requires some additions to cmocka and testbench. Then there is also couple of minor fixes at the end of series.

This is the first split of this huge PR: https://github.com/thesofproject/sof/pull/10195

The older already merged PR on the same subject is here: https://github.com/thesofproject/sof/pull/10164