### PR TITLE
app: boards: imx95: switch to cortex-m systick as system timer

### DIFF
--- a/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
+++ b/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
@@ -5,6 +5,11 @@
  */
 
 / {
+	/* this'll select Cortex-M SysTick as the system timer */
+	chosen {
+		/delete-property/ zephyr,system-timer;
+	};
+
 	host_dma: dma {
 		compatible = "nxp,sof-host-dma";
 		dma-channels = <32>;


### PR DESCRIPTION
Zephyr commit c4efe9821c6b ("dts: soc: arm: nxp: imx95: designate lptmr1 as system timer via chosen") switched the system timer to LPTMR1 from Cortex-M systick.

This change was never carefully tested in the context of SOF and it ended up causing some issues, one of which being that after a couple of suspend and resume cycles, the timer interrupt never seems to get triggered again, causing the firmware to crash at some point.

Cortex-M's systick has done the job well so far so switch back to it for now.