### PR TITLE
topology2: sdw-amp-generic: Set correct number of feedback copier cha…

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -346,6 +346,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 
 							Object.Base.input_audio_format [
 								{
+									in_channels		$AMP_FEEDBACK_CH
 									in_bit_depth            32
 									in_valid_bit_depth      $SDW_LINK_VALID_BITS
 									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
@@ -354,6 +355,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 							]
 							Object.Base.output_audio_format [
 								{
+									out_channels		$AMP_FEEDBACK_CH
 									out_bit_depth            32
 									out_valid_bit_depth      32
 								}
@@ -494,6 +496,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 
 							Object.Base.input_audio_format [
 								{
+									in_channels		$AMP_FEEDBACK_CH
 									in_bit_depth            32
 									in_valid_bit_depth      $SDW_LINK_VALID_BITS
 									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
@@ -502,6 +505,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 							]
 							Object.Base.output_audio_format [
 								{
+									out_channels		$AMP_FEEDBACK_CH
 									out_bit_depth            32
 									out_valid_bit_depth      32
 								}
@@ -521,6 +525,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 
 							Object.Base.input_audio_format [
 								{
+									in_channels		$AMP_FEEDBACK_CH
 									in_bit_depth            32
 									in_valid_bit_depth      $SDW_LINK_VALID_BITS
 									in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
@@ -529,6 +534,7 @@ IncludeByKey.NUM_SDW_AMP_LINKS {
 							]
 							Object.Base.output_audio_format [
 								{
+									out_channels		$AMP_FEEDBACK_CH
 									out_bit_depth            32
 									out_valid_bit_depth      32
 								}


### PR DESCRIPTION
…nnels

The alh-copiers for 2nd and 3rd feedback links were not setting the number of channels, so it was defaulting to 2 channels.

The number of channels on these copiers must be $AMP_FEEDBACK_CH, the same as on the first link copier.