### PR TITLE
llext: Fix wrong literals placement in modules

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -58,6 +58,14 @@ function(sof_llext_build module)
 		file(WRITE ${PROJECT_BINARY_DIR}/${module}_llext/lib_name.txt ${SOF_LLEXT_LIB})
 	endif()
 
+	if("${ARCH}" STREQUAL "xtensa")
+		# This makes sure literals are placed in memory before they are used by
+		# the L32R instruction. Usually this is guaranteed by the linker script.
+		# However, since a linker script is not used for LLEXT modules builds,
+		# correct literal placement is ensured with a compilation option here.
+		set(SOF_LLEXT_CFLAGS ${SOF_LLEXT_CFLAGS} -mtext-section-literals)
+	endif()
+
 	target_include_directories(${module}_llext_lib PRIVATE
 		"${SOF_BASE}/xtos/include"
 		"${SOF_BASE}/src/include"


### PR DESCRIPTION
Xtensa L32R instruction requires the literal it loads to be located in memory before the L32R address. Such a requirement is usually satisfied by linker script rules which put literals sections before text sections in which they are used. LLEXT module builds do not use a linker script, and so correct placement of literals is ensured by a compilation option.