### PR TITLE
Scripts: Add testbench build for Intel NVL platform DSP

### DIFF
--- a/scripts/set_xtensa_params.sh
+++ b/scripts/set_xtensa_params.sh
@@ -66,6 +66,11 @@ case "$platform" in
 	XTENSA_CORE="ace30_LX7HiFi4_PIF"
 	TOOLCHAIN_VER="RI-2022.10-linux"
 	;;
+    nvl)
+	PLATFORM="$platform"
+	XTENSA_CORE="ace4px_HiFi5MMU_PIF_nlib"
+	TOOLCHAIN_VER="RI-2022.10-linux"
+	;;
 
     # NXP
     imx8)
@@ -153,7 +158,7 @@ esac
 
 # Pre-zephyr "XTOS" build, testbench,...
 case "$platform" in
-    mtl|lnl|ptl|acp_7_0|mt8196)
+    mtl|lnl|ptl|acp_7_0|mt8196|nvl)
 	SOF_CC_BASE='clang';;
     *)
 	SOF_CC_BASE='xcc';;


### PR DESCRIPTION
This patch adds to "scripts/rebuild-testbench.sh -p nvl" option to test processing components with NVL DSP build.