### PR TITLE
dma: dma_sg: allocate on specific heap

### DIFF
--- a/posix/include/sof/lib/dma.h
+++ b/posix/include/sof/lib/dma.h
@@ -35,6 +35,7 @@
 
 struct comp_buffer;
 struct comp_dev;
+struct k_heap;
 
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  DMA Drivers API specification.
@@ -511,13 +512,14 @@ static inline void dma_sg_init(struct dma_sg_elem_array *ea)
 	ea->elems = NULL;
 }
 
-int dma_sg_alloc(struct dma_sg_elem_array *ea,
+int dma_sg_alloc(struct k_heap *heap,
+		 struct dma_sg_elem_array *ea,
 		 uint32_t flags,
 		 uint32_t direction,
 		 uint32_t buffer_count, uint32_t buffer_bytes,
 		 uintptr_t dma_buffer_addr, uintptr_t external_addr);
 
-void dma_sg_free(struct dma_sg_elem_array *ea);
+void dma_sg_free(struct k_heap *heap, struct dma_sg_elem_array *ea);
 
 /**
  * \brief Get the total size of SG buffer

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -379,7 +379,7 @@ static int dai_playback_params(struct comp_dev *dev, uint32_t period_bytes,
 
 		comp_info(dev, "fifo 0x%x", fifo);
 
-		err = dma_sg_alloc(&config->elem_array, SOF_MEM_FLAG_USER,
+		err = dma_sg_alloc(NULL, &config->elem_array, SOF_MEM_FLAG_USER,
 				   config->direction,
 				   period_count,
 				   period_bytes,
@@ -444,7 +444,7 @@ static int dai_capture_params(struct comp_dev *dev, uint32_t period_bytes,
 
 		comp_info(dev, "fifo 0x%x", fifo);
 
-		err = dma_sg_alloc(&config->elem_array, SOF_MEM_FLAG_USER,
+		err = dma_sg_alloc(NULL, &config->elem_array, SOF_MEM_FLAG_USER,
 				   config->direction,
 				   period_count,
 				   period_bytes,
@@ -709,7 +709,7 @@ void dai_common_reset(struct dai_data *dd, struct comp_dev *dev)
 	if (!dd->delayed_dma_stop)
 		dai_dma_release(dd, dev);
 
-	dma_sg_free(&config->elem_array);
+	dma_sg_free(NULL, &config->elem_array);
 
 	if (dd->dma_buffer) {
 		buffer_free(dd->dma_buffer);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -843,7 +843,7 @@ static int dai_set_sg_config(struct dai_data *dd, struct comp_dev *dev, uint32_t
 			} while (--max_block_count > 0);
 		}
 
-		err = dma_sg_alloc(&config->elem_array, SOF_MEM_FLAG_USER,
+		err = dma_sg_alloc(NULL, &config->elem_array, SOF_MEM_FLAG_USER,
 				   config->direction,
 				   period_count,
 				   period_bytes,
@@ -1124,7 +1124,7 @@ out:
 	if (err < 0) {
 		buffer_free(dd->dma_buffer);
 		dd->dma_buffer = NULL;
-		dma_sg_free(&config->elem_array);
+		dma_sg_free(NULL, &config->elem_array);
 		rfree(dd->z_config);
 		dd->z_config = NULL;
 	}
@@ -1255,7 +1255,7 @@ void dai_common_reset(struct dai_data *dd, struct comp_dev *dev)
 	if (!dd->delayed_dma_stop)
 		dai_dma_release(dd, dev);
 
-	dma_sg_free(&config->elem_array);
+	dma_sg_free(NULL, &config->elem_array);
 	if (dd->z_config) {
 		rfree(dd->z_config->head_block);
 		rfree(dd->z_config);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -445,7 +445,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		elem_array = &hd->local.elem_array;
 
 		/* config buffer will be used as proxy */
-		err = dma_sg_alloc(&hd->config.elem_array, SOF_MEM_FLAG_USER,
+		err = dma_sg_alloc(NULL, &hd->config.elem_array, SOF_MEM_FLAG_USER,
 				   dir, 1, 0, 0, 0);
 		if (err < 0) {
 			comp_err(dev, "dma_sg_alloc() failed");
@@ -455,7 +455,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev, uint32
 		elem_array = &hd->config.elem_array;
 	}
 
-	err = dma_sg_alloc(elem_array, SOF_MEM_FLAG_USER, dir, buffer_count,
+	err = dma_sg_alloc(NULL, elem_array, SOF_MEM_FLAG_USER, dir, buffer_count,
 			   buffer_bytes,
 			   (uintptr_t)(audio_stream_get_addr(&hd->dma_buffer->stream)), 0);
 	if (err < 0) {
@@ -615,7 +615,7 @@ void host_common_free(struct host_data *hd)
 	dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
-	dma_sg_free(&hd->config.elem_array);
+	dma_sg_free(NULL, &hd->config.elem_array);
 }
 
 static void host_free(struct comp_dev *dev)
@@ -937,9 +937,9 @@ void host_common_reset(struct host_data *hd, uint16_t state)
 	}
 
 	/* free all DMA elements */
-	dma_sg_free(&hd->host.elem_array);
-	dma_sg_free(&hd->local.elem_array);
-	dma_sg_free(&hd->config.elem_array);
+	dma_sg_free(NULL, &hd->host.elem_array);
+	dma_sg_free(NULL, &hd->local.elem_array);
+	dma_sg_free(NULL, &hd->config.elem_array);
 
 	/* It's safe that cleaning out `hd->config` after `dma_sg_free` for config.elem_array */
 	memset(&hd->config, 0, sizeof(hd->config));

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -610,7 +610,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev,
 		elem_array = &hd->local.elem_array;
 
 		/* config buffer will be used as proxy */
-		err = dma_sg_alloc(&hd->config.elem_array, SOF_MEM_FLAG_USER,
+		err = dma_sg_alloc(NULL, &hd->config.elem_array, SOF_MEM_FLAG_USER,
 				   dir, 1, 0, 0, 0);
 		if (err < 0) {
 			comp_err(dev, "dma_sg_alloc() failed");
@@ -620,7 +620,7 @@ static int create_local_elems(struct host_data *hd, struct comp_dev *dev,
 		elem_array = &hd->config.elem_array;
 	}
 
-	err = dma_sg_alloc(elem_array, SOF_MEM_FLAG_USER, dir, buffer_count,
+	err = dma_sg_alloc(NULL, elem_array, SOF_MEM_FLAG_USER, dir, buffer_count,
 			   buffer_bytes,
 			   (uintptr_t)audio_stream_get_addr(&hd->dma_buffer->stream), 0);
 	if (err < 0) {
@@ -787,7 +787,7 @@ __cold void host_common_free(struct host_data *hd)
 	sof_dma_put(hd->dma);
 
 	ipc_msg_free(hd->msg);
-	dma_sg_free(&hd->config.elem_array);
+	dma_sg_free(NULL, &hd->config.elem_array);
 }
 
 __cold static void host_free(struct comp_dev *dev)
@@ -1177,9 +1177,9 @@ void host_common_reset(struct host_data *hd, uint16_t state)
 	}
 
 	/* free all DMA elements */
-	dma_sg_free(&hd->host.elem_array);
-	dma_sg_free(&hd->local.elem_array);
-	dma_sg_free(&hd->config.elem_array);
+	dma_sg_free(NULL, &hd->host.elem_array);
+	dma_sg_free(NULL, &hd->local.elem_array);
+	dma_sg_free(NULL, &hd->config.elem_array);
 
 	/* free DMA buffer */
 	if (hd->dma_buffer) {

--- a/src/ipc/ipc3/handler.c
+++ b/src/ipc/ipc3/handler.c
@@ -878,7 +878,7 @@ static int ipc_dma_trace_config(uint32_t header)
 
 error:
 #if CONFIG_HOST_PTABLE
-	dma_sg_free(&elem_array);
+	dma_sg_free(NULL, &elem_array);
 
 processing_error:
 #endif

--- a/src/ipc/ipc3/host-page-table.c
+++ b/src/ipc/ipc3/host-page-table.c
@@ -239,6 +239,6 @@ int ipc_process_host_buffer(struct ipc *ipc,
 
 	return 0;
 error:
-	dma_sg_free(elem_array);
+	dma_sg_free(NULL, elem_array);
 	return err;
 }

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -285,7 +285,8 @@ void dma_put(struct dma *dma)
 }
 #endif
 
-int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
+int dma_sg_alloc(struct k_heap *heap,
+		 struct dma_sg_elem_array *elem_array,
 		 uint32_t flags,
 		 uint32_t direction,
 		 uint32_t buffer_count, uint32_t buffer_bytes,
@@ -293,10 +294,12 @@ int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 {
 	int i;
 
-	elem_array->elems = rzalloc(SOF_MEM_FLAG_USER,
-				    sizeof(struct dma_sg_elem) * buffer_count);
+	elem_array->elems = sof_heap_alloc(heap, SOF_MEM_FLAG_USER,
+					   sizeof(struct dma_sg_elem) * buffer_count, 0);
 	if (!elem_array->elems)
 		return -ENOMEM;
+
+	memset(elem_array->elems, 0, sizeof(struct dma_sg_elem) * buffer_count);
 
 	for (i = 0; i < buffer_count; i++) {
 		elem_array->elems[i].size = buffer_bytes;
@@ -319,9 +322,9 @@ int dma_sg_alloc(struct dma_sg_elem_array *elem_array,
 	return 0;
 }
 
-void dma_sg_free(struct dma_sg_elem_array *elem_array)
+void dma_sg_free(struct k_heap *heap, struct dma_sg_elem_array *elem_array)
 {
-	rfree(elem_array->elems);
+	sof_heap_free(heap, elem_array->elems);
 	dma_sg_init(elem_array);
 }
 

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -175,7 +175,7 @@ static int probe_dma_init(struct probe_dma_ext *dma, uint32_t direction)
 	dma->config.dest_width = sizeof(uint32_t);
 	dma->config.cyclic = 0;
 
-	err = dma_sg_alloc(&dma->config.elem_array, SOF_MEM_FLAG_USER,
+	err = dma_sg_alloc(NULL, &dma->config.elem_array, SOF_MEM_FLAG_USER,
 			   dma->config.direction, elem_num, elem_size, elem_addr, 0);
 	if (err < 0)
 		return err;
@@ -254,7 +254,7 @@ static int probe_dma_init(struct probe_dma_ext *dma, uint32_t direction)
 static int probe_dma_deinit(struct probe_dma_ext *dma)
 {
 	int err = 0;
-	dma_sg_free(&dma->config.elem_array);
+	dma_sg_free(NULL, &dma->config.elem_array);
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS
 	err = dma_stop(dma->dc.dmac->z_dev, dma->dc.chan->index);
 #else

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -407,7 +407,7 @@ void dma_trace_disable(struct dma_trace_data *d)
 #if (CONFIG_HOST_PTABLE)
 	/* Free up the host SG if it is set */
 	if (d->host_size) {
-		dma_sg_free(&d->config.elem_array);
+		dma_sg_free(NULL, &d->config.elem_array);
 		d->host_size = 0;
 	}
 #endif

--- a/zephyr/include/sof/lib/dma.h
+++ b/zephyr/include/sof/lib/dma.h
@@ -34,6 +34,7 @@
 
 struct comp_buffer;
 struct comp_dev;
+struct k_heap;
 
 /** \addtogroup sof_dma_drivers DMA Drivers
  *  SOF DMA Drivers API specification (deprecated interface, to be
@@ -291,13 +292,14 @@ static inline void dma_sg_init(struct dma_sg_elem_array *ea)
 	ea->elems = NULL;
 }
 
-int dma_sg_alloc(struct dma_sg_elem_array *ea,
+int dma_sg_alloc(struct k_heap *heap,
+		 struct dma_sg_elem_array *ea,
 		 uint32_t flags,
 		 uint32_t direction,
 		 uint32_t buffer_count, uint32_t buffer_bytes,
 		 uintptr_t dma_buffer_addr, uintptr_t external_addr);
 
-void dma_sg_free(struct dma_sg_elem_array *ea);
+void dma_sg_free(struct k_heap *heap, struct dma_sg_elem_array *ea);
 
 /**
  * \brief Get the total size of SG buffer


### PR DESCRIPTION
Add a heap parameter to DMA scatter-gather allocation interface. This makes it possible to control how allocations are done for the DMA buffers.