### PR TITLE
module-adapter: Add NULL check for sink buffer

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -460,10 +460,15 @@ int module_adapter_prepare(struct comp_dev *dev)
 
 	mod->deep_buff_bytes = 0;
 
-	/* Get period_bytes first on prepare(). At this point it is guaranteed that the stream
-	 * parameter from sink buffer is settled, and still prior to all references to period_bytes.
+	/* Get period_bytes first on prepare(). At this point the stream parameter from sink buffer
+	 * shall be settled, provided that the pipeline is built correctly (bind IPC received).
+	 * Hence check for NULL.
 	 */
 	sink = comp_dev_get_first_data_consumer(dev);
+	if (!sink) {
+		comp_err(dev, "no sink present on period size calculation");
+		return -EINVAL;
+	}
 
 	mod->period_bytes = audio_stream_period_bytes(&sink->stream, dev->frames);
 	comp_dbg(dev, "got period_bytes = %u", mod->period_bytes);


### PR DESCRIPTION
Just a corner case found in a test with incorrect topology. I think it should be fixed.

Return error if a sink buffer is not present before it is accessed while calculating period size in module_adapter_prepare. This might occur when a pipeline is built incorrectly (without binding) and the sink buffer is not connected to a module.