### PR TITLE
West update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 8c264d30ea1b5c218a2efd4288820814ff16f1e2
+      revision: f3b9d1871104b0d69abf6182ef7d262652b13729
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: f3b9d1871104b0d69abf6182ef7d262652b13729
+      revision: 8c264d30ea1b5c218a2efd4288820814ff16f1e2
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -18,6 +18,7 @@
 #include <sof/trace/trace.h>
 #include <rtos/symbol.h>
 #include <rtos/wait.h>
+#include <adsp_memory.h>
 
 #define SHARED_BUFFER_HEAP_MEM_SIZE	0
 
@@ -213,11 +214,11 @@ static inline size_t get_l3_heap_size(void)
 {
 	 /*
 	  * Calculate the IMR heap size using:
-	  * - total IMR size
+	  * - total IMR size (dynamically detected by ace_imr_get_mem_size())
 	  * - IMR base address
 	  * - actual IMR heap start
 	  */
-	return ROUND_DOWN(IMR_L3_HEAP_SIZE, L3_MEM_PAGE_SIZE);
+	return ROUND_DOWN(ace_imr_get_mem_size(), L3_MEM_PAGE_SIZE);
 }
 
 void l3_heap_save(void)

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -18,7 +18,7 @@
 #include <sof/trace/trace.h>
 #include <rtos/symbol.h>
 #include <rtos/wait.h>
-#include <adsp_memory.h>
+
 
 #define SHARED_BUFFER_HEAP_MEM_SIZE	0
 
@@ -218,7 +218,7 @@ static inline size_t get_l3_heap_size(void)
 	  * - IMR base address
 	  * - actual IMR heap start
 	  */
-	return ROUND_DOWN(ace_imr_get_mem_size(), L3_MEM_PAGE_SIZE);
+	return ROUND_DOWN(IMR_L3_HEAP_SIZE, L3_MEM_PAGE_SIZE);
 }
 
 void l3_heap_save(void)


### PR DESCRIPTION
 After Zephyr changes in commit [af974c30747 ](https://github.com/zephyrproject-rtos/zephyr/commit/af974c307477f4e0e093abbfca768419f14a865f)replace removed IMR_L3_HEAP_SIZE to ace_imr_get_mem_size().
    
 This fixes build error : zephyr/lib/alloc.c:220:27: error: 'IMR_L3_HEAP_SIZE' undeclared (first use in this function)