### PR TITLE
ipc4: base_fw: Make Astate handler a function

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -630,6 +630,16 @@ __cold static int basefw_get_large_config(struct comp_dev *dev, uint32_t param_i
 						data_offset, data);
 };
 
+__cold static int basefw_astate_table(void)
+{
+	assert_can_be_cold();
+
+	/* Trivial handler possible due to an empty Astate Table requested in get_large_config */
+	STATIC_ASSERT(IPC4_MAX_CLK_STATES == 0, IPC4_NON_ZERO_ASTATE_UNSUPPORTED);
+
+	return IPC4_SUCCESS;
+}
+
 /**
  * Handles the DMA Control IPC message to initialize or modify DMA gateway configuration.
  *
@@ -682,9 +692,7 @@ __cold static int basefw_set_large_config(struct comp_dev *dev, uint32_t param_i
 
 	switch (param_id) {
 	case IPC4_ASTATE_TABLE:
-		/* Trivial handler due to an empty Astate Table requested in get_large_config */
-		STATIC_ASSERT(IPC4_MAX_CLK_STATES == 0, IPC4_NON_ZERO_ASTATE_UNSUPPORTED);
-		return IPC4_SUCCESS;
+		return basefw_astate_table();
 	case IPC4_DMA_CONTROL:
 		return basefw_dma_control(first_block, last_block, data_offset, data);
 	case IPC4_PERF_MEASUREMENTS_STATE:


### PR DESCRIPTION
It turns out the current implementation of STATIC_ASSERT cannot be used as the first instruction of switch/case for all the supported compilers. Initially I wanted to fix the macro itself but it’s not that easy (mainly because the macro is used in both global and local contexts). So I decided to move the code to a separate function (this should work because we already have similar occurrences).