### PR TITLE
ptl: reduce the size of the shared buffer on ACE 3.0

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -61,7 +61,7 @@ config SOF_ZEPHYR_SHARED_BUFFER_HEAP_SIZE
 	hex "Size of the shared buffer heap for SOF userspace modules"
 	default 0x0 if !SOF_USERSPACE_USE_SHARED_HEAP
 	default 0x1E000 if SOC_INTEL_ACE15_MTPM || SOC_INTEL_ACE20_LNL
-	default 0x1A000 if SOC_INTEL_ACE30
+	default 0x10000 if SOC_INTEL_ACE30
 	default 0x0
 	depends on USERSPACE
 	help


### PR DESCRIPTION
CI nocodec tests on PTL are running out of memory since shared memory has been introduced. Since it isn't widely used yet, reduce its default size on ACE 3.0.