### PR TITLE
google_rtc_aec: add module_cfg to the toml

### DIFF
--- a/src/audio/google/google_rtc_audio_processing.toml
+++ b/src/audio/google/google_rtc_audio_processing.toml
@@ -19,5 +19,7 @@
 	pin = [0, 0, 0x8, 0x2, 0x2, 0x1,
 		0, 0, 0x8, 0x2, 0x2, 0x4,
 		1, 0, 0x8, 0x2, 0x2, 0x1]
+	REM # mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 1000000, 128, 128, 0, 0, 0]
 
 	index = __COUNTER__


### PR DESCRIPTION
google_rtc_aec module does not have a module_cfg specified in its toml file. Even if the config is not needed, there is no harm in adding it. The benefit is reusability of generic tests that perform basic manifest verification for all provided modules.