### PR TITLE
ipc4: base_fw: fix and enhance MODULES_INFO_GET

### DIFF
--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -171,6 +171,15 @@ __cold int basefw_vendor_modules_info_get(uint32_t *data_offset, char *data)
 			return IPC4_OUT_OF_MEMORY;
 		}
 
+		/* replace structure id ("$AME" tag) with runtime info */
+		for (uint32_t idx = 0; idx < curr_mod_cnt; ++idx) {
+			uint32_t mod_id = LIB_MANAGER_PACK_MODULE_ID(lib_id, idx);
+
+			module_info->modules[total_mod_cnt + idx].runtime_info.module_id = mod_id;
+			/* TODO: set bit[0] for modules loaded into ADSP memory */
+			module_info->modules[total_mod_cnt + idx].runtime_info.state_flags = 0x0;
+		}
+
 		total_mod_cnt += curr_mod_cnt;
 		total_size_left -= curr_cpy_size;
 	}

--- a/src/include/sof/lib_manager.h
+++ b/src/include/sof/lib_manager.h
@@ -77,7 +77,9 @@
 
 #define LIB_MANAGER_GET_LIB_ID(module_id) (((module_id) & 0xF000) >> LIB_MANAGER_LIB_ID_SHIFT)
 #define LIB_MANAGER_GET_MODULE_INDEX(module_id) ((module_id) & 0xFFF)
-#define LIB_MANAGER_PACK_LIB_ID(lib_index) (((lib_index) << LIB_MANAGER_LIB_ID_SHIFT) & 0xF000)
+#define LIB_MANAGER_PACK_MODULE_ID(lib_index, module_index) (((module_index) & 0xFFF) | \
+	(((lib_index) << LIB_MANAGER_LIB_ID_SHIFT) & 0xF000))
+#define LIB_MANAGER_PACK_LIB_ID(lib_index) LIB_MANAGER_PACK_MODULE_ID(lib_index, 0x0)
 
 #ifdef CONFIG_LIBRARY_MANAGER
 struct ipc_lib_msg {

--- a/tools/rimage/src/include/rimage/sof/user/manifest.h
+++ b/tools/rimage/src/include/rimage/sof/user/manifest.h
@@ -103,11 +103,19 @@ struct sof_man_uuid {
 	uint8_t  d[8];
 };
 
+struct sof_man_runtime_info {
+	uint16_t module_id;
+	uint16_t state_flags;
+};
+
 /*
  * Each module has an entry in the FW header. Used by ROM - Immutable.
  */
 struct sof_man_module {
-	uint8_t struct_id[SOF_MAN_MOD_ID_LEN];	/* SOF_MAN_MOD_ID */
+	union {
+		uint8_t struct_id[SOF_MAN_MOD_ID_LEN];	/* SOF_MAN_MOD_ID */
+		struct sof_man_runtime_info runtime_info;
+	};
 	uint8_t name[SOF_MAN_MOD_NAME_LEN];
 	struct sof_man_uuid uuid;
 	struct sof_man_module_type type;


### PR DESCRIPTION
There are two issues with MODULES_INFO_GET property of LargeConfigGet IPC:

1) Info is limited to built-in modules (the spec says all the modules shall be considered)
2) Runtime modules IDs are not sent so that driver has to guess them