### PR TITLE
audio: module: increase heap size

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -63,7 +63,7 @@ static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
 	/* FIXME: the size will be derived from configuration */
-	const size_t buf_size = 20 * 1024;
+	const size_t buf_size = 28 * 1024;
 
 	/*
 	 * A 1-to-1 replacement of the original heap implementation would be to


### PR DESCRIPTION
The check-src-play.sh test fails on PTL nocodec with 20k module heap and passes with 24k. Increase it to 28k to add a bit of security until we switch to using module configuration.