### PR TITLE
platform: simplify setting CORE_COUNT and MAX_CORE_COUNT

### DIFF
--- a/src/arch/host/Kconfig
+++ b/src/arch/host/Kconfig
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-
-# Host architecture configs
-
-config CORE_COUNT
-	int
-	default 1
-	help
-	  Number of used cores

--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -332,21 +332,30 @@ config MT8196
 
 endchoice
 
+#
+# For non-Zephyr builds like testbench, cmocka and SOF ALSA plugin,
+# set core count separately.
+#
+if !ZEPHYR_SOF_MODULE
+
+config MP_MAX_NUM_CPUS
+	int
+	default 1
+	help
+	  Maximum number of cores per configuration
+
+endif # !ZEPHYR_SOF_MODULE
+
 config MAX_CORE_COUNT
 	int
-	default 5 if LUNARLAKE || PANTHERLAKE
-	default 4 if TIGERLAKE || NOVALAKE
-	default 3 if METEORLAKE
-	default 3 if WILDCATLAKE
-	default 1
+	default MP_MAX_NUM_CPUS
 	help
 	  Maximum number of cores per configuration
 
 config CORE_COUNT
 	int "Number of cores"
-	default MP_MAX_NUM_CPUS if KERNEL_BIN_NAME = "zephyr"
-	default MAX_CORE_COUNT
-	range 1 MAX_CORE_COUNT
+	default MP_MAX_NUM_CPUS
+	range 1 MP_MAX_NUM_CPUS
 	help
 	  Number of used cores
 	  Lowering available core count could result in lower power consumption


### PR DESCRIPTION
All normal SOF builds use Zephyr build system, so common settings like system core count can be simply set based on Zephyr build options.

There are a few speciality builds left to build SOF without Zephyr. Testbench, cmocka and the SOF ALSA plugin are a few such examples. To keep these builds functional, add a simple definition of key Zephyr definitions (like in this case MP_MAX_NUM_CPUS) to allow these builds to use common build rules even when Zephyr definitions are not available.

The old arch/host/Kconfig is removed. It is no longer needed and caused confusion as it added a unconditional default to CORE_COUNT that was used (more or less unintentionally) by some of the speciality build targets.