### PR TITLE
zephyr: userspace: remove an indiscriminate option

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -552,10 +552,6 @@ if (NOT CONFIG_COMPILER_INLINE_FUNCTION_OPTION)
 target_compile_options(SOF INTERFACE -fno-inline-functions)
 endif()
 
-if (CONFIG_USERSPACE)
-target_compile_options(SOF INTERFACE -mno-global-merge)
-endif()
-
 # SOF needs `typeof`, `__VA_ARGS__` and maybe other GNU C99
 # extensions. TODO other flags required ?
 target_compile_options(SOF INTERFACE $<$<COMPILE_LANGUAGE:C,ASM>: -std=gnu99>)


### PR DESCRIPTION
The -mno-global-merge compiler option is added by Zephyr for clang userspace builds in the top-level CMakeLists.txt as if(CONFIG_USERSPACE)
  zephyr_compile_options($<TARGET_PROPERTY:compiler,no_global_merge>)
endif()
so there's no need to add it again in SOF. Particularly because it's only available with clang and shouldn't be enabled for gcc.