### PR TITLE
ipc: ipc-helper: use list_mutex to guard buffer list in userspace LL

### DIFF
--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -333,7 +333,16 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 		return -EINVAL;
 	}
 
+	/* Lock buffer lists to prevent racing with the LL scheduler.
+	 * In user-space builds, irq_local_disable() is a privileged
+	 * operation, so use the per-component list_mutex instead
+	 * (same pattern as PPL_LOCK in pipeline_disconnect()).
+	 */
+#ifdef CONFIG_SOF_USERSPACE_LL
+	sys_mutex_lock(&icd->cd->list_mutex, K_FOREVER);
+#else
 	irq_local_disable(flags);
+#endif
 	comp_dev_for_each_producer_safe(icd->cd, buffer, safe) {
 		comp_buffer_set_sink_component(buffer, NULL);
 		/* This breaks the list, but we anyway delete all buffers */
@@ -346,7 +355,11 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 		comp_buffer_reset_source_list(buffer);
 	}
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+	sys_mutex_unlock(&icd->cd->list_mutex);
+#else
 	irq_local_enable(flags);
+#endif
 
 	/* free component and remove from list */
 	comp_free(icd->cd);


### PR DESCRIPTION
In user-space LL builds (CONFIG_SOF_USERSPACE_LL), irq_local_disable() is a privileged operation. In ipc_comp_free(), use sys_mutex_lock/unlock on the per-component list_mutex to protect buffer list iteration instead.

This follows the same locking pattern as PPL_LOCK/PPL_UNLOCK used in pipeline_disconnect().