### PR TITLE
audio: module-adapter: Fix SRC regression when ext_init dp_data present

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -159,8 +159,8 @@ int module_adapter_init_data(struct comp_dev *dev,
 		}
 	}
 
-	if (!config->ipc_extended_init ||
-	    (!dst->ext_data->dp_data && !dst->ext_data->module_data)) {
+	/* Assume legacy API if module data was not found in ext_init payload */
+	if (!config->ipc_extended_init || !dst->ext_data->module_data) {
 		dst->init_data = cfg; /* legacy API */
 		dst->avail = true;
 	}


### PR DESCRIPTION
Fix SRC DP regression when dp_data is present in the ext_init payload.

The only situation where we can assume that there is no module specific init after the ext_init payload is when it was offered as part of ext_init payload.

Completes fix abf1aa954311 ("audio: module-adapter: fix SRC DP regression")

Fixes: d26364912305 ("module: Add support for module-specific init data")

This fix is required for https://github.com/thesofproject/linux/pull/5537 to work as it shoud.