### PR TITLE
lib_manager: Add cache writeback after library loading to IMR

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -937,6 +937,9 @@ static int lib_manager_store_library(struct lib_manager_dma_ext *dma_ext,
 		return ret;
 	}
 
+	/* Writeback entire library to ensure it's visible to other cores */
+	dcache_writeback_region((__sparse_force void *)library_base_address, preload_size);
+
 #if CONFIG_LIBRARY_AUTH_SUPPORT
 	/* AUTH_PHASE_LAST - do final library authentication checks */
 	ret = lib_manager_auth_proc((__sparse_force void *)library_base_address,


### PR DESCRIPTION
Add dcache_writeback_region() calls after copying library data to IMR (Isolated Memory Region) to ensure cache coherency in multicore scenarios.

Without these cache operations, when Core 0 loads a library into IMR via memcpy_s(), the data remains in Core 0's data cache and is not written back to main memory. When Core 1 later tries to create a module from this library, it reads uninitialized or stale data from IMR, causing either:
- "Unsupported module API version" errors (reading garbage build info)
- Fatal PIF data errors and crashes (accessing corrupted module data)

The fix adds cache writeback operations at two critical points:
1. After copying the manifest (MAN_MAX_SIZE_V1_8 bytes)
2. After copying the entire library (preload_size bytes)

This ensures library data written by Core 0 is flushed from cache to IMR memory before Core 1 attempts to read it, following the standard cache coherency protocol for non-coherent Harvard architecture (Xtensa).

Fixes multicore topology crashes on Intel MTL, LNL, PTL, NVL platforms when loading external libraries with modules instantiated on secondary cores.