### PR TITLE
ring_buffer: Use cached allocation for ring_buffer stream data

### DIFF
--- a/src/audio/buffers/ring_buffer.c
+++ b/src/audio/buffers/ring_buffer.c
@@ -359,7 +359,8 @@ struct ring_buffer *ring_buffer_create(struct comp_dev *dev, size_t min_availabl
 	ring_buffer->data_buffer_size =
 			ALIGN_UP(ring_buffer->data_buffer_size, PLATFORM_DCACHE_ALIGN);
 	ring_buffer->_data_buffer = (__sparse_force __sparse_cache void *)
-			rballoc_align(memory_flags, ring_buffer->data_buffer_size,
+			rballoc_align(user_get_buffer_memory_region(dev->drv),
+				      ring_buffer->data_buffer_size,
 				      PLATFORM_DCACHE_ALIGN);
 	if (!ring_buffer->_data_buffer)
 		goto err;


### PR DESCRIPTION
_data_buffer should always be allocated as cached. It became uncached (when is_shared==true) by mistake as a result of a regression introduced by this commit: d519e7ed9d740065a04afa3194aa94d601df32e4.

This restores the original cached allocation behaviour for _data_buffer.