### PR TITLE
modules: module_adapter: Remove redundant exports of internal functions

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -53,7 +53,6 @@ int comp_register(struct comp_driver_info *drv)
 
 	return 0;
 }
-EXPORT_SYMBOL(comp_register);
 
 void comp_unregister(struct comp_driver_info *drv)
 {

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -282,7 +282,6 @@ err:
 
 	return NULL;
 }
-EXPORT_SYMBOL(module_adapter_new);
 
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 static void module_adapter_calculate_dp_period(struct comp_dev *dev)
@@ -619,7 +618,6 @@ in_out_free:
 	mod->input_buffers = NULL;
 	return ret;
 }
-EXPORT_SYMBOL(module_adapter_prepare);
 
 int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *params)
 {
@@ -659,7 +657,6 @@ int module_adapter_params(struct comp_dev *dev, struct sof_ipc_stream_params *pa
 
 	return 0;
 }
-EXPORT_SYMBOL(module_adapter_params);
 
 /*
  * Function to copy from source buffer to the module buffer
@@ -1274,7 +1271,6 @@ int module_adapter_copy(struct comp_dev *dev)
 	comp_err(dev, "unknown processing_data_type");
 	return -EINVAL;
 }
-EXPORT_SYMBOL(module_adapter_copy);
 
 int module_adapter_trigger(struct comp_dev *dev, int cmd)
 {
@@ -1300,7 +1296,6 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 
 	return module_adapter_set_state(mod, dev, cmd);
 }
-EXPORT_SYMBOL(module_adapter_trigger);
 
 int module_adapter_reset(struct comp_dev *dev)
 {
@@ -1348,7 +1343,6 @@ int module_adapter_reset(struct comp_dev *dev)
 
 	return comp_set_state(dev, COMP_TRIGGER_RESET);
 }
-EXPORT_SYMBOL(module_adapter_reset);
 
 void module_adapter_free(struct comp_dev *dev)
 {
@@ -1381,7 +1375,6 @@ void module_adapter_free(struct comp_dev *dev)
 
 	module_adapter_mem_free(mod);
 }
-EXPORT_SYMBOL(module_adapter_free);
 
 size_t module_adapter_heap_usage(struct processing_module *mod, size_t *hwm)
 {
@@ -1392,7 +1385,6 @@ size_t module_adapter_heap_usage(struct processing_module *mod, size_t *hwm)
 
 	return res->heap_usage;
 }
-EXPORT_SYMBOL(module_adapter_heap_usage);
 
 /*
  * \brief Get DAI hw params
@@ -1415,7 +1407,6 @@ int module_adapter_get_hw_params(struct comp_dev *dev, struct sof_ipc_stream_par
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_get_hw_params);
 
 /*
  * \brief Get stream position
@@ -1436,7 +1427,6 @@ int module_adapter_position(struct comp_dev *dev, struct sof_ipc_stream_posn *po
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_position);
 
 /*
  * \brief DAI timestamp configure
@@ -1456,7 +1446,6 @@ int module_adapter_ts_config_op(struct comp_dev *dev)
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_ts_config_op);
 
 /*
  * \brief DAI timestamp start
@@ -1476,7 +1465,6 @@ int module_adapter_ts_start_op(struct comp_dev *dev)
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_ts_start_op);
 
 /*
  * \brief DAI timestamp stop
@@ -1496,7 +1484,6 @@ int module_adapter_ts_stop_op(struct comp_dev *dev)
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_ts_stop_op);
 
 /*
  * \brief Get DAI timestamp
@@ -1521,4 +1508,3 @@ int module_adapter_ts_get_op(struct comp_dev *dev, struct timestamp_data *tsd)
 
 	return -EOPNOTSUPP;
 }
-EXPORT_SYMBOL(module_adapter_ts_get_op);

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -212,7 +212,6 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 						    NULL, 0);
 	return 0;
 }
-EXPORT_SYMBOL(module_set_large_config);
 
 int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_block,
 			    bool last_block, uint32_t *data_offset_size, char *data)
@@ -244,7 +243,6 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 	 */
 	return -EIO;
 }
-EXPORT_SYMBOL(module_get_large_config);
 
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value)
 {
@@ -266,7 +264,6 @@ int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *valu
 
 	return 0;
 }
-EXPORT_SYMBOL(module_adapter_get_attribute);
 
 int module_adapter_set_attribute(struct comp_dev *dev, uint32_t type, void *value)
 {
@@ -284,7 +281,6 @@ int module_adapter_set_attribute(struct comp_dev *dev, uint32_t type, void *valu
 
 	return 0;
 }
-EXPORT_SYMBOL(module_adapter_set_attribute);
 
 static bool module_adapter_multi_sink_source_prepare(struct comp_dev *dev)
 {
@@ -369,7 +365,6 @@ int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 
 	return 0;
 }
-EXPORT_SYMBOL(module_adapter_bind);
 
 int module_adapter_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
 {
@@ -384,7 +379,6 @@ int module_adapter_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
 
 	return 0;
 }
-EXPORT_SYMBOL(module_adapter_unbind);
 
 uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input)
@@ -400,7 +394,6 @@ uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 	else
 		return mod->total_data_consumed;
 }
-EXPORT_SYMBOL(module_adapter_get_total_data_processed);
 
 int module_adapter_sink_src_prepare(struct comp_dev *dev)
 {


### PR DESCRIPTION
Remove redundant exports of internal module adapter functions.

Loadable modules expose the module_interface interface, which is used by the module adapter. They do not need to call any module_adapter functions directly because they do not provide the comp_driver interface.