### PR TITLE
scheduler: dp: fix memory leak / implicit freeing

### DIFF
--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -295,24 +295,12 @@ static int scheduler_dp_task_free(void *data, struct task *task)
 		pdata->thread_id = NULL;
 	}
 
-#ifdef CONFIG_USERSPACE
-#if CONFIG_SOF_USERSPACE_PROXY
-	if (pdata->event != &pdata->event_struct)
-		k_object_free(pdata->event);
-#else
-	k_object_free(pdata->sem);
-#endif
-	if (pdata->thread != &pdata->thread_struct)
-		k_object_free(pdata->thread);
-#endif
-
 	/* free task stack */
 	ret = user_stack_free(pdata->p_stack);
 	pdata->p_stack = NULL;
 
-	scheduler_dp_domain_free(pdata->mod);
+	scheduler_dp_internal_free(task);
 
-	/* all other memory has been allocated as a single malloc, will be freed later by caller */
 	return ret;
 }
 

--- a/src/schedule/zephyr_dp_schedule.h
+++ b/src/schedule/zephyr_dp_schedule.h
@@ -58,8 +58,4 @@ void scheduler_dp_grant(k_tid_t thread_id, uint16_t core);
 int scheduler_dp_task_init(struct task **task, const struct sof_uuid_entry *uid,
 			   const struct task_ops *ops, struct processing_module *mod,
 			   uint16_t core, size_t stack_size, uint32_t options);
-#if CONFIG_SOF_USERSPACE_APPLICATION
-void scheduler_dp_domain_free(struct processing_module *pmod);
-#else
-static inline void scheduler_dp_domain_free(struct processing_module *pmod) {}
-#endif
+void scheduler_dp_internal_free(struct task *task);


### PR DESCRIPTION
Task memory was freed implicitly by one DP implementation and was leaked by another one. Free it explicitly for both.

Reported-by: Jun Lai <jun.lai@dolby.com>

An alternative implementation of #10512 