### PR TITLE
west.yml: update zephyr to v4.4.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: afcfbf6dee02ec40e1690132228da1c5faa7d5fd
+      revision: 684c9e8f32e4373a21098559f748f06915f950c9
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Updating zephyr version to v4.4.0 release.

Total of 37 commits.

Changes include:

07fa9eabfe06 kernel: fix name of scheduler/wait queue: Dumb -> Simple
5184eac62197 logging: fix starvation caused by uncommitted message
083629e520f4 kernel: timer: Fix k_timer re-use in its handler
f26393b43532 doc: releases: Clean up 4.4 release notes
80ee819be578 drivers: systimer: xtensa: Fix ISR/idle_exit concurrency