### PR TITLE
vmh: limit additional buffers to non-Linux configurations

### DIFF
--- a/app/os_linux_overlay.conf
+++ b/app/os_linux_overlay.conf
@@ -22,3 +22,6 @@ CONFIG_SOF_USERSPACE_PROXY=n
 # set here to INFO to ensure expected behavior if platform configurations set a
 # lower default level (e.g., ERROR).
 CONFIG_LOG_RUNTIME_DEFAULT_LEVEL=3
+
+# Disable additional VMH buffers to use memory for virtual regions.
+CONFIG_VIRTUAL_HEAP_EXTENDED=n

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -82,10 +82,20 @@ config SOF_ZEPHYR_SHARED_BUFFER_HEAP_SIZE
 	 NOTE: Keep in mind that the shared heap size should not be greater than the
 	 heap size.
 
+config VIRTUAL_HEAP_EXTENDED
+	bool "Extend the Virtual Heap configuration with additional buffers"
+	depends on MM_DRV_INTEL_ADSP_MTL_TLB
+	default y
+	help
+	  Enable additional Virtual Heap buffers. Some configurations need this
+	  while others need the memory for other purposes, e.g. for the virtual
+	  page / virtual region storage.
+
 config SOF_ZEPHYR_VIRTUAL_HEAP_REGION_SIZE
 	hex "Size in bytes of virtual memory region for virtual heap shared for all cores"
 	depends on MM_DRV_INTEL_ADSP_MTL_TLB
-	default 0x140000
+	default 0x140000 if VIRTUAL_HEAP_EXTENDED
+	default 0x100000
 	help
 	  This config defines size of virtual heap region shared between all cores
 

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -339,7 +339,9 @@ static const struct vmh_heap_config static_hp_buffers = {
 		{ 2048, 8},
 		{ 4096, 11},
 		{ 8192, 10},
+#if CONFIG_VIRTUAL_HEAP_EXTENDED
 		{ 32768, 8},
+#endif
 		{ 65536, 3},
 		{ 131072, 1},
 		{ 524288, 1} /* buffer for kpb */


### PR DESCRIPTION
Commit 7f66827a2bdc ("zephyr: alloc: add 32K virtual heap bucket") unconditionally added 256k to Virtual Heap buckets. Make this conditional on a Kconfig option.