### PR TITLE
ipc4: base_fw: Request empty Astate table

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -681,6 +681,10 @@ __cold static int basefw_set_large_config(struct comp_dev *dev, uint32_t param_i
 	assert_can_be_cold();
 
 	switch (param_id) {
+	case IPC4_ASTATE_TABLE:
+		/* Trivial handler due to an empty Astate Table requested in get_large_config */
+		STATIC_ASSERT(IPC4_MAX_CLK_STATES == 0, IPC4_NON_ZERO_ASTATE_UNSUPPORTED);
+		return IPC4_SUCCESS;
 	case IPC4_DMA_CONTROL:
 		return basefw_dma_control(first_block, last_block, data_offset, data);
 	case IPC4_PERF_MEASUREMENTS_STATE:

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -17,10 +17,11 @@
 #ifndef __SOF_IPC4_BASE_FW_H__
 #define __SOF_IPC4_BASE_FW_H__
 
-/* Three clk src states :low power XTAL,  low power ring
- * and high power ring oscillator
+/* SOF FW performs autonomous management of clock sources.
+ * Set MAX_CLK_STATES to 0 in order to propagate this information through IPC and thus
+ * prevent reception of unsupported clock configuration.
  */
-#define IPC4_MAX_CLK_STATES 3
+#define IPC4_MAX_CLK_STATES 0
 
 /* Max src queue count count supported by ipc4 */
 #define IPC4_MAX_SRC_QUEUE 8


### PR DESCRIPTION
Improve IPC4 compatibility in respect to the Astate table that is received by FW as a part of set_large_config IPC. The table contains maximal KCPS thresholds, one for each supported clock source. Currently SOF FW performs autonomous management of clock sources and does not take such a configuration into account. Despite this, FW reports through get_large_config its support for 3 elements of Astate table. This change sets the supported Astate table size to 0. Also, as a corner case, a trivial handler is added for handling the empty table.