### PR TITLE
audio: cadence: add optional API error reporting

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -471,13 +471,31 @@ int cadence_codec_resolve_api_with_id(struct processing_module *mod, uint32_t co
 	return 0;
 }
 
-int cadence_codec_process_data(struct processing_module *mod)
+static void cadence_store_api_error_code(struct comp_dev *dev,
+					 XA_ERRORCODE *api_error_code,
+					 int ret, const char *cmd_name)
+{
+	if (!api_error_code)
+		return;
+
+	if (*api_error_code && *api_error_code != ret)
+		comp_dbg(dev, "overwriting api error code at %s: old %#x new %#x",
+			 cmd_name, *api_error_code, ret);
+
+	*api_error_code = ret;
+}
+
+int cadence_codec_process_data(struct processing_module *mod,
+			       XA_ERRORCODE *api_error_code)
 {
 	struct cadence_codec_data *cd = module_get_private_data(mod);
 	struct module_data *codec = &mod->priv;
 	struct comp_dev *dev = mod->dev;
 	uint32_t done = 0;
 	int ret;
+
+	if (api_error_code)
+		*api_error_code = 0;
 
 	if (codec->mpd.eos_reached) {
 		codec->mpd.produced = 0;
@@ -490,11 +508,13 @@ int cadence_codec_process_data(struct processing_module *mod)
 		/* Signal that the stream is expected to end anytime soon */
 		API_CALL(cd, XA_API_CMD_INPUT_OVER, 0, NULL, ret);
 		if (ret != LIB_NO_ERROR) {
+			if (api_error_code)
+				*api_error_code = ret;
+
 			if (LIB_IS_FATAL_ERROR(ret)) {
 				comp_err(dev, "input_over failed with error: %x", ret);
 				return ret;
 			}
-			comp_warn(dev, "input_over failed with nonfatal error: %x", ret);
 		}
 	}
 
@@ -506,20 +526,24 @@ int cadence_codec_process_data(struct processing_module *mod)
 
 	API_CALL(cd, XA_API_CMD_EXECUTE, XA_CMD_TYPE_DO_EXECUTE, NULL, ret);
 	if (ret != LIB_NO_ERROR) {
+		cadence_store_api_error_code(dev, api_error_code, ret,
+					     "XA_API_CMD_EXECUTE_DO_EXECUTE");
+
 		if (LIB_IS_FATAL_ERROR(ret)) {
 			comp_err(dev, "processing failed with error: %x", ret);
 			return ret;
 		}
-		comp_warn(dev, "processing failed with nonfatal error: %x", ret);
 	}
 
 	API_CALL(cd, XA_API_CMD_EXECUTE, XA_CMD_TYPE_DONE_QUERY, &done, ret);
 	if (ret != LIB_NO_ERROR) {
+		cadence_store_api_error_code(dev, api_error_code, ret,
+					     "XA_API_CMD_EXECUTE_DONE_QUERY");
+
 		if (LIB_IS_FATAL_ERROR(ret)) {
 			comp_err(dev, "done query failed with error: %x", ret);
 			return ret;
 		}
-		comp_warn(dev, "done query failed with nonfatal error: %x", ret);
 	}
 
 	API_CALL(cd, XA_API_CMD_GET_OUTPUT_BYTES, 0, &codec->mpd.produced, ret);

--- a/src/audio/module_adapter/module/cadence_ipc3.c
+++ b/src/audio/module_adapter/module/cadence_ipc3.c
@@ -264,7 +264,7 @@ cadence_codec_process(struct processing_module *mod,
 
 	comp_dbg(dev, "cadence_codec_process() start");
 
-	ret = cadence_codec_process_data(mod);
+	ret = cadence_codec_process_data(mod, NULL);
 	if (ret)
 		return ret;
 

--- a/src/audio/module_adapter/module/cadence_ipc4.c
+++ b/src/audio/module_adapter/module/cadence_ipc4.c
@@ -465,7 +465,7 @@ static int cadence_codec_process(struct processing_module *mod, struct sof_sourc
 
 	comp_dbg(dev, "cadence_codec_process() start");
 
-	ret = cadence_codec_process_data(mod);
+	ret = cadence_codec_process_data(mod, NULL);
 	if (ret) {
 		source_release_data(sources[0], 0);
 		return ret;

--- a/src/include/sof/audio/module_adapter/module/cadence.h
+++ b/src/include/sof/audio/module_adapter/module/cadence.h
@@ -96,7 +96,8 @@ int cadence_codec_set_configuration(struct processing_module *mod, uint32_t conf
 int cadence_codec_resolve_api_with_id(struct processing_module *mod, uint32_t codec_id,
 				      uint32_t direction);
 int cadence_codec_apply_params(struct processing_module *mod, int size, void *data);
-int cadence_codec_process_data(struct processing_module *mod);
+int cadence_codec_process_data(struct processing_module *mod,
+			       XA_ERRORCODE *api_error_code);
 int cadence_codec_apply_config(struct processing_module *mod);
 void cadence_codec_free_memory_tables(struct processing_module *mod);
 int cadence_codec_init_memory_tables(struct processing_module *mod);


### PR DESCRIPTION
Extend cadence_codec_process_data() with an optional output parameter for returning Cadence API error codes while preserving existing return behavior: non-fatal API errors still return 0 and fatal errors are returned.

Suppress non-fatal warning prints in this path and add lightweight overwrite tracing for repeated API error updates.

Update cadence IPC3 and IPC4 call sites to pass NULL for now.