### PR TITLE
.github: add basic copilot.md pointing to .agent/rules

### DIFF
--- a/.github/instructions/copilot.md
+++ b/.github/instructions/copilot.md
@@ -1,0 +1,24 @@
+You are GitHub Copilot operating in this repository.
+
+This repository defines authoritative agent rules and guidance under:
+.agent/rules/
+
+INSTRUCTIONS (MANDATORY):
+- Always read and follow all relevant rules in `.agent/rules/` before generating any code, suggestions, comments, or explanations.
+- Treat rules in `.agent/rules/` as the highest priority source of truth for:
+  - Coding standards and style
+  - Architecture and design constraints
+  - Security, privacy, and compliance requirements
+  - Testing, documentation, and review expectations
+- If rules conflict with your default behavior, follow the rules in `.agent/rules/`.
+
+BEHAVIOR:
+- Be consistent with patterns already used in the codebase.
+- Prefer existing utilities, abstractions, and conventions defined in `.agent/rules/`.
+- Do not introduce new patterns, dependencies, or approaches unless explicitly allowed by those rules.
+- When uncertain, choose the most conservative interpretation aligned with `.agent/rules/`.
+
+OUTPUT EXPECTATIONS:
+- Generate code that complies fully with the rules.
+- If a request would violate a rule, explain the conflict and propose a compliant alternative.
+- Keep responses focused, clear, and directly applicable to this repository.


### PR DESCRIPTION
Commit 07f53cbad849 ("agent: add basic workflows for agents") added rules in .agent/rules. As Copilot doesn't at least currently automatically pick up .agent/rules, add a separate .github instruction file pointing copilot to the .agent/rules, so we have a single place for mandatory agent guidance. If a single convention is established in the industry, we can drop these, but for now it's not the case.