### PR TITLE
debug: temporarily disable dynamic slots for "thread" userspace

### DIFF
--- a/app/boards/intel_adsp/Kconfig.defconfig
+++ b/app/boards/intel_adsp/Kconfig.defconfig
@@ -175,5 +175,4 @@ config ZTEST
 # ----------------------------------------
 
 config INTEL_ADSP_DEBUG_SLOT_MANAGER
-	default y
-
+	default y if !SOF_USERSPACE_PROXY


### PR DESCRIPTION
The "thread" userspace variant currently breaks when dynamic debug slots are used. Temporarily disable that configuration until fixed.