### PR TITLE
nvl: disable GDB stub until fixed in Zephyr

### DIFF
--- a/app/boards/intel_adsp_ace40_nvl.conf
+++ b/app/boards/intel_adsp_ace40_nvl.conf
@@ -55,3 +55,6 @@ CONFIG_PM_DEVICE_RUNTIME_ASYNC=n
 # Zephyr / logging
 CONFIG_LOG_BACKEND_ADSP=n
 CONFIG_WINSTREAM_CONSOLE=n
+
+# Zephyr / debug: temporary, until fixed
+CONFIG_GDBSTUB=n

--- a/app/boards/intel_adsp_ace40_nvls.conf
+++ b/app/boards/intel_adsp_ace40_nvls.conf
@@ -55,3 +55,6 @@ CONFIG_PM_DEVICE_RUNTIME_ASYNC=n
 # Zephyr / logging
 CONFIG_LOG_BACKEND_ADSP=n
 CONFIG_WINSTREAM_CONSOLE=n
+
+# Zephyr / debug: temporary, until fixed
+CONFIG_GDBSTUB=n


### PR DESCRIPTION
Zephyr currently lacks GDB support for NVL, temporarily disable it in SOF.