### PR TITLE
copier: fix queue ID extraction using correct IPC4 macro

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -540,7 +540,12 @@ static int do_conversion_copy(struct comp_dev *dev,
 
 	comp_get_copy_limits(src, sink, processed_data);
 
-	i = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
+	/*
+	 * Buffer ID is constructed as IPC4_COMP_ID(src_queue, dst_queue).
+	 * From the buffer's perspective, copier's sink is the source,
+	 * so we use IPC4_SRC_QUEUE_ID() to get the correct copier sink index.
+	 */
+	i = IPC4_SRC_QUEUE_ID(buf_get_id(sink));
 	if (i >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT)
 		return -EINVAL;
 	buffer_stream_invalidate(src, processed_data->source_bytes);
@@ -617,7 +622,12 @@ static int copier_module_copy(struct processing_module *mod,
 			uint32_t source_samples;
 			int sink_queue_id;
 
-			sink_queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(sink_c));
+			/*
+			 * Buffer ID is constructed as IPC4_COMP_ID(src_queue, dst_queue).
+			 * From the buffer's perspective, copier's sink is the source,
+			 * so we use IPC4_SRC_QUEUE_ID() to get the correct copier sink index.
+			 */
+			sink_queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(sink_c));
 			if (sink_queue_id >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT)
 				return -EINVAL;
 


### PR DESCRIPTION
Fix NULL pointer dereference crash in copier module by using the correct IPC4 macro to extract queue IDs from buffer IDs.

The issue occurred in do_conversion_copy() and copier_module_copy() when accessing cd->converter[i] where i was extracted using IPC4_SINK_QUEUE_ID().

This was incorrect because buffer IDs are constructed as: IPC4_COMP_ID(src_queue, dst_queue)

From the buffer's perspective, the copier's sink is actually the source, so IPC4_SRC_QUEUE_ID() should be used to get the correct copier sink index.

Using IPC4_SINK_QUEUE_ID() extracted the dst_queue (upper 16 bits) instead of src_queue (lower 16 bits), leading to wrong array indices and NULL pointer crashes when the converter array wasn't initialized for those indices.

This resolves crashes in RTC AEC topologies where internal module copiers have buffer IDs that map to non-zero queue IDs.