### PR TITLE
Audio: Template: Fix typo in comment

### DIFF
--- a/src/audio/template/template.c
+++ b/src/audio/template/template.c
@@ -17,7 +17,7 @@ SOF_DEFINE_REG_UUID(template);
 /* Creates logging data for the component */
 LOG_MODULE_REGISTER(template, CONFIG_SOF_LOG_LEVEL);
 
-/* Creates the compont trace. Traces show in trace console the component
+/* Creates the component trace. Traces show in trace console the component
  * info, warning, and error messages.
  */
 DECLARE_TR_CTX(template_tr, SOF_UUID(template_uuid), LOG_LEVEL_INFO);


### PR DESCRIPTION
This small fix avoids the typo to propagate to new components created with scripts/sdk-create-module.py.