### PR TITLE
ipc4: helper: guard TLV loop against NULL from tlv_next()

### DIFF
--- a/src/include/sof/tlv.h
+++ b/src/include/sof/tlv.h
@@ -91,7 +91,7 @@ static inline void tlv_value_get(const void *data,
 	const struct sof_tlv *tlv = (const struct sof_tlv *)data;
 	const uint32_t end_addr = (uint32_t)data + size;
 
-	while ((uint32_t)tlv < end_addr) {
+	while (tlv && (uint32_t)tlv < end_addr) {
 		if (tlv->type == type) {
 			*value = (void *)tlv->value;
 			*length = tlv->length;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1307,7 +1307,7 @@ int ipc4_find_dma_config_multiple(struct ipc_config_dai *dai, uint8_t *data_buff
 	struct ipc_dma_config *dma_cfg;
 	struct sof_tlv *tlvs;
 
-	for (tlvs = (struct sof_tlv *)data_buffer; (uint32_t)tlvs < end_addr;
+	for (tlvs = (struct sof_tlv *)data_buffer; tlvs && (uint32_t)tlvs < end_addr;
 	     tlvs = tlv_next(tlvs)) {
 		dma_cfg = tlv_value_ptr_get(tlvs, GTW_DMA_CONFIG_ID);
 		if (!dma_cfg)


### PR DESCRIPTION
Add 'tlvs &&' to the for-loop condition in ipc4_find_dma_config_multiple(). tlv_next() returns NULL on malformed TLV (length not a multiple of 4). The existing loop condition '(uint32_t)tlvs < end_addr' does not catch NULL (0 < end_addr is always true), causing a NULL pointer dereference.