### PR TITLE
test: userspace: add a sys_sem test

### DIFF
--- a/zephyr/test/userspace/ksem.c
+++ b/zephyr/test/userspace/ksem.c
@@ -57,6 +57,62 @@ ZTEST(sof_boot, user_space)
 {
 	test_user_thread();
 	test_user_thread_with_sem();
+}
 
-	ztest_test_pass();
+#include <zephyr/sys/sem.h>
+#include <zephyr/app_memory/mem_domain.h>
+
+struct sem_mem {
+	struct sys_sem sem1;
+	struct sys_sem sem2;
+	uint8_t reserved[4096 - 2 * sizeof(struct sys_sem)];
+};
+
+static struct sem_mem simple_sem __attribute__((aligned(4096)));
+static struct k_mem_domain dp_mdom;
+
+static void sys_sem_function(void *p1, void *p2, void *p3)
+{
+	__ASSERT(k_is_user_context(), "isn't user");
+	/* This is the goal, but it hangs with this disabled too */
+	sys_sem_give(&simple_sem.sem1);
+	int ret = sys_sem_take(&simple_sem.sem2, K_MSEC(20));
+
+	LOG_INF("SOF thread %s (%s) sem %p: %d",
+		k_is_user_context() ? "UserSpace!" : "privileged mode.",
+		CONFIG_BOARD_TARGET, &simple_sem, ret);
+}
+
+static void test_user_thread_sys_sem(void)
+{
+	struct k_mem_partition mpart = {
+		.start = (uintptr_t)&simple_sem,
+		.size = 4096,
+		.attr = K_MEM_PARTITION_P_RW_U_RW/* | XTENSA_MMU_CACHED_WB*/,
+	};
+
+	k_mem_domain_init(&dp_mdom, 0, NULL);
+	sys_sem_init(&simple_sem.sem1, 0, 1);
+	sys_sem_init(&simple_sem.sem2, 0, 1);
+
+	k_thread_create(&user_thread, user_stack, USER_STACKSIZE,
+			sys_sem_function, NULL, NULL, NULL,
+			-1, K_USER, K_FOREVER);
+	k_mem_domain_add_partition(&dp_mdom, &mpart);
+	k_mem_domain_add_thread(&dp_mdom, &user_thread);
+
+	k_thread_start(&user_thread);
+
+	/* This is what doesn't work: enabling this line crashes the DSP  */
+	zassert_ok(sys_sem_take(&simple_sem.sem1, K_MSEC(20)));
+
+	sys_sem_give(&simple_sem.sem2);
+
+	k_thread_join(&user_thread, K_FOREVER);
+	k_mem_domain_remove_partition(&dp_mdom, &mpart);
+}
+
+ZTEST(sof_boot, test_sys_sem)
+{
+	test_user_thread_sys_sem();
 }


### PR DESCRIPTION
Add a sys_sem test between kernel- and user-space. @dcpleung any idea why this might not be working? Just adding a `sys_sem_take()` in the kernel thread with a timeout hangs the DSP, instead of returning with a timeout as expected.