### PR TITLE
audio: pcm_converter: make global tables available to user-space

### DIFF
--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -27,6 +27,7 @@
 #include <sof/common.h>
 #include <sof/compiler_attributes.h>
 #include <ipc/stream.h>
+#include <rtos/userspace_helper.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -669,7 +670,7 @@ static int pcm_convert_f_to_s32(const struct audio_stream *source,
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
-const struct pcm_func_map pcm_func_map[] = {
+APP_TASK_DATA const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_U8
 	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 */
@@ -732,7 +733,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 };
 
-const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
+APP_TASK_DATA const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
@@ -1020,7 +1021,7 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *so
 
 #endif
 
-const struct pcm_func_vc_map pcm_func_vc_map[] = {
+APP_TASK_DATA const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
 		pcm_convert_s16_c16_to_s16_c32 },
@@ -1101,6 +1102,6 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 };
 
-const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
+APP_TASK_DATA const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
 
 #endif

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -18,6 +18,7 @@
 #include <sof/audio/buffer.h>
 #include <sof/common.h>
 #include <sof/compiler_attributes.h>
+#include <rtos/userspace_helper.h>
 #include <ipc/stream.h>
 #include <xtensa/tie/xt_hifi3.h>
 
@@ -764,7 +765,7 @@ static int pcm_convert_f_to_s32(const struct audio_stream *source,
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_32LE */
 #endif /* XCHAL_HAVE_FP */
 
-const struct pcm_func_map pcm_func_map[] = {
+APP_TASK_DATA const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
@@ -807,7 +808,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #endif /* XCHAL_HAVE_FP */
 };
-const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
+APP_TASK_DATA const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
@@ -1206,7 +1207,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
  */
 #endif
 
-const struct pcm_func_vc_map pcm_func_vc_map[] = {
+APP_TASK_DATA const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
 		pcm_convert_s16_c16_to_s16_c32 },
@@ -1283,6 +1284,6 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 };
 
-const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
+APP_TASK_DATA const size_t pcm_func_vc_count = ARRAY_SIZE(pcm_func_vc_map);
 
 #endif

--- a/src/audio/pcm_converter/pcm_remap.c
+++ b/src/audio/pcm_converter/pcm_remap.c
@@ -5,6 +5,7 @@
 
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/audio_stream.h>
+#include <rtos/userspace_helper.h>
 
 static void mute_channel_c16(struct audio_stream *stream, int channel, int frames)
 {
@@ -423,7 +424,7 @@ static int remap_c16_to_c32_no_shift(const struct audio_stream *source, uint32_t
 /* Unfortunately, all these nice "if"s were commented out to suppress
  * CI "defined but not used" warnings.
  */
-const struct pcm_func_map pcm_remap_func_map[] = {
+APP_TASK_DATA const struct pcm_func_map pcm_remap_func_map[] = {
 /* #if CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, remap_c16},
 /* #endif */
@@ -474,4 +475,4 @@ const struct pcm_func_map pcm_remap_func_map[] = {
 /* #endif */
 };
 
-const size_t pcm_remap_func_count = ARRAY_SIZE(pcm_remap_func_map);
+APP_TASK_DATA const size_t pcm_remap_func_count = ARRAY_SIZE(pcm_remap_func_map);


### PR DESCRIPTION
The pcm_converter depends on a set of global function tables to set up correct conversion functions. These objects need to be made available to user-space threads, so that pcm_converter can be also run in user-space. No impact to kernel-space use of pcm_converter.