### PR TITLE
audio: buffer: use add BUFFER_USAGE_ flags to improve readability

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -592,7 +592,7 @@ __cold static int chain_task_init(struct comp_dev *dev, uint8_t host_dma_id, uin
 	fifo_size = ALIGN_UP_INTERNAL(fifo_size, addr_align);
 	/* allocate not shared buffer */
 	cd->dma_buffer = buffer_alloc(fifo_size, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
-				      addr_align, false);
+				      addr_align, BUFFER_USAGE_NOT_SHARED);
 
 	if (!cd->dma_buffer) {
 		comp_err(dev, "failed to alloc dma buffer");

--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -427,8 +427,7 @@ __cold int create_multi_endpoint_buffer(struct comp_dev *dev,
 	ipc_buf.size = buf_size;
 	ipc_buf.comp.pipeline_id = config->pipeline_id;
 	ipc_buf.comp.core = config->core;
-	/* allocate not shared buffer */
-	buffer = buffer_new(&ipc_buf, false);
+	buffer = buffer_new(&ipc_buf, BUFFER_USAGE_NOT_SHARED);
 	if (!buffer)
 		return -ENOMEM;
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -562,7 +562,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 		}
 	} else {
 		dd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
-					      addr_align, false);
+					      addr_align, BUFFER_USAGE_NOT_SHARED);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "failed to alloc dma buffer");
 			return -ENOMEM;

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -1020,7 +1020,8 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 		}
 	} else {
 		dd->dma_buffer = buffer_alloc_range(buffer_size_preferred, buffer_size,
-						    SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA, addr_align, false);
+						    SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
+						    addr_align, BUFFER_USAGE_NOT_SHARED);
 		if (!dd->dma_buffer) {
 			comp_err(dev, "failed to alloc dma buffer");
 			return -ENOMEM;

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -760,7 +760,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 		}
 	} else {
 		hd->dma_buffer = buffer_alloc(buffer_size, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
-					      addr_align, false);
+					      addr_align, BUFFER_USAGE_NOT_SHARED);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "failed to alloc dma buffer");
 			err = -ENOMEM;

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -921,7 +921,8 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	} else {
 		/* allocate not shared buffer */
 		hd->dma_buffer = buffer_alloc_range(buffer_size_preferred, buffer_size,
-						    SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA, addr_align, false);
+						    SOF_MEM_FLAG_USER | SOF_MEM_FLAG_DMA,
+						    addr_align, BUFFER_USAGE_NOT_SHARED);
 		if (!hd->dma_buffer) {
 			comp_err(dev, "failed to alloc dma buffer");
 			return -ENOMEM;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -451,7 +451,8 @@ int module_adapter_prepare(struct comp_dev *dev)
 		for (i = 0; i < mod->num_of_sinks; i++) {
 			/* allocate not shared buffer */
 			struct comp_buffer *buffer = buffer_alloc(buff_size, memory_flags,
-								  PLATFORM_DCACHE_ALIGN, false);
+								  PLATFORM_DCACHE_ALIGN,
+								  BUFFER_USAGE_NOT_SHARED);
 			uint32_t flags;
 
 			if (!buffer) {

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -117,6 +117,10 @@ extern struct tr_ctx buffer_tr;
 #define BUFF_PARAMS_RATE	BIT(2)
 #define BUFF_PARAMS_CHANNELS	BIT(3)
 
+/* buffer usage */
+#define BUFFER_USAGE_SHARED	true	/* buffer used by multiple DSP core and/or HW blocks */
+#define BUFFER_USAGE_NOT_SHARED false	/* buffer only used by one HW block */
+
 /*
  * audio component buffer - connects 2 audio components together in pipeline.
  *

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -485,7 +485,7 @@ int ipc_buffer_new(struct ipc *ipc, const struct sof_ipc_buffer *desc)
 	}
 
 	/* register buffer with pipeline */
-	buffer = buffer_new(desc, false);
+	buffer = buffer_new(desc, BUFFER_USAGE_NOT_SHARED);
 	if (!buffer) {
 		tr_err(&ipc_tr, "buffer_new() failed");
 		return -ENOMEM;

--- a/test/cmocka/src/audio/buffer/buffer_copy.c
+++ b/test/cmocka/src/audio/buffer/buffer_copy.c
@@ -29,8 +29,8 @@ static void test_audio_buffer_copy_underrun(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -56,8 +56,8 @@ static void test_audio_buffer_copy_overrun(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -85,8 +85,8 @@ static void test_audio_buffer_copy_success(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -111,8 +111,8 @@ static void test_audio_buffer_copy_fit_space_constraint(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(src);
 	assert_non_null(snk);
@@ -139,8 +139,8 @@ static void test_audio_buffer_copy_fit_no_space_constraint(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *src = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *snk = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *src = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *snk = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(src);
 	assert_non_null(snk);

--- a/test/cmocka/src/audio/buffer/buffer_new.c
+++ b/test/cmocka/src/audio/buffer/buffer_new.c
@@ -27,7 +27,7 @@ static void test_audio_buffer_new(void **state)
 		.size = 256
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/audio/buffer/buffer_wrap.c
+++ b/test/cmocka/src/audio/buffer/buffer_wrap.c
@@ -27,7 +27,7 @@ static void test_audio_buffer_write_fill_10_bytes_and_write_5(void **state)
 		.size = 10
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/audio/buffer/buffer_write.c
+++ b/test/cmocka/src/audio/buffer/buffer_write.c
@@ -28,7 +28,7 @@ static void test_audio_buffer_write_10_bytes_out_of_256_and_read_back
 		.size = 256
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);
@@ -63,7 +63,7 @@ static void test_audio_buffer_fill_10_bytes(void **state)
 		.size = 10
 	};
 
-	struct comp_buffer *buf = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *buf = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 
 	assert_non_null(buf);
 	assert_int_equal(audio_stream_get_avail_bytes(&buf->stream), 0);

--- a/test/cmocka/src/math/fft/fft.c
+++ b/test/cmocka/src/math/fft/fft.c
@@ -265,8 +265,8 @@ static void test_math_fft_256(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 256 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 256;
@@ -307,8 +307,8 @@ static void test_math_fft_512(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 512;
@@ -349,8 +349,8 @@ static void test_math_fft_1024(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int32_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	int32_t *in = (int32_t *)source->stream.addr;
 	int fft_size = 1024;
@@ -391,9 +391,9 @@ static void test_math_fft_1024_ifft(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 4 * 2,
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *intm = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *intm = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex32 *out = (struct icomplex32 *)sink->stream.addr;
 	float db;
 	int64_t signal = 0;
@@ -432,9 +432,9 @@ static void test_math_fft_512_2ch(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 4 * 2,
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink1 = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink2 = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink1 = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink2 = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex32 *out1 = (struct icomplex32 *)sink1->stream.addr;
 	struct icomplex32 *out2 = (struct icomplex32 *)sink2->stream.addr;
 	uint32_t fft_size = 512;
@@ -625,8 +625,8 @@ static void test_math_fft_256_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 256 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 256;
@@ -667,8 +667,8 @@ static void test_math_fft_512_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 512 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 512;
@@ -709,8 +709,8 @@ static void test_math_fft_1024_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	int16_t *in = (int16_t *)source->stream.addr;
 	int fft_size = 1024;
@@ -751,9 +751,9 @@ static void test_math_fft_1024_ifft_16(void **state)
 	struct sof_ipc_buffer test_buf_desc = {
 		.size = 1024 * 2 * sizeof(int16_t),
 	};
-	struct comp_buffer *source = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *intm = buffer_new(&test_buf_desc, false);
-	struct comp_buffer *sink = buffer_new(&test_buf_desc, false);
+	struct comp_buffer *source = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *intm = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
+	struct comp_buffer *sink = buffer_new(&test_buf_desc, BUFFER_USAGE_NOT_SHARED);
 	struct icomplex16 *out = (struct icomplex16 *)sink->stream.addr;
 	float db;
 	int64_t signal = 0;

--- a/test/cmocka/src/util.h
+++ b/test/cmocka/src/util.h
@@ -23,7 +23,7 @@ static inline struct comp_buffer *create_test_sink(struct comp_dev *dev,
 		},
 		.size = buffer_size,
 	};
-	struct comp_buffer *buffer = buffer_new(&desc, false);
+	struct comp_buffer *buffer = buffer_new(&desc, BUFFER_USAGE_NOT_SHARED);
 
 	memset(buffer->stream.addr, 0, buffer_size);
 
@@ -58,7 +58,7 @@ static inline struct comp_buffer *create_test_source(struct comp_dev *dev,
 		},
 		.size = buffer_size,
 	};
-	struct comp_buffer *buffer = buffer_new(&desc, false);
+	struct comp_buffer *buffer = buffer_new(&desc, BUFFER_USAGE_NOT_SHARED);
 
 	memset(buffer->stream.addr, 0, buffer_size);
 


### PR DESCRIPTION
Passing boolean parameters to key functions results in hard to read code. Add BUFFER_USAGE_SHARED and BUFFER_USAGE_NOT_SHARED definitions to make code allocating buffers easier to read and maintain.

No functional change.