### PR TITLE
rimage: manifest: Make "cold" section size 0 when not used

### DIFF
--- a/tools/rimage/src/include/rimage/sof/user/manifest.h
+++ b/tools/rimage/src/include/rimage/sof/user/manifest.h
@@ -257,6 +257,10 @@ struct sof_man_module_manifest {
  * enough and that SRAM will not use these addresses.
  */
 #define SOF_MODULE_DRAM_LINK_START	0
+#if CONFIG_COLD_STORE_EXECUTE_DRAM
 #define SOF_MODULE_DRAM_LINK_END	0x08000000
+#else
+#define SOF_MODULE_DRAM_LINK_END	SOF_MODULE_DRAM_LINK_START
+#endif
 
 #endif /* __RIMAGE_USER_MANIFEST_H__ */


### PR DESCRIPTION
There are some non-critical data and code sections that are kept in DRAM to be accessed and executed from there without being copyind to SRAM.

Such sections are marked as `detached` and linked into a separate "cold.mod" module.

rimage considers zones starting at SOF_MODULE_DRAM_LINK_START to SOF_MODULE_DRAM_LINK_END to be cold and links them separately.

On i.MX8MP for M7 support this overalps with ITCM/DTCM/OCRAM areas which causes boot problems.

So, treat all sections as SRAM when CONFIG_COLD_STORE_EXECUTE_DRAM is not enabled by making DRAM link sections size equal to 0 in this case.

Closes: https://github.com/thesofproject/sof/issues/10602