### PR TITLE
For tac5572 and tas2883

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace1.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace1.cmake
@@ -70,6 +70,15 @@ NUM_DMICS=0,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,\
 HDMI1_ID=7,HDMI2_ID=8,HDMI3_ID=9,DMIC0_ENHANCED_CAPTURE=true,\
 EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
 
+"cavs-sdw\;sof-mtl-tac5672-2ch\;PLATFORM=mtl,\
+NUM_SDW_AMP_LINKS=1,SDW_AMP_FEEDBACK=true,SDW_SPK_STREAM=Playback-SmartAmp,\
+SDW_SPK_IN_STREAM=Capture-SmartAmp,\
+NUM_DMICS=0,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,\
+SDW_DMIC=1,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+HDMI1_ID=7,HDMI2_ID=8,HDMI3_ID=9,DMIC0_ENHANCED_CAPTURE=true,\
+EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
+
 # sof_sdw creates dmic01 and dmic16k no matter 1 or 2 dmics are present.
 # So, HDMI link ids are the same for -2ch and -4ch topologies.
 "cavs-sdw\;sof-mtl-rt712-l0-2ch\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=1,\


### PR DESCRIPTION
This is the initial commit to support family of devices tac5xx2 with SoundWire interface.
This PR includes the changes for .cmake files to create the tplg files.
