### PR TITLE
DP: application: switch back to events

### DIFF
--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -266,11 +266,8 @@ static int scheduler_dp_task_stop(void *data, struct task *task)
 		schedule_task_cancel(&dp_sch->ll_tick_src);
 
 	/* if the task is waiting - let it run and self-terminate */
-#if CONFIG_SOF_USERSPACE_APPLICATION
-	k_sem_give(pdata->sem);
-#else
 	k_event_set(pdata->event, DP_TASK_EVENT_CANCEL);
-#endif
+
 	scheduler_dp_unlock(lock_key);
 
 	/* wait till the task has finished, if there was any task created */

--- a/src/schedule/zephyr_dp_schedule.h
+++ b/src/schedule/zephyr_dp_schedule.h
@@ -41,15 +41,11 @@ struct task_dp_pdata {
 	struct processing_module *mod;	/* the module to be scheduled */
 	uint32_t ll_cycles_to_start;    /* current number of LL cycles till delayed start */
 #if CONFIG_SOF_USERSPACE_APPLICATION
-	struct k_sem *sem;              /* pointer to semaphore for task scheduling */
 	struct ipc4_flat *flat;
-	unsigned char pend_ipc;
-	unsigned char pend_proc;
 	struct k_mem_partition mpart[SOF_DP_PART_TYPE_COUNT];
-#else
+#endif
 	struct k_event *event;		/* pointer to event for task scheduling */
 	struct k_event event_struct;	/* event for task scheduling for kernel threads */
-#endif
 };
 
 void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_run);


### PR DESCRIPTION
Events provide a more natural API when the listener have to wait for several kinds of alarms at once. As the userspace code stabilises initial difficulties with the API got fixed.