### PR TITLE
audio: component: add comp_free_device() and use it as pair of comp_a…

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -671,7 +671,7 @@ __cold static struct comp_dev *chain_task_create(const struct comp_driver *drv,
 
 	rfree(cd);
 error:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -683,7 +683,7 @@ __cold static void chain_task_free(struct comp_dev *dev)
 
 	chain_release(dev);
 	rfree(cd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static const struct comp_driver comp_chain_dma = {

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -196,7 +196,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 	dd = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, sizeof(*dd));
 	if (!dd) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -211,7 +211,7 @@ static struct comp_dev *dai_new(const struct comp_driver *drv,
 
 error:
 	rfree(dd);
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -248,7 +248,7 @@ static void dai_free(struct comp_dev *dev)
 	dai_common_free(dd);
 
 	rfree(dd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -589,7 +589,7 @@ __cold static struct comp_dev *dai_new(const struct comp_driver *drv,
 error:
 	rfree(dd);
 e_data:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -630,7 +630,7 @@ __cold static void dai_free(struct comp_dev *dev)
 	dai_common_free(dd);
 
 	rfree(dd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 int dai_common_get_hw_params(struct dai_data *dd, struct comp_dev *dev,

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -134,7 +134,7 @@ cd_fail:
 	ipc_msg_free(cd->msg);
 	rfree(cd);
 fail:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -147,7 +147,7 @@ static void ghd_free(struct comp_dev *dev)
 	comp_data_blob_handler_free(cd->model_handler);
 	ipc_msg_free(cd->msg);
 	rfree(cd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static int ghd_params(struct comp_dev *dev,

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -593,7 +593,7 @@ static struct comp_dev *host_new(const struct comp_driver *drv,
 e_dev:
 	rfree(hd);
 e_data:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -612,7 +612,7 @@ static void host_free(struct comp_dev *dev)
 	comp_dbg(dev, "entry");
 	host_common_free(hd);
 	rfree(hd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static int host_elements_reset(struct host_data *hd, struct comp_dev *dev)

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -775,7 +775,7 @@ __cold static struct comp_dev *host_new(const struct comp_driver *drv,
 e_dev:
 	rfree(hd);
 e_data:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -798,7 +798,7 @@ __cold static void host_free(struct comp_dev *dev)
 	comp_dbg(dev, "entry");
 	host_common_free(hd);
 	rfree(hd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static int host_elements_reset(struct host_data *hd, int direction)

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -501,7 +501,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 
 	kpb = rzalloc(SOF_MEM_FLAG_USER, sizeof(*kpb));
 	if (!kpb) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -509,7 +509,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 
 	ret = kpb_set_verify_ipc_params(dev, ipc_process);
 	if (ret) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -544,7 +544,7 @@ static struct comp_dev *kpb_new(const struct comp_driver *drv,
 	/* retrieve params from the base config for IPC4 */
 	ret = kpb_params(dev, &params);
 	if (ret < 0) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 #endif
@@ -720,7 +720,7 @@ static void kpb_free(struct comp_dev *dev)
 
 	/* Free KPB */
 	rfree(kpb);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 /**

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -163,7 +163,7 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 
 	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(*cd));
 	if (!cd) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -172,7 +172,7 @@ static struct comp_dev *selector_new(const struct comp_driver *drv,
 	ret = memcpy_s(&cd->config, sizeof(cd->config), ipc_process->data, bs);
 	if (ret) {
 		rfree(cd);
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -191,7 +191,7 @@ static void selector_free(struct comp_dev *dev)
 	comp_dbg(dev, "entry");
 
 	rfree(cd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 /**

--- a/src/audio/tone/tone-ipc3.c
+++ b/src/audio/tone/tone-ipc3.c
@@ -58,7 +58,7 @@ static struct comp_dev *tone_new(const struct comp_driver *drv,
 
 	cd = rzalloc(SOF_MEM_FLAG_USER, sizeof(*cd));
 	if (!cd) {
-		rfree(dev);
+		comp_free_device(dev);
 		return NULL;
 	}
 
@@ -82,7 +82,7 @@ static void tone_free(struct comp_dev *dev)
 	comp_info(dev, "entry");
 
 	rfree(td);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 /* set component audio stream parameters */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -893,6 +893,19 @@ static inline struct comp_dev *comp_alloc(const struct comp_driver *drv, size_t 
 }
 
 /**
+ * Frees memory allocated for component device.
+ *
+ * This is a counterpart to comp_alloc() and not to be confused with
+ * comp_free().
+ *
+ * @param dev Pointer to the component device.
+ */
+static inline void comp_free_device(struct comp_dev *dev)
+{
+	sof_heap_free(dev->drv->user_heap, dev);
+}
+
+/**
  * \brief Module adapter associated with a component
  * @param dev Component device
  */

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -766,7 +766,7 @@ cd_fail:
 	comp_data_blob_handler_free(cd->model_handler);
 	rfree(cd);
 fail:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -788,7 +788,7 @@ static void test_keyword_free(struct comp_dev *dev)
 	ipc_msg_free(cd->msg);
 	comp_data_blob_handler_free(cd->model_handler);
 	rfree(cd);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static int test_keyword_verify_params(struct comp_dev *dev,

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -88,7 +88,7 @@ sad_fail:
 	comp_data_blob_handler_free(sad->model_handler);
 	rfree(sad);
 fail:
-	rfree(dev);
+	comp_free_device(dev);
 	return NULL;
 }
 
@@ -261,7 +261,7 @@ static void smart_amp_free(struct comp_dev *dev)
 	comp_data_blob_handler_free(sad->model_handler);
 
 	rfree(sad);
-	rfree(dev);
+	comp_free_device(dev);
 }
 
 static int smart_amp_verify_params(struct comp_dev *dev,


### PR DESCRIPTION
…lloc()

In commit c49283a9a47f1 ("ptl: mmu: Introduce module driver heap for non-privileged modules"), implementation of comp_alloc() was modified to use module heap alloc functions instead of rzalloc(). The calling functions kept using direct rfree() to free the component device.

In commit e8e5ff0532e1 ("module-adapter: fix wrong memory freeing"), some of the callers were modified to use user heap functions for freeing the component device.

To make this code safer, introduce comp_free_device() that frees the memory using the method used in comp_alloc() and use comp_free_device() in all places where comp_alloc() is used. The naming is a bit awkward as comp_free() is already taken to invoke the "free" method of the component interface.