### PR TITLE
dp: switch the lock to use sys_sem

### DIFF
--- a/src/schedule/zephyr_dp_schedule.h
+++ b/src/schedule/zephyr_dp_schedule.h
@@ -55,11 +55,12 @@ void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_
 void dp_thread_fn(void *p1, void *p2, void *p3);
 unsigned int scheduler_dp_lock(uint16_t core);
 void scheduler_dp_unlock(unsigned int key);
-void scheduler_dp_grant(k_tid_t thread_id, uint16_t core);
 int scheduler_dp_task_init(struct task **task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops, struct processing_module *mod,
 			   uint16_t core, size_t stack_size, uint32_t options);
 #if CONFIG_SOF_USERSPACE_APPLICATION
+int scheduler_dp_add_domain(struct k_mem_domain *domain);
+int scheduler_dp_rm_domain(struct k_mem_domain *domain);
 void scheduler_dp_domain_free(struct processing_module *pmod);
 int scheduler_dp_domain_init(void);
 #else

--- a/src/schedule/zephyr_dp_schedule_thread.c
+++ b/src/schedule/zephyr_dp_schedule_thread.c
@@ -270,7 +270,6 @@ int scheduler_dp_task_init(struct task **task,
 					   CONFIG_DP_THREAD_PRIORITY, (*task)->flags, K_FOREVER);
 
 	k_thread_access_grant(pdata->thread_id, pdata->event);
-	scheduler_dp_grant(pdata->thread_id, cpu_get_id());
 
 	/* pin the thread to specific core */
 	ret = k_thread_cpu_pin(pdata->thread_id, core);


### PR DESCRIPTION
sys_sem semaphores don't invoke a syscall in uncongested cases. Switch over to it to reduce syscall number.