### PR TITLE
app: os_linux: Remove CONFIG_ADSP_IMR_CONTEXT_SAVE=n

### DIFF
--- a/app/os_linux_overlay.conf
+++ b/app/os_linux_overlay.conf
@@ -3,6 +3,3 @@
 # with SOF driver in Linux kernel
 #
 
-# SOF Linux driver does not require FW to retain its
-# state, so context save can be disabled
-CONFIG_ADSP_IMR_CONTEXT_SAVE=n


### PR DESCRIPTION
Remove CONFIG_ADSP_IMR_CONTEXT_SAVE=n from app/os_linux_overlay.conf.

This is a temporary remedy to overcome an issue we currently have in loading individual llext modules on second boot. The open-modules bundle apparently works Ok still.