### PR TITLE
userspace: dp: add a Kconfig option to simplify conditionals

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -120,7 +120,7 @@ int module_init(struct processing_module *mod)
 	mod->priv.resources.rsrc_mngr = k_current_get();
 #endif
 	/* Now we can proceed with module specific initialization */
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 	if (mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP)
 		ret = scheduler_dp_thread_ipc(mod, SOF_IPC4_MOD_INIT_INSTANCE, NULL);
 	else
@@ -501,7 +501,7 @@ int module_prepare(struct processing_module *mod,
 	if (ops->prepare) {
 		int ret;
 
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		if (dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
 			const union scheduler_dp_thread_ipc_param param = {
 				.pipeline_state = {
@@ -638,11 +638,11 @@ int module_reset(struct processing_module *mod)
 
 	/* cancel task if DP task*/
 	if (mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP && mod->dev->task &&
-	    (IS_ENABLED(CONFIG_SOF_USERSPACE_PROXY) || !IS_ENABLED(CONFIG_USERSPACE)))
+	    !IS_ENABLED(CONFIG_SOF_USERSPACE_APPLICATION))
 		schedule_task_cancel(mod->dev->task);
 
 	if (ops->reset) {
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		if (mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
 			const union scheduler_dp_thread_ipc_param param = {
 				.pipeline_state.trigger_cmd = COMP_TRIGGER_STOP,
@@ -723,7 +723,7 @@ int module_free(struct processing_module *mod)
 	int ret = 0;
 
 	if (ops->free && (mod->dev->ipc_config.proc_domain != COMP_PROCESSING_DOMAIN_DP ||
-			  IS_ENABLED(CONFIG_SOF_USERSPACE_PROXY) || !IS_ENABLED(CONFIG_USERSPACE))) {
+			  !IS_ENABLED(CONFIG_SOF_USERSPACE_APPLICATION))) {
 		ret = ops->free(mod);
 		if (ret)
 			comp_warn(mod->dev, "error: %d", ret);
@@ -869,7 +869,7 @@ int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 		return ret;
 
 	if (ops->bind) {
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		if (mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
 			const union scheduler_dp_thread_ipc_param param = {
 				.bind_data = bind_data,
@@ -902,7 +902,7 @@ int module_unbind(struct processing_module *mod, struct bind_info *unbind_data)
 		return ret;
 
 	if (ops->unbind) {
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		if (mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
 			const union scheduler_dp_thread_ipc_param param = {
 				.bind_data = unbind_data,

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1335,7 +1335,7 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	if (interface->trigger) {
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		if (dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP) {
 			/* Process DP module's trigger */
 			const union scheduler_dp_thread_ipc_param param = {
@@ -1415,7 +1415,7 @@ void module_adapter_free(struct comp_dev *dev)
 		 * thread context, then cancel the thread, and then execute
 		 * final clean up
 		 */
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 		scheduler_dp_thread_ipc(mod, SOF_IPC4_MOD_DELETE_INSTANCE, NULL);
 #endif
 		schedule_task_free(dev->task);

--- a/src/schedule/CMakeLists.txt
+++ b/src/schedule/CMakeLists.txt
@@ -38,15 +38,15 @@ else()
 	)
 endif()
 
-if (CONFIG_SOF_USERSPACE_PROXY OR NOT CONFIG_USERSPACE)
+if (CONFIG_SOF_USERSPACE_APPLICATION)
 	zephyr_library_sources_ifdef(CONFIG_ZEPHYR_DP_SCHEDULER
 		zephyr_dp_schedule.c
-		zephyr_dp_schedule_thread.c
+		zephyr_dp_schedule_application.c
 	)
 else()
 	zephyr_library_sources_ifdef(CONFIG_ZEPHYR_DP_SCHEDULER
 		zephyr_dp_schedule.c
-		zephyr_dp_schedule_application.c
+		zephyr_dp_schedule_thread.c
 	)
 endif()
 

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -240,7 +240,7 @@ void scheduler_dp_ll_tick(void *receiver_data, enum notify_id event_type, void *
 	scheduler_dp_unlock(lock_key);
 }
 
-#if CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY
+#if CONFIG_SOF_USERSPACE_APPLICATION
 static int scheduler_dp_task_cancel(void *data, struct task *task)
 {
 	/* Should never be called */
@@ -266,10 +266,10 @@ static int scheduler_dp_task_stop(void *data, struct task *task)
 		schedule_task_cancel(&dp_sch->ll_tick_src);
 
 	/* if the task is waiting - let it run and self-terminate */
-#if CONFIG_SOF_USERSPACE_PROXY || !CONFIG_USERSPACE
-	k_event_set(pdata->event, DP_TASK_EVENT_CANCEL);
-#else
+#if CONFIG_SOF_USERSPACE_APPLICATION
 	k_sem_give(pdata->sem);
+#else
+	k_event_set(pdata->event, DP_TASK_EVENT_CANCEL);
 #endif
 	scheduler_dp_unlock(lock_key);
 
@@ -350,10 +350,10 @@ static int scheduler_dp_task_shedule(void *data, struct task *task, uint64_t sta
 
 static struct scheduler_ops schedule_dp_ops = {
 	.schedule_task		= scheduler_dp_task_shedule,
-#if CONFIG_SOF_USERSPACE_PROXY || !CONFIG_USERSPACE
-	.schedule_task_cancel	= scheduler_dp_task_stop,
-#else
+#if CONFIG_SOF_USERSPACE_APPLICATION
 	.schedule_task_cancel	= scheduler_dp_task_cancel,
+#else
+	.schedule_task_cancel	= scheduler_dp_task_stop,
 #endif
 	.schedule_task_free	= scheduler_dp_task_free,
 };

--- a/src/schedule/zephyr_dp_schedule.h
+++ b/src/schedule/zephyr_dp_schedule.h
@@ -38,15 +38,15 @@ struct task_dp_pdata {
 	k_thread_stack_t *p_stack;	/* pointer to thread stack */
 	struct processing_module *mod;	/* the module to be scheduled */
 	uint32_t ll_cycles_to_start;    /* current number of LL cycles till delayed start */
-#if CONFIG_SOF_USERSPACE_PROXY || !CONFIG_USERSPACE
-	struct k_event *event;		/* pointer to event for task scheduling */
-	struct k_event event_struct;	/* event for task scheduling for kernel threads */
-#else
+#if CONFIG_SOF_USERSPACE_APPLICATION
 	struct k_sem *sem;              /* pointer to semaphore for task scheduling */
 	struct k_sem sem_struct;        /* semaphore for task scheduling for kernel threads */
 	unsigned char pend_ipc;
 	unsigned char pend_proc;
 	struct k_mem_partition mpart[SOF_DP_PART_TYPE_COUNT];
+#else
+	struct k_event *event;		/* pointer to event for task scheduling */
+	struct k_event event_struct;	/* event for task scheduling for kernel threads */
 #endif
 };
 
@@ -58,10 +58,10 @@ void scheduler_dp_grant(k_tid_t thread_id, uint16_t core);
 int scheduler_dp_task_init(struct task **task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops, struct processing_module *mod,
 			   uint16_t core, size_t stack_size, uint32_t options);
-#if CONFIG_SOF_USERSPACE_PROXY || !CONFIG_USERSPACE
-static inline void scheduler_dp_domain_free(struct processing_module *pmod) {}
-static inline int scheduler_dp_domain_init(void) {return 0;}
-#else
+#if CONFIG_SOF_USERSPACE_APPLICATION
 void scheduler_dp_domain_free(struct processing_module *pmod);
 int scheduler_dp_domain_init(void);
+#else
+static inline void scheduler_dp_domain_free(struct processing_module *pmod) {}
+static inline int scheduler_dp_domain_init(void) {return 0;}
 #endif

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -113,6 +113,13 @@ config SOF_USERSPACE_PROXY
 	  It is responsible for forwarding module function calls coming from sof running in
 	  kernelspace to the module code executed with user privileges.
 
+config SOF_USERSPACE_APPLICATION
+	bool
+	default USERSPACE && !SOF_USERSPACE_PROXY
+	help
+	  Not manually settable. This is effectively a shortcut to replace numerous
+	  checks for (CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY)
+
 config ZEPHYR_NATIVE_DRIVERS
 	bool "Use Zephyr native drivers"
 	help


### PR DESCRIPTION
Add an automatic (non-user selectable) Kconfig option to enable the "application variant" of the DP userspace implementation. Effectively it replaces (CONFIG_USERSPACE && !CONFIG_SOF_USERSPACE_PROXY) with a single new option.