### PR TITLE
audio: base_fw: fix race condition in perf counters reset operation

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -439,8 +439,8 @@ __cold int set_perf_meas_state(const char *data)
 		break;
 	case IPC4_PERF_MEASUREMENTS_STOPPED:
 		enable_performance_counters();
-		reset_performance_counters();
 		perf_meas_set_state(IPC4_PERF_MEASUREMENTS_STOPPED);
+		reset_performance_counters();
 		break;
 	case IPC4_PERF_MEASUREMENTS_STARTED:
 		enable_performance_counters();


### PR DESCRIPTION
Change the order of operations in the performance measurement initialization sequence to avoid a race condition.
Previously, the performance counters were reset before setting the state to STOPPED, which created a window where an LL task could preempt the execution and record new measurements between these operations.