### PR TITLE
audio: mixin_mixout: fix build when XRUN reporting is disabled

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -707,7 +707,9 @@ static int mixin_prepare(struct processing_module *mod,
 	int ret;
 
 	comp_info(dev, "entry");
+#if CONFIG_XRUN_NOTIFICATIONS_ENABLE
 	md->eos_delay_configured = false;
+#endif
 
 	ret = mixin_params(mod);
 	if (ret < 0)


### PR DESCRIPTION
Build fails with CONFIG_XRUN_NOTIFICATIONS_ENABLE=n due to invalid access to "md->eos_delay_configured". Fix the build error by proper ifdefs.