### PR TITLE
rimage: Add support to ignore detached sections

### DIFF
--- a/tools/rimage/src/include/rimage/module.h
+++ b/tools/rimage/src/include/rimage/module.h
@@ -127,10 +127,11 @@ void module_close(struct module *module);
  * @param module module structure
  * @param mem_cfg memory configration structure
  * @param verbose verbose logging selection
+ * @param ignore_detached do not mark detached sections
  * @return error code
  */
 void module_parse_sections(struct module *module, const struct memory_config *mem_cfg,
-			   bool verbose);
+			   bool verbose, bool ignore_detached);
 
 /**
  * Read module section to memory buffer

--- a/tools/rimage/src/include/rimage/rimage.h
+++ b/tools/rimage/src/include/rimage/rimage.h
@@ -65,6 +65,9 @@ struct image {
 
 	/* Output image is a loadable module */
 	bool loadable_module;
+
+	/* Do not mark detached sections */
+	bool ignore_detached;
 };
 
 struct memory_zone {

--- a/tools/rimage/src/module.c
+++ b/tools/rimage/src/module.c
@@ -310,7 +310,8 @@ static enum module_section_type get_section_type(const struct elf_section_header
 	}
 }
 
-void module_parse_sections(struct module *module, const struct memory_config *mem_cfg, bool verbose)
+void module_parse_sections(struct module *module, const struct memory_config *mem_cfg, bool verbose,
+			   bool ignore_detached)
 {
 	const uint32_t valid = (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR);
 	uint16_t i;
@@ -344,7 +345,7 @@ void module_parse_sections(struct module *module, const struct memory_config *me
 		out_section->size = sect->data.size;
 		out_section->type = get_section_type(sect);
 		out_section->rom = section_is_rom(mem_cfg, sect);
-		out_section->detached = section_is_detached(mem_cfg, sect);
+		out_section->detached = !ignore_detached && section_is_detached(mem_cfg, sect);
 		out_section->address = sect->data.vaddr;
 		out_section->load_address = find_physical_address(&module->elf, sect->data.vaddr);
 

--- a/tools/rimage/src/rimage.c
+++ b/tools/rimage/src/rimage.c
@@ -34,6 +34,7 @@ static void usage(char *name)
 	fprintf(stdout, "\t -y verify signed file\n");
 	fprintf(stdout, "\t -q resign binary\n");
 	fprintf(stdout, "\t -p set PV bit\n");
+	fprintf(stdout, "\t -d ignore detached sections\n");
 }
 
 int main(int argc, char *argv[])
@@ -50,7 +51,7 @@ int main(int argc, char *argv[])
 
 	image.imr_type = MAN_DEFAULT_IMR_TYPE;
 
-	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:pl")) != -1) {
+	while ((opt = getopt(argc, argv, "ho:va:s:k:ri:f:b:ec:y:q:pld")) != -1) {
 		switch (opt) {
 		case 'o':
 			image.out_file = optarg;
@@ -100,6 +101,10 @@ int main(int argc, char *argv[])
 			break;
 		case 'l':
 			image.loadable_module = true;
+			break;
+		case 'd':
+			/* ignore detached sections */
+			image.ignore_detached = true;
 			break;
 		default:
 		 /* getopt's default error message is good enough */
@@ -225,7 +230,8 @@ int main(int argc, char *argv[])
 		if (ret < 0)
 			goto out;
 
-		module_parse_sections(&image.module[i].file, &image.adsp->mem, image.verbose);
+		module_parse_sections(&image.module[i].file, &image.adsp->mem, image.verbose,
+				      image.ignore_detached);
 
 		/* When there is more than one module, then first one is bootloader.
 		 * Does not apply to building a image of a loadable module. */


### PR DESCRIPTION
There are some non-critical data and code sections that are kept in DRAM to be accessed and executed from there without being copyind to SRAM.

Such sections are marked as detached and linked into a separate "cold.mod" module.

SOF marks sections between: SOF_MODULE_DRAM_LINK_START (0x00000000) to SOF_MODULE_DRAM_LINK_END (0x080000000) but this overalps with ITCM memory on M7 core of i.MX8MP.

Add an option to ignore marking section as detached.

Ideally in the future the dram start/end should be configured per platform.

By default the behavior is unmodified, to enable this option one would need to pass `-d` to rimage.