### PR TITLE
vregion: Disable virtual regions on ACE 2.0 and earlier

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -252,7 +252,7 @@ config SOF_ZEPHYR_NO_SOF_CLOCK
 
 config SOF_VREGIONS
 	bool "Enable virtual memory regions"
-	default y if ACE
+	default y if ACE && !ACE_VERSION_1_5 && !ACE_VERSION_2_0
 	depends on ACE
 	help
 	  Enable the virtual regions memory allocator for pipeline resource management.


### PR DESCRIPTION
The virtual memory heap does not work properly on MTL or LNL and effectively the system from functioning due to virtual memory heap allocations failing when the demand for module memory is high, like in this test:

TPLG="/lib/firmware/intel/development/sof-lnl-nocodec.tplg" MODEL=LNLP_RVP_NOCODEC SOF_TEST_INTERVAL=10 ~/sof-test/test-case/multiple-pipeline.sh -f a -c 20 -l

Disable virtual memory heap for ACE 2.0 and earlier as quick remedy to the problem. With proper tuning it may be possible to get VMH working on these platforms too.

Fixes: b3d0c47ae15c (vregion: Add support for per pipeline/module virtual regions)