### PR TITLE
src: cosmetic: simplify an invalid configuration check

### DIFF
--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -523,12 +523,12 @@ int src_params_general(struct processing_module *mod,
 	 * be aligned to 8 bytes as required by some Xtensa
 	 * instructions (e.g AE_L32X2F24_XC)
 	 */
-	delay_lines_size = ALIGN_UP(sizeof(int32_t) * cd->param.total, 8);
-	if (delay_lines_size == 0) {
-		comp_err(dev, "delay_lines_size = 0");
+	if (cd->param.total == 0) {
+		comp_err(dev, "configuration failed: total size = 0");
 
 		return  -EINVAL;
 	}
+	delay_lines_size = ALIGN_UP(sizeof(int32_t) * cd->param.total, 8);
 
 	/* free any existing delay lines. TODO reuse if same size */
 	mod_free(mod, cd->delay_lines);

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -481,6 +481,7 @@ int src_params_general(struct processing_module *mod,
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
 	size_t delay_lines_size;
+	size_t old_total;
 	int32_t *buffer_start;
 	int n;
 	int err;
@@ -511,6 +512,8 @@ int src_params_general(struct processing_module *mod,
 	cd->source_frames = dev->frames * cd->source_rate / cd->sink_rate;
 	cd->sink_frames = dev->frames;
 
+	old_total = cd->param.total;
+
 	/* Allocate needed memory for delay lines */
 	err = src_buffer_lengths(dev, cd, cd->channels_count);
 	if (err < 0) {
@@ -530,14 +533,16 @@ int src_params_general(struct processing_module *mod,
 	}
 	delay_lines_size = ALIGN_UP(sizeof(int32_t) * cd->param.total, 8);
 
-	/* free any existing delay lines. TODO reuse if same size */
-	mod_free(mod, cd->delay_lines);
+	if (!cd->delay_lines || old_total != cd->param.total) {
+		/* free any existing delay lines */
+		mod_free(mod, cd->delay_lines);
 
-	cd->delay_lines = mod_alloc(mod, delay_lines_size);
-	if (!cd->delay_lines) {
-		comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
-			 delay_lines_size);
-		return  -EINVAL;
+		cd->delay_lines = mod_alloc(mod, delay_lines_size);
+		if (!cd->delay_lines) {
+			comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
+				 delay_lines_size);
+			return  -EINVAL;
+		}
 	}
 
 	/* Clear all delay lines here */

--- a/src/audio/src/src_common.h
+++ b/src/audio/src/src_common.h
@@ -21,25 +21,25 @@ struct src_stage {
 	int idm;
 	int odm;
 	int num_of_subfilters;
-	int subfilter_length;
-	int filter_length;
-	int blk_in;
-	int blk_out;
+	size_t subfilter_length;
+	size_t filter_length;
+	size_t blk_in;
+	size_t blk_out;
 	int halfband;
 	int shift;
 	const void *coefs; /* Can be int16_t or int32_t depending on config */
 };
 
 struct src_param {
-	int fir_s1;
-	int fir_s2;
-	int out_s1;
-	int out_s2;
-	int sbuf_length;
-	int src_multich;
-	int total;
-	int blk_in;
-	int blk_out;
+	size_t fir_s1;
+	size_t fir_s2;
+	size_t out_s1;
+	size_t out_s2;
+	size_t sbuf_length;
+	size_t src_multich;
+	size_t total;
+	size_t blk_in;
+	size_t blk_out;
 	int stage1_times;
 	int stage2_times;
 	int idx_in;


### PR DESCRIPTION
The condition delay_lines_size == 0 in src_params_general() can trigger if cd->param.total == 0 or if cd->param.total == -1. However, the latter is supposedly invalid and should be checked in a more generic non-negativity test, so here it suffices to just check cd->param.total != 0 before delay_lines_size is calculated.