### PR TITLE
audio: src: simplify src_is_ready_to_process()

### DIFF
--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -649,9 +649,7 @@ bool src_is_ready_to_process(struct processing_module *mod,
 			     struct sof_source **sources, int num_of_sources,
 			     struct sof_sink **sinks, int num_of_sinks)
 {
-	struct comp_data *cd = module_get_private_data(mod);
-
-	return src_get_copy_limits(cd, sources[0], sinks[0]);
+	return sink_get_free_frames(sinks[0]) || source_get_data_frames_available(sources[0]);
 }
 
 int src_process(struct processing_module *mod,


### PR DESCRIPTION
src_get_copy_limits() only returns false if both
sink_get_free_frames(sink) and
source_get_data_frames_available(source) return 0. They are calculated in the beginning of the function, the rest of the function is calculating intermediate values, used later for sample calculation. But src_get_copy_limits(() is also called in src_process(), so inside src_is_ready_to_process() it's enough to perform a much simpler check, skipping all the calculations.