### PR TITLE
Module api additions for cadence code and taking them into use

### DIFF
--- a/src/include/sof/audio/module_adapter/module/cadence.h
+++ b/src/include/sof/audio/module_adapter/module/cadence.h
@@ -53,6 +53,8 @@ struct cadence_codec_data {
 	void *self;
 	xa_codec_func_t *api;
 	void *mem_tabs;
+	size_t mem_to_be_freed_len;
+	void **mem_to_be_freed;
 	uint32_t api_id;
 	struct module_config setup_cfg;
 };


### PR DESCRIPTION
This is a bit crude way to solve the issue with cadence codec's prepare() / reset() allocation cycle, but I did not want to implement anything more complex than what is needed. This concept also maps well on the comming static allocation vs. dynamic heap concept.