### PR TITLE
Revert "module_adapter: Count sinks/sources during bind"

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -723,11 +723,9 @@ int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 	switch (bind_data->bind_type) {
 	case COMP_BIND_TYPE_SINK:
 		ret = sink_bind(bind_data->sink, mod);
-		mod->num_of_sinks++;
 		break;
 	case COMP_BIND_TYPE_SOURCE:
 		ret = source_bind(bind_data->source, mod);
-		mod->num_of_sources++;
 		break;
 	default:
 		ret = -EINVAL;
@@ -749,11 +747,9 @@ int module_unbind(struct processing_module *mod, struct bind_info *unbind_data)
 	switch (unbind_data->bind_type) {
 	case COMP_BIND_TYPE_SINK:
 		ret = sink_unbind(unbind_data->sink);
-		mod->num_of_sinks--;
 		break;
 	case COMP_BIND_TYPE_SOURCE:
 		ret = source_unbind(unbind_data->source);
-		mod->num_of_sources--;
 		break;
 	default:
 		ret = -EINVAL;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -313,6 +313,16 @@ int module_adapter_prepare(struct comp_dev *dev)
 	if (IS_PROCESSING_MODE_SINK_SOURCE(mod))
 		return 0;
 
+	/* compute number of input buffers */
+	mod->num_of_sources = 0;
+	list_for_item(blist, &dev->bsource_list)
+		mod->num_of_sources++;
+
+	/* compute number of output buffers */
+	mod->num_of_sinks = 0;
+	list_for_item(blist, &dev->bsink_list)
+		mod->num_of_sinks++;
+
 	if (!mod->num_of_sources && !mod->num_of_sinks) {
 		comp_err(dev, "no source and sink buffers connected!");
 		return -EINVAL;
@@ -1212,6 +1222,9 @@ int module_adapter_reset(struct comp_dev *dev)
 	if (IS_PROCESSING_MODE_RAW_DATA(mod) || IS_PROCESSING_MODE_AUDIO_STREAM(mod)) {
 		rfree(mod->output_buffers);
 		rfree(mod->input_buffers);
+
+		mod->num_of_sources = 0;
+		mod->num_of_sinks = 0;
 	}
 
 	mod->total_data_consumed = 0;


### PR DESCRIPTION
This reverts commit ba3e73fe75ca369260f653db71c8d60672c57097.

This breaks IPC3 API because not function updates the num_sources and num_sinks for IPC3.

Thus any processing pipeline using module adapter will fail with:

[00:00:00.003,212] <err> module_adapter: comp:1.1 no source and sink buffers connected!