### PR TITLE
audio: buffer: replace notifier events with direct probe callbacks

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -16,7 +16,6 @@
 #include <rtos/interrupt.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
-#include <sof/lib/notifier.h>
 #include <sof/list.h>
 #include <sof/schedule/dp_schedule.h>
 #include <rtos/spinlock.h>
@@ -147,17 +146,12 @@ static void comp_buffer_free(struct sof_audio_buffer *audio_buffer)
 
 	struct comp_buffer *buffer = container_of(audio_buffer, struct comp_buffer, audio_buffer);
 
-	struct buffer_cb_free cb_data = {
-		.buffer = buffer,
-	};
-
 	buf_dbg(buffer, "buffer_free()");
 
-	notifier_event(buffer, NOTIFIER_ID_BUFFER_FREE,
-		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
-
-	/* In case some listeners didn't unregister from buffer's callbacks */
-	notifier_unregister_all(NULL, buffer);
+#if CONFIG_PROBE
+	if (buffer->probe_cb_free)
+		buffer->probe_cb_free(buffer->probe_cb_arg);
+#endif
 
 	struct k_heap *heap = buffer->audio_buffer.heap;
 
@@ -478,12 +472,6 @@ bool buffer_params_match(struct comp_buffer *buffer,
 
 void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 {
-	struct buffer_cb_transact cb_data = {
-		.buffer = buffer,
-		.transaction_amount = bytes,
-		.transaction_begin_address = audio_stream_get_wptr(&buffer->stream),
-	};
-
 	/* return if no bytes */
 	if (!bytes) {
 #if CONFIG_SOF_LOG_DBG_BUFFER
@@ -499,10 +487,23 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 		return;
 	}
 
+#if CONFIG_PROBE
+	void *produce_begin = audio_stream_get_wptr(&buffer->stream);
+#endif
+
 	audio_stream_produce(&buffer->stream, bytes);
 
-	notifier_event(buffer, NOTIFIER_ID_BUFFER_PRODUCE,
-		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
+#if CONFIG_PROBE
+	if (buffer->probe_cb_produce) {
+		struct buffer_cb_transact cb_data = {
+			.buffer = buffer,
+			.transaction_amount = bytes,
+			.transaction_begin_address = produce_begin,
+		};
+
+		buffer->probe_cb_produce(buffer->probe_cb_arg, &cb_data);
+	}
+#endif
 
 #if CONFIG_SOF_LOG_DBG_BUFFER
 	buf_dbg(buffer, "((buffer->avail << 16) | buffer->free) = %08x, ((buffer->id << 16) | buffer->size) = %08x",
@@ -519,12 +520,6 @@ void comp_update_buffer_produce(struct comp_buffer *buffer, uint32_t bytes)
 
 void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 {
-	struct buffer_cb_transact cb_data = {
-		.buffer = buffer,
-		.transaction_amount = bytes,
-		.transaction_begin_address = audio_stream_get_rptr(&buffer->stream),
-	};
-
 	CORE_CHECK_STRUCT(&buffer->audio_buffer);
 
 	/* return if no bytes */
@@ -543,9 +538,6 @@ void comp_update_buffer_consume(struct comp_buffer *buffer, uint32_t bytes)
 	}
 
 	audio_stream_consume(&buffer->stream, bytes);
-
-	notifier_event(buffer, NOTIFIER_ID_BUFFER_CONSUME,
-		       NOTIFIER_TARGET_CORE_LOCAL, &cb_data, sizeof(cb_data));
 
 #if CONFIG_SOF_LOG_DBG_BUFFER
 	buf_dbg(buffer, "(buffer->avail << 16) | buffer->free = %08x, (buffer->id << 16) | buffer->size = %08x, (buffer->r_ptr - buffer->addr) << 16 | (buffer->w_ptr - buffer->addr)) = %08x",

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 
 struct comp_dev;
+struct buffer_cb_transact;
 
 /** \name Trace macros
  *  @{
@@ -148,6 +149,15 @@ struct comp_buffer {
 
 	/* list of buffers, to be used i.e. in raw data processing mode*/
 	struct list_item buffers_list;
+
+#if CONFIG_PROBE
+	/** probe produce callback, called on buffer produce */
+	void (*probe_cb_produce)(void *arg, struct buffer_cb_transact *cb_data);
+	/** probe free callback, called on buffer free */
+	void (*probe_cb_free)(void *arg);
+	/** opaque argument passed to probe callbacks */
+	void *probe_cb_arg;
+#endif
 };
 
 /*
@@ -188,15 +198,11 @@ static inline void comp_buffer_reset_sink_list(struct comp_buffer *buffer)
 	list_init(&buffer->sink_list);
 }
 
-/* Only to be used for synchronous same-core notifications! */
+/* Used as parameter for probe produce callback */
 struct buffer_cb_transact {
 	struct comp_buffer *buffer;
 	uint32_t transaction_amount;
 	void *transaction_begin_address;
-};
-
-struct buffer_cb_free {
-	struct comp_buffer *buffer;
 };
 
 #define buffer_from_list(ptr, dir) \

--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -27,9 +27,6 @@ enum notify_id {
 	NOTIFIER_ID_SSP_FREQ,			/* struct clock_notify_data * */
 	NOTIFIER_ID_KPB_CLIENT_EVT,		/* struct kpb_event_data * */
 	NOTIFIER_ID_DMA_DOMAIN_CHANGE,		/* struct dma_chan_data * */
-	NOTIFIER_ID_BUFFER_PRODUCE,		/* struct buffer_cb_transact* */
-	NOTIFIER_ID_BUFFER_CONSUME,		/* struct buffer_cb_transact* */
-	NOTIFIER_ID_BUFFER_FREE,		/* struct buffer_cb_free* */
 	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
 	NOTIFIER_ID_LL_POST_RUN,		/* NULL */
 	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -13,7 +13,6 @@
 #include <rtos/alloc.h>
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
-#include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/ipc/topology.h>
 #include <sof/ipc/driver.h>
@@ -902,14 +901,12 @@ static ssize_t probe_logging_hook(uint8_t *buffer, size_t length)
  *	  Extraction probe: generate format, header and copy data to probe buffer.
  *	  Injection probe: find corresponding DMA, check avail data, copy data,
  *	  update pointers and request more data from host if needed.
- * \param[in] arg pointer (not used).
- * \param[in] type of notify.
- * \param[in] data pointer.
+ * \param[in] arg pointer to buffer_id.
+ * \param[in] cb_data pointer to buffer callback transaction data.
  */
-static void probe_cb_produce(void *arg, enum notify_id type, void *data)
+static void probe_cb_produce(void *arg, struct buffer_cb_transact *cb_data)
 {
 	struct probe_pdata *_probe = probe_get();
-	struct buffer_cb_transact *cb_data = data;
 	struct comp_buffer *buffer = cb_data->buffer;
 	struct probe_dma_ext *dma;
 	uint32_t buffer_id;
@@ -921,7 +918,7 @@ static void probe_cb_produce(void *arg, enum notify_id type, void *data)
 	uint32_t format;
 	uint64_t checksum;
 
-	buffer_id = *(int *)arg;
+	buffer_id = *(uint32_t *)arg;
 
 	/* search for probe point connected to this buffer */
 	for (i = 0; i < CONFIG_PROBE_POINTS_MAX; i++)
@@ -1068,13 +1065,11 @@ err:
 
 /**
  * \brief Callback for buffer free, it will remove probe point.
- * \param[in] arg pointer (not used).
- * \param[in] type of notify.
- * \param[in] data pointer.
+ * \param[in] arg pointer to buffer_id.
  */
-static void probe_cb_free(void *arg, enum notify_id type, void *data)
+static void probe_cb_free(void *arg)
 {
-	uint32_t buffer_id = *(int *)arg;
+	uint32_t buffer_id = *(uint32_t *)arg;
 	int ret;
 
 	tr_dbg(&pr_tr, "buffer_id = %u", buffer_id);
@@ -1315,16 +1310,13 @@ int probe_point_add(uint32_t count, const struct probe_point *probe)
 			probe_point_id_t *new_buf_id = &_probe->probe_points[first_free].buffer_id;
 
 #if CONFIG_IPC_MAJOR_4
-			notifier_register(&new_buf_id->full_id, buf, NOTIFIER_ID_BUFFER_PRODUCE,
-					  &probe_cb_produce, 0);
-			notifier_register(&new_buf_id->full_id, buf, NOTIFIER_ID_BUFFER_FREE,
-					  &probe_cb_free, 0);
+			struct comp_buffer *probe_buf = buf;
 #else
-			notifier_register(&new_buf_id->full_id, dev->cb, NOTIFIER_ID_BUFFER_PRODUCE,
-					  &probe_cb_produce, 0);
-			notifier_register(&new_buf_id->full_id, dev->cb, NOTIFIER_ID_BUFFER_FREE,
-					  &probe_cb_free, 0);
+			struct comp_buffer *probe_buf = (struct comp_buffer *)dev->cb;
 #endif
+			probe_buf->probe_cb_produce = probe_cb_produce;
+			probe_buf->probe_cb_free = probe_cb_free;
+			probe_buf->probe_cb_arg = &new_buf_id->full_id;
 		}
 	}
 
@@ -1444,19 +1436,20 @@ int probe_point_remove(uint32_t count, const uint32_t *buffer_id)
 				if (dev) {
 					buf = ipc4_get_buffer(dev, *buf_id);
 					if (buf) {
-						notifier_unregister(NULL, buf,
-								    NOTIFIER_ID_BUFFER_PRODUCE);
-						notifier_unregister(NULL, buf,
-								    NOTIFIER_ID_BUFFER_FREE);
+						buf->probe_cb_produce = NULL;
+						buf->probe_cb_free = NULL;
+						buf->probe_cb_arg = NULL;
 					}
 				}
 #else
 				dev = ipc_get_comp_by_id(ipc_get(), buffer_id[i]);
 				if (dev) {
-					notifier_unregister(&buf_id->full_id, dev->cb,
-							    NOTIFIER_ID_BUFFER_PRODUCE);
-					notifier_unregister(&buf_id->full_id, dev->cb,
-							    NOTIFIER_ID_BUFFER_FREE);
+					struct comp_buffer *probe_buf =
+						(struct comp_buffer *)dev->cb;
+
+					probe_buf->probe_cb_produce = NULL;
+					probe_buf->probe_cb_free = NULL;
+					probe_buf->probe_cb_arg = NULL;
 				}
 #endif
 				_probe->probe_points[j].stream_tag =


### PR DESCRIPTION
Replace the generic notifier dispatch for buffer produce, consume, and free events with direct function pointer callbacks on struct comp_buffer. The only consumer of this notifier event has been probe.c, so there is really no need to use the notifier framework for this.

This change allows to run more audio modules in user-space, where the notifier framework is not available.