### PR TITLE
zephyr: lib/alloc: Relax virtual_heap_alloc() assert condition

### DIFF
--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -286,7 +286,7 @@ static void *virtual_heap_alloc(struct vmh_heap *heap, uint32_t flags, size_t by
 	if (!mem)
 		return NULL;
 
-	assert(IS_ALIGNED(mem, align));
+	assert(align == 0 || IS_ALIGNED(mem, align));
 
 	if (flags & SOF_MEM_FLAG_COHERENT)
 		return sys_cache_uncached_ptr_get((__sparse_force void __sparse_cache *)mem);


### PR DESCRIPTION
Relax virtual_heap_alloc() assert condition so that it allows zero alignment for the case where no particular alignment is requested.