### PR TITLE
audio: copier: Refactor deep copy of copier config

### DIFF
--- a/src/audio/copier/copier.h
+++ b/src/audio/copier/copier.h
@@ -241,13 +241,6 @@ struct ipc4_data_segment_enabled {
 } __attribute__((packed, aligned(4)));
 
 struct copier_data {
-	/*
-	 * struct ipc4_copier_module_cfg actually has variable size, but we
-	 * don't need the variable size array at the end, we won't be copying it
-	 * from the IPC data.
-	 */
-	struct ipc4_copier_module_cfg config;
-	void *gtw_cfg;
 	enum ipc4_gateway_type gtw_type;
 	uint32_t endpoint_num;
 
@@ -277,6 +270,8 @@ struct copier_data {
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
 	struct mic_privacy_data *mic_priv;
 #endif
+	/* Has to be at the end due to variable size array */
+	struct ipc4_copier_module_cfg config;
 };
 
 int apply_attenuation(struct comp_dev *dev, struct copier_data *cd,

--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -270,6 +270,8 @@ __cold int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 	struct ipc_config_dai dai;
 	int dai_count;
 	int i, ret;
+	uint8_t *gtw_cfg_data = (uint8_t *)cd->config.gtw_cfg.config_data;
+	size_t gtw_cfg_szie = cd->config.gtw_cfg.config_length * 4;
 
 	assert_can_be_cold();
 
@@ -296,8 +298,7 @@ __cold int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.type = SOF_DAI_INTEL_SSP;
 		dai.is_config_blob = true;
 		cd->gtw_type = ipc4_gtw_ssp;
-		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
-					   copier->gtw_cfg.config_length * 4);
+		ret = ipc4_find_dma_config(&dai, gtw_cfg_data, gtw_cfg_szie);
 		if (ret != 0) {
 			comp_err(dev, "No ssp dma_config found in blob!");
 			return -EINVAL;
@@ -315,8 +316,8 @@ __cold int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.is_config_blob = true;
 		cd->gtw_type = ipc4_gtw_alh;
 #endif /* ACE_VERSION > ACE_VERSION_1_5 */
-		ret = copier_alh_assign_dai_index(dev, cd->gtw_cfg, node_id,
-						  &dai, dai_index, &dai_count);
+		ret = copier_alh_assign_dai_index(dev, gtw_cfg_data, node_id, &dai, dai_index,
+						  &dai_count);
 		if (ret)
 			return ret;
 		break;
@@ -324,8 +325,7 @@ __cold int copier_dai_create(struct comp_dev *dev, struct copier_data *cd,
 		dai.type = SOF_DAI_INTEL_DMIC;
 		dai.is_config_blob = true;
 		cd->gtw_type = ipc4_gtw_dmic;
-		ret = ipc4_find_dma_config(&dai, (uint8_t *)cd->gtw_cfg,
-					   copier->gtw_cfg.config_length * 4);
+		ret = ipc4_find_dma_config(&dai, gtw_cfg_data, gtw_cfg_szie);
 		if (ret != 0) {
 			comp_err(dev, "No dmic dma_config found in blob!");
 			return -EINVAL;

--- a/src/audio/copier/copier_gain.c
+++ b/src/audio/copier/copier_gain.c
@@ -34,12 +34,8 @@ __cold int copier_gain_set_params(struct comp_dev *dev, struct copier_gain_param
 	switch (dai_type) {
 	case SOF_DAI_INTEL_DMIC:
 		{
-			struct dmic_config_data *dmic_cfg = cd->gtw_cfg;
-
-			if (!dmic_cfg) {
-				comp_err(dev, "No dmic config found");
-				return -EINVAL;
-			}
+			struct dmic_config_data *dmic_cfg =
+					(void *)cd->config.gtw_cfg.config_data;
 
 			union dmic_global_cfg *dmic_glb_cfg = &dmic_cfg->dmic_blob.global_cfg;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -91,13 +91,9 @@ int dai_config_dma_channel(struct dai_data *dd, struct comp_dev *dev, const void
 			struct processing_module *mod = comp_mod(dev);
 			struct copier_data *cd = module_get_private_data(mod);
 
-			if (!cd->gtw_cfg) {
-				comp_err(dev, "No gateway config found!");
-				return SOF_DMA_CHAN_INVALID;
-			}
-
 			channel = SOF_DMA_CHAN_INVALID;
-			const struct sof_alh_configuration_blob *alh_blob = cd->gtw_cfg;
+			const struct sof_alh_configuration_blob *alh_blob =
+							(void *)cd->config.gtw_cfg.config_data;
 
 			for (int i = 0; i < alh_blob->alh_cfg.count; i++) {
 				if (dai->host_dma_config[i]->stream_id == dai->dai_index) {

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -122,7 +122,8 @@ static void resume_dais(void)
 		if (dai_probe(dd->dai->dev) < 0) {
 			tr_err(&zephyr_tr, "DAI resume failed on probe, type %d index %d",
 			       dd->dai->type, dd->dai->index);
-		} else if (dai_set_config(dd->dai, &dd->ipc_config, cd->gtw_cfg,
+		} else if (dai_set_config(dd->dai, &dd->ipc_config,
+					  cd->config.gtw_cfg.config_data,
 					  cd->config.gtw_cfg.config_length) < 0) {
 			tr_err(&zephyr_tr, "DAI resume failed on config, type %d index %d",
 			       dd->dai->type, dd->dai->index);


### PR DESCRIPTION
Code for copying copier_data is ambiguous. A comment suggests that the deep
copy (data structure + variable-length array) is not needed but the copy of
variable-length array is performed afterwards. This change rectifies this by
placing ipc4_copier_module_cfg at the end of copier_data structure as it
contains a variable-length array. This enables single memory allocation and
single, clean 1:1 copy for the complete copier_data with the variable-length
addition.