### PR TITLE
vmh: add virtual heap stats

### DIFF
--- a/zephyr/include/sof/lib/regions_mm.h
+++ b/zephyr/include/sof/lib/regions_mm.h
@@ -87,6 +87,9 @@ int vmh_free_heap(struct vmh_heap *heap);
 int vmh_free(struct vmh_heap *heap, void *ptr);
 void vmh_get_default_heap_config(const struct sys_mm_drv_region *region,
 		struct vmh_heap_config *cfg);
+#ifdef CONFIG_SYS_MEM_BLOCKS_RUNTIME_STATS
+void vmh_log_stats(struct vmh_heap *heap);
+#endif
 /**
  * @brief Checks if ptr is in range of given memory range
  *

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -292,8 +292,12 @@ static void *virtual_heap_alloc(struct vmh_heap *heap, uint32_t flags, size_t by
 {
 	void *mem = vmh_alloc(heap, bytes);
 
-	if (!mem)
+	if (!mem) {
+#ifdef CONFIG_SYS_MEM_BLOCKS_RUNTIME_STATS
+		vmh_log_stats(heap);
+#endif
 		return NULL;
+	}
 
 	assert(align == 0 || IS_ALIGNED(mem, align));
 


### PR DESCRIPTION
Option that allows collecting statistics on individual regions of a virtual
memory heap. By defaults the following states are output per region:
1. Maximal number of blocks allocated at any given moment during the heap
   lifespan
2. How many times the region was full, and an allocation had to be redirected
   to another region (with greater/less optimal block size)
By default, stats are outputted only on allocation error

This feature depends on SYS_MEM_BLOCKS_RUNTIME_STATS Zephyr option and
hence is controlled by the same config option