### PR TITLE
audio: ipc4: dai: pass correct blob size to dai driver

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -396,8 +396,11 @@ __cold int dai_config(struct dai_data *dd, struct comp_dev *dev,
 	if (ret < 0)
 		return ret;
 
+	/* gtw_cfg.config_length is in words */
+	size = copier_cfg->gtw_cfg.config_length << 2;
+
 	return dai_set_config(dd->dai, common_config,
-			      copier_cfg->gtw_cfg.config_data, copier_cfg->gtw_cfg.config_length);
+			      copier_cfg->gtw_cfg.config_data, size);
 }
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS


### PR DESCRIPTION
When converting to new dai_set_config() interface, incorrect size was passed. copier_cfg->gtw_cfg.config_length is in words, but dai_set_config() takes size in bytes.

Fixes: b9fb0b44da78 ("audio: dai: Pass bespoke config size through dai_set_config chain")