### PR TITLE
audio: chain_dma: Fix error handling in chain_init()

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -458,15 +458,16 @@ __cold static int chain_init(struct comp_dev *dev, void *addr, size_t length)
 	channel = cd->host_connector_node_id.f.v_index;
 	channel = dma_request_channel(cd->dma_host->z_dev, &channel);
 	if (channel < 0) {
-		comp_err(dev, "dma_request_channel() failed");
-		return -EINVAL;
+		comp_err(dev, "host dma_request_channel() failed for %u",
+			 cd->host_connector_node_id.f.v_index);
+		return channel;
 	}
 
 	cd->chan_host = &cd->dma_host->chan[channel];
 
 	err = dma_config(cd->dma_host->z_dev, cd->chan_host->index, dma_cfg_host);
 	if (err < 0) {
-		comp_err(dev, "dma_config() failed");
+		comp_err(dev, "host dma_config() failed for %d", channel);
 		goto error_host;
 	}
 
@@ -474,7 +475,9 @@ __cold static int chain_init(struct comp_dev *dev, void *addr, size_t length)
 	channel = cd->link_connector_node_id.f.v_index;
 	channel = dma_request_channel(cd->dma_link->z_dev, &channel);
 	if (channel < 0) {
-		comp_err(dev, "dma_request_channel() failed");
+		comp_err(dev, "link dma_request_channel() failed for %u",
+			 cd->link_connector_node_id.f.v_index);
+		err = channel;
 		goto error_host;
 	}
 
@@ -482,7 +485,7 @@ __cold static int chain_init(struct comp_dev *dev, void *addr, size_t length)
 
 	err = dma_config(cd->dma_link->z_dev, cd->chan_link->index, dma_cfg_link);
 	if (err < 0) {
-		comp_err(dev, "dma_config() failed");
+		comp_err(dev, "link dma_config() failed for %d", channel);
 		goto error_link;
 	}
 	return 0;


### PR DESCRIPTION
If the dma_request_channel() for the link fails we print the error, jump to error_host to release the channel and return with success. This can lead to firmware crash later on when the ChainDMA  is started.

Correct the error handling by setting the err correctly in this case and also update the prints to print unique strings and information to help debugging.