### PR TITLE
Add sof_sys_user_heap_get() and APP_SYSUSER_DATA/BSS macros

### DIFF
--- a/posix/include/rtos/alloc.h
+++ b/posix/include/rtos/alloc.h
@@ -141,6 +141,7 @@ void *sof_heap_alloc(struct k_heap *heap, uint32_t flags, size_t bytes,
 		     size_t alignment);
 void sof_heap_free(struct k_heap *heap, void *addr);
 struct k_heap *sof_sys_heap_get(void);
+struct k_heap *sof_sys_user_heap_get(void);
 
 /**
  * Calculates length of the null-terminated string.

--- a/src/platform/library/lib/alloc.c
+++ b/src/platform/library/lib/alloc.c
@@ -75,3 +75,8 @@ struct k_heap *sof_sys_heap_get(void)
 {
 	return NULL;
 }
+
+struct k_heap *sof_sys_user_heap_get(void)
+{
+	return NULL;
+}

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -127,6 +127,22 @@ void *sof_heap_alloc(struct k_heap *heap, uint32_t flags, size_t bytes,
 void sof_heap_free(struct k_heap *heap, void *addr);
 struct k_heap *sof_sys_heap_get(void);
 
+/**
+ * Returns heap object to use for SOF heap allocations
+ * for audio application code.
+ *
+ * The returned value may be NULL. This matches with semantics
+ * of sof_heap_alloc() that allows passing NULL as the 'heap'.
+ * In this case, the heap implementation will choose the heap to
+ * use.
+ *
+ * The function should not be used for heap allocations for objects that
+ * are only used in SOF kernel space.
+ *
+ * Note: audio modules should use mod_alloc() instead!
+ */
+struct k_heap *sof_sys_user_heap_get(void);
+
 /* TODO: remove - debug only - only needed for linking */
 static inline void heap_trace_all(int force) {}
 

--- a/zephyr/include/rtos/userspace_helper.h
+++ b/zephyr/include/rtos/userspace_helper.h
@@ -26,6 +26,14 @@
 #define APP_TASK_BSS	K_APP_BMEM(common_partition)
 #define APP_TASK_DATA	K_APP_DMEM(common_partition)
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+#define APP_SYSUSER_BSS	K_APP_BMEM(sysuser_partition)
+#define APP_SYSUSER_DATA	K_APP_DMEM(sysuser_partition)
+#else
+#define APP_SYSUSER_BSS
+#define APP_SYSUSER_DATA
+#endif
+
 struct processing_module;
 struct userspace_context;
 
@@ -136,5 +144,28 @@ static inline int user_access_to_mailbox(struct k_mem_domain *domain, k_tid_t th
 }
 
 #endif /* CONFIG_USERSPACE */
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+
+int user_memory_attach_system_user_partition(struct k_mem_domain *dom);
+
+#else
+
+/**
+ * Attach SOF system user memory partition to a memory domain.
+ * @param dom - memory domain to attach the sysuser partition to.
+ *
+ * @return 0 for success, error otherwise.
+ *
+ * @note
+ * Function used only when CONFIG_USERSPACE is set.
+ * The sysuser partition contains shared objects required by user-space modules.
+ */
+static inline int user_memory_attach_system_user_partition(struct k_mem_domain *dom)
+{
+	return 0;
+}
+
+#endif /* CONFIG_SOF_USERSPACE_LL */
 
 #endif /* __ZEPHYR_LIB_USERSPACE_HELPER_H__ */

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -13,6 +13,7 @@
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/audio/pipeline.h>
+#include <sof/schedule/ll_schedule_domain.h> /* for zephyr_ll_user_heap() */
 #include <sof/trace/trace.h>
 #include <rtos/symbol.h>
 #include <rtos/wait.h>
@@ -378,6 +379,16 @@ SYS_INIT(virtual_heap_init, POST_KERNEL, 1);
 struct k_heap *sof_sys_heap_get(void)
 {
 	return &sof_heap;
+}
+
+struct k_heap *sof_sys_user_heap_get(void)
+{
+#ifdef CONFIG_SOF_USERSPACE_LL
+	return zephyr_ll_user_heap();
+#else
+	/* let sof_heap_alloc() pick */
+	return NULL;
+#endif
 }
 
 static void *heap_alloc_aligned(struct k_heap *h, size_t min_align, size_t bytes)

--- a/zephyr/lib/userspace_helper.c
+++ b/zephyr/lib/userspace_helper.c
@@ -36,6 +36,10 @@ LOG_MODULE_REGISTER(userspace_helper, CONFIG_SOF_LOG_LEVEL);
 
 K_APPMEM_PARTITION_DEFINE(common_partition);
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+K_APPMEM_PARTITION_DEFINE(sysuser_partition);
+#endif
+
 struct k_heap *module_driver_heap_init(void)
 {
 	struct k_heap *mod_drv_heap = rballoc(SOF_MEM_FLAG_USER, sizeof(*mod_drv_heap));
@@ -83,6 +87,10 @@ int user_memory_attach_common_partition(struct k_mem_domain *dom)
 }
 
 #ifdef CONFIG_SOF_USERSPACE_LL
+int user_memory_attach_system_user_partition(struct k_mem_domain *dom)
+{
+	return k_mem_domain_add_partition(dom, &sysuser_partition);
+}
 
 int user_access_to_mailbox(struct k_mem_domain *domain, k_tid_t thread_id)
 {


### PR DESCRIPTION
Add helpers to allocate heap memory that should be accessible to the LL audio pipelines when they are ran in a user-space thread. Also add userspace helper macros for APP_SYSUSER_DATA/BSS to allow tag static objects such that they are made accessible to the LL userspace threads. These changes have no impact to regular SOF builds where LL audio pipelines are run in kernel threads.

For context, these commits are part of https://github.com/thesofproject/sof/pull/10558