### PR TITLE
west.yml: update zephyr to v4.3.0 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: fb01c781b6c0ca6cee65ea853157704742c74cdd
+      revision: 3568e1b6d5cdd51a6b964a2a1d6d29200fea2056
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Updating zephyr version to 3568e1b6d5c.

Total of 313 commits.

Changes include:

70961e26be4 drivers: mm: Fix vm region range check
6a0ddc3ca1e west: update hal_nxp to fix I2S run issue on MCXN947
c434ed8843c intel_adsp: select log_backend_xtensa_sim for simulator
45a4f381c7d xtensa: suppress warning on variable used uninitialized
611f381ed91 xtensa: properly compute irq number