### PR TITLE
platform: intel: cavs: modify pm_notifier init for older toolchains

### DIFF
--- a/src/platform/intel/cavs/platform.c
+++ b/src/platform/intel/cavs/platform.c
@@ -107,9 +107,7 @@ int platform_boot_complete(uint32_t boot_message)
 	return 0;
 }
 
-static struct pm_notifier pm_state_notifier = {
-	.state_exit = cpu_notify_state_exit,
-};
+static struct pm_notifier pm_state_notifier;
 
 /* Runs on the primary core only */
 int platform_init(struct sof *sof)
@@ -138,6 +136,7 @@ int platform_init(struct sof *sof)
 		return ret;
 
 	/* register power states exit notifiers */
+	pm_state_notifier.state_exit = cpu_notify_state_exit;
 	pm_notifier_register(&pm_state_notifier);
 
 	/* initialize the host IPC mechanisms */


### PR DESCRIPTION
With Zephyr commit ae1f13149fcd ("pm: Extend pm notifier to be able to report substate"), the pm_notifier struct was changed to include multiple structs within a union. The xcc toolchain used for cAVS targets cannot initialize the struct with the existing code.

Modify the code to work with the new pm.h definition and the old compiler used.