### PR TITLE
[stable-v2.2] Tools: Topology1: Fix topologies build with new alsa-lib

### DIFF
--- a/tools/topology/topology1/sof/pipe-rtnr-capture.m4
+++ b/tools/topology/topology1/sof/pipe-rtnr-capture.m4
@@ -40,7 +40,7 @@ CONTROLBYTES_PRIV(DEF_RTNR_PRIV,
 # RTNR Bytes control with max value of 255
 C_CONTROLBYTES_READONLY(DEF_RTNR_BYTES, PIPELINE_ID,
 	CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get handlers, 258),
-	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get handlers, 258),
+	CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
 	, , ,
 	CONTROLBYTES_MAX(, 256),
 	,

--- a/tools/topology/topology1/sof/pipe-rtnr-google-rtc-audio-processing-capture.m4
+++ b/tools/topology/topology1/sof/pipe-rtnr-google-rtc-audio-processing-capture.m4
@@ -42,7 +42,7 @@ CONTROLBYTES_PRIV(DEF_RTNR_PRIV,
 # RTNR Bytes control with max value of 255
 C_CONTROLBYTES_READONLY(DEF_RTNR_BYTES, PIPELINE_ID,
         CONTROLBYTES_OPS(bytes, 258 binds the mixer control to bytes get/put handlers, 258),
-        CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258),
+        CONTROLBYTES_EXTOPS(258 binds the mixer control to bytes get/put handlers, 258, 258),
         , , ,
         CONTROLBYTES_MAX(, 256),
         ,


### PR DESCRIPTION
Backport of #10598

This patch fixes build error with alsa-lib commit 541427761292.

ALSA lib ops.c:47:(lookup_ops) [error.topology] wrong kcontrol ops value string ''

It impacts build of sof-mt8195-mt6359-max98390-rt5682-rtnr.tplg and sof-mt8195-mt6359-max98390-rt5682-google-aec-rtnr.tplg.

In the created .conf from m4 conversion, the value of put is an empty string in SectionControlBytes.

	# control uses bespoke driver get/put/info ID for ext ops
	extops."extctl" {
		#258 binds the mixer control to bytes get handlers
		get "258"
		put ""
	}

The use of m4 macro CONTROLBYTES_OPS() requires three parameters while originally there was only two. All other usages of CONTROLBYTES_EXTOPS() in SOF are with 258, 258 as 2nd and 3rd parameters, so it is assumed it should be same for RTNR controls also.


(cherry picked from commit 8f98a4e55046129528f42cdda5c17b6f49a01a94)