### PR TITLE
ipc: Fix incorrect dcache invalidate

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -55,9 +55,11 @@ int ipc_process_on_core(uint32_t core, bool blocking)
 		return -EACCES;
 	}
 
+#if CONFIG_IPC_MAJOR_3
 	/* The other core will write there its response */
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
 				 ((struct sof_ipc_cmd_hdr *)ipc->comp_data)->size);
+#endif
 
 	/*
 	 * If the primary core is waiting for secondary cores to complete, it


### PR DESCRIPTION
There are few problems with the invalidate call here:

struct sof_ipc_cmd_hdr belongs to IPC3. There is no 'size' field in IPC4 payload at that offset. comp_data is zeroed on init and on IPC4 it is only used to send responses by get_large_config. Probably get_large_config is rarely used as, otherwise, that would result in invalidates of dcache with weird sizes and problems at runtime.

I do not see any point to invalidate dcache here. It's definitely not needed for IPC4. Not an expert in IPC3, however, it seems IPC3 does not need such code either.