### PR TITLE
userspace: proxy: Fix typo in variable name

### DIFF
--- a/src/audio/module_adapter/library/userspace_proxy.c
+++ b/src/audio/module_adapter/library/userspace_proxy.c
@@ -74,7 +74,7 @@ static int userspace_proxy_memory_init(struct userspace_context *user,
 
 	struct k_mem_partition *parts_ptr[] = {
 #ifdef HEAP_PART_CACHED
-		&heap_part_cached,
+		&heap_cached_part,
 #endif
 		&heap_part
 	};


### PR DESCRIPTION
Fix typo in variable name from `heap_part_cached` to `heap_cached_part`.

Fixes #10431