### PR TITLE
topology2: add deep buffer speaker support to amp function topologies to v2.14

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
@@ -13,19 +13,19 @@ SDW_JACK_IN_STREAM=Capture-SimpleJack,NUM_HDMIS=0"
 
 "cavs-sdw\;sof-sdca-1amp-id2\;NUM_SDW_AMP_LINKS=1,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-2amp-id2\;NUM_SDW_AMP_LINKS=2,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-3amp-id2\;NUM_SDW_AMP_LINKS=3,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-4amp-id2\;NUM_SDW_AMP_LINKS=4,SDW_JACK=false,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,NUM_HDMIS=0,\
-DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+DEEP_BUF_SPK=true"
 
 "cavs-sdw\;sof-sdca-mic-id4\;SDW_JACK=false,SDW_DMIC=1,NUM_HDMIS=0,\
 SDW_DMIC_STREAM=Capture-SmartMic"


### PR DESCRIPTION
cherry pick the deep buffer speaker support to v2.14