### PR TITLE
buffers: Fix set_underrun/set_overrun calls

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -217,9 +217,6 @@ static struct comp_buffer *buffer_alloc_struct(void *stream_addr, size_t size,
 	audio_stream_set_addr(&buffer->stream, stream_addr);
 	buffer_init_stream(buffer, size);
 
-	audio_stream_set_underrun(&buffer->stream, !!(flags & SOF_BUF_UNDERRUN_PERMITTED));
-	audio_stream_set_overrun(&buffer->stream, !!(flags & SOF_BUF_OVERRUN_PERMITTED));
-
 	comp_buffer_reset_source_list(buffer);
 	comp_buffer_reset_sink_list(buffer);
 

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -85,6 +85,11 @@ __cold struct comp_buffer *buffer_new(const struct sof_ipc_buffer *desc, bool is
 		buffer->stream.runtime_stream_params.pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
 
+		audio_stream_set_underrun(&buffer->stream,
+					  !!(desc->flags & SOF_BUF_UNDERRUN_PERMITTED));
+		audio_stream_set_overrun(&buffer->stream,
+					 !!(desc->flags & SOF_BUF_OVERRUN_PERMITTED));
+
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
 			 &buffer_tr, sizeof(struct tr_ctx));
 	}


### PR DESCRIPTION
After commit 5821682809c73dd2a ("heap: simplify heap API") flags sent via IPC by the App processor are merged with caps.

There is an overlap after this merged so SOF_BUF_OVERRUN_PERMITTED overlaps with SOF_MEM_FLAG_DMA for example.

Also, it looks like the old `flags` are mostly unused. For now just remove the call audio_stream_set_underrun/audio_stream_set_overrun inside buffer_alloc_struct and set it in the buffer_new() function where we do have access to unmodified flags received from Linux.

In the future, we might completely remove the `old` flags.