### PR TITLE
app: kconfig: fix indentation of CONFIG_COMPILER_CODEGEN_VLIW

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -6,7 +6,7 @@ config SMP_BOOT_DELAY
 
 # Allow compiler to determine whether to generate FLIX instructions.
 choice COMPILER_CODEGEN_VLIW
-        default COMPILER_CODEGEN_VLIW_AUTO if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xt-clang"
+	default COMPILER_CODEGEN_VLIW_AUTO if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "xt-clang"
 endchoice
 
 source "Kconfig.zephyr"


### PR DESCRIPTION
Need to use tab instead of spaces.