### PR TITLE
[stable-v2.14] Topology2: add new sdca amp function topologies support

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
@@ -17,6 +17,12 @@ SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0"
 "cavs-sdw\;sof-sdca-2amp-id2\;NUM_SDW_AMP_LINKS=2,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0"
 
+"cavs-sdw\;sof-sdca-3amp-id2\;NUM_SDW_AMP_LINKS=3,SDW_JACK=false,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0"
+
+"cavs-sdw\;sof-sdca-4amp-id2\;NUM_SDW_AMP_LINKS=4,SDW_JACK=false,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0"
+
 "cavs-sdw\;sof-sdca-mic-id4\;SDW_JACK=false,SDW_DMIC=1,NUM_HDMIS=0,\
 SDW_DMIC_STREAM=Capture-SmartMic"
 


### PR DESCRIPTION
The SDCA amps can be on 3 or 4 SoundWire links.


(cherry picked from commit 46e8ed16de2ef794c8dfd21b648df96719f8dfe4)