### PR TITLE
west.yml: update zephyr to 70969f88f53

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 653ebccc49ad1f79cae2729f4c6fabd5ff54d397
+      revision: 70969f88f5373d8f99b2d1a2b9d85a4462df2ac8
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 2864 commits.

Changes include:

* 73075d7c754 xtensa: mmu: Update K_MEM_PARTITION_P_RW_U_NA macro
* 465f488b6ab logging: mtrace: Enable thread ID prefix support
* 4f7a485af7b logging: mtrace: Enable core ID prefix support
* e254a97cf15 logging: add CONFIG_LOG_CORE_ID_PREFIX for multicore systems
* 616a0a6ab10 intel_adsp: ace4: adsp_power.h: Declare intel_adsp_clock_soft_off_exit()
* ee0cc5a6205 arch: xtensa: Add XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK Kconfig option
* 8655e64cae6 arch: exception: Add Kconfig EXCEPTION_DUMP_HOOK_ONLY
* 9446b09ff24 arch: xtensa: Use exception dump hook helpers in exception dumping
* 499cdcd51cd arch: exception: Add hooks for delivering exception dumps
* 11f89f73ebb kernel: userspace: Add k_object_access_check syscall
* 890eb11be93 llext: memblk kconfigs in docs
* 8bcc333e65f llext: custom sections for heap
* c8b9adaec98 drivers: dai: intel: uaol: fix linker error
* 93a25f7b244 xtensa: set is_fatal_error before stack bound check
* 9842b062bb2 cpuidle: optimize out weak stub function call for !TRACING
* 224f5f74c47 pm: device: Refine device driver initialization
* de97ddb0e83 pm: device: Refactor power domain add/remove logic
* ce3343422bf drivers: uaol: add streams mapping retrieval
* e1a48417274 dts: intel_adsp: add UAOL device for ACE4
* 33b482235a6 drivers: dai: intel: uaol: add a driver for Intel UAOL DAI
* b50fcbd6eee drivers: uaol: add a driver for Intel UAOL IP
* 2e9f09e12dd pm: policy: change 'greater than or equal' to 'greater than'
* 5800f4e2fe1 pm: policy: move pm_policy_device_is_disabling_state() declaration
* 9834dac28ad pm: policy: add NULL callback support for latency subscriptions
* 2865d5ce0d5 pm: policy: replace DT_PROP_LEN with ARRAY_SIZE
* af746bc8400 pm: policy: Improve the event implementation