### PR TITLE
ipc4: Fix queue ID extraction

### DIFF
--- a/src/audio/copier/copier_generic.c
+++ b/src/audio/copier/copier_generic.c
@@ -328,7 +328,7 @@ void copier_update_params(struct copier_data *cd, struct comp_dev *dev,
 	/* update each sink format */
 	comp_dev_for_each_consumer(dev, sink) {
 		int j;
-		j = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
+		j = IPC4_SRC_QUEUE_ID(buf_get_id(sink));
 
 		ipc4_update_buffer_format(sink, &cd->out_fmt[j]);
 	}

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -362,7 +362,7 @@ dai_dma_cb(struct dai_data *dd, struct comp_dev *dev, uint32_t bytes,
 
 				sink_dev = comp_buffer_get_sink_component(sink);
 
-				j = IPC4_SINK_QUEUE_ID(buf_get_id(sink));
+				j = IPC4_SRC_QUEUE_ID(buf_get_id(sink));
 
 				if (j >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT) {
 					comp_err(dev, "Sink queue ID: %d >= max output pin count: %d\n",

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -1102,7 +1102,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 	switch (probe_point.fields.type) {
 	case PROBE_TYPE_INPUT:
 		comp_dev_for_each_producer(dev->cd, buf) {
-			queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(buf));
+			queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(buf));
 
 			if (queue_id == probe_point.fields.index)
 				return buf;
@@ -1110,7 +1110,7 @@ static struct comp_buffer *ipc4_get_buffer(struct ipc_comp_dev *dev, probe_point
 		break;
 	case PROBE_TYPE_OUTPUT:
 		comp_dev_for_each_consumer(dev->cd, buf) {
-			queue_id = IPC4_SINK_QUEUE_ID(buf_get_id(buf));
+			queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(buf));
 
 			if (queue_id == probe_point.fields.index)
 				return buf;
@@ -1581,14 +1581,14 @@ static int probe_get_available_points(struct processing_module *mod,
 
 		id.fields.type = PROBE_TYPE_INPUT;
 		comp_dev_for_each_producer(icd->cd, buf) {
-			id.fields.index = IPC4_SRC_QUEUE_ID(buf_get_id(buf));
+			id.fields.index = IPC4_SINK_QUEUE_ID(buf_get_id(buf));
 			if (probe_add_point_info_params(info, id, i, max_size))
 				return 0;
 			i++;
 		}
 		id.fields.type = PROBE_TYPE_OUTPUT;
 		comp_dev_for_each_consumer(icd->cd, buf) {
-			id.fields.index = IPC4_SINK_QUEUE_ID(buf_get_id(buf));
+			id.fields.index = IPC4_SRC_QUEUE_ID(buf_get_id(buf));
 			if (probe_add_point_info_params(info, id, i, max_size))
 				return 0;
 			i++;


### PR DESCRIPTION
This is a follow-up to https://github.com/thesofproject/sof/pull/10257.

This fixes all occurrences of incorrect use of IPC4_SRC_QUEUE_ID() and IPC4_SINK_QUEUE_ID().

IPC4_SRC_QUEUE_ID() expects buffer as a parameter and returns the queue ID of the module that produces data for that buffer. So from the buffer's point of view, such a module and queue is the source (hence the name IPC4_SRC_QUEUE_ID()), however, from the module's point of view, such a queue is a sink. That, unfortunately, makes it easy to make a mistake
when deciding whether IPC4_SRC_QUEUE_ID() vs. IPC4_SINK_QUEUE_ID() should be used.