### PR TITLE
west.yml: update Zephyr to c162980efd9ad86

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 07f5e1488f221a31f145406b5ee53e3cbc9b5620
+      revision: c162980efd9ad8616d0e2fe886ca917d8d8d240a
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Fixes accidental downgrade of Zephyr in commit 000fb33b3a671 ("west.yml: update zephyr to 07f5e1488f22").

Change Zephyr version back to c162980efd9ad86, which was already previously used in commit 2bde174eb68d ("west.yml: update zephyr to c162980efd9a").