### PR TITLE
rtos: string: Add memory barrier to memset_s for security

### DIFF
--- a/zephyr/include/rtos/string.h
+++ b/zephyr/include/rtos/string.h
@@ -69,8 +69,14 @@ static inline int memset_s(void *dest, size_t dest_size, int data, size_t count)
 	if (count > dest_size)
 		return -EINVAL;
 
-	if (!memset(dest, data, count))
-		return -ENOMEM;
+	memset(dest, data, count);
+	/*
+	 * Prevent compiler from optimizing away the memset.
+	 * Memory barrier prevents dead store elimination.
+	 */
+#if defined(CONFIG_XTENSA)
+	__asm__ __volatile__("memw" ::: "memory");
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Add Xtensa memory barrier (memw) instruction after memset() in memset_s() implementation to prevent compiler dead store elimination (DSE) optimization from removing the memory clearing operation.

When optimization flags like -O2 are enabled, compilers may perform dead store elimination and incorrectly remove memset() calls used for security purposes to scrub sensitive data from memory. This is critical for confidential data handling where memory must be reliably cleared after use.

The memory barrier ensures the memset operation completes and cannot be optimized away, satisfying secure memory scrubbing requirements for cryptographic operations and sensitive data processing.

Additionally, the patch removes the check for the return value of memset. The standard C library memset always returns the pointer passed as its first argument and does not indicate errors through its return value. Error handling for a NULL destination is already performed earlier in the function, so the return value check is unnecessary and can be safely omitted.