### PR TITLE
copier: fix NULL converter crash for non-zero sink_queue_id

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -540,7 +540,12 @@ static int do_conversion_copy(struct comp_dev *dev,
 
 	comp_get_copy_limits(src, sink, processed_data);
 
-	i = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
+	/*
+	 * Buffer ID is constructed as IPC4_COMP_ID(src_queue, dst_queue).
+	 * From the buffer's perspective, copier's sink is the source,
+	 * so we use IPC4_SRC_QUEUE_ID() to get the correct copier sink index.
+	 */
+	i = IPC4_SRC_QUEUE_ID(buf_get_id(sink));
 	if (i >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT)
 		return -EINVAL;
 	buffer_stream_invalidate(src, processed_data->source_bytes);
@@ -617,7 +622,12 @@ static int copier_module_copy(struct processing_module *mod,
 			uint32_t source_samples;
 			int sink_queue_id;
 
-			sink_queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(sink_c));
+			/*
+			 * Buffer ID is constructed as IPC4_COMP_ID(src_queue, dst_queue).
+			 * From the buffer's perspective, copier's sink is the source,
+			 * so we use IPC4_SRC_QUEUE_ID() to get the correct copier sink index.
+			 */
+			sink_queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(sink_c));
 			if (sink_queue_id >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT)
 				return -EINVAL;
 


### PR DESCRIPTION
This PR fixes a NULL pointer dereference crash in the IPC4 copier module that occurs when sink buffer IDs map to non-zero `sink_queue_id` values but corresponding converters are not initialized.

## Problem Description

The crash occurs in `do_conversion_copy()` when accessing `cd->converter[i]` where `i` is extracted from sink buffer IDs using `IPC4_SINK_QUEUE_ID(buf_get_id(sink))`.

### Root Cause
1. **Buffer ID Mapping**: `IPC4_SINK_QUEUE_ID()` can extract non-zero queue IDs from buffer IDs, even in single-sink scenarios
2. **Limited Initialization**: `copier_prepare()` only initializes `converter[0]` for pin 0
3. **Runtime Mismatch**: Accessing `converter[1]` when only `converter[0]` exists causes NULL pointer dereference

### Crash Conditions
The crash occurs when **all** conditions are met:
- Copier component has `endpoint_num == 0` (module copier, not gateway copier)
- Connected sink buffer's ID maps to non-zero `sink_queue_id` via `IPC4_SINK_QUEUE_ID()`
- Only `converter[0]` was initialized in `copier_prepare()`
- Audio processing attempts to use `converter[sink_queue_id]` where `sink_queue_id != 0`

**Example**: Buffer ID `0x10000` extracts to `sink_queue_id=1`, but only `converter[0]` exists.

### Current Implementation
`copier_prepare()` only initializes `converter[0]`:
```c
if (!cd->endpoint_num) {
    cd->converter[0] = get_converter_func(&cd->config.base.audio_fmt,
                          &cd->config.out_fmt, ipc4_gtw_none,
                          ipc4_bidirection, DUMMY_CHMAP);
}
```

This assumes all sink buffers map to `sink_queue_id=0`, which is incorrect when buffer IDs encode different queue information.

## Test Pipeline Description

The crash occurs in RTC AEC topologies with internal module copiers. Example topology:

```mermaid
flowchart TD

    subgraph Pipeline0
        direction LR
        style Pipeline0 fill:#daf5e5,stroke:#3cb371,stroke-width:2px
        copier0["COPIER <br/> Module Id: 0x3 <br/> Instance Id: 0x0 <br/> HOST -> DSP <br/> 4/16(16)/48000"] --> aec["RTC AEC <br/> Module Id: 0x2000 <br/> Instance Id: 0x0"]
        aec --> copier1["COPIER <br/> Module Id: 0x3 <br/> Instance Id: 0x1 <br/> HOST <- DSP <br/> 4/16(16)/48000"]
    end

    subgraph Pipeline1
        direction LR
        style Pipeline1 fill:#daf5e5,stroke:#3cb371,stroke-width:2px
        copier2["COPIER <br/> Module Id: 0x3 <br/> Instance Id: 0x3 <br/> HOST -> DSP <br/> 2/16(16)/48000"] --> copier3["COPIER <br/> Module Id: 0x3 <br/> Instance Id: 0x2"]
        copier3 --> aec
    end
```

The crash occurs in **copier3** (Instance 0x2), an internal module copier (`endpoint_num == 0`) whose sink buffer ID maps to non-zero `sink_queue_id`, but the corresponding converter was never initialized.