### PR TITLE
cmocka: mux_copy and demux_copy: Fix comp_check_eos() checking

### DIFF
--- a/test/cmocka/src/audio/mux/mux_copy.c
+++ b/test/cmocka/src/audio/mux/mux_copy.c
@@ -179,12 +179,20 @@ static int setup_test_case(void **state)
 	struct processing_module *mod;
 	struct sof_ipc_comp_process *ipc;
 	size_t sample_size = td->format == SOF_IPC_FRAME_S16_LE ? sizeof(int16_t) : sizeof(int32_t);
+	struct pipeline *dummy_pipe;
 
 	ipc = create_mux_comp_ipc(td);
 	dev = comp_new((struct sof_ipc_comp *)ipc);
 	free(ipc);
 	if (!dev)
 		return -EINVAL;
+
+	/* Add dummy pipeline to bypass comp_check_eos() */
+	dummy_pipe = test_malloc(sizeof(*dummy_pipe));
+	if (!dummy_pipe)
+		return -ENOMEM;
+	dummy_pipe->expect_eos = false;
+	dev->pipeline = dummy_pipe;
 
 	mod = comp_mod(dev);
 	td->dev = dev;
@@ -207,6 +215,8 @@ static int teardown_test_case(void **state)
 		free_test_source(td->sources[i]);
 
 	free_test_sink(td->sink);
+	test_free(td->dev->pipeline);
+	td->dev->pipeline = NULL;
 	comp_free(td->dev);
 	return 0;
 }


### PR DESCRIPTION
After comp_check_eos() checks were added mux_copy and demux_copy started crashing. Add dummy pipeline with expect_eos = false to bypass the tests.

Fixes: d472d22b38a2 ("component: Add eos support in components copy function")