### PR TITLE
module_adapter: dp: Decrease default heap size from 20k to 16k

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -62,7 +62,7 @@ static struct dp_heap_user *module_adapter_dp_heap_new(const struct comp_ipc_con
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
 	/* FIXME: the size will be derived from configuration */
-	const size_t buf_size = 20 * 1024;
+	const size_t buf_size = 16 * 1024;
 
 	/* Keep uncached to match the default SOF heap! */
 	uint8_t *mod_heap_mem = rballoc_align(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,


### PR DESCRIPTION
Decrease default heap size from 20k to 16k. It appears the 20k heap size is too big for the system to survive our CI capture stress test. Luckily 16k is enough for SRC module in that test, so lets drop the default to a number that works better than previous.