### PR TITLE
topology2: tplg-targets-sdca-generic: remove 10ms deep buffer dma buffer

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
@@ -13,19 +13,19 @@ SDW_JACK_IN_STREAM=Capture-SimpleJack,NUM_HDMIS=0"
 
 "cavs-sdw\;sof-sdca-1amp-id2\;NUM_SDW_AMP_LINKS=1,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-2amp-id2\;NUM_SDW_AMP_LINKS=2,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-3amp-id2\;NUM_SDW_AMP_LINKS=3,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-4amp-id2\;NUM_SDW_AMP_LINKS=4,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-mic-id4\;SDW_JACK=false,SDW_DMIC=1,NUM_HDMIS=0,\
 SDW_DMIC_STREAM=Capture-SmartMic"


### PR DESCRIPTION
With Dynamic DeepBuffer the host DMA buffer size is calculated based on the requested ALSA period size (with a headroom between the two) using the DEEP_BUFFER token as a maximum limit for the host DMA buffer.

This way applications can use the same DeepBuffer enabled PCM for different use cases and still benefit of the power saving of a bigger host DMA

Kernel has been updated
https://github.com/thesofproject/linux/pull/5673