### PR TITLE
Tools: Topology: Add to nocodec port2 24 kHz rate capability

### DIFF
--- a/tools/topology/topology2/cavs-nocodec.conf
+++ b/tools/topology/topology2/cavs-nocodec.conf
@@ -1696,14 +1696,18 @@ IncludeByKey.PASSTHROUGH {
 					direction	"playback"
 					name "SSP2 Playback"
 					formats 'S16_LE,S24_LE,S32_LE'
-					rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
+					rates "8000,11025,16000,22050,24000,32000,44100,48000,64000,88200,96000,176400,192000"
+					rate_min 8000
+					rate_max 192000
 				}
 
 				Object.PCM.pcm_caps.2 {
 					direction	"capture"
 					name "SSP2 Capture"
 					formats 'S16_LE,S24_LE,S32_LE'
-					rates "8000,11025,16000,22050,32000,44100,48000,64000,88200,96000,176400,192000"
+					rates "8000,11025,16000,22050,24000,32000,44100,48000,64000,88200,96000,176400,192000"
+					rate_min 8000
+					rate_max 192000
 				}
 			}
 		]


### PR DESCRIPTION
This patch adds the 24 kHz rate to PCM capabilities. The 24 kHz rate is defined in the MPEG-2 standard. This also needs a patch to alsa-lib to build the topology without error.

The added rate_min/rate_max is not mandatory but it narrows down the range of rates evaluated in alsa-lib in snd_pcm_hw_refine().