### PR TITLE
app: prj.conf: use trigger threshold of 1 as default

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -20,10 +20,9 @@ CONFIG_LOG=y
 CONFIG_LOG_PRINTK=y
 # Log processing is offloaded to a low-priority thread.
 CONFIG_LOG_MODE_DEFERRED=y
-# Wake the low-priority log thread every 100ms and/or
-# if more than 5 messages are queued by the frontend.
-CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=5
-CONFIG_LOG_PROCESS_THREAD_SLEEP_MS=100
+# Wake the low-priority log thread every time new log
+# messages are available
+CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=1
 # Frontend buffer must be large enough to cover all
 # typical bursts of log messages.
 CONFIG_LOG_BUFFER_SIZE=4096


### PR DESCRIPTION
Set CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=1 as the default behaviour.

Given most actions in the DSP FW happen every LL (msec) tick, having defer logic of upto 100msec in the logging subsystem is not really helpful. Logging thread should be preempted by higher priority threads in any case.

This setting will cause the logger thread to be woken up (with a semaphore) every time a log entry is printed and no timer is used at all. The actual logging will not happen until logger thread gets to run, but the wakeup request is immediate.

This setting works better with logging backends that have a limited internal buffer (like mtrace and Zephyr winconsole) that are commonly used with SOF targets.