### PR TITLE
Audio: SRC: Fix return code for failed delay lines allocate

### DIFF
--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -537,7 +537,7 @@ int src_params_general(struct processing_module *mod,
 	if (!cd->delay_lines) {
 		comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
 			 delay_lines_size);
-		return  -EINVAL;
+		return  -ENOMEM;
 	}
 
 	/* Clear all delay lines here */


### PR DESCRIPTION
The proper return code is -ENOMEM. The -EINVAL makes this look like at higher logs level a component internal failure that it isn't.