### PR TITLE
audio: fix cache invalidation in audio_stream_invalidate

### DIFF
--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -733,10 +733,10 @@ static inline void audio_stream_invalidate(struct audio_stream *buffer, uint32_t
 		tail_size = bytes - head_size;
 	}
 
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->r_ptr, head_size);
+	sys_cache_data_flush_range((__sparse_force void __sparse_cache *)buffer->r_ptr, head_size);
 	if (tail_size)
-		dcache_invalidate_region((__sparse_force void __sparse_cache *)buffer->addr,
-					 tail_size);
+		sys_cache_data_flush_range((__sparse_force void __sparse_cache *)buffer->addr,
+					   tail_size);
 }
 
 /**


### PR DESCRIPTION
Fix remaining calls to old dcache_invalidate_region() API in the audio_stream_invalidate() function that were missed during the cache API migration. Replace with proper sys_cache_data_invd_range() calls.

The previous refactor left two calls to the old API which causes build failures.

Fixes: f78acf4e44b4 ("audio: use zephyr/cache.h for cache flush/invalidate")