### PR TITLE
topology2: add sof-ptl-rt713-l3-rt1320-l1 for LG Gram 16Z90U

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -158,6 +158,13 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
+# LG Gram Pro 2026 (16Z90U-KU7BK) with RT713 on link 3 and single stereo RT1320 on link 1
+"cavs-sdw\;sof-ptl-rt713-l3-rt1320-l1\;PLATFORM=ptl,SDW_DMIC=0,NUM_SDW_AMP_LINKS=1,\
+NUM_DMICS=2,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=SDW1-Playback,\
+SDW_JACK_OUT_STREAM=SDW3-Playback,SDW_JACK_IN_STREAM=SDW3-Capture,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt713-l3-rt1320-l1.bin"
+
 "cavs-sdw\;sof-ptl-cs42l43-l2-cs35l56x6-l13\;NUM_SDW_AMP_LINKS=3,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"


### PR DESCRIPTION
## Summary

Add a new SOF topology build target for the LG Gram Pro 2026 (16Z90U-KU7BK), which uses an unusual SoundWire configuration:
- RT713 jack/headset codec on link 3
- A single stereo RT1320 SmartAmp on link 1 (not two amps on different links)
- 2 NHLT DMICs (built-in laptop microphone array)
- No SMART_MIC ACPI function exposed by RT713

## Why a new target

Existing rt713-rt1320 boards have two RT1320 amps on different links (`NUM_SDW_AMP_LINKS=2`), but the LG Gram uses one stereo RT1320 chip:

```
sdw:0:1:025d:1320:01   single RT1320 (stereo) on link 1
sdw:0:3:025d:0713:01   RT713 on link 3
```

So this target uses `NUM_SDW_AMP_LINKS=1` and type-less stream names (`SDW1-Playback` / `SDW3-Playback` / `SDW3-Capture`) because each link has only one dailink, which makes the kernel machine driver skip the `-SimpleJack` / `-SmartAmp` suffix (`append_dai_type=false` when `num_link_dailinks==1`).

## Test plan

- [x] Built tplg + nhlt bin succeed
- [x] Loaded on real hardware (LG Gram 16Z90U-KU7BK, Ubuntu 26.04, kernel 7.0.0-15)
- [x] Speaker (RT1320 stereo) plays both channels
- [x] Headphone jack output works with auto-routing on plug
- [x] Headset jack mic captures audio
- [x] Internal DMIC stereo capture works
- [x] HDMI 1/2/3 output devices exposed (verified on monitor with audio)
- [x] PipeWire UCM HiFi profile auto-activates and exposes proper sinks/sources

## Dependencies

This topology requires a matching kernel SoundWire machine table entry that I will submit separately to alsa-devel:
- `sound/soc/intel/common/soc-acpi-intel-ptl-match.c` — adds `link_mask = BIT(1) | BIT(3)` entry referencing `sof-ptl-rt713-l3-rt1320-l1.tplg`

I'll also submit the built `.tplg` and `nhlt-*.bin` to linux-firmware once this lands.
