### PR TITLE
lib: cpu: Check return value from platform_boot_complete

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -211,7 +211,12 @@ void cpu_notify_state_exit(enum pm_state state)
 		global_imr_ram_storage = NULL;
 
 		/* send FW Ready message */
-		platform_boot_complete(0);
+		int ret = platform_boot_complete(0);
+
+		if (ret) {
+			tr_err(&zephyr_tr, "platform_boot_complete failed: %d", ret);
+			k_panic();
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Add error handling for platform_boot_complete() during D3 exit to improve debugging capabilities.

Previously, platform_boot_complete() could fail silently if the DSP entered D3 state with an invalid IPC driver state, making it difficult to identify the root cause of issues. This change captures the return value and triggers a panic with a clear error message when the function fails.

This improvement makes debugging easier by explicitly indicating when the boot completion fails after resuming from D3, rather than allowing execution to continue with potential undefined behavior.