### PR TITLE
zephyr: adapt to SOF not being a zephyr module

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -1,4 +1,3 @@
-CONFIG_SOF=y
 CONFIG_BUILD_OUTPUT_BIN=n
 
 # The additional stripped .elf files are deterministic.

--- a/src/arch/host/Kconfig
+++ b/src/arch/host/Kconfig
@@ -4,6 +4,6 @@
 
 config CORE_COUNT
 	int
-	default 1
+	default MP_MAX_NUM_CPUS
 	help
 	  Number of used cores

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: e876dee6f2e78788e983385de231eab50e1db543
+      revision: pull/97946/head
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -2,8 +2,6 @@
 # compile every Zephyr module that can be found. See
 # sof/zephyr/module.yml and
 # https://docs.zephyrproject.org/latest/develop/modules.html
-if(CONFIG_SOF)
-
 if(CONFIG_ZEPHYR_POSIX)
 	set(ARCH host)
 	set(PLATFORM "posix")
@@ -554,5 +552,3 @@ include(../scripts/cmake/uuid-registry.cmake)
 
 # Create Trace realtive file paths
 sof_append_relative_path_definitions(modules_sof)
-
-endif() # CONFIG_SOF

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,5 +1,3 @@
-if SOF
-
 config SOF_STAGING
 	bool "Enable SOF staging features and modules"
 	help
@@ -166,5 +164,3 @@ config STACK_SIZE_IPC_TX
 	default 2048
 	help
 	  IPC sender work-queue thread stack size. Keep a power of 2.
-
-endif


### PR DESCRIPTION
Adapt code to work with SOF not being a module in Zephyr.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
