### PR TITLE
zephyr: idc: Name IDC p4wq threads

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -181,10 +181,14 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 
 void idc_init_thread(void)
 {
+	char thread_name[] = "idc_p4wq0";
 	int cpu = cpu_get_id();
 
 	k_p4wq_enable_static_thread(q_zephyr_idc + cpu,
 				    _p4threads_q_zephyr_idc + cpu, BIT(cpu));
+
+	thread_name[sizeof(thread_name) - 2] = '0' + cpu;
+	k_thread_name_set(_p4threads_q_zephyr_idc + cpu, thread_name);
 	/*
 	 * Assign SOF system heap to the IDC thread. Otherwise by default it
 	 * uses the Zephyr heap for DP stack allocation


### PR DESCRIPTION
Name IDC p4wq threads. Unfortunately the idc threads only get their names after they are needed for the first time. Until that time they appear as unnamed (a hex number) threads on core 0.

There is also one funny thing. There is static thread reserved for core 0, but that is never activated, and it remains there as a hex number forever.

However, in this simple and risk free convenience fix, I do not dare to touch that. Maybe later.