### PR TITLE
topology2: sof-sdca-jack: change deep buffer DMA buffer to 10ms

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
@@ -9,7 +9,7 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 # Split topologies
 "cavs-sdw\;sof-sdca-jack-id0\;SDW_JACK_OUT_STREAM=Playback-SimpleJack,\
-SDW_JACK_IN_STREAM=Capture-SimpleJack,NUM_HDMIS=0"
+SDW_JACK_IN_STREAM=Capture-SimpleJack,NUM_HDMIS=0,DEEPBUFFER_FW_DMA_MS=10"
 
 "cavs-sdw\;sof-sdca-1amp-id2\;NUM_SDW_AMP_LINKS=1,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\


### PR DESCRIPTION
To align with the existing Chrome topologies.