### PR TITLE
Audio: SRC: Replace mod_alloc with mod_balloc in rballoc usage

### DIFF
--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -533,7 +533,7 @@ int src_params_general(struct processing_module *mod,
 	/* free any existing delay lines. TODO reuse if same size */
 	mod_free(mod, cd->delay_lines);
 
-	cd->delay_lines = mod_alloc(mod, delay_lines_size);
+	cd->delay_lines = mod_balloc(mod, delay_lines_size);
 	if (!cd->delay_lines) {
 		comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
 			 delay_lines_size);


### PR DESCRIPTION
The original change introduced in commit https://github.com/thesofproject/sof/commit/9fcc269031c9a1c9dd31d2107ee5ca5d15890f13 incorrectly replaced `rballoc` with `mod_alloc`. This commit fixes the issue by using `mod_balloc` instead.