### PR TITLE
lib: fast-get: fix userspace build

### DIFF
--- a/src/include/sof/lib/fast-get.h
+++ b/src/include/sof/lib/fast-get.h
@@ -12,7 +12,7 @@
 
 struct k_heap;
 
-#if defined(__ZEPHYR__) && defined(CONFIG_SOF)
+#if defined(__ZEPHYR__) && defined(CONFIG_SOF_FULL_ZEPHYR_APPLICATION)
 #include <zephyr/toolchain.h>
 
 __syscall const void *fast_get(struct k_heap *heap, const void * const dram_ptr, size_t size);


### PR DESCRIPTION
CONFIG_SOF was removed in upstream Zephyr and this broke builds with user-space overlay.

Fixes: 60780a61c4bc ("west.yml: update zephyr to f3b9d1871104")