### PR TITLE
docs: AGENTS.md: align commit subject format with SOF conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@ This document outlines the rules AI agents must follow when checking out branche
 ## Development Standards
 
 ### Commitment and Sign-off Rules
-* **Commit Subject:** Must follow the format `feature: descriptive title`.
+* **Commit Subject:** Must follow the format `subsystem: component: short description` matching the SOF project convention. Use the git history of the modified file(s) (`git log --oneline -10 -- <file>`) to determine the correct subsystem and component prefix. Examples:
+  * `audio: chain_dma: add user-space scheduling support`
+  * `ipc4: handler: fix large config dispatch`
+  * `schedule: zephyr_domain: add user-space LL thread`
 * **Commit Body:** Should describe the changes in detail in the commit message body.
 * **Sign-off:** All commits must be signed off by the developer (`Signed-off-by: Name <email>`) using the identity from the local git config.
 


### PR DESCRIPTION
Replace generic "feature: descriptive title" format with the actual SOF project convention "subsystem: component: short description" and add instruction to derive prefix from git log of modified files.