### PR TITLE
base_fw: Extend fw_config with information about the host buffer size

### DIFF
--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -373,6 +373,8 @@ enum ipc4_fw_config_params {
 	IPC4_DMI_FORCE_L1_EXIT = 28,
 	/* FW context save on D3 entry */
 	IPC4_FW_CONTEXT_SAVE = 29,
+	/* Minimum size of host buffer in ms */
+	IPC4_FW_MIN_HOST_BUFFER_PERIODS = 33,
 	/* Total number of FW config parameters  */
 	IPC4_FW_CFG_PARAMS_COUNT,
 	/* Max config parameter id */


### PR DESCRIPTION
The host buffer default or minimum size can be platform dependent and it is not know by the host.
It is in sole discretion of the firmware and the hardware where it is running and can be changed by recompiling the firmware.

Add new tlv item to fw_config with ID 33 and store the host DMA default period size, which is the indication of the default, minimum size of the host buffer in ms.