### PR TITLE
platform: Kconfig: set RIMAGE_SIGNING_SCHEMA for imx95

### DIFF
--- a/src/platform/Kconfig
+++ b/src/platform/Kconfig
@@ -529,6 +529,7 @@ config RIMAGE_SIGNING_SCHEMA
 	default "imx8x" if IMX8X
 	default "imx8m" if IMX8M
 	default "imx8ulp" if IMX8ULP
+	default "imx95" if IMX95
 	default "rn" if RENOIR
 	default "rmb" if REMBRANDT
 	default "vangogh" if VANGOGH


### PR DESCRIPTION
This is required as of zephyr commit 098f61700f8e
("west: sign/rimage: do not assume SOF source exists"). Without it, rimage won't set the external manifest magic, thus resulting in a failure when this is check on the kernel side.