### PR TITLE
audio: volume: Memory, blob, and fast_get allocs to module API

### DIFF
--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -24,7 +24,6 @@
 #include <sof/common.h>
 #include <rtos/panic.h>
 #include <sof/ipc/msg.h>
-#include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/uuid.h>
@@ -776,9 +775,9 @@ static int volume_free(struct processing_module *mod)
 
 	comp_dbg(mod->dev, "volume_free()");
 
-	volume_peak_free(cd);
-	rfree(cd->vol);
-	rfree(cd);
+	volume_peak_free(mod);
+	mod_free(mod, cd->vol);
+	mod_free(mod, cd);
 
 	return 0;
 }

--- a/src/audio/volume/volume.h
+++ b/src/audio/volume/volume.h
@@ -300,7 +300,7 @@ void sys_comp_module_volume_interface_init(void);
 /* source_or_sink, true means source, false means sink */
 void set_volume_process(struct vol_data *cd, struct comp_dev *dev, bool source_or_sink);
 
-void volume_peak_free(struct vol_data *cd);
+void volume_peak_free(struct processing_module *mod);
 
 int volume_peak_prepare(struct vol_data *cd, struct processing_module *mod);
 

--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -14,7 +14,6 @@
 #include <sof/common.h>
 #include <rtos/panic.h>
 #include <sof/ipc/msg.h>
-#include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/uuid.h>
@@ -81,7 +80,7 @@ int volume_init(struct processing_module *mod)
 		return -EINVAL;
 	}
 
-	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(struct vol_data));
+	cd = mod_zalloc(mod, sizeof(struct vol_data));
 	if (!cd)
 		return -ENOMEM;
 
@@ -89,9 +88,9 @@ int volume_init(struct processing_module *mod)
 	 * malloc memory to store current volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->vol = rmalloc(SOF_MEM_FLAG_USER, vol_size);
+	cd->vol = mod_alloc(mod, vol_size);
 	if (!cd->vol) {
-		rfree(cd);
+		mod_free(mod, cd);
 		comp_err(dev, "Failed to allocate %zu", vol_size);
 		return -ENOMEM;
 	}
@@ -158,8 +157,8 @@ int volume_init(struct processing_module *mod)
 		break;
 	default:
 		comp_err(dev, "invalid ramp type %d", vol->ramp);
-		rfree(cd);
-		rfree(cd->vol);
+		mod_free(mod, cd);
+		mod_free(mod, cd->vol);
 		return -EINVAL;
 	}
 
@@ -168,7 +167,7 @@ int volume_init(struct processing_module *mod)
 	return 0;
 }
 
-void volume_peak_free(struct vol_data *cd)
+void volume_peak_free(struct processing_module *mod)
 {
 }
 

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -14,7 +14,6 @@
 #include <sof/common.h>
 #include <rtos/panic.h>
 #include <sof/ipc/msg.h>
-#include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/cpu.h>
 #include <sof/lib/uuid.h>
@@ -128,7 +127,7 @@ int volume_init(struct processing_module *mod)
 		return -EINVAL;
 	}
 
-	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(struct vol_data));
+	cd = mod_zalloc(mod, sizeof(struct vol_data));
 	if (!cd)
 		return -ENOMEM;
 
@@ -136,9 +135,9 @@ int volume_init(struct processing_module *mod)
 	 * malloc memory to store current volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->vol = rmalloc(SOF_MEM_FLAG_USER, vol_size);
+	cd->vol = mod_alloc(mod, vol_size);
 	if (!cd->vol) {
-		rfree(cd);
+		mod_free(mod, cd);
 		comp_err(dev, "Failed to allocate %d", vol_size);
 		return -ENOMEM;
 	}
@@ -146,10 +145,10 @@ int volume_init(struct processing_module *mod)
 	/* malloc memory to store temp peak volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->peak_vol = rzalloc(SOF_MEM_FLAG_USER, vol_size);
+	cd->peak_vol = mod_zalloc(mod, vol_size);
 	if (!cd->peak_vol) {
-		rfree(cd->vol);
-		rfree(cd);
+		mod_free(mod, cd->vol);
+		mod_free(mod, cd);
 		comp_err(dev, "Failed to allocate %d for peak_vol", vol_size);
 		return -ENOMEM;
 	}
@@ -189,14 +188,15 @@ int volume_init(struct processing_module *mod)
 	return 0;
 }
 
-void volume_peak_free(struct vol_data *cd)
+void volume_peak_free(struct processing_module *mod)
 {
+	struct vol_data *cd = module_get_private_data(mod);
 	struct ipc4_peak_volume_regs regs;
 
 	/* clear mailbox */
 	memset_s(&regs, sizeof(regs), 0, sizeof(regs));
 	mailbox_sw_regs_write(cd->mailbox_offset, &regs, sizeof(regs));
-	rfree(cd->peak_vol);
+	mod_free(mod, cd->peak_vol);
 }
 
 static int volume_set_volume(struct processing_module *mod, const uint8_t *data, int data_size)


### PR DESCRIPTION
Allocate all memory, blob handlers, and fast_get() buffers through module API mod_alloc() and friends.