### PR TITLE
audio: volume: Align volume vector to cache line size

### DIFF
--- a/src/audio/volume/volume_ipc3.c
+++ b/src/audio/volume/volume_ipc3.c
@@ -88,7 +88,7 @@ int volume_init(struct processing_module *mod)
 	 * malloc memory to store current volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->vol = mod_alloc(mod, vol_size);
+	cd->vol = mod_alloc_align(mod, vol_size, SOF_FRAME_BYTE_ALIGN);
 	if (!cd->vol) {
 		mod_free(mod, cd);
 		comp_err(dev, "Failed to allocate %zu", vol_size);

--- a/src/audio/volume/volume_ipc4.c
+++ b/src/audio/volume/volume_ipc4.c
@@ -135,7 +135,7 @@ int volume_init(struct processing_module *mod)
 	 * malloc memory to store current volume 4 times to ensure the address
 	 * is 8-byte aligned for multi-way xtensa intrinsic operations.
 	 */
-	cd->vol = mod_alloc(mod, vol_size);
+	cd->vol = mod_alloc_align(mod, vol_size, SOF_FRAME_BYTE_ALIGN);
 	if (!cd->vol) {
 		mod_free(mod, cd);
 		comp_err(dev, "Failed to allocate %d", vol_size);


### PR DESCRIPTION
Some of the HIFI optimized versions of the volume processing callbacks require the volume vector to be suitably aligned. Cache line size should be good enough for all versions.

The ultimate over engineered solution would be some mechanism for the used implementation (HIFI3/4/5 or generic with max volume needed or not permutation) pass the information of the required alignment to the init function, but following the KISS principle this is as good as it gets.