### PR TITLE
zephyr-lite: update base to zephyr-build v0.28.4 and rework zephyr workflows

### DIFF
--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -7,9 +7,15 @@ name: Zephyr LLEXT
 # yamllint disable-line rule:truthy
 on: [pull_request, workflow_dispatch]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-22.04
+    container:
+      image: thesofproject/zephyr-lite:v0.28.4
 
     strategy:
       fail-fast: false
@@ -17,33 +23,30 @@ jobs:
         platform: [mtl, lnl]
 
     steps:
-      - name: free space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-
-      - name: git clone sof
+      - name: checkout
         uses: actions/checkout@v4
         with:
-          path: ./workspace/sof
+          path: sof
           fetch-depth: 0  # fix git describe
           filter: 'tree:0'
 
-      - name: west clones
-        run: pip3 install west && cd workspace/sof/ && west init -l &&
-               west update --narrow --fetch-opt=--depth=5
+      - name: west update
+        working-directory: sof
+        run: |
+          west init -l
+          west update --narrow --fetch-opt=--depth=5
 
-      - name: Download docker image && ls /opt/toolchains/
-        run: cd workspace && ./sof/zephyr/docker-run.sh ls -l /opt/toolchains/
+      - name: print all available sdks in /opt/toolchains/
+        run: |
+          ls -l /opt/toolchains/
 
       - name: llext build
         run: |
-          cd workspace && ./sof/zephyr/docker-run.sh /bin/sh -c \
-             "ln -s  /opt/toolchains/zephyr-sdk-*  ~/;
-              python sof/scripts/xtensa-build-zephyr.py \
-              --cmake-args=-DEXTRA_CFLAGS=-Werror \
-              --cmake-args=-DEXTRA_CXXFLAGS=-Werror \
-              --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings' \
-              --cmake-args=--warn-uninitialized \
-              --overlay=sof/app/configs/${{ matrix.platform }}/modules.conf \
-              ${{ matrix.platform }}"
+          ln -s  /opt/toolchains/zephyr-sdk-*  ~/
+          python sof/scripts/xtensa-build-zephyr.py \
+            --cmake-args=-DEXTRA_CFLAGS=-Werror \
+            --cmake-args=-DEXTRA_CXXFLAGS=-Werror \
+            --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings' \
+            --cmake-args=--warn-uninitialized \
+            --overlay=sof/app/configs/${{ matrix.platform }}/modules.conf \
+            ${{ matrix.platform }}

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -7,6 +7,10 @@ name: Sparse Zephyr
 # yamllint disable-line rule:truthy
 on: [push, pull_request, workflow_dispatch, workflow_call]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of
   # sparse.c is an unusable mess and always zero in practice. Moreover
@@ -18,6 +22,8 @@ jobs:
     # We're sharing the sparse binary with the zephyr-build container so keep
     # this in sync with it.
     runs-on: ubuntu-24.04
+    container:
+      image: thesofproject/zephyr-lite:v0.28.4
 
     strategy:
       fail-fast: false
@@ -25,43 +31,39 @@ jobs:
         platform: [tgl, mtl, lnl]
 
     steps:
-      - name: free space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-
       - name: git clone sparse analyzer
         uses: actions/checkout@v4
         with:
           repository: thesofproject/sparse
           fetch-depth: 0
           filter: 'tree:0'
-          path: workspace/sparse
+          path: sparse
 
       # As of its 2023 commit 98b203419679, sparse-llvm.c uses symbols
       # (LLVMConstGEP, LLVMBuildLoad, LLVMBuildCall,...) which are:
       #   -  -Wdeprecated in LLVM v14
       #   -  Removed in LLVM v16
       - name: build sparse analyzer
-        run: cd workspace/sparse && make -j4  # HAVE_LLVM=no
+        working-directory: sparse
+        run: |
+          make -j4  # HAVE_LLVM=no
 
       - name: git clone sof
         uses: actions/checkout@v4
         with:
-          path: ./workspace/sof
+          path: sof
           fetch-depth: 0  # fix git describe
           filter: 'tree:0'
 
-      - name: west clones
-        run: pip3 install west && cd workspace/sof/ && west init -l &&
-               west update --narrow --fetch-opt=--depth=5
+      - name: west update
+        working-directory: sof
+        run: |
+          west init -l
+          west update --narrow --fetch-opt=--depth=5
 
-      # Not strictly necessary but saves a lot of scrolling in the next step
-      # Caching a 12G image is unfortunately not possible:
-      #   https://github.com/ScribeMD/docker-cache/issues/304
-      # For faster builds we would have to pay for some persistent runners.
-      - name: Download docker image && ls /opt/toolchains/
-        run: cd workspace && ./sof/zephyr/docker-run.sh ls -l /opt/toolchains/
+      - name: print all available sdks in /opt/toolchains/
+        run: |
+          ls -l /opt/toolchains/
 
       # --pristine is important to reproduce _warnings_. It makes no
       # difference for github but it's useful for anyone trying to
@@ -69,13 +71,11 @@ jobs:
       # "sparse" is currently incompatible with PICOLIBC (the new Zephyr default),
       # see https://github.com/zephyrproject-rtos/zephyr/issues/63003
       - name: analyze zephyr
-        working-directory: ./workspace
         run: |
-             ./sof/zephyr/docker-run.sh                          \
-             ./sof/zephyr/docker-build.sh ${{ matrix.platform }}          \
-             --cmake-args=-DZEPHYR_SCA_VARIANT=sparse --cmake-args=-DCONFIG_LOG_USE_VLA=n  \
-             --cmake-args=-DCONFIG_MINIMAL_LIBC=y  \
-             --pristine 2>&1 | tee _.log
+          ./sof/zephyr/docker-build.sh ${{ matrix.platform }} \
+            --cmake-args=-DZEPHYR_SCA_VARIANT=sparse --cmake-args=-DCONFIG_LOG_USE_VLA=n \
+            --cmake-args=-DCONFIG_MINIMAL_LIBC=y \
+            --pristine 2>&1 | tee _.log
 
-             printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'
-             (set -x; ./sof/scripts/parse_sparse_output.sh ${{ matrix.platforms.platform }} <_.log)
+          printf '\n\n\t\t\t  ---- Messages below are treated as sparse errors --- \n\n\n'
+          (set -x; ./sof/scripts/parse_sparse_output.sh ${{ matrix.platforms.platform }} <_.log)

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -15,18 +15,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   manifest-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: thesofproject/zephyr-lite:v0.28.4
     steps:
       - uses: actions/checkout@v4
         with:
-          path: ./workspace/sof
+          path: sof
           filter: 'tree:0'
 
       - name: plain west update
+        working-directory: sof
         run: |
-
           : This plain 'west update' does not provide 100% certainty that
           : all the manifest revisions make sense but it is quick and
           : will catch many revision problems. Other jobs typically
@@ -35,8 +39,6 @@ jobs:
           : is useful for testing unmerged Zephyr commits but risks
           : accepting "invalid" ones, this will not.
 
-          pip3 install west
-          cd workspace/sof/
           west init -l
           west update --fetch-opt=--filter=tree:0
 
@@ -45,9 +47,8 @@ jobs:
       # XTOS submodules and... temporarily break every CI, which is why
       # it hasn't been done yet.
       - name: git submodules consistency
+        working-directory: sof
         run: |
-
-          cd workspace/sof
           git submodule update --init --recursive
 
           west update
@@ -66,40 +67,42 @@ jobs:
   # job will be disappear, folded back in the regular build-* jobs below.
   LP64-WIP:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: thesofproject/zephyr-lite:v0.28.4
 
     steps:
       - uses: actions/checkout@v4
         with:
-          path: ./workspace/sof
+          path: sof
           filter: 'tree:0'
 
-      - name: free space
+      - name: west update
+        working-directory: sof
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
+          west init -l
+          west update --narrow --fetch-opt=--filter=tree:0
 
-      - name: west clones
-        run: pip3 install west && cd workspace/sof/ && west init -l &&
-               west update --narrow --fetch-opt=--filter=tree:0
-
-      # Not strictly necessary but saves a lot of scrolling in the next step
-      # Caching a 12G image is unfortunately not possible:
-      #   https://github.com/ScribeMD/docker-cache/issues/304
-      # For faster builds we would have to pay for some persistent runners.
-      - name: Download docker image && ls /opt/toolchains/
-        run: cd workspace && ./sof/zephyr/docker-run.sh ls -l /opt/toolchains/
+      - name: print all available sdks in /opt/toolchains/
+        run: |
+          ls -l /opt/toolchains/
 
       - name: 64 bits build
         run: |
-          cd workspace && ./sof/zephyr/docker-run.sh /bin/sh -c \
-             'ln -s  /opt/toolchains/zephyr-sdk-*  ~/;
-              west build --board imx93_evk/mimx9352/a55 sof/app      \
-              -- -DEXTRA_CFLAGS=-Werror -DEXTRA_CXXFLAGS=-Werror     \
-              -DEXTRA_AFLAGS=-Werror'
-
+          ln -s  /opt/toolchains/zephyr-sdk-*  ~/
+          west build --board imx93_evk/mimx9352/a55 sof/app \
+            -- -DEXTRA_CFLAGS=-Werror -DEXTRA_CXXFLAGS=-Werror \
+            -DEXTRA_AFLAGS=-Werror
 
   build-linux:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: thesofproject/zephyr-lite:v0.28.4
     strategy:
       fail-fast: false
       matrix:
@@ -143,20 +146,15 @@ jobs:
         with:
           fetch-depth: 0
           filter: 'tree:0'
-          path: ./workspace/sof
+          path: sof
 
-      - name: free space
+      - name: west update
+        working-directory: sof
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-
-      - name: west clones
-
-        run: pip3 install west && cd workspace/sof/ && west init -l &&
-               time west update --narrow --fetch-opt=--filter=tree:0
+          west init -l
+          west update --narrow --fetch-opt=--filter=tree:0
 
       - name: select zephyr revision
-        working-directory: ${{ github.workspace }}/workspace
         run: |
           if [ 'mnfst' =  '${{ matrix.zephyr_revision }}' ]; then
              rem_rev=$(git -C zephyr rev-parse HEAD)
@@ -175,7 +173,7 @@ jobs:
       # Get some tags to fix `git describe` hence BUILD_VERSION, etc.
       # Keep in sync with build-windows below
       - name: Fetch tags for git describe
-        working-directory: ${{ github.workspace }}/workspace/zephyr
+        working-directory: zephyr
         run: |
           # Because we used git tricks to speed things up, we now have two git
           # problems:
@@ -205,25 +203,19 @@ jobs:
           git describe --long --always --dirty
           git describe --long --always --dirty --tags
 
-      # Not strictly necessary but saves a lot of scrolling in the next step
-      # Caching a 12G image is unfortunately not possible:
-      #   https://github.com/ScribeMD/docker-cache/issues/304
-      # For faster builds we would have to pay for some persistent runners.
-      - name: Download docker image && ls /opt/toolchains/
-        run: cd workspace && ./sof/zephyr/docker-run.sh ls -l /opt/toolchains/
+      - name: print all available sdks in /opt/toolchains/
+        run: |
+          ls -l /opt/toolchains/
 
-      # https://github.com/zephyrproject-rtos/docker-image
-      # Note: env variables can be passed to the container with
-      # -e https_proxy=...
       - name: build
-        run: cd workspace && ./sof/zephyr/docker-run.sh
-             ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror
-             --cmake-args=-DEXTRA_CXXFLAGS=-Werror
-             --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings'
-             --cmake-args=--warn-uninitialized
-             --overlay=sof/app/configs/repro-build.conf
-             --no-tarball
-             ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
+        run: |
+          ./sof/zephyr/docker-build.sh --cmake-args=-DEXTRA_CFLAGS=-Werror \
+            --cmake-args=-DEXTRA_CXXFLAGS=-Werror \
+            --cmake-args=-DEXTRA_AFLAGS='-Werror -Wa,--fatal-warnings' \
+            --cmake-args=--warn-uninitialized \
+            --overlay=sof/app/configs/repro-build.conf \
+            --no-tarball \
+            ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -232,8 +224,8 @@ jobs:
           name: linux-build ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
           if-no-files-found: error
           path: |
-            ${{ github.workspace }}/workspace/build-sof-staging
-            ${{ github.workspace }}/workspace/**/compile_commands.json
+            build-sof-staging
+            ./**/compile_commands.json
 
   build-windows:
     runs-on: windows-latest
@@ -285,12 +277,12 @@ jobs:
 
       # Keep this SDK version identical to the one in
       # sof/zephyr/docker-run.sh
-      - name: Cache Zephyr SDK 0.17.0
+      - name: Cache Zephyr SDK 0.17.4
         id: cache-zephyr-sdk
         uses: actions/cache@v4
         with:
-          path: zephyr-sdk-0.17.0_windows-x86_64.7z
-          key: ${{ runner.os }}-cache-zephyr-sdk-0-17-0
+          path: zephyr-sdk-0.17.4_windows-x86_64.7z
+          key: ${{ runner.os }}-cache-zephyr-sdk-0-17-4
 
       # Wget is needed by Zephyr SDK setup.cmd installation script
       - name: Download wget
@@ -298,11 +290,11 @@ jobs:
         run: |
           curl -L -O http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip
 
-      - name: Download Zephyr SDK 0.17.0
+      - name: Download Zephyr SDK 0.17.4
         if: ${{ steps.cache-zephyr-sdk.outputs.cache-hit != 'true' }}
         run: |  # yamllint disable-line rule:line-length
           curl -L -O `
-          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/zephyr-sdk-0.17.0_windows-x86_64.7z
+          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.4/zephyr-sdk-0.17.4_windows-x86_64.7z
 
       # Unzips every .zip package to directory matching its name without extension
       - name: Unzip downloaded packages
@@ -325,7 +317,7 @@ jobs:
       # setup.cmd may not be called in from msys shell as it does not parse
       # forward slash script input arguments correctly.
       - name: Install Zephyr SDK
-        run: zephyr-sdk-0.17.0_windows-x86_64/zephyr-sdk-0.17.0/setup.cmd /t all /h /c
+        run: zephyr-sdk-0.17.4_windows-x86_64/zephyr-sdk-0.17.4/setup.cmd /t all /h /c
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/scripts/docker_build/zephyr_lite/Dockerfile
+++ b/scripts/docker_build/zephyr_lite/Dockerfile
@@ -2,35 +2,25 @@
 # Copyright(c) 2025 Intel Corporation. All rights reserved.
 
 # Use zephyr-build as base image
-FROM ghcr.io/zephyrproject-rtos/zephyr-build:v0.27.4 as base
+FROM ghcr.io/zephyrproject-rtos/zephyr-build:v0.28.4 as base
 
 # Remove additional toolchains.
 # As this is not ideal solution there is a plan to build docker image without zephyr-build as the base
-# and install only needeed toolchains in the future.
-RUN cd /opt/toolchains/zephyr-sdk-0.17.0 && \
-    sudo rm -rvf arc* \
+# and install only needed toolchains in the future.
+USER root
+
+RUN cd /opt/toolchains/zephyr-sdk-0.17.4 && \
+    rm -rvf arc* \
         micro* \
         mips* \
         nios* \
         risc* \
         sparc* \
+        sysroots \
         x86* \
         xtensa-espressif* \
         xtensa-sample* \
         xtensa-dc233c*
-
-# Some of tests require python 3.12 - instll it from source
-RUN cd /tmp && wget -q --show-progress --progress=bar:force:noscroll --no-check-certificate https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tgz && \
-    tar -xf Python-3.12.9.tgz && \
-    cd Python-3.12.9 && \
-    ./configure && \
-    sudo make -j$(nproc) && \
-    sudo make install && \
-    sudo rm -rf /tmp/Python-3*
-
-# Reinstall python3.10 packages with python3.12
-RUN python3.10 -m pip freeze > /tmp/python3.10.pip.txt && \
-    cat /tmp/python3.10.pip.txt | xargs -n 1 python3.12 -m pip install || true
 
 # Use ubuntu24.04 as base for zephyr-lite
 FROM ubuntu:24.04 as zephyr-lite
@@ -39,9 +29,11 @@ FROM ubuntu:24.04 as zephyr-lite
 # /opt for toolchains and sdk
 # /usr for binaries and libs
 # /home for libs installed in .local
+# /etc/ssl for ssl certs for python packages
 COPY --from=base /opt /opt
 COPY --from=base /usr /usr
 COPY --from=base /home /home
+COPY --from=base /etc/ssl /etc/ssl
 
 USER root
 
@@ -49,10 +41,17 @@ USER root
 # Add user to dialout and sudo group
 RUN useradd -ms /bin/bash user && \
     chown -R user:user /home/user && \
+    chown -R user:user /opt/python && \
     usermod -a -G dialout,sudo user
 
 USER user
 
+# Install cmake and jsonschema in venv
+RUN /opt/python/venv/bin/pip install 'cmake>=3.21' jsonschema
+
 # Set zephyr env variables
-ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.0
+ENV PATH="/opt/python/venv/bin/:$PATH"
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-0.17.4
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+
+CMD ["/bin/bash", "-l"]

--- a/zephyr/docker-build.sh
+++ b/zephyr/docker-build.sh
@@ -50,8 +50,6 @@ unset ZEPHYR_SDK_INSTALL_DIR
 # CMake v3.21 changed the order object files are passed to the linker.
 # This makes builds before that version not reproducible.
 # To save time don't install if recent enough.
-pip install 'cmake>=3.21'
-PATH="$HOME"/.local/bin:"$PATH"
 
 if test -e .west || test -e zephyr; then
     init_update=''

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -54,8 +54,8 @@ main()
 
 run_command()
 {
-    # zephyr-lite:v0.27.4 has /opt/toolchains/zephyr-sdk-0.17.0
-    # zephyr-lite:v0.27.4 is based on zephyr-build:v0.27.4
+    # zephyr-lite:v0.28.4 has /opt/toolchains/zephyr-sdk-0.17.4
+    # zephyr-lite:v0.28.4 is based on zephyr-build:v0.28.4
     # https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags
     # https://hub.docker.com/r/thesofproject/zephyr-lite/tags
     #
@@ -65,7 +65,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           thesofproject/zephyr-lite:v0.27.4 \
+           thesofproject/zephyr-lite:v0.28.4 \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
## zephyr-lite dockerimage
Update base to zephyr-build v0.28.4 and add improvements to the dockerimage
- Remove python3.12 installation as it's already supplied by new
docker base
- Remove sysroots from toolchains to free up space
- Install jsonschema and cmake
- Update SDK to 0.17.4
- Use venv for python packages

## Zephyr workflows rework
Drop support of docker-run.sh wrapper used in zephyr workflows in favor of using ```container: image:``` tag that is built into github workflow syntax
Reworked workflows include:
- .github/workflows/zephyr.yml - https://github.com/thesofproject/sof/actions/runs/18163609096
- .github/workflows/sparse-zephyr.yml - https://github.com/thesofproject/sof/actions/runs/18163609031
- .github/workflows/llext.yml - https://github.com/thesofproject/sof/actions/runs/18163609061/job/51700001165

Signed-off-by: Mateusz Redzynia <mateuszx.redzynia@intel.com>