### PR TITLE
module_adapter: generic: Call mod_free_all() if module_init() fails

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -117,6 +117,7 @@ int module_init(struct processing_module *mod)
 	ret = interface->init(mod);
 	if (ret) {
 		comp_err(dev, "error %d: module specific init failed", ret);
+		mod_free_all(mod);
 		return ret;
 	}
 


### PR DESCRIPTION
Call mod_free_all() if module specific init fails. This fixes a resource leak in case the module initialization fails in module specific init.