### PR TITLE
west.yml: update zephyr to 7e3c5ab2bb2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 6c410584dd64b5e51540ce931342c315ccbb5d9b
+      revision: 7e3c5ab2bb2a9f4bf1b0afd43c872e6f19461777
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 471 commits.

Changes include:

6cab38312bd soc: intel_adsp: add GDB stub register list for ACE 4.0
00bf0915d6e llext: Skip MPU region alignment if userspace is disabled.
72d06609af0 drivers: dai: intel: hda: implement get_properties_copy
43e45a2b502 drivers: dai: intel: dmic: implement get_properties_copy
82f28ff7745 drivers: dai: intel: alh: implement get_properties_copy
6110b9728fb drivers: dai: fix dai_config_set() syscall validation
8fb3da57f35 drivers: dai: intel: ssp: handle no properties case for properties_copy()
a64a4325e7a drivers: dai: intel: ssp: fix indentation for dai_ssp_get_properties_copy
cf318bb1f25 drivers: dai: fix optional use of dai_get_properties_copy()
b98fc2740a1 soc: intel_adsp/ace40: disable spin validation on simulator
45dd7fa9ad9 xtensa: debug: enable xtensa thread awareness
ce558ecdc31 boards: intel_adsp: add ram tags
15fa6a374ec ipc: intel_adsp: simplify host IPC service backend
4cf753bfb2e ipc_service: Add ipc_service_send_critical function
d334130d5da soc: intel_adsp/ace: skip building arch reset vector