### PR TITLE
ipc: Fix ipc_msg_send() with payload already prepared

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -205,7 +205,7 @@ __cold void ipc_msg_send_direct(struct ipc_msg *msg, void *data)
 	key = k_spin_lock(&ipc->lock);
 
 	/* copy mailbox data to message if not already copied */
-	if (msg->tx_size > 0 && msg->tx_size <= SOF_IPC_MSG_MAX_SIZE &&
+	if (data && msg->tx_size > 0 && msg->tx_size <= SOF_IPC_MSG_MAX_SIZE &&
 	    msg->tx_data != data) {
 		ret = memcpy_s(msg->tx_data, msg->tx_size, data, msg->tx_size);
 		assert(!ret);
@@ -225,7 +225,7 @@ void ipc_msg_send(struct ipc_msg *msg, void *data, bool high_priority)
 	key = k_spin_lock(&ipc->lock);
 
 	/* copy mailbox data to message if not already copied */
-	if ((msg->tx_size > 0 && msg->tx_size <= SOF_IPC_MSG_MAX_SIZE) &&
+	if (data && (msg->tx_size > 0 && msg->tx_size <= SOF_IPC_MSG_MAX_SIZE) &&
 	    msg->tx_data != data) {
 		ret = memcpy_s(msg->tx_data, msg->tx_size, data, msg->tx_size);
 		assert(!ret);


### PR DESCRIPTION
If the msg->tx_size/data have been prepared by caller and it calls the function with NULL as data: ipc_msg_send(msg, NULL, false);

then we try to copy from NULL to the msg->tx_data because msg->tx_data != data is true.

The callers could be fixed as well, but the ipc_msg_send() should handle this.