### PR TITLE
math: numbers: only define SOF gcd() if not already defined

### DIFF
--- a/src/include/sof/math/numbers.h
+++ b/src/include/sof/math/numbers.h
@@ -36,7 +36,11 @@
 	__a > 0 ? 1 : 0;	\
 })
 
+/* Zephyr added gcd() in 2025/Nov to sys/util.h */
+#ifndef gcd
+#define USE_SOF_GCD 1
 int gcd(int a, int b); /* Calculate greatest common divisor for a and b */
+#endif
 
 /* This is a divide function that returns ceil of the quotient.
  * E.g. ceil_divide(9, 3) returns 3, ceil_divide(10, 3) returns 4.

--- a/src/math/numbers.c
+++ b/src/math/numbers.c
@@ -15,6 +15,9 @@
 #include <rtos/symbol.h>
 #include <stdint.h>
 
+/* see numbers.h */
+#ifdef USE_SOF_GCD
+
 /* This function returns the greatest common divisor of two numbers
  * If both parameters are 0, gcd(0, 0) returns 0
  * If first parameters is 0 or second parameter is 0, gcd(0, b) returns b
@@ -74,6 +77,7 @@ int gcd(int a, int b)
 	return a << k;
 }
 EXPORT_SYMBOL(gcd);
+#endif /* USE_SOF_GCD */
 
 #if CONFIG_NUMBERS_VECTOR_FIND
 


### PR DESCRIPTION
Zephyr commit ("sys: util: Add gcd and lcm utilities") added a version of gcd() to sys/util.h that now can conflict with SOF numbers.h definition of gcd().

Make the SOF definition conditional. The Zephyr default gcd() version takes unsigned numbers while SOF version took signed, but it seems SOF existing usage is fine to make this change.

Link: https://github.com/thesofproject/sof/issues/10428