### PR TITLE
math: fft: move NULL guard before plan dereferences in HiFi3 variants

### DIFF
--- a/src/math/fft/fft_16_hifi3.c
+++ b/src/math/fft/fft_16_hifi3.c
@@ -35,11 +35,13 @@ void fft_execute_16(struct fft_plan *plan, bool ifft)
 	ae_valign outu = AE_ZALIGN64();
 	int depth, top, bottom, index;
 	int i, j, k, m, n;
-	int size = plan->size;
-	int len = plan->len;
+	int size, len;
 
 	if (!plan || !plan->bit_reverse_idx)
 		return;
+
+	size = plan->size;
+	len = plan->len;
 
 	outb = plan->outb16;
 	if (!plan->inb16 || !outb)

--- a/src/math/fft/fft_32_hifi3.c
+++ b/src/math/fft/fft_32_hifi3.c
@@ -20,23 +20,28 @@ void fft_execute_32(struct fft_plan *plan, bool ifft)
 	ae_int32x2 sample1;
 	ae_int32x2 sample2;
 	ae_int32x2 tw;
-	ae_int32x2 *inx = (ae_int32x2 *)plan->inb32;
-	ae_int32x2 *outx = (ae_int32x2 *)plan->outb32;
+	ae_int32x2 *inx;
+	ae_int32x2 *outx;
 	ae_int32x2 *top_ptr;
 	ae_int32x2 *bot_ptr;
-	uint16_t *idx = &plan->bit_reverse_idx[0];
+	uint16_t *idx;
 	const int32_t *tw_r;
 	const int32_t *tw_i;
 	int depth, i;
 	int j, k, m, n;
-	int size = plan->size;
-	int len = plan->len;
+	int size, len;
 
 	if (!plan || !plan->bit_reverse_idx)
 		return;
 
 	if (!plan->inb32 || !plan->outb32)
 		return;
+
+	inx = (ae_int32x2 *)plan->inb32;
+	outx = (ae_int32x2 *)plan->outb32;
+	idx = &plan->bit_reverse_idx[0];
+	size = plan->size;
+	len = plan->len;
 
 	/* step 1: re-arrange input in bit reverse order, and shrink the level to avoid overflow */
 	if (ifft) {


### PR DESCRIPTION
In fft_execute_16() and fft_execute_32() HiFi3 implementations, local variables are initialized from plan->size, plan->len (and in 32-bit: plan->inb32, plan->outb32, plan->bit_reverse_idx) before the 'if (!plan)' guard is reached. Move all plan-> accesses after the NULL check, matching the generic fft_16.c / fft_32.c ordering.