### PR TITLE
test: ztest: Add scalar power function support and unit test

### DIFF
--- a/src/math/power.c
+++ b/src/math/power.c
@@ -10,6 +10,7 @@
 #include <sof/audio/format.h>
 #include <sof/trace/trace.h>
 #include <sof/math/power.h>
+
 #include <sof/lib/uuid.h>
 #include <ipc/trace.h>
 #include <user/trace.h>

--- a/test/ztest/unit/math/advanced/functions/CMakeLists.txt
+++ b/test/ztest/unit/math/advanced/functions/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test_math_advanced_functions)
+
+set(SOF_ROOT "${PROJECT_SOURCE_DIR}/../../../../../..")
+
+# Set SOF top directory for UUID registry generation
+set(sof_top_dir ${SOF_ROOT})
+
+# Include SOF CMake utilities for proper SOF source compilation
+include(${SOF_ROOT}/scripts/cmake/misc.cmake)
+include(${SOF_ROOT}/scripts/cmake/uuid-registry.cmake)
+
+target_include_directories(app PRIVATE
+	${SOF_ROOT}/zephyr/include
+	${SOF_ROOT}/src/include
+	${SOF_ROOT}/src/platform/posix/include
+	${SOF_ROOT}/test/cmocka/include
+	${PROJECT_BINARY_DIR}/include/generated  # For uuid-registry.h
+)
+
+# Define SOF-specific configurations for unit testing
+target_compile_definitions(app PRIVATE
+	-DCONFIG_SOF_LOG_LEVEL=CONFIG_LOG_DEFAULT_LEVEL
+	-DCONFIG_ZEPHYR_POSIX=1
+	-DCONFIG_LIBRARY=1
+	-DUNIT_TEST=1
+)
+
+target_sources(app PRIVATE
+	test_scalar_power_ztest.c
+	${SOF_ROOT}/src/math/power.c
+)
+
+# Apply SOF relative path definitions for proper compilation
+sof_append_relative_path_definitions(app)
+
+# Link math library for advanced math functions
+target_link_libraries(app PRIVATE m)

--- a/test/ztest/unit/math/advanced/functions/prj.conf
+++ b/test/ztest/unit/math/advanced/functions/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ZTEST=y

--- a/test/ztest/unit/math/advanced/functions/test_scalar_power_ztest.c
+++ b/test/ztest/unit/math/advanced/functions/test_scalar_power_ztest.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2025 Intel Corporation. All rights reserved.
+//
+// These contents may have been developed with support from one or more Intel-operated
+// generative artificial intelligence solutions.
+//
+// Converted from CMock to Ztest
+//
+// Original test from sof/test/cmocka/src/math/arithmetic/scalar_power.c:
+// Author: Shriram Shastry <malladi.sastry@linux.intel.com>
+
+#include <zephyr/ztest.h>
+#include <zephyr/logging/log.h>
+#include <sof/audio/format.h>
+#include <sof/math/power.h>
+#include <sof/common.h>
+#include <math.h>
+
+LOG_MODULE_REGISTER(test_scalar_power, LOG_LEVEL_INF);
+
+/* Test data tables from MATLAB-generated reference */
+#include "power_tables.h"
+
+/* Error tolerance: max error = 0.000034912111005, THD+N = -96.457180359025074 */
+#define CMP_TOLERANCE 0.0000150363575813f
+
+/**
+ * @brief Test scalar power function with fixed-point arithmetic
+ *
+ * This test validates the power_int32() function against MATLAB-generated
+ * reference values. It tests 64 base values against 6 exponent values,
+ * checking that the fixed-point power calculation stays within acceptable
+ * tolerance.
+ *
+ * Base values: Fixed-point Q6.25 format (range -1.0 to 1.0)
+ * Exponent values: Fixed-point Q2.29 format
+ * Result: Fixed-point Q16.15 format
+ */
+ZTEST(math_advanced_functions_suite, test_math_arithmetic_power_fixed)
+{
+	double p;
+	int i;
+	int j;
+
+	for (i = 0; i < ARRAY_SIZE(b); i++) {
+		for (j = 0; j < ARRAY_SIZE(e); j++) {
+			p = power_int32(b[i], e[j]);
+			float delta = fabsf((float)(power_table[i][j] - (double)p / (1 << 15)));
+
+			zassert_true(delta <= CMP_TOLERANCE,
+				     "Power calc error: delta=%f > %f at b[%d]=%d, e[%d]=%d",
+				     (double)delta, (double)CMP_TOLERANCE, i, b[i], j, e[j]);
+		}
+	}
+}
+
+ZTEST_SUITE(math_advanced_functions_suite, NULL, NULL, NULL, NULL, NULL);

--- a/test/ztest/unit/math/advanced/functions/testcase.yaml
+++ b/test/ztest/unit/math/advanced/functions/testcase.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright(c) 2025 Intel Corporation. All rights reserved.
+#
+# Math advanced functions unit tests for Ztest framework
+#
+# These contents may have been developed with support from one or more Intel-operated
+# generative artificial intelligence solutions.
+#
+
+tests:
+  math.advanced.functions:
+    tags: math advanced functions power
+    platform_allow: native_sim
+    integration_platforms:
+      - native_sim
+    build_only: false


### PR DESCRIPTION
Add Zephyr ztest framework support for scalar power function and convert existing CMock unit test to ztest.

## Changes

1. ~~**math/power.c**: Add conditional Zephyr logging for ztest compatibility~~
2. **test_scalar_power_ztest.c**: Convert CMock test to ztest framework