### PR TITLE
kpb: Increase number of supported clients to 4

### DIFF
--- a/src/include/sof/audio/kpb.h
+++ b/src/include/sof/audio/kpb.h
@@ -42,7 +42,7 @@ struct comp_buffer;
 #define KPB_MAX_BUFFER_SIZE(sw, channels_number) ((KPB_SAMPLNG_FREQUENCY / 1000) * \
 	(KPB_SAMPLE_CONTAINER_SIZE(sw) / 8) * KPB_MAX_BUFF_TIME * \
 	 (channels_number))
-#define KPB_MAX_NO_OF_CLIENTS 2
+#define KPB_MAX_NO_OF_CLIENTS 4
 #define KPB_MAX_SINK_CNT (1 + KPB_MAX_NO_OF_CLIENTS)
 #define KPB_NO_OF_HISTORY_BUFFERS 2 /**< no of internal buffers */
 #define KPB_ALLOCATION_STEP 0x100


### PR DESCRIPTION
This increases the supported number of KPB clients from 2 to 4 to be aligned with the existing testing framework and Windows ACE FW.