### PR TITLE
Tools: Testbench: Fix notification pool memory leak

### DIFF
--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -98,8 +98,8 @@ static int mfcc_free(struct processing_module *mod)
 
 	comp_info(mod->dev, "entry");
 	mod_data_blob_handler_free(mod, cd->model_handler);
-	mod_free(mod, cd);
 	mfcc_free_buffers(mod);
+	mod_free(mod, cd);
 	return 0;
 }
 

--- a/src/audio/sound_dose/sound_dose.c
+++ b/src/audio/sound_dose/sound_dose.c
@@ -327,10 +327,7 @@ __cold static int sound_dose_free(struct processing_module *mod)
 	comp_dbg(mod->dev, "entry");
 
 	sound_dose_filters_free(cd);
-	if (cd->msg) {
-		rfree(cd->msg->tx_data);
-		rfree(cd->msg);
-	}
+	ipc_msg_free(cd->msg);
 	rfree(cd->abi);
 	rfree(cd);
 	return 0;

--- a/src/include/sof/ipc/notification_pool.h
+++ b/src/include/sof/ipc/notification_pool.h
@@ -23,4 +23,15 @@
  */
 struct ipc_msg *ipc_notification_pool_get(size_t size);
 
+#if CONFIG_LIBRARY
+/**
+ * @brief Frees all IPC notification messages in the pool.
+ *
+ * This function frees all notification messages currently held in
+ * the pool free list and resets the pool depth counter. It is
+ * required only in library (testbench) build.
+ */
+void ipc_notification_pool_free(void);
+#endif /* CONFIG_LIBRARY */
+
 #endif /* __SOF_IPC_NOTIFICATION_POOL_H__ */

--- a/src/ipc/notification_pool.c
+++ b/src/ipc/notification_pool.c
@@ -100,3 +100,22 @@ struct ipc_msg *ipc_notification_pool_get(size_t size)
 	item->msg.tx_size = size;
 	return &item->msg;
 }
+
+#if CONFIG_LIBRARY
+void ipc_notification_pool_free(void)
+{
+	struct ipc_notif_pool_item *item;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&pool_free_list_lock);
+	while (!list_is_empty(&pool_free_list)) {
+		item = list_first_item(&pool_free_list, struct ipc_notif_pool_item, msg.list);
+		list_item_del(&item->msg.list);
+		--pool_depth;
+		k_spin_unlock(&pool_free_list_lock, key);
+		rfree(item);
+		key = k_spin_lock(&pool_free_list_lock);
+	}
+	k_spin_unlock(&pool_free_list_lock, key);
+}
+#endif /* CONFIG_LIBRARY */

--- a/tools/testbench/utils.c
+++ b/tools/testbench/utils.c
@@ -6,6 +6,8 @@
 #include <platform/lib/ll_schedule.h>
 #include <sof/audio/component.h>
 #include <sof/ipc/topology.h>
+#include <sof/ipc/msg.h>
+#include <sof/ipc/notification_pool.h>
 #include <sof/lib/notifier.h>
 
 #include <ctype.h>
@@ -210,6 +212,13 @@ void tb_free(struct sof *sof)
 		free(sch);
 	}
 	free(*arch_schedulers_get());
+
+	/* Drain IPC message queue to free queued notifications */
+	while (!list_is_empty(&sof->ipc->msg_list))
+		ipc_send_queued_msg();
+
+	/* Free notification pool items */
+	ipc_notification_pool_free();
 
 	/* free IPC data */
 	iipc = sof->ipc->private;


### PR DESCRIPTION
This PR fixes two MFCC testbench run related memory leaks

- Tools: Testbench: Fix notification pool memory leak
- Audio: MFCC: Fix memory leak in mfcc_free()

The notification pool fix triggered an issue in Sound Dose that also needed a fix

- Audio: Sound Dose: Fix use-after-free in sound_dose_free