### PR TITLE
tools: topology2: move deepbuffer defaults to separate file

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -52,6 +52,7 @@
 <output_audio_format.conf>
 <dmic-default.conf>
 <ssp-default.conf>
+<deep-buffer-default.conf>
 
 Define {
 	MCLK 				24576000

--- a/tools/topology/topology2/cavs-rt5682.conf
+++ b/tools/topology/topology2/cavs-rt5682.conf
@@ -45,6 +45,7 @@
 <dmic-default.conf>
 <hdmi-default.conf>
 <bt-default.conf>
+<deep-buffer-default.conf>
 <input_pin_binding.conf>
 <output_pin_binding.conf>
 <input_audio_format.conf>

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -75,7 +75,7 @@ Define {
 	DEEP_BUFFER_PCM_ID_2		35
 	DEEP_BUFFER_PIPELINE_SRC_2	'mixin.16.1'
 	DEEP_BUFFER_PIPELINE_SINK_2	'mixout.21.1'
-	DEEP_BUFFER_PCM_NAME_2          'Deepbuffer Amps'
+	DEEP_BUFFER_PCM_NAME_2          'Deepbuffer Speaker'
 	SDW_JACK_OUT_STREAM	'SDW0-Playback'
 	SDW_JACK_IN_STREAM	'SDW0-Capture'
 	SDW_JACK_OUT_BE_ID	0

--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -48,6 +48,7 @@
 <intel/ssp_aux_config.conf>
 <ssp.conf>
 <bt-default.conf>
+<deep-buffer-default.conf>
 
 Define {
 	PLATFORM 		"none"
@@ -70,6 +71,11 @@ Define {
 	DEEP_BUFFER_PIPELINE_SRC        'mixin.15.1'
 	DEEP_BUFFER_PIPELINE_SINK       'mixout.1.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
+	DEEP_BUFFER_PIPELINE_ID_2	16
+	DEEP_BUFFER_PCM_ID_2		35
+	DEEP_BUFFER_PIPELINE_SRC_2	'mixin.16.1'
+	DEEP_BUFFER_PIPELINE_SINK_2	'mixout.21.1'
+	DEEP_BUFFER_PCM_NAME_2          'Deepbuffer Amps'
 	SDW_JACK_OUT_STREAM	'SDW0-Playback'
 	SDW_JACK_IN_STREAM	'SDW0-Capture'
 	SDW_JACK_OUT_BE_ID	0

--- a/tools/topology/topology2/platform/intel/deep-buffer-default.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer-default.conf
@@ -1,0 +1,8 @@
+# default settings for Deep Buffer Speaker
+Define {
+	DEEP_BUF_SPK	false
+	DEEP_BUF_JACK_RATE	48000
+
+	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
+	DEEP_BUFFER_PCM_NAME_2		'Deepbuffer Amps'
+}

--- a/tools/topology/topology2/platform/intel/deep-buffer-default.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer-default.conf
@@ -4,5 +4,5 @@ Define {
 	DEEP_BUF_JACK_RATE	48000
 
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer Jack Out'
-	DEEP_BUFFER_PCM_NAME_2		'Deepbuffer Amps'
+	DEEP_BUFFER_PCM_NAME_2		'Deepbuffer Speaker'
 }

--- a/tools/topology/topology2/platform/intel/deep-buffer.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer.conf
@@ -1,7 +1,3 @@
-Define {
-	DEEP_BUF_SPK	false
-	DEEP_BUF_JACK_RATE	48000
-}
 
 Object.Pipeline.deepbuffer-playback [
 	{
@@ -126,11 +122,6 @@ Object.Base.route [
 IncludeByKey.DEEP_BUF_SPK {
 "true"	{
 		Define {
-			DEEP_BUFFER_PIPELINE_ID_2	16
-			DEEP_BUFFER_PCM_ID_2		35
-			DEEP_BUFFER_PIPELINE_SRC_2	'mixin.16.1'
-			DEEP_BUFFER_PIPELINE_SINK_2	'mixout.21.1'
-			DEEP_BUFFER_PCM_NAME_2		'Deepbuffer Amps'
 			SPEAKER_PCM_CORE_ID		0
 		}
 

--- a/tools/topology/topology2/sof-hda-generic.conf
+++ b/tools/topology/topology2/sof-hda-generic.conf
@@ -40,6 +40,7 @@
 <common_definitions.conf>
 <dmic-default.conf>
 <hdmi-default.conf>
+<deep-buffer-default.conf>
 <module-copier.conf>
 
 Define {


### PR DESCRIPTION
Related to #10221 and solving the issue found in #10165

Marking as draft, need to do more testing, but getting this out early as this impacts #10221 review process.