### PR TITLE
app: os_linux_overlay: use Linux log format by default

### DIFF
--- a/app/os_linux_overlay.conf
+++ b/app/os_linux_overlay.conf
@@ -6,4 +6,5 @@
 # SOF Linux driver does not require FW to retain its
 # state, so context save can be disabled
 CONFIG_ADSP_IMR_CONTEXT_SAVE=n
+CONFIG_LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP=y
 CONFIG_SOF_USERSPACE_PROXY=n


### PR DESCRIPTION
Add CONFIG_LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP=y to the Linux overlay. This aligns the timestamp format between SOF firmware and host Linux kernel logs.