### PR TITLE
west.yml: update zephyr to 5bef4a9d626

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9f4bd38ef7d3b52a41e715f45c9a4b2d9caf3bc4
+      revision: 5bef4a9d6264761c10d739b345eb2f7ded719099
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 686 commits.

Changes include:

- **68be678c4b9** intel_adsp: tlb: Configure HPSRAM retention mode after power transitions
- **a1adced1c42** intel_adsp: ace: Remove redundant HPSRAM init from D3 restore
- **91d17f69312** kernel: add k_thread_absolute_deadline_set call
- **df40dff6fb1** arch: xtensa: clean up interrupt handling
- **827a4f73874** coredump: xtensa: Add support for ARCH_SUPPORTS_COREDUMP_STACK_PTR