### PR TITLE
west.yml: update zephyr to b246d3f3f98

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: f6a32b27dc17bdb4e1ba4ad84de0c56ca71e257d
+      revision: b246d3f3f987f5ddfa6530bea2082c09ce1f00d8
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 790 commits.

Changes include:

966737f1373 logging: Add CONFIG_LOG_RUNTIME_DEFAULT_LEVEL for startup filter control
b669a397384 kernel: events: use abort thread timeout using dedicated function
5a0f73f0450 kernel: events: wake threads atomically using waitq post-walk callback
73feef8b20c kernel: sched: add post-walk callback argument to z_sched_waitq_walk()
3ba7dcfe2c1 kernel: events: wake threads during wait queue walk if possible
e7252254894 kernel: sched: perform safe waitq walk inside z_sched_waitq_walk()
eac6c7cb24a kernel: sched: don't acquire scheduler spinlock in z_sched_wake_thread()
098f61700f8 west: sign/rimage: do not assume SOF source exists
a4c37560d5e west: sign/rimage: remove --no-manifest workaround
dbd231853db west: sign: use local signing key if specified
3d46072e913 boards: intel_adsp: add support files for image signing
a14a5b2d60b llext: remove leading -D from CMakeLists.txt
e843931194a kernel: check if interrupt is disabled in k_can_yield
ec2e20530c9 kernel: Disable k_mutex priority inheritance
f97b9ad9e9f xtensa: clear LCOUNT special register after saving it
4523fa57c57 soc: intel_adsp: clear BSS on core #0 at boot
3d03c55e1dc llext: define global mutex using K_MUTEX_DEFINE