### PR TITLE
Few minor fixes

### DIFF
--- a/src/include/ipc4/notification.h
+++ b/src/include/ipc4/notification.h
@@ -88,7 +88,7 @@ enum sof_ipc4_resource_event_type {
 	/* SNDW debug notification e.g. external VAD detected */
 	SOF_IPC4_SNDW_DEBUG_INFO		= 18,
 	/* Invalid type */
-	SOF_IPC4_INVALID_RESORUCE_EVENT_TYPE	= 19,
+	SOF_IPC4_INVALID_RESOURCE_EVENT_TYPE	= 19,
 };
 
 /* Resource Type - source of the event */

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1271,7 +1271,6 @@ __cold static int ipc4_add_comp_dev(struct comp_dev *dev)
 		      sizeof(struct ipc_comp_dev));
 	if (!icd) {
 		tr_err(&ipc_tr, "alloc failed");
-		rfree(icd);
 		return IPC4_OUT_OF_MEMORY;
 	}
 


### PR DESCRIPTION
* ipc4: remove unnecessary code
icd is NULL by the time rfree(icd) is called, hence rfree(icd) can be removed.

* ipc4: fix minor typo
Fix two switched letters in SOF_IPC4_INVALID_RESOURCE_EVENT_TYPE declaration.