### PR TITLE
rtos: alloc: Fix SOF_MEM_FLAG_* values

### DIFF
--- a/posix/include/rtos/alloc.h
+++ b/posix/include/rtos/alloc.h
@@ -32,22 +32,28 @@
  *  @{
  */
 
+/*
+ * for compatibility with the initial `flags` meaning
+ * SOF_MEM_FLAG_ should start at BIT(2)
+ * the first two positions are reserved for SOF_BUF_ flags
+ */
+
  /** \brief Indicates we should return DMA-able memory. */
-#define SOF_MEM_FLAG_DMA		BIT(0)
+#define SOF_MEM_FLAG_DMA		BIT(2)
 /** \brief Indicates that original content should not be copied by realloc. */
-#define SOF_MEM_FLAG_NO_COPY		BIT(1)
+#define SOF_MEM_FLAG_NO_COPY		BIT(3)
 /** \brief Indicates that if we should return uncached address. */
-#define SOF_MEM_FLAG_COHERENT		BIT(2)
+#define SOF_MEM_FLAG_COHERENT		BIT(4)
 /** \brief Indicates that if we should return L3 address. */
-#define SOF_MEM_FLAG_L3			BIT(3)
+#define SOF_MEM_FLAG_L3			BIT(5)
 /** \brief Indicates that if we should return Low power memory address. */
-#define SOF_MEM_FLAG_LOW_POWER		BIT(4)
+#define SOF_MEM_FLAG_LOW_POWER		BIT(6)
 /** \brief Indicates that if we should return kernel memory address. */
-#define SOF_MEM_FLAG_KERNEL		BIT(5)
+#define SOF_MEM_FLAG_KERNEL		BIT(7)
 /** \brief Indicates that if we should return user memory address. */
-#define SOF_MEM_FLAG_USER		BIT(6)
+#define SOF_MEM_FLAG_USER		BIT(8)
 /** \brief Indicates that if we should return shared user memory address. */
-#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(7)
+#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(9)
 
 /** @} */
 

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -19,26 +19,32 @@
  *  @{
  */
 
+/*
+ * for compatibility with the initial `flags` meaning
+ * SOF_MEM_FLAG_ should start at BIT(2)
+ * the first two positions are reserved for SOF_BUF_ flags
+ */
+
 /** \name Heap zone flags
  *  @{
  */
 
  /** \brief Indicates we should return DMA-able memory. */
-#define SOF_MEM_FLAG_DMA		BIT(0)
+#define SOF_MEM_FLAG_DMA		BIT(2)
 /** \brief Indicates that original content should not be copied by realloc. */
-#define SOF_MEM_FLAG_NO_COPY		BIT(1)
+#define SOF_MEM_FLAG_NO_COPY		BIT(3)
 /** \brief Indicates that if we should return uncached address. */
-#define SOF_MEM_FLAG_COHERENT		BIT(2)
+#define SOF_MEM_FLAG_COHERENT		BIT(4)
 /** \brief Indicates that if we should return L3 address. */
-#define SOF_MEM_FLAG_L3			BIT(3)
+#define SOF_MEM_FLAG_L3			BIT(5)
 /** \brief Indicates that if we should return Low power memory address. */
-#define SOF_MEM_FLAG_LOW_POWER		BIT(4)
+#define SOF_MEM_FLAG_LOW_POWER		BIT(6)
 /** \brief Indicates that if we should return kernel memory address. */
-#define SOF_MEM_FLAG_KERNEL		BIT(5)
+#define SOF_MEM_FLAG_KERNEL		BIT(7)
 /** \brief Indicates that if we should return user memory address. */
-#define SOF_MEM_FLAG_USER		BIT(6)
+#define SOF_MEM_FLAG_USER		BIT(8)
 /** \brief Indicates that if we should return shared user memory address. */
-#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(7)
+#define SOF_MEM_FLAG_USER_SHARED_BUFFER	BIT(9)
 
 /** @} */
 


### PR DESCRIPTION
Commit 5821682809c73dd2a ("heap: simplify heap API") changed the heap API to make it more like Linux kernel API.

For example:
  -> rballoc_align(flags, caps, bytes, align)

transformed into:

  -> rballoc_align(flags, bytes, align)

So, caps was merged into flags! Causing overrun_permitted to be set and making a lots of test (e.g SRC, Compress) to fail.

The original `flags` were the SOF_BUF_ flags mostly sent from Linux and read from topology (e.g SOF_BUF_OVERRUN_PERMITTED, SOF_BUF_UNDERRUN_PERMITTED).

But the new `flags` SOF_MEM_FLAG_* did not take this into account and overlap with the older flags.

For now, what we can do is just shift the new flags so that they do not overlap with the old flags.