### PR TITLE
lib-manager: fix lib id packing

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -410,7 +410,7 @@ __cold static int basefw_libraries_info_get(uint32_t *data_offset, char *data)
 			desc = basefw_vendor_get_manifest();
 		} else {
 #if CONFIG_LIBRARY_MANAGER
-			desc = (struct sof_man_fw_desc *)lib_manager_get_library_manifest(lib_id);
+			desc = lib_manager_get_library_manifest(LIB_MANAGER_PACK_LIB_ID(lib_id));
 #else
 			desc = NULL;
 #endif

--- a/src/debug/telemetry/performance_monitor.c
+++ b/src/debug/telemetry/performance_monitor.c
@@ -344,7 +344,7 @@ int enable_performance_counters(void)
 			desc = basefw_vendor_get_manifest();
 		} else {
 #if CONFIG_LIBRARY_MANAGER
-			desc = (struct sof_man_fw_desc *)lib_manager_get_library_manifest(lib_id);
+			desc = lib_manager_get_library_manifest(LIB_MANAGER_PACK_LIB_ID(lib_id));
 #else
 			desc = NULL;
 #endif

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -77,6 +77,7 @@
 
 #define LIB_MANAGER_GET_LIB_ID(module_id) (((module_id) & 0xF000) >> LIB_MANAGER_LIB_ID_SHIFT)
 #define LIB_MANAGER_GET_MODULE_INDEX(module_id) ((module_id) & 0xFFF)
+#define LIB_MANAGER_PACK_LIB_ID(lib_index) (((lib_index) << LIB_MANAGER_LIB_ID_SHIFT) & 0xF000)
 
 #ifdef CONFIG_LIBRARY_MANAGER
 struct ipc_lib_msg {


### PR DESCRIPTION
I found this issue in lib_manager during testing. For now, I want to apply a simple fix to unblock my pending work because I don’t know yet how to remove this confusion from the lib_manager function interface that caused the mistake. On one hand the signature of lib_manager_get_library_manifest says clearly that the function takes module ID as a parameter (which is LIB_ID << 12 | MODULE_INDEX). On the other hand, I can understand how someone would expect a different behavior just by looking at the function name itself. We can change the argument type, but some functions in this file also take module_id encoded this way. Maybe we should group some functions related to a module in a separate C file?