### PR TITLE
audio: mux: fix IPC4 configuration and use blob handler

### DIFF
--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -390,19 +390,9 @@ static int mux_prepare(struct processing_module *mod,
 {
 	struct comp_dev *dev = mod->dev;
 	struct comp_data *cd = module_get_private_data(mod);
-	struct sof_mux_config *config;
-	size_t blob_size;
 	int ret;
 
 	comp_dbg(dev, "mux_prepare()");
-
-	config = comp_get_data_blob(cd->model_handler, &blob_size, NULL);
-	if (blob_size > MUX_BLOB_MAX_SIZE) {
-		comp_err(dev, "illegal blob size %zu", blob_size);
-		return -EINVAL;
-	}
-
-	memcpy_s(&cd->config, MUX_BLOB_MAX_SIZE, config, blob_size);
 
 	ret = mux_params(mod);
 	if (ret < 0)

--- a/src/audio/mux/mux.h
+++ b/src/audio/mux/mux.h
@@ -213,7 +213,11 @@ void sys_comp_module_demux_interface_init(void);
 #endif /* UNIT_TEST */
 
 #define MUX_BLOB_STREAMS_SIZE	(MUX_MAX_STREAMS * sizeof(struct mux_stream_data))
+#ifdef CONFIG_IPC_MAJOR_4
+#define MUX_BLOB_MAX_SIZE	(sizeof(struct mux_data))
+#else
 #define MUX_BLOB_MAX_SIZE	(sizeof(struct sof_mux_config) + MUX_BLOB_STREAMS_SIZE)
+#endif
 
 extern const struct sof_uuid demux_uuid;
 extern struct tr_ctx mux_tr;

--- a/src/audio/mux/mux_ipc3.c
+++ b/src/audio/mux/mux_ipc3.c
@@ -9,6 +9,7 @@
 
 #include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/component.h>
+#include <sof/audio/data_blob.h>
 #include <module/module/base.h>
 #include <sof/trace/trace.h>
 #include <rtos/string_macro.h>
@@ -98,6 +99,18 @@ static int mux_set_values(struct processing_module *mod)
 
 int mux_params(struct processing_module *mod)
 {
+	struct comp_data *cd = module_get_private_data(mod);
+	struct sof_mux_config *config;
+	size_t blob_size;
+
+	config = comp_get_data_blob(cd->model_handler, &blob_size, NULL);
+	if (blob_size > MUX_BLOB_MAX_SIZE) {
+		comp_err(mod->dev, "illegal blob size %zu", blob_size);
+		return -EINVAL;
+	}
+
+	memcpy_s(&cd->config, MUX_BLOB_MAX_SIZE, config, blob_size);
+
 	return mux_set_values(mod);
 }
 #endif /* CONFIG_COMP_MUX */


### PR DESCRIPTION
This PR will fix IPC4 build for mux and allow basic IPC4 mux tests to pass.