### PR TITLE
[SKIP SOF-TEST] .github: really disable spar-se instead of breaking it

### DIFF
--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -12,16 +12,15 @@ defaults:
     shell: bash
 
 jobs:
-  # disable until https://github.com/zephyrproject-rtos/zephyr/issues/93444
-  # is fixed
-  if: false
-
   # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of
   # sparse.c is an unusable mess and always zero in practice. Moreover
   # SOF has hundreds of sparse warnings right now. So fail only on a
   # small subset of specific warnings defined in
   # sof/scripts/parse_sparse_output.sh
   warnings-subset:
+    # disable until https://github.com/zephyrproject-rtos/zephyr/issues/93444
+    # is fixed
+    if: false
 
     # We're sharing the sparse binary with the zephyr-build container so keep
     # this in sync with it.


### PR DESCRIPTION
Fixes commit 56649f6c158b ("github: workflows: disable sparse checks temporarily") which caused a syntax error

GitHub jobs can be disabled one by one but not all at once: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif

This syntax error was found by Copilot; quoting the original PR:
- https://github.com/thesofproject/sof/pull/10337#discussion_r2470608489

> The if: false statement is incorrectly placed at the file level
> between jobs: and the job definition. This will cause a syntax
> error. It should be placed within a specific job definition. Move this
> line and the preceding comments to be indented under the job
> name (e.g., after the job key on the next line

This has blocked daily tests from running for ages:

https://github.com/thesofproject/sof/actions/runs/20048113632
```
Invalid workflow file: .github/workflows/daily-tests.yml#L42
error parsing called workflow
".github/workflows/daily-tests.yml"
-> "./.github/workflows/sparse-zephyr.yml"
  (source branch with sha:e00764e7fbe3315c0d8e1fa87624aec4e37db7e3)
: (Line: 17, Col: 7): Unexpected value 'false'
```