### PR TITLE
init: core: Add log after first boot

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -154,6 +154,8 @@ __cold int secondary_core_init(struct sof *sof)
 
 	trace_point(TRACE_BOOT_PLATFORM);
 
+	LOG_INF("init done");
+
 	return err;
 }
 


### PR DESCRIPTION
This patch is adding a single log message after secondary core is initialized.

Motivation for that is to allow a simple way of testing that memory window logging is properly working on secondary cores as well. This is the simplest solution to allow testing in a simple and quick flow, without creating modules and pipelines on secondary cores.