### PR TITLE
module: tester: Ensure tester module is only built when explicitly selected

### DIFF
--- a/src/debug/tester/CMakeLists.txt
+++ b/src/debug/tester/CMakeLists.txt
@@ -14,7 +14,7 @@ if(zephyr) ###  Zephyr ###
     add_subdirectory(llext ${PROJECT_BINARY_DIR}/tester_llext)
     add_dependencies(app tester)
 
-  elseif(CONFIG_COMP_TESTER)
+  elseif(CONFIG_COMP_TESTER STREQUAL "y")
 
     zephyr_library_sources(${base_files})
 


### PR DESCRIPTION
Prevent the tester module from being built into the image unless explicitly configured, especially when it's configured as a loadable module and llext support is disabled.