### PR TITLE
modules: Apparently asking 0 alignment is dangerous, use 4 as default

### DIFF
--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -191,13 +191,15 @@ int module_init(struct processing_module *mod);
 void *mod_balloc_align(struct processing_module *mod, size_t size, size_t alignment);
 static inline void *mod_balloc(struct processing_module *mod, size_t size)
 {
-	return mod_balloc_align(mod, size, 0);
+	/* IS_ALIGNED() crashes if alignment is 0, so use pointer size as default alignment */
+	return mod_balloc_align(mod, size, sizeof(void *));
 }
 
 void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment);
 static inline void *mod_alloc(struct processing_module *mod, size_t size)
 {
-	return mod_alloc_align(mod, size, 0);
+	/* IS_ALIGNED() crashes if alignment is 0, so use pointer size as default alignment */
+	return mod_alloc_align(mod, size, sizeof(void *));
 }
 
 static inline void *mod_zalloc(struct processing_module *mod, size_t size)


### PR DESCRIPTION
The current rballoc_align() implementation has this line:
assert(IS_ALIGNED(mem, align));

Which will cause division by zero due to IS_ALIGNED() Zephyr implementation:
define IS_ALIGNED(ptr, align) (((uintptr_t)(ptr)) % (align) == 0)

So better use 4 as the default value.