### PR TITLE
Tools: Test: Audio: process_test: Fix plot title texts with "_"

### DIFF
--- a/tools/test/audio/process_test.m
+++ b/tools/test/audio/process_test.m
@@ -442,7 +442,7 @@ function test_result_print(t, testverbose, testacronym, test)
 	%% FIXME: get unique string to keep all the incremental logs
 
 	for i = 1:length(test.ph)
-		title(test.ph(i), tstr);
+		title(test.ph(i), tstr, 'Interpreter', 'none');
 	end
 
 	for i = 1:length(test.fh)

--- a/tools/test/audio/src_test.m
+++ b/tools/test/audio/src_test.m
@@ -486,9 +486,9 @@ end
 function src_test_result_print(t, testverbose, testacronym, ph)
 tstr = sprintf('%s SRC %d, %d', testverbose, t.fs1, t.fs2);
 if nargin > 3 && ~isempty(ph)
-        title(ph, tstr);
+        title(ph, tstr, 'Interpreter', 'none');
 else
-        title(tstr);
+        title(tstr, 'Interpreter', 'none');
 end
 pfn = sprintf('plots/%s_src_%d_%d.png', testacronym, t.fs1, t.fs2);
 print(pfn, '-dpng');

--- a/tools/test/audio/tdfb_test.m
+++ b/tools/test/audio/tdfb_test.m
@@ -208,7 +208,7 @@ if cfg.do_plots
 	hold off
 	grid on;
 	legend('ch1 in','ch1 out');
-	title(tstr);
+	title(tstr, 'Interpreter', 'none');
 end
 
 end


### PR DESCRIPTION
The interpreter for LaTeX style formatting messes up text strings with underscores (to use subscript font). With disable of formatting interpreter the plot title texts from e.g. process_test.m look sane since we don't use formatted text.