### PR TITLE
Audio: FIR: Use mod_data_blob_handler_free() in eq_fir_free()

### DIFF
--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -313,7 +313,7 @@ static int eq_fir_free(struct processing_module *mod)
 	comp_dbg(mod->dev, "eq_fir_free()");
 
 	eq_fir_free_delaylines(mod);
-	comp_data_blob_handler_free(cd->model_handler);
+	mod_data_blob_handler_free(mod, cd->model_handler);
 
 	mod_free(mod, cd);
 


### PR DESCRIPTION
The conversion to mod_alloc/free missed the comp_data_blob_handler_free() in eq_fir_free, which cause firmware crash.

Fixes: 1c722f2e16bf ("Audio: FIR: Memory, blob, and fast_get allocs to module API")