### PR TITLE
ipc4: Fix buffer use after free

### DIFF
--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -321,6 +321,7 @@ __cold static int ipc_pipeline_module_free(uint32_t pipeline_id)
 
 		/* free sink buffer allocated by current component in bind function */
 		comp_dev_for_each_consumer_safe(icd->cd, buffer, safe) {
+			pipeline_disconnect(icd->cd, buffer, PPL_CONN_DIR_COMP_TO_BUFFER);
 			struct comp_dev *sink = comp_buffer_get_sink_component(buffer);
 
 			/* free the buffer only when the sink module has also been disconnected */


### PR DESCRIPTION
Buffer has to be disconnected from both components before being freed.

Buffer is usually freed at unbind. However, if unbind was not called before pipeline delete (e.g., because of a driver or test bug) buffer is freed at ipc_pipeline_module_free(). Without this fix buffer is freed without being disconnected from its source component and then several lines below at ipc_comp_free() the component disconnects itself from any buffers and so writes to already freed struct comp_buffer.

This problem seems to be a regression introduced by this commit: 8aa90d69a825316d6c17bd715ad94e2ed3fd24a7