### PR TITLE
audio: copier: Use module API also for allocating non cached memory

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -283,7 +283,7 @@ __cold static int copier_free(struct processing_module *mod)
 			copier_ipcgtw_free(mod);
 		break;
 	case SOF_COMP_DAI:
-		copier_dai_free(cd);
+		copier_dai_free(mod);
 		break;
 	default:
 		break;

--- a/src/audio/copier/dai_copier.h
+++ b/src/audio/copier/dai_copier.h
@@ -79,7 +79,7 @@ int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		      const struct ipc4_copier_module_cfg *copier,
 		      struct pipeline *pipeline);
 
-void copier_dai_free(struct copier_data *cd);
+void copier_dai_free(struct processing_module *mod);
 
 int copier_dai_prepare(struct comp_dev *dev, struct copier_data *cd);
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -202,7 +202,7 @@ void *mod_alloc_ext(struct processing_module *mod, uint32_t flags, size_t size, 
  */
 static inline void *mod_alloc_align(struct processing_module *mod, size_t size, size_t alignment)
 {
-	return mod_alloc_ext(mod, 0, size, alignment);
+	return mod_alloc_ext(mod, SOF_MEM_FLAG_USER, size, alignment);
 }
 
 static inline void *mod_balloc(struct processing_module *mod, size_t size)


### PR DESCRIPTION
The module API was extended to pass flags the allocation back-end [1]. With this change there is no reason not use module API also to allocate the DMA buffers.

[1] 1d170fcec34c module: add an allocation function with flags