### PR TITLE
audio: use zephyr/cache.h for cache flush/invalidate

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -15,7 +15,6 @@
 #include <sof/common.h>
 #include <rtos/interrupt.h>
 #include <rtos/alloc.h>
-#include <rtos/cache.h>
 #include <sof/lib/notifier.h>
 #include <sof/list.h>
 #include <rtos/spinlock.h>
@@ -24,6 +23,7 @@
 #include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <zephyr/cache.h>
 
 LOG_MODULE_REGISTER(buffer, CONFIG_SOF_LOG_LEVEL);
 
@@ -307,9 +307,9 @@ void buffer_zero(struct comp_buffer *buffer)
 
 	bzero(audio_stream_get_addr(&buffer->stream), audio_stream_get_size(&buffer->stream));
 	if (buffer->flags & SOF_MEM_FLAG_DMA)
-		dcache_writeback_region((__sparse_force void __sparse_cache *)
-					audio_stream_get_addr(&buffer->stream),
-					audio_stream_get_size(&buffer->stream));
+		sys_cache_data_flush_range((__sparse_force void __sparse_cache *)
+					   audio_stream_get_addr(&buffer->stream),
+					   audio_stream_get_size(&buffer->stream));
 }
 
 int buffer_set_size(struct comp_buffer *buffer, uint32_t size, uint32_t alignment)

--- a/src/audio/buffers/ring_buffer.c
+++ b/src/audio/buffers/ring_buffer.c
@@ -13,6 +13,8 @@
 #include <rtos/alloc.h>
 #include <ipc/topology.h>
 
+#include <zephyr/cache.h>
+
 LOG_MODULE_REGISTER(ring_buffer, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(ring_buffer);
@@ -56,13 +58,13 @@ static inline void ring_buffer_invalidate_shared(struct ring_buffer *ring_buffer
 	/* wrap-around? */
 	if ((uintptr_t)ptr + size > (uintptr_t)ring_buffer_buffer_end(ring_buffer)) {
 		/* writeback till the end of circular buffer */
-		dcache_invalidate_region
+		sys_cache_data_invd_range
 			(ptr, (uintptr_t)ring_buffer_buffer_end(ring_buffer) - (uintptr_t)ptr);
 		size -= (uintptr_t)ring_buffer_buffer_end(ring_buffer) - (uintptr_t)ptr;
 		ptr = ring_buffer->_data_buffer;
 	}
 	/* invalidate rest of data */
-	dcache_invalidate_region(ptr, size);
+	sys_cache_data_invd_range(ptr, size);
 }
 
 static inline void ring_buffer_writeback_shared(struct ring_buffer *ring_buffer,
@@ -75,13 +77,13 @@ static inline void ring_buffer_writeback_shared(struct ring_buffer *ring_buffer,
 	/* wrap-around? */
 	if ((uintptr_t)ptr + size > (uintptr_t)ring_buffer_buffer_end(ring_buffer)) {
 		/* writeback till the end of circular buffer */
-		dcache_writeback_region
+		sys_cache_data_flush_range
 			(ptr, (uintptr_t)ring_buffer_buffer_end(ring_buffer) - (uintptr_t)ptr);
 		size -= (uintptr_t)ring_buffer_buffer_end(ring_buffer) - (uintptr_t)ptr;
 		ptr = ring_buffer->_data_buffer;
 	}
 	/* writeback rest of data */
-	dcache_writeback_region(ptr, size);
+	sys_cache_data_flush_range(ptr, size);
 }
 
 

--- a/src/audio/copier/copier_ipcgtw.c
+++ b/src/audio/copier/copier_ipcgtw.c
@@ -8,6 +8,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/ut.h>
 #include <rtos/init.h>
+#include <zephyr/cache.h>
 #include "copier.h"
 #include "ipcgtw_copier.h"
 
@@ -94,8 +95,8 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 	uint32_t data_size;
 	struct ipc4_ipc_gateway_cmd_data_reply *out;
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
-				 sizeof(struct ipc4_ipc_gateway_cmd_data));
+	sys_cache_data_invd_range((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+				  sizeof(struct ipc4_ipc_gateway_cmd_data));
 	in = (const struct ipc4_ipc_gateway_cmd_data *)MAILBOX_HOSTBOX_BASE;
 
 	dev = find_ipcgtw_by_node_id(in->node_id);
@@ -138,7 +139,7 @@ int copier_ipcgtw_process(const struct ipc4_ipcgtw_cmd *cmd,
 		if (buf) {
 			data_size = MIN(cmd->extension.r.data_size,
 					audio_stream_get_free_bytes(&buf->stream));
-			dcache_invalidate_region((__sparse_force void __sparse_cache *)
+			sys_cache_data_invd_range((__sparse_force void __sparse_cache *)
 						 MAILBOX_HOSTBOX_BASE,
 						 data_size +
 						 offsetof(struct ipc4_ipc_gateway_cmd_data,

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -22,7 +22,7 @@
 #include <sof/math/numbers.h>
 #include <sof/lib/dma.h>
 #include <rtos/alloc.h>
-#include <rtos/cache.h>
+#include <zephyr/cache.h>
 #include <ipc/stream.h>
 #include <ipc4/base-config.h>
 #include <module/audio/audio_stream.h>
@@ -756,10 +756,10 @@ static inline void audio_stream_writeback(struct audio_stream *buffer, uint32_t 
 		tail_size = bytes - head_size;
 	}
 
-	dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->w_ptr, head_size);
+	sys_cache_data_flush_range((__sparse_force void __sparse_cache *)buffer->w_ptr, head_size);
 	if (tail_size)
-		dcache_writeback_region((__sparse_force void __sparse_cache *)buffer->addr,
-					tail_size);
+		sys_cache_data_flush_range((__sparse_force void __sparse_cache *)buffer->addr,
+					   tail_size);
 }
 
 /**


### PR DESCRIPTION
Use Zephyr native cache interface instead of legacy rtos/cache.h. This ensures audio code is using interfaces that supports use from user-space (if enabled at build time).