### PR TITLE
west.yml: update zephyr to 217a5ac0ca46

### DIFF
--- a/src/audio/module_adapter/library/userspace_proxy.c
+++ b/src/audio/module_adapter/library/userspace_proxy.c
@@ -220,12 +220,14 @@ static int userspace_proxy_invoke(struct userspace_context *user_ctx, uint32_t c
 		goto done;
 	}
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	/* Pin worker thread to the same core as the module */
 	ret = k_thread_cpu_pin(worker.thread_id, cpu_get_id());
 	if (ret < 0) {
 		tr_err(&userspace_proxy_tr, "Failed to pin cpu, error: %d", ret);
 		goto done;
 	}
+#endif
 
 	ret = k_work_user_submit_to_queue(&worker.work_queue, &user_ctx->work_item->work_item);
 	if (ret < 0) {

--- a/src/debug/debug_stream/debug_stream_thread_info.c
+++ b/src/debug/debug_stream/debug_stream_thread_info.c
@@ -367,12 +367,14 @@ static int thread_info_start(void)
 			LOG_ERR("k_thread_create() failed for core %u", i);
 			continue;
 		}
+#ifdef CONFIG_SCHED_CPU_MASK
 		ret = k_thread_cpu_pin(tid, i);
 		if (ret < 0) {
 			LOG_ERR("Pinning thread to code core %u", i);
 			k_thread_abort(tid);
 			continue;
 		}
+#endif
 		snprintf(name, sizeof(name), "%u thread info", i);
 		ret = k_thread_name_set(tid, name);
 		if (ret < 0)

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -337,7 +337,9 @@ __cold int ipc_init(struct sof *sof)
 
 	k_thread_suspend(thread);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	k_thread_cpu_pin(thread, PLATFORM_PRIMARY_CORE_ID);
+#endif
 	k_thread_name_set(thread, "ipc_send_wq");
 
 	k_thread_resume(thread);

--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -461,8 +461,10 @@ static int zephyr_dma_domain_register(struct ll_schedule_domain *domain,
 				 0,
 				 K_FOREVER);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	k_thread_cpu_mask_clear(thread);
 	k_thread_cpu_mask_enable(thread, core);
+#endif
 	k_thread_name_set(thread, thread_name);
 
 	k_thread_start(thread);

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -216,8 +216,10 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 				 zephyr_domain_thread_fn, zephyr_domain, INT_TO_POINTER(core),
 				 NULL, CONFIG_LL_THREAD_PRIORITY, 0, K_FOREVER);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	k_thread_cpu_mask_clear(thread);
 	k_thread_cpu_mask_enable(thread, core);
+#endif
 	k_thread_name_set(thread, thread_name);
 
 	k_thread_start(thread);
@@ -330,8 +332,10 @@ static int zephyr_domain_register_user(struct ll_schedule_domain *domain,
 					 INT_TO_POINTER(core), NULL, CONFIG_LL_THREAD_PRIORITY,
 					 K_USER, K_FOREVER);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 		k_thread_cpu_mask_clear(thread);
 		k_thread_cpu_mask_enable(thread, core);
+#endif
 		k_thread_name_set(thread, thread_name);
 
 		k_mem_domain_add_thread(zephyr_ll_mem_domain(), thread);

--- a/src/schedule/zephyr_dp_schedule_application.c
+++ b/src/schedule/zephyr_dp_schedule_application.c
@@ -493,12 +493,14 @@ int scheduler_dp_task_init(struct task **task, const struct sof_uuid_entry *uid,
 					   stack_size, dp_thread_fn, ptask, NULL, NULL,
 					   CONFIG_DP_THREAD_PRIORITY, ptask->flags, K_FOREVER);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	/* pin the thread to specific core */
 	ret = k_thread_cpu_pin(pdata->thread_id, core);
 	if (ret < 0) {
 		tr_err(&dp_tr, "zephyr task pin to core failed");
 		goto e_thread;
 	}
+#endif
 
 	k_thread_access_grant(pdata->thread_id, pdata->event, &dp_sync[core]);
 	scheduler_dp_grant(pdata->thread_id, core);

--- a/src/schedule/zephyr_dp_schedule_thread.c
+++ b/src/schedule/zephyr_dp_schedule_thread.c
@@ -287,12 +287,14 @@ int scheduler_dp_task_init(struct task **task,
 					   CONFIG_DP_THREAD_PRIORITY, task_memory->task.flags,
 					   K_FOREVER);
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	/* pin the thread to specific core */
 	ret = k_thread_cpu_pin(pdata->thread_id, core);
 	if (ret < 0) {
 		tr_err(&dp_tr, "zephyr task pin to core failed");
 		goto e_thread;
 	}
+#endif
 
 #ifdef CONFIG_USERSPACE
 	if (options & K_USER) {

--- a/src/schedule/zephyr_twb_schedule.c
+++ b/src/schedule/zephyr_twb_schedule.c
@@ -441,6 +441,7 @@ int scheduler_twb_task_init(struct task **task,
 		goto err;
 	}
 
+#ifdef CONFIG_SCHED_CPU_MASK
 	/* pin the thread to specific core */
 	ret = k_thread_cpu_pin(thread_id, core);
 	if (ret < 0) {
@@ -448,6 +449,7 @@ int scheduler_twb_task_init(struct task **task,
 		tr_err(&twb_tr, "zephyr task pin to core %d failed", core);
 		goto err;
 	}
+#endif
 
 	/* set the thread name */
 	if (name) {

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 684c9e8f32e4373a21098559f748f06915f950c9
+      revision: 217a5ac0ca4671ec0cf5c1fd4ea1d222f492fe1e
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -113,8 +113,10 @@ int scheduler_init_edf(void)
 	k_thread_suspend(thread);
 
 	k_thread_heap_assign(thread, sof_sys_heap_get());
+#ifdef CONFIG_SCHED_CPU_MASK
 	k_thread_cpu_mask_clear(thread);
 	k_thread_cpu_mask_enable(thread, PLATFORM_PRIMARY_CORE_ID);
+#endif
 	k_thread_name_set(thread, "edf_workq");
 
 	k_thread_resume(thread);


### PR DESCRIPTION
Total of 1024 commits.

Changes include:

19fa644e348c arch: xtensa: semihost: Account for NULL terminator in path length
a53ab458d532 arch: xtensa: semihost: Add QEMU target support
9a8657193a2e arch: xtensa: semihost: Add simulator support
03263c5213a0 kernel: heap: add BLOCKING trace and fix EXIT ordering in k_heap_realloc
2f58de062669 kernel: stack: move BLOCKING trace to after K_NO_WAIT check in k_stack_pop
8dbe9770901a kernel: mailbox: emit tracing EXIT on async-send matched-receiver path
d01ea12e787e kernel: queue: remove spurious BLOCKING trace in queue_insert
5ca3c912b29b kernel: userspace: Add k_object_access_revoke_others
24b75db466f6 llext: add CONFIG_LLEXT_CUSTOM_HEAP_PLACEMENT
edcfe755ae87 logging: fix unaligned access in z_log_msg_enqueue
33d43d093371 xtensa: ptables: fix dangling memory domains
4d5f470290ae soc: arch: select SCHED_IPI_SUPPORTED if SMP
243012c33c97 kernel: move thread_entry from lib/os to kernel
c60e0e943605 kernel: move userspace sem into kernel/sys
b572cb23fc8b kernel: userspace: move mutex/user_work to userspace
85ca9bb992e2 kernel: move smp code into smp/
974dbbf2c0f6 kernel: move userspace kconfigs into own file
d8a1960c8bae kernel: reorg mem domain kconfig
eb294b7a1eb9 kernel: move userspace code to own folder
bac294c90f4c xtensa: remove mem_manage.c
b72e6dcdba50 soc: intel_adsp/ace: add custom memory range check code
d6d419264421 include: drivers: dai: Use DEVICE_API_GET
eeb0a701f1e9 doc: dmic: improve main DMIC documentation page
bd556f218bf8 scripts: runners: xtensa: ignore SIGINT while GDB is running
e0c2585bebf1 include: drivers: i2s: Use DEVICE_API_GET