### PR TITLE
Memory attributes to user space dp module

### DIFF
--- a/posix/include/zephyr/logging/log.h
+++ b/posix/include/zephyr/logging/log.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2026 Intel Corporation. All rights reserved.
+ *
+ * Stub for <zephyr/logging/log.h> used by testbench / posix builds.
+ */
+
+#ifndef __POSIX_ZEPHYR_LOGGING_LOG_H__
+#define __POSIX_ZEPHYR_LOGGING_LOG_H__
+
+#include <stdio.h>
+
+#ifndef LOG_ERR
+#define LOG_ERR(fmt, ...)	fprintf(stderr, "ERR: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_WRN
+#define LOG_WRN(fmt, ...)	fprintf(stderr, "WRN: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_INF
+#define LOG_INF(fmt, ...)	printf("INF: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_DBG
+#define LOG_DBG(fmt, ...)	do { } while (0)
+#endif
+
+#ifndef LOG_MODULE_REGISTER
+#define LOG_MODULE_REGISTER(ctx, level)
+#endif
+#ifndef LOG_MODULE_DECLARE
+#define LOG_MODULE_DECLARE(ctx, level)
+#endif
+
+#endif /* __POSIX_ZEPHYR_LOGGING_LOG_H__ */

--- a/posix/include/zephyr/sys/util.h
+++ b/posix/include/zephyr/sys/util.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2026 Intel Corporation. All rights reserved.
+ *
+ * Stub for <zephyr/sys/util.h> used by testbench / posix builds.
+ */
+
+#ifndef __POSIX_ZEPHYR_SYS_UTIL_H__
+#define __POSIX_ZEPHYR_SYS_UTIL_H__
+
+#include <stddef.h>
+
+#ifndef KB
+#define KB(x) (((size_t)(x)) << 10)
+#endif
+
+#ifndef MB
+#define MB(x) (KB(x) << 10)
+#endif
+
+#endif /* __POSIX_ZEPHYR_SYS_UTIL_H__ */

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -13,6 +13,16 @@ menu "Processing modules"
 		  containers to allocate at once is selected by this
 		  config option.
 
+	config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+		int "Default heap size for DP userspace threads"
+		default 20480
+		help
+		  Defines the default heap size for userspace DP processing
+		  threads. The value can be overridden with IPC module init
+		  ext_init module payload. The default is derived from what is
+		  required for SRC module to produce all supported conversions.
+		  (This is a dummy Kconfig option to help testbench to build.)
+
 	config CADENCE_CODEC
 		bool "Cadence codec"
 		help

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -13,6 +13,15 @@ menu "Processing modules"
 		  containers to allocate at once is selected by this
 		  config option.
 
+	config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+		int "Default heap size for DP userspace threads"
+		default 20480
+		help
+		  Defines the default heap size for userspace DP processing
+		  threads. The value can be overridden with IPC module init
+		  ext_init module payload. The default is derived from what is
+		  required for SRC module to produce all supported conversions.
+
 	config CADENCE_CODEC
 		bool "Cadence codec"
 		help

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -244,6 +244,17 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 
 	struct comp_dev *dev = mod->dev;
 
+	dst = &mod->priv.cfg;
+	/*
+	 * NOTE: dst->ext_data points to stack variable and contains
+	 *       pointers to IPC payload mailbox, so its only valid in
+	 *       functions that called from this function. This why
+	 *       the pointer is set NULL before this function exits.
+	 */
+#if CONFIG_IPC_MAJOR_4
+	dst->ext_data = &ext_data;
+#endif
+
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 	/* create a task for DP processing */
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP) {
@@ -256,16 +267,6 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	}
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
-	dst = &mod->priv.cfg;
-	/*
-	 * NOTE: dst->ext_data points to stack variable and contains
-	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
-	 */
-#if CONFIG_IPC_MAJOR_4
-	dst->ext_data = &ext_data;
-#endif
 	ret = module_adapter_init_data(dev, dst, config, &spec);
 	if (ret) {
 		comp_err(dev, "%d: module init data failed",

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -58,8 +58,7 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 #define PAGE_SZ HOST_PAGE_SIZE
 #endif
 
-static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
-						  size_t *heap_size)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config)
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
 	/* FIXME: the size will be derived from configuration */
@@ -84,11 +83,10 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
-	size_t heap_size;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		mod_vreg = module_adapter_dp_heap_new(config, &heap_size);
+		mod_vreg = module_adapter_dp_heap_new(config);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -101,7 +99,6 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 #else
 		mod_heap = drv->user_heap;
 #endif
-		heap_size = 0;
 		mod_vreg = NULL;
 	}
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -58,17 +58,39 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 #define PAGE_SZ HOST_PAGE_SIZE
 #endif
 
-static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
+						  const struct module_ext_init_data *ext_init)
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
-	/* FIXME: the size will be derived from configuration */
-	const size_t buf_size = 28 * 1024;
+	size_t buf_size = CONFIG_SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE;
 
+#if CONFIG_IPC_MAJOR_4
+	if (config->ipc_extended_init && ext_init && ext_init->dp_data &&
+	    ext_init->dp_data->heap_bytes > 0) {
+		if (ext_init->dp_data->heap_bytes > MB(64)) {
+			LOG_ERR("Bad heap size %u bytes for %#x",
+				ext_init->dp_data->heap_bytes, config->id);
+			return NULL;
+		}
+
+		buf_size = ext_init->dp_data->heap_bytes;
+
+		LOG_INF("%zu byte heap size requested in IPC for %#x", buf_size, config->id);
+	}
+#endif
+	/*
+	 * A 1-to-1 replacement of the original heap implementation would be to
+	 * have "lifetime size" equal to 0. But (1) this is invalid for
+	 * vregion_create() and (2) we gradually move objects, that are simple
+	 * to move to the lifetime buffer. Make it 4k for the beginning.
+	 */
 	return vregion_create(buf_size);
 }
 
-static struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
-							  const struct comp_ipc_config *config)
+static
+struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
+						   const struct comp_ipc_config *config,
+						   const struct module_ext_init_data *ext_init)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -86,7 +108,7 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		mod_vreg = module_adapter_dp_heap_new(config);
+		mod_vreg = module_adapter_dp_heap_new(config, ext_init);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -227,8 +249,14 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 			return NULL;
 	}
 #endif
+	const struct module_ext_init_data *ext_init =
+#if CONFIG_IPC_MAJOR_4
+		&ext_data;
+#else
+		NULL;
+#endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config);
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
 
 	if (!mod)
 		return NULL;
@@ -245,8 +273,9 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	/*
 	 * NOTE: dst->ext_data points to stack variable and contains
 	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
+	 *       functions that are called from this function. This is
+	 *       why the pointer is set to NULL before this function
+	 *       exits.
 	 */
 #if CONFIG_IPC_MAJOR_4
 	dst->ext_data = &ext_data;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -237,6 +237,18 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 
 	struct comp_dev *dev = mod->dev;
 
+	dst = &mod->priv.cfg;
+	/*
+	 * NOTE: dst->ext_data points to stack variable and contains
+	 *       pointers to IPC payload mailbox, so its only valid in
+	 *       functions that are called from this function. This is
+	 *       why the pointer is set to NULL before this function
+	 *       exits.
+	 */
+#if CONFIG_IPC_MAJOR_4
+	dst->ext_data = &ext_data;
+#endif
+
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 	/* create a task for DP processing */
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP) {
@@ -249,16 +261,6 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	}
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
-	dst = &mod->priv.cfg;
-	/*
-	 * NOTE: dst->ext_data points to stack variable and contains
-	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
-	 */
-#if CONFIG_IPC_MAJOR_4
-	dst->ext_data = &ext_data;
-#endif
 	ret = module_adapter_init_data(dev, dst, config, &spec);
 	if (ret) {
 		comp_err(dev, "%d: module init data failed",

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -51,8 +51,33 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	return module_adapter_new_ext(drv, config, spec, NULL, NULL, NULL);
 }
 
-static struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
-							  const struct comp_ipc_config *config)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
+						  const struct module_ext_init_data *ext_init)
+{
+	size_t buf_size = CONFIG_SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE;
+	uintptr_t vreg_start;
+
+#if CONFIG_IPC_MAJOR_4
+	if (config->ipc_extended_init && ext_init && ext_init->dp_data &&
+	    ext_init->dp_data->heap_bytes > 0) {
+		if (ext_init->dp_data->heap_bytes > MB(64)) {
+			LOG_ERR("Bad heap size %u bytes for %#x",
+				ext_init->dp_data->heap_bytes, config->id);
+			return NULL;
+		}
+
+		buf_size = ext_init->dp_data->heap_bytes;
+
+		LOG_INF("%zu byte heap size requested in IPC for %#x", buf_size, config->id);
+	}
+#endif
+	return vregion_create_map(&vreg_start, &buf_size);
+}
+
+static
+struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
+						   const struct comp_ipc_config *config,
+						   const struct module_ext_init_data *ext_init)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -67,15 +92,10 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
-	size_t vreg_size;
-	uintptr_t vreg_start;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		/* src-lite with 8 channels has been seen allocating 14k in one go */
-		/* FIXME: the size will be derived from configuration */
-		vreg_size = 28 * 1024;
-		mod_vreg = vregion_create_map(&vreg_start, &vreg_size);
+		mod_vreg = module_adapter_dp_heap_new(config, ext_init);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -92,8 +112,6 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 #else
 		mod_heap = drv->user_heap;
 #endif
-		vreg_size = 0;
-		vreg_start = 0;
 		mod_vreg = NULL;
 	}
 
@@ -223,8 +241,14 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 			return NULL;
 	}
 #endif
+	const struct module_ext_init_data *ext_init =
+#if CONFIG_IPC_MAJOR_4
+		&ext_data;
+#else
+		NULL;
+#endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config);
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
 
 	if (!mod)
 		return NULL;

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -590,6 +590,7 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	/* DP tasks are guaranteed to have a module_adapter */
 	struct processing_module *mod = comp_mod(comp);
+	size_t stack_size = TASK_DP_STACK_SIZE;
 	struct task_ops ops  = {
 		.run		= dp_task_run,
 		.get_deadline	= NULL,
@@ -605,8 +606,17 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 	unsigned int flags = IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0;
 #endif
 
+	if (mod->priv.cfg.ext_data && mod->priv.cfg.ext_data->dp_data &&
+	    mod->priv.cfg.ext_data->dp_data->stack_bytes > 0) {
+		stack_size = MAX(mod->priv.cfg.ext_data->dp_data->stack_bytes,
+				 CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+		comp_info(comp, "stack size set to %zu, %zu requested, min allowed %zu",
+			  stack_size, mod->priv.cfg.ext_data->dp_data->stack_bytes,
+			  CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+	}
+
 	return scheduler_dp_task_init(&comp->task, SOF_UUID(dp_task_uuid), &ops, mod,
-				      comp->ipc_config.core, TASK_DP_STACK_SIZE, flags);
+				      comp->ipc_config.core, stack_size, flags);
 }
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -409,6 +409,7 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	/* DP tasks are guaranteed to have a module_adapter */
 	struct processing_module *mod = comp_mod(comp);
+	size_t stack_size = TASK_DP_STACK_SIZE;
 	struct task_ops ops  = {
 		.run		= dp_task_run,
 		.get_deadline	= NULL,
@@ -424,8 +425,17 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 	unsigned int flags = IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0;
 #endif
 
+	if (mod->priv.cfg.ext_data && mod->priv.cfg.ext_data->dp_data &&
+	    mod->priv.cfg.ext_data->dp_data->stack_bytes > 0) {
+		stack_size = MAX(mod->priv.cfg.ext_data->dp_data->stack_bytes,
+				 CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+		comp_info(comp, "stack size set to %zu, %zu requested, min allowed %zu",
+			  stack_size, mod->priv.cfg.ext_data->dp_data->stack_bytes,
+			  CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+	}
+
 	return scheduler_dp_task_init(&comp->task, SOF_UUID(dp_task_uuid), &ops, mod,
-				      comp->ipc_config.core, TASK_DP_STACK_SIZE, flags);
+				      comp->ipc_config.core, stack_size, flags);
 }
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -14,9 +14,7 @@
 /* callers must check/use the return value */
 #define __must_check __attribute__((warn_unused_result))
 
-#ifdef __ZEPHYR__
 #include <zephyr/sys/util.h>
-#endif
 
 /* Align the number to the nearest alignment value */
 #ifndef IS_ALIGNED

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -23,8 +23,8 @@
 
 #ifdef __ZEPHYR__
 #include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
 #endif
+#include <zephyr/logging/log.h>
 
 #if !CONFIG_LIBRARY
 #include <platform/trace/trace.h>
@@ -154,13 +154,5 @@ struct tr_ctx {
 		.uuid_p = uuid,					\
 		.level = default_log_level,			\
 	}
-
-/* Only define these two macros for XTOS to avoid the collision with
- * zephyr/include/zephyr/logging/log.h
- */
-#ifndef __ZEPHYR__
-#define LOG_MODULE_REGISTER(ctx, level)
-#define LOG_MODULE_DECLARE(ctx, level)
-#endif
 
 #endif /* __SOF_TRACE_TRACE_H__ */

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -38,6 +38,7 @@ target_compile_options(sof-logger PRIVATE
 
 target_include_directories(sof-logger PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
+	"${SOF_ROOT_SOURCE_DIRECTORY}/posix/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}/tools/rimage/src/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}"
 )

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -86,6 +86,15 @@ config SOF_ZEPHYR_HEAP_SIZE
 	 NOTE: Keep in mind that the heap size should not be greater than the physical
 	 memory size of the system defined in DT (and this includes baseFW text/data).
 
+config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+       int "Default heap size for DP userspace threads"
+       default 20480
+       help
+         Defines the default heap size for userspace DP processing
+         threads. The value can be overridden with IPC module init
+         ext_init module payload. The default is derived from what is
+         required for SRC module to produce all supported conversions.
+
 config SOF_USERSPACE_USE_SHARED_HEAP
 	bool "Use shared heap for SOF userspace modules"
 	depends on USERSPACE

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -258,6 +258,15 @@ config ZEPHYR_DP_SCHEDULER
 	  DP modules can be located in dieffrent cores than LL pipeline modules, may have
 	  different tick (i.e. 300ms for speech reccognition, etc.)
 
+config ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE
+       int "Minimum stack size for DP processing thread"
+       default 512
+       help
+         Defines the minimum stack size allowed for DP processing
+         threads despite what is requested in the module init IPC
+         ext_init payload. If the stack size requested in the IPC is
+         smaller than this, then the value defined here takes over.
+
 config CROSS_CORE_STREAM
 	bool "Enable cross-core connected pipelines"
 	default y if IPC_MAJOR_4

--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -19,14 +19,7 @@
 #include <rtos/symbol.h>
 #include <ipc/topology.h>
 
-#ifdef __ZEPHYR__
 #include <zephyr/logging/log.h>
-#else
-#define LOG_DBG(...) do {} while (0)
-#define LOG_INF(...) do {} while (0)
-#define LOG_WRN(...) do {} while (0)
-#define LOG_ERR(...) do {} while (0)
-#endif
 
 struct sof_fast_get_entry {
 	const void *dram_ptr;
@@ -154,7 +147,7 @@ const void *fast_get(struct mod_alloc_ctx *alloc, const void *dram_ptr, size_t s
 
 	if (entry->sram_ptr) {
 		if (entry->size != size || entry->dram_ptr != dram_ptr) {
-			LOG_ERR("size %u != %u or ptr %p != %p mismatch",
+			LOG_ERR("size %zu != %zu or ptr %p != %p mismatch",
 				entry->size, size, entry->dram_ptr, dram_ptr);
 			ret = NULL;
 			goto out;


### PR DESCRIPTION
Pass current DP memory attributes to the user-space DP  thread.

This implementation does not do anything before we have https://github.com/thesofproject/linux/pull/5537 merged (and before that we should merge https://github.com/thesofproject/sof/pull/10544).

So quite a few conditions before CI can get any hold of this. I'll mark this as draft for now, even if the implementation is mostly complete. FYI @lyakh , @kv2019i , @lgirdwood.