### PR TITLE
common.h: Make IS_ALIGNED() safe for testing with alignment == 0

### DIFF
--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -20,7 +20,7 @@
 
 /* Align the number to the nearest alignment value */
 #ifndef IS_ALIGNED
-#define IS_ALIGNED(size, alignment) ((size) % (alignment) == 0)
+#define IS_ALIGNED(size, alignment) (!(alignment) || (size) % (alignment) == 0)
 #endif
 
 /* Treat zero as a special case because it wraps around */


### PR DESCRIPTION
Make IS_ALIGNED() safe for testing with alignment == 0. Without this fix the DSP will crash if alignemnet is 0.


This is why:

The current virtual heap implementation has this line:
	assert(IS_ALIGNED(mem, align));

And mod_balloc() implementation looks like this:
static inline void *mod_balloc(struct processing_module *mod, size_t size)
{
	return mod_balloc_align(mod, size, 0);
}

Which means, that without this fix any call to mod_balloc() would cause division by zero crash.

I think the correct place to fix this error is in IS_ALIGNED() macro. It should not crash if someone wants to check alignment to zero.