### PR TITLE
boards: wcl: add Google RTC Audio Processing to WCL configuration

### DIFF
--- a/app/boards/intel_adsp_ace30_wcl.conf
+++ b/app/boards/intel_adsp_ace30_wcl.conf
@@ -9,6 +9,12 @@ CONFIG_COMP_TESTER=m
 CONFIG_COMP_SRC_IPC4_FULL_MATRIX=y
 CONFIG_FORMAT_CONVERT_HIFI3=n
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL=n
 CONFIG_PROBE=y


### PR DESCRIPTION
This patch introduces the Google RTC Audio Processing component into the WCL configuration for the SOF firmware. The component is added as a loadable module (`m`).

**Changes:**
- Added `CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m` to enable Google RTC Audio Processing.
- Included `CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y` for mock testing support.