### PR TITLE
fast-get: fix a recent regression: write before mapping RO

### DIFF
--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -224,6 +224,9 @@ const void *fast_get(struct k_heap *heap, const void *dram_ptr, size_t size)
 	if (!ret)
 		goto out;
 
+	memcpy_s(ret, alloc_size, dram_ptr, size);
+	dcache_writeback_region((__sparse_force void __sparse_cache *)ret, size);
+
 #if CONFIG_USERSPACE
 	if (size > FAST_GET_MAX_COPY_SIZE && current_is_userspace) {
 		/* Otherwise we've allocated on thread's heap, so it already has access */
@@ -242,8 +245,6 @@ const void *fast_get(struct k_heap *heap, const void *dram_ptr, size_t size)
 	entry->dram_ptr = dram_ptr;
 	entry->size = size;
 	entry->sram_ptr = ret;
-	memcpy_s(ret, alloc_size, dram_ptr, size);
-	dcache_writeback_region((__sparse_force void __sparse_cache *)ret, size);
 	entry->refcount = 1;
 out:
 	k_spin_unlock(&data->lock, key);


### PR DESCRIPTION
A recent commit introduced a regression: it moved writing data to a buffer after the call, mapping the target buffer as read-only. Fix it by moving the copy operation back up.

Fixes commit cfa5f020c016 ("fast-get: don't corrupt entries when failing")