### PR TITLE
module_adapter: generic: Fix use after free

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -599,6 +599,13 @@ void mod_free_all(struct processing_module *mod)
 		list_item_del(&container->list);
 	}
 
+	list_for_item_safe(list, _list, &res->free_cont_list) {
+		struct module_resource *container =
+			container_of(list, struct module_resource, list);
+
+		list_item_del(&container->list);
+	}
+
 	list_for_item_safe(list, _list, &res->cont_chunk_list) {
 		struct container_chunk *chunk =
 			container_of(list, struct container_chunk, chunk_list);
@@ -606,6 +613,9 @@ void mod_free_all(struct processing_module *mod)
 		list_item_del(&chunk->chunk_list);
 		rfree(chunk);
 	}
+
+	/* Make sure resource lists and accounting are reset */
+	mod_resource_init(mod);
 }
 EXPORT_SYMBOL(mod_free_all);
 


### PR DESCRIPTION
Remove any containers from the free container list so that we don't keep pointers to containers that are no longer used and will be freed when container chunks are released below.

Leaving those nodes in the free container list would cause use-after-free on subsequent allocations.

While at it, make sure all resource lists are reset.