### PR TITLE
topology2: include: common: pcm: Add quotes for string values

### DIFF
--- a/tools/topology/topology2/include/common/pcm.conf
+++ b/tools/topology/topology2/include/common/pcm.conf
@@ -25,9 +25,9 @@ Class.PCM."pcm" {
 	DefineAttribute."direction" {
 		constraints {
 			!valid_values [
-				playback
-				capture
-				duplex
+				"playback"
+				"capture"
+				"duplex"
 			]
 		}
 	}


### PR DESCRIPTION
Add quotes around the valid values for direction to prevent compilation errors with the latest alsa-lib that fails with the error: ALSA lib conf.c:1224:(parse_value) id is not an integer ALSA lib conf.c:2014:(_snd_config_load_with_include) _toplevel_:224:17:Unexpected char