### PR TITLE
[DNM] vregions phase II: Actually use the lifetime allocations and make the memory division between lifetime and interim dynamic

### DIFF
--- a/posix/include/zephyr/logging/log.h
+++ b/posix/include/zephyr/logging/log.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2026 Intel Corporation. All rights reserved.
+ *
+ * Stub for <zephyr/logging/log.h> used by testbench / posix builds.
+ */
+
+#ifndef __POSIX_ZEPHYR_LOGGING_LOG_H__
+#define __POSIX_ZEPHYR_LOGGING_LOG_H__
+
+#include <stdio.h>
+
+#ifndef LOG_ERR
+#define LOG_ERR(fmt, ...)	fprintf(stderr, "ERR: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_WRN
+#define LOG_WRN(fmt, ...)	fprintf(stderr, "WRN: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_INF
+#define LOG_INF(fmt, ...)	printf("INF: " fmt "\n", ##__VA_ARGS__)
+#endif
+#ifndef LOG_DBG
+#define LOG_DBG(fmt, ...)	do { } while (0)
+#endif
+
+#ifndef LOG_MODULE_REGISTER
+#define LOG_MODULE_REGISTER(ctx, level)
+#endif
+#ifndef LOG_MODULE_DECLARE
+#define LOG_MODULE_DECLARE(ctx, level)
+#endif
+
+#endif /* __POSIX_ZEPHYR_LOGGING_LOG_H__ */

--- a/posix/include/zephyr/sys/util.h
+++ b/posix/include/zephyr/sys/util.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright(c) 2026 Intel Corporation. All rights reserved.
+ *
+ * Stub for <zephyr/sys/util.h> used by testbench / posix builds.
+ */
+
+#ifndef __POSIX_ZEPHYR_SYS_UTIL_H__
+#define __POSIX_ZEPHYR_SYS_UTIL_H__
+
+#include <stddef.h>
+
+#ifndef KB
+#define KB(x) (((size_t)(x)) << 10)
+#endif
+
+#ifndef MB
+#define MB(x) (KB(x) << 10)
+#endif
+
+#endif /* __POSIX_ZEPHYR_SYS_UTIL_H__ */

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -13,6 +13,16 @@ menu "Processing modules"
 		  containers to allocate at once is selected by this
 		  config option.
 
+	config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+		int "Default heap size for DP userspace threads"
+		default 20480
+		help
+		  Defines the default heap size for userspace DP processing
+		  threads. The value can be overridden with IPC module init
+		  ext_init module payload. The default is derived from what is
+		  required for SRC module to produce all supported conversions.
+		  (This is a dummy Kconfig option to help testbench to build.)
+
 	config CADENCE_CODEC
 		bool "Cadence codec"
 		help

--- a/src/audio/module_adapter/Kconfig
+++ b/src/audio/module_adapter/Kconfig
@@ -13,6 +13,15 @@ menu "Processing modules"
 		  containers to allocate at once is selected by this
 		  config option.
 
+	config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+		int "Default heap size for DP userspace threads"
+		default 20480
+		help
+		  Defines the default heap size for userspace DP processing
+		  threads. The value can be overridden with IPC module init
+		  ext_init module payload. The default is derived from what is
+		  required for SRC module to produce all supported conversions.
+
 	config CADENCE_CODEC
 		bool "Cadence codec"
 		help

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -244,6 +244,17 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 
 	struct comp_dev *dev = mod->dev;
 
+	dst = &mod->priv.cfg;
+	/*
+	 * NOTE: dst->ext_data points to stack variable and contains
+	 *       pointers to IPC payload mailbox, so its only valid in
+	 *       functions that called from this function. This why
+	 *       the pointer is set NULL before this function exits.
+	 */
+#if CONFIG_IPC_MAJOR_4
+	dst->ext_data = &ext_data;
+#endif
+
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 	/* create a task for DP processing */
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP) {
@@ -256,16 +267,6 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	}
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
-	dst = &mod->priv.cfg;
-	/*
-	 * NOTE: dst->ext_data points to stack variable and contains
-	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
-	 */
-#if CONFIG_IPC_MAJOR_4
-	dst->ext_data = &ext_data;
-#endif
 	ret = module_adapter_init_data(dev, dst, config, &spec);
 	if (ret) {
 		comp_err(dev, "%d: module init data failed",

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -58,8 +58,7 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 #define PAGE_SZ HOST_PAGE_SIZE
 #endif
 
-static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
-						  size_t *heap_size)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config)
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
 	/* FIXME: the size will be derived from configuration */
@@ -84,11 +83,10 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
-	size_t heap_size;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		mod_vreg = module_adapter_dp_heap_new(config, &heap_size);
+		mod_vreg = module_adapter_dp_heap_new(config);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -101,7 +99,6 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 #else
 		mod_heap = drv->user_heap;
 #endif
-		heap_size = 0;
 		mod_vreg = NULL;
 	}
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -58,17 +58,39 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 #define PAGE_SZ HOST_PAGE_SIZE
 #endif
 
-static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
+						  const struct module_ext_init_data *ext_init)
 {
 	/* src-lite with 8 channels has been seen allocating 14k in one go */
-	/* FIXME: the size will be derived from configuration */
-	const size_t buf_size = 28 * 1024;
+	size_t buf_size = CONFIG_SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE;
 
+#if CONFIG_IPC_MAJOR_4
+	if (config->ipc_extended_init && ext_init && ext_init->dp_data &&
+	    ext_init->dp_data->heap_bytes > 0) {
+		if (ext_init->dp_data->heap_bytes > MB(64)) {
+			LOG_ERR("Bad heap size %u bytes for %#x",
+				ext_init->dp_data->heap_bytes, config->id);
+			return NULL;
+		}
+
+		buf_size = ext_init->dp_data->heap_bytes;
+
+		LOG_INF("%zu byte heap size requested in IPC for %#x", buf_size, config->id);
+	}
+#endif
+	/*
+	 * A 1-to-1 replacement of the original heap implementation would be to
+	 * have "lifetime size" equal to 0. But (1) this is invalid for
+	 * vregion_create() and (2) we gradually move objects, that are simple
+	 * to move to the lifetime buffer. Make it 4k for the beginning.
+	 */
 	return vregion_create(buf_size);
 }
 
-static struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
-							  const struct comp_ipc_config *config)
+static
+struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
+						   const struct comp_ipc_config *config,
+						   const struct module_ext_init_data *ext_init)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -86,7 +108,7 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		mod_vreg = module_adapter_dp_heap_new(config);
+		mod_vreg = module_adapter_dp_heap_new(config, ext_init);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -227,8 +249,14 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 			return NULL;
 	}
 #endif
+	const struct module_ext_init_data *ext_init =
+#if CONFIG_IPC_MAJOR_4
+		&ext_data;
+#else
+		NULL;
+#endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config);
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
 
 	if (!mod)
 		return NULL;
@@ -245,8 +273,9 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	/*
 	 * NOTE: dst->ext_data points to stack variable and contains
 	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
+	 *       functions that are called from this function. This is
+	 *       why the pointer is set to NULL before this function
+	 *       exits.
 	 */
 #if CONFIG_IPC_MAJOR_4
 	dst->ext_data = &ext_data;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -237,6 +237,18 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 
 	struct comp_dev *dev = mod->dev;
 
+	dst = &mod->priv.cfg;
+	/*
+	 * NOTE: dst->ext_data points to stack variable and contains
+	 *       pointers to IPC payload mailbox, so its only valid in
+	 *       functions that are called from this function. This is
+	 *       why the pointer is set to NULL before this function
+	 *       exits.
+	 */
+#if CONFIG_IPC_MAJOR_4
+	dst->ext_data = &ext_data;
+#endif
+
 #if CONFIG_ZEPHYR_DP_SCHEDULER
 	/* create a task for DP processing */
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP) {
@@ -249,16 +261,6 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 	}
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 
-	dst = &mod->priv.cfg;
-	/*
-	 * NOTE: dst->ext_data points to stack variable and contains
-	 *       pointers to IPC payload mailbox, so its only valid in
-	 *       functions that called from this function. This why
-	 *       the pointer is set NULL before this function exits.
-	 */
-#if CONFIG_IPC_MAJOR_4
-	dst->ext_data = &ext_data;
-#endif
 	ret = module_adapter_init_data(dev, dst, config, &spec);
 	if (ret) {
 		comp_err(dev, "%d: module init data failed",

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -51,8 +51,33 @@ struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 	return module_adapter_new_ext(drv, config, spec, NULL, NULL, NULL);
 }
 
-static struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
-							  const struct comp_ipc_config *config)
+static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *config,
+						  const struct module_ext_init_data *ext_init)
+{
+	size_t buf_size = CONFIG_SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE;
+	uintptr_t vreg_start;
+
+#if CONFIG_IPC_MAJOR_4
+	if (config->ipc_extended_init && ext_init && ext_init->dp_data &&
+	    ext_init->dp_data->heap_bytes > 0) {
+		if (ext_init->dp_data->heap_bytes > MB(64)) {
+			LOG_ERR("Bad heap size %u bytes for %#x",
+				ext_init->dp_data->heap_bytes, config->id);
+			return NULL;
+		}
+
+		buf_size = ext_init->dp_data->heap_bytes;
+
+		LOG_INF("%zu byte heap size requested in IPC for %#x", buf_size, config->id);
+	}
+#endif
+	return vregion_create_map(&vreg_start, &buf_size);
+}
+
+static
+struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
+						   const struct comp_ipc_config *config,
+						   const struct module_ext_init_data *ext_init)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -67,15 +92,10 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
-	size_t vreg_size;
-	uintptr_t vreg_start;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
-		/* src-lite with 8 channels has been seen allocating 14k in one go */
-		/* FIXME: the size will be derived from configuration */
-		vreg_size = 28 * 1024;
-		mod_vreg = vregion_create_map(&vreg_start, &vreg_size);
+		mod_vreg = module_adapter_dp_heap_new(config, ext_init);
 		if (!mod_vreg) {
 			comp_cl_err(drv, "Failed to allocate DP module heap / vregion");
 			return NULL;
@@ -92,8 +112,6 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 #else
 		mod_heap = drv->user_heap;
 #endif
-		vreg_size = 0;
-		vreg_start = 0;
 		mod_vreg = NULL;
 	}
 
@@ -223,8 +241,14 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 			return NULL;
 	}
 #endif
+	const struct module_ext_init_data *ext_init =
+#if CONFIG_IPC_MAJOR_4
+		&ext_data;
+#else
+		NULL;
+#endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config);
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
 
 	if (!mod)
 		return NULL;

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -78,7 +78,7 @@ static
 struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
 						   const struct comp_ipc_config *config,
 						   const struct module_ext_init_data *ext_init,
-						   struct vregion *ppl_vreg)
+						   struct mod_alloc_ctx *ppl_alloc)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -93,6 +93,8 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
+	bool use_ppl_alloc = ppl_alloc &&
+			     config->proc_domain == COMP_PROCESSING_DOMAIN_LL;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
@@ -106,10 +108,9 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 #else
 		mod_heap = NULL;
 #endif
-	} else if (ppl_vreg && config->proc_domain == COMP_PROCESSING_DOMAIN_LL) {
-		mod_vreg = vregion_get(ppl_vreg);
-		mod_heap = NULL;
-		heap_size = 0;
+	} else if (use_ppl_alloc) {
+		mod_vreg = ppl_alloc->vreg ? vregion_get(ppl_alloc->vreg) : NULL;
+		mod_heap = ppl_alloc->heap;
 	} else {
 #ifdef CONFIG_SOF_USERSPACE_LL
 		mod_heap = sof_sys_user_heap_get();
@@ -120,26 +121,38 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 		mod_vreg = NULL;
 	}
 
-	if (!mod_vreg)
+	if (use_ppl_alloc) {
+		/* LL modules use the pipeline's alloc context */
+		mod = sof_ctx_alloc(ppl_alloc, flags, sizeof(*mod), 0);
+	} else if (!mod_vreg) {
 		mod = sof_heap_alloc(mod_heap, flags, sizeof(*mod), 0);
-	else if (flags & SOF_MEM_FLAG_COHERENT)
+	} else if (flags & SOF_MEM_FLAG_COHERENT) {
 		mod = vregion_alloc_coherent(mod_vreg, sizeof(*mod));
-	else
+	} else {
 		mod = vregion_alloc(mod_vreg, sizeof(*mod));
+	}
 
 	if (!mod) {
 		comp_cl_err(drv, "failed to allocate memory for module");
 		goto emod;
 	}
 
-	struct mod_alloc_ctx *alloc = sof_heap_alloc(mod_heap, flags, sizeof(*alloc), 0);
+	struct mod_alloc_ctx *alloc;
 
-	if (!alloc)
-		goto ealloc;
+	if (use_ppl_alloc) {
+		/* LL modules share the pipeline's alloc context */
+		alloc = ppl_alloc;
+	} else {
+		alloc = sof_heap_alloc(mod_heap, flags, sizeof(*alloc), 0);
+		if (!alloc)
+			goto ealloc;
+
+		memset(alloc, 0, sizeof(*alloc));
+		alloc->heap = mod_heap;
+		alloc->vreg = mod_vreg;
+	}
 
 	memset(mod, 0, sizeof(*mod));
-	alloc->heap = mod_heap;
-	alloc->vreg = mod_vreg;
 	mod->priv.resources.alloc = alloc;
 	mod_resource_init(mod);
 
@@ -149,7 +162,9 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	 * then it can be cached. Effectively it can be only cached in
 	 * single-core configurations.
 	 */
-	if (mod_vreg)
+	if (use_ppl_alloc)
+		dev = sof_ctx_alloc(ppl_alloc, SOF_MEM_FLAG_COHERENT, sizeof(*dev), 0);
+	else if (mod_vreg)
 		dev = vregion_alloc_coherent(mod_vreg, sizeof(*dev));
 	else
 		dev = sof_heap_alloc(mod_heap, SOF_MEM_FLAG_COHERENT, sizeof(*dev), 0);
@@ -168,14 +183,20 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	return mod;
 
 edev:
-	sof_heap_free(mod_heap, alloc);
+	if (!use_ppl_alloc)
+		sof_heap_free(mod_heap, alloc);
 ealloc:
-	if (mod_vreg)
+	if (use_ppl_alloc)
+		sof_ctx_free(ppl_alloc, mod);
+	else if (mod_vreg)
 		vregion_free(mod_vreg, mod);
 	else
 		sof_heap_free(mod_heap, mod);
 emod:
-	vregion_put(mod_vreg);
+	if (use_ppl_alloc)
+		vregion_put(ppl_alloc->vreg);
+	else
+		vregion_put(mod_vreg);
 
 	return NULL;
 }
@@ -183,27 +204,27 @@ emod:
 static void module_adapter_mem_free(struct processing_module *mod)
 {
 	struct mod_alloc_ctx *alloc = mod->priv.resources.alloc;
-	struct k_heap *mod_heap = alloc->heap;
+	bool ppl_alloc = mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL &&
+			 mod->dev->pipeline && mod->dev->pipeline->alloc == alloc;
 
 	/*
 	 * In principle it shouldn't even be needed to free individual objects
 	 * on the module heap since we're freeing the heap itself too
 	 */
 #if CONFIG_IPC_MAJOR_4
-	sof_heap_free(mod_heap, mod->priv.cfg.input_pins);
+	sof_heap_free(alloc->heap, mod->priv.cfg.input_pins);
 #endif
-	if (alloc->vreg) {
-		struct vregion *mod_vreg = alloc->vreg;
-		uint32_t proc_domain = mod->dev->ipc_config.proc_domain;
+	sof_ctx_free(alloc, mod->dev);
+	sof_ctx_free(alloc, mod);
 
-		vregion_free(mod_vreg, mod->dev);
-		vregion_free(mod_vreg, mod);
-		if (!vregion_put(mod_vreg) || proc_domain == COMP_PROCESSING_DOMAIN_LL)
-			sof_heap_free(alloc->heap, alloc);
+	if (ppl_alloc) {
+		/* alloc belongs to pipeline, just release vregion reference */
+		vregion_put(alloc->vreg);
+	} else if (alloc->vreg) {
+		if (!vregion_put(alloc->vreg))
+			rfree(alloc);
 	} else {
-		sof_heap_free(mod_heap, mod->dev);
-		sof_heap_free(mod_heap, mod);
-		sof_heap_free(mod_heap, alloc);
+		rfree(alloc);
 	}
 }
 
@@ -257,18 +278,18 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 #if CONFIG_IPC_MAJOR_4
 	struct ipc_comp_dev *ipc_pipe;
 	struct ipc *ipc = ipc_get();
-	struct vregion *ppl_vreg = NULL;
+	struct mod_alloc_ctx *ppl_alloc = NULL;
 
-	/* resolve the pipeline pointer early to pass its vregion to mem_alloc */
+	/* resolve the pipeline pointer early to pass its alloc to mem_alloc */
 	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
 					  IPC_COMP_IGNORE_REMOTE);
 	if (ipc_pipe && ipc_pipe->pipeline)
-		ppl_vreg = ipc_pipe->pipeline->vreg;
+		ppl_alloc = ipc_pipe->pipeline->alloc;
 #endif
 
 	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init,
 #if CONFIG_IPC_MAJOR_4
-								 ppl_vreg
+								 ppl_alloc
 #else
 								 NULL
 #endif

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -91,7 +91,7 @@ static
 struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
 						   const struct comp_ipc_config *config,
 						   const struct module_ext_init_data *ext_init,
-						   struct vregion *ppl_vreg)
+						   struct mod_alloc_ctx *ppl_alloc)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -106,6 +106,8 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	 */
 	uint32_t flags = config->proc_domain == COMP_PROCESSING_DOMAIN_DP ?
 		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT : SOF_MEM_FLAG_USER;
+	bool use_ppl_alloc = ppl_alloc &&
+			     config->proc_domain == COMP_PROCESSING_DOMAIN_LL;
 
 	if (config->proc_domain == COMP_PROCESSING_DOMAIN_DP && IS_ENABLED(CONFIG_SOF_VREGIONS) &&
 	    IS_ENABLED(CONFIG_USERSPACE) && !IS_ENABLED(CONFIG_SOF_USERSPACE_USE_DRIVER_HEAP)) {
@@ -115,10 +117,9 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 			return NULL;
 		}
 		mod_heap = NULL;
-	} else if (ppl_vreg && config->proc_domain == COMP_PROCESSING_DOMAIN_LL) {
-		mod_vreg = vregion_get(ppl_vreg);
-		mod_heap = NULL;
-		heap_size = 0;
+	} else if (use_ppl_alloc) {
+		mod_vreg = ppl_alloc->vreg ? vregion_get(ppl_alloc->vreg) : NULL;
+		mod_heap = ppl_alloc->heap;
 	} else {
 #ifdef CONFIG_SOF_USERSPACE_LL
 		mod_heap = sof_sys_user_heap_get();
@@ -129,26 +130,38 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 		mod_vreg = NULL;
 	}
 
-	if (!mod_vreg)
+	if (use_ppl_alloc) {
+		/* LL modules use the pipeline's alloc context */
+		mod = sof_ctx_alloc(ppl_alloc, flags, sizeof(*mod), 0);
+	} else if (!mod_vreg) {
 		mod = sof_heap_alloc(mod_heap, flags, sizeof(*mod), 0);
-	else if (flags & SOF_MEM_FLAG_COHERENT)
+	} else if (flags & SOF_MEM_FLAG_COHERENT) {
 		mod = vregion_alloc_coherent(mod_vreg, sizeof(*mod));
-	else
+	} else {
 		mod = vregion_alloc(mod_vreg, sizeof(*mod));
+	}
 
 	if (!mod) {
 		comp_cl_err(drv, "failed to allocate memory for module");
 		goto emod;
 	}
 
-	struct mod_alloc_ctx *alloc = sof_heap_alloc(mod_heap, flags, sizeof(*alloc), 0);
+	struct mod_alloc_ctx *alloc;
 
-	if (!alloc)
-		goto ealloc;
+	if (use_ppl_alloc) {
+		/* LL modules share the pipeline's alloc context */
+		alloc = ppl_alloc;
+	} else {
+		alloc = sof_heap_alloc(mod_heap, flags, sizeof(*alloc), 0);
+		if (!alloc)
+			goto ealloc;
+
+		memset(alloc, 0, sizeof(*alloc));
+		alloc->heap = mod_heap;
+		alloc->vreg = mod_vreg;
+	}
 
 	memset(mod, 0, sizeof(*mod));
-	alloc->heap = mod_heap;
-	alloc->vreg = mod_vreg;
 	mod->priv.resources.alloc = alloc;
 	mod_resource_init(mod);
 
@@ -158,7 +171,9 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	 * then it can be cached. Effectively it can be only cached in
 	 * single-core configurations.
 	 */
-	if (mod_vreg)
+	if (use_ppl_alloc)
+		dev = sof_ctx_alloc(ppl_alloc, SOF_MEM_FLAG_COHERENT, sizeof(*dev), 0);
+	else if (mod_vreg)
 		dev = vregion_alloc_coherent(mod_vreg, sizeof(*dev));
 	else
 		dev = sof_heap_alloc(mod_heap, SOF_MEM_FLAG_COHERENT, sizeof(*dev), 0);
@@ -177,14 +192,20 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 	return mod;
 
 edev:
-	sof_heap_free(mod_heap, alloc);
+	if (!use_ppl_alloc)
+		sof_heap_free(mod_heap, alloc);
 ealloc:
-	if (mod_vreg)
+	if (use_ppl_alloc)
+		sof_ctx_free(ppl_alloc, mod);
+	else if (mod_vreg)
 		vregion_free(mod_vreg, mod);
 	else
 		sof_heap_free(mod_heap, mod);
 emod:
-	vregion_put(mod_vreg);
+	if (use_ppl_alloc)
+		vregion_put(ppl_alloc->vreg);
+	else
+		vregion_put(mod_vreg);
 
 	return NULL;
 }
@@ -192,27 +213,27 @@ emod:
 static void module_adapter_mem_free(struct processing_module *mod)
 {
 	struct mod_alloc_ctx *alloc = mod->priv.resources.alloc;
-	struct k_heap *mod_heap = alloc->heap;
+	bool ppl_alloc = mod->dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL &&
+			 mod->dev->pipeline && mod->dev->pipeline->alloc == alloc;
 
 	/*
 	 * In principle it shouldn't even be needed to free individual objects
 	 * on the module heap since we're freeing the heap itself too
 	 */
 #if CONFIG_IPC_MAJOR_4
-	sof_heap_free(mod_heap, mod->priv.cfg.input_pins);
+	sof_heap_free(alloc->heap, mod->priv.cfg.input_pins);
 #endif
-	if (alloc->vreg) {
-		struct vregion *mod_vreg = alloc->vreg;
-		uint32_t proc_domain = mod->dev->ipc_config.proc_domain;
+	sof_ctx_free(alloc, mod->dev);
+	sof_ctx_free(alloc, mod);
 
-		vregion_free(mod_vreg, mod->dev);
-		vregion_free(mod_vreg, mod);
-		if (!vregion_put(mod_vreg) || proc_domain == COMP_PROCESSING_DOMAIN_LL)
-			sof_heap_free(alloc->heap, alloc);
+	if (ppl_alloc) {
+		/* alloc belongs to pipeline, just release vregion reference */
+		vregion_put(alloc->vreg);
+	} else if (alloc->vreg) {
+		if (!vregion_put(alloc->vreg))
+			rfree(alloc);
 	} else {
-		sof_heap_free(mod_heap, mod->dev);
-		sof_heap_free(mod_heap, mod);
-		sof_heap_free(mod_heap, alloc);
+		rfree(alloc);
 	}
 }
 
@@ -265,18 +286,18 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 #if CONFIG_IPC_MAJOR_4
 	struct ipc_comp_dev *ipc_pipe;
 	struct ipc *ipc = ipc_get();
-	struct vregion *ppl_vreg = NULL;
+	struct mod_alloc_ctx *ppl_alloc = NULL;
 
-	/* resolve the pipeline pointer early to pass its vregion to mem_alloc */
+	/* resolve the pipeline pointer early to pass its alloc to mem_alloc */
 	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
 					  IPC_COMP_IGNORE_REMOTE);
 	if (ipc_pipe && ipc_pipe->pipeline)
-		ppl_vreg = ipc_pipe->pipeline->vreg;
+		ppl_alloc = ipc_pipe->pipeline->alloc;
 #endif
 
 	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init,
 #if CONFIG_IPC_MAJOR_4
-								 ppl_vreg
+								 ppl_alloc
 #else
 								 NULL
 #endif

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -77,7 +77,8 @@ static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *
 static
 struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
 						   const struct comp_ipc_config *config,
-						   const struct module_ext_init_data *ext_init)
+						   const struct module_ext_init_data *ext_init,
+						   struct vregion *ppl_vreg)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -105,6 +106,10 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 #else
 		mod_heap = NULL;
 #endif
+	} else if (ppl_vreg && config->proc_domain == COMP_PROCESSING_DOMAIN_LL) {
+		mod_vreg = vregion_get(ppl_vreg);
+		mod_heap = NULL;
+		heap_size = 0;
 	} else {
 #ifdef CONFIG_SOF_USERSPACE_LL
 		mod_heap = sof_sys_user_heap_get();
@@ -189,10 +194,11 @@ static void module_adapter_mem_free(struct processing_module *mod)
 #endif
 	if (alloc->vreg) {
 		struct vregion *mod_vreg = alloc->vreg;
+		uint32_t proc_domain = mod->dev->ipc_config.proc_domain;
 
 		vregion_free(mod_vreg, mod->dev);
 		vregion_free(mod_vreg, mod);
-		if (!vregion_put(mod_vreg))
+		if (!vregion_put(mod_vreg) || proc_domain == COMP_PROCESSING_DOMAIN_LL)
 			sof_heap_free(alloc->heap, alloc);
 	} else {
 		sof_heap_free(mod_heap, mod->dev);
@@ -248,7 +254,25 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 		NULL;
 #endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
+#if CONFIG_IPC_MAJOR_4
+	struct ipc_comp_dev *ipc_pipe;
+	struct ipc *ipc = ipc_get();
+	struct vregion *ppl_vreg = NULL;
+
+	/* resolve the pipeline pointer early to pass its vregion to mem_alloc */
+	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
+					  IPC_COMP_IGNORE_REMOTE);
+	if (ipc_pipe && ipc_pipe->pipeline)
+		ppl_vreg = ipc_pipe->pipeline->vreg;
+#endif
+
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init,
+#if CONFIG_IPC_MAJOR_4
+								 ppl_vreg
+#else
+								 NULL
+#endif
+								 );
 
 	if (!mod)
 		return NULL;
@@ -307,12 +331,7 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 		goto err;
 
 #if CONFIG_IPC_MAJOR_4
-	struct ipc_comp_dev *ipc_pipe;
-	struct ipc *ipc = ipc_get();
-
 	/* set the pipeline pointer if ipc_pipe is valid */
-	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
-					  IPC_COMP_IGNORE_REMOTE);
 	if (ipc_pipe) {
 		dev->pipeline = ipc_pipe->pipeline;
 

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -90,7 +90,8 @@ static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *
 static
 struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
 						   const struct comp_ipc_config *config,
-						   const struct module_ext_init_data *ext_init)
+						   const struct module_ext_init_data *ext_init,
+						   struct vregion *ppl_vreg)
 {
 	struct k_heap *mod_heap;
 	struct vregion *mod_vreg;
@@ -114,6 +115,10 @@ struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv
 			return NULL;
 		}
 		mod_heap = NULL;
+	} else if (ppl_vreg && config->proc_domain == COMP_PROCESSING_DOMAIN_LL) {
+		mod_vreg = vregion_get(ppl_vreg);
+		mod_heap = NULL;
+		heap_size = 0;
 	} else {
 #ifdef CONFIG_SOF_USERSPACE_LL
 		mod_heap = sof_sys_user_heap_get();
@@ -198,10 +203,11 @@ static void module_adapter_mem_free(struct processing_module *mod)
 #endif
 	if (alloc->vreg) {
 		struct vregion *mod_vreg = alloc->vreg;
+		uint32_t proc_domain = mod->dev->ipc_config.proc_domain;
 
 		vregion_free(mod_vreg, mod->dev);
 		vregion_free(mod_vreg, mod);
-		if (!vregion_put(mod_vreg))
+		if (!vregion_put(mod_vreg) || proc_domain == COMP_PROCESSING_DOMAIN_LL)
 			sof_heap_free(alloc->heap, alloc);
 	} else {
 		sof_heap_free(mod_heap, mod->dev);
@@ -256,7 +262,25 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 		NULL;
 #endif
 
-	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init);
+#if CONFIG_IPC_MAJOR_4
+	struct ipc_comp_dev *ipc_pipe;
+	struct ipc *ipc = ipc_get();
+	struct vregion *ppl_vreg = NULL;
+
+	/* resolve the pipeline pointer early to pass its vregion to mem_alloc */
+	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
+					  IPC_COMP_IGNORE_REMOTE);
+	if (ipc_pipe && ipc_pipe->pipeline)
+		ppl_vreg = ipc_pipe->pipeline->vreg;
+#endif
+
+	struct processing_module *mod = module_adapter_mem_alloc(drv, config, ext_init,
+#if CONFIG_IPC_MAJOR_4
+								 ppl_vreg
+#else
+								 NULL
+#endif
+								 );
 
 	if (!mod)
 		return NULL;
@@ -315,12 +339,7 @@ struct comp_dev *module_adapter_new_ext(const struct comp_driver *drv,
 		goto err;
 
 #if CONFIG_IPC_MAJOR_4
-	struct ipc_comp_dev *ipc_pipe;
-	struct ipc *ipc = ipc_get();
-
 	/* set the pipeline pointer if ipc_pipe is valid */
-	ipc_pipe = ipc_get_comp_by_ppl_id(ipc, COMP_TYPE_PIPELINE, config->pipeline_id,
-					  IPC_COMP_IGNORE_REMOTE);
 	if (ipc_pipe) {
 		dev->pipeline = ipc_pipe->pipeline;
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -115,6 +115,7 @@ void pipeline_posn_init(struct sof *sof)
 struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_t priority,
 			      uint32_t comp_id, struct create_pipeline_params *pparams)
 {
+	struct mod_alloc_ctx *alloc;
 	struct sof_ipc_stream_posn posn;
 	struct pipeline *p;
 	int ret;
@@ -125,17 +126,13 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 	/* show heap status */
 	heap_trace_all(0);
 
-	/* allocate new pipeline */
-	p = sof_heap_alloc(heap, SOF_MEM_FLAG_USER, sizeof(*p), 0);
-	if (!p) {
-		pipe_cl_err("Out of Memory");
+	alloc = rzalloc(SOF_MEM_FLAG_USER, sizeof(*alloc));
+	if (!alloc) {
+		pipe_cl_err("Failed to allocate pipeline alloc context");
 		return NULL;
 	}
 
-	memset(p, 0, sizeof(*p));
-
-	/* init pipeline */
-	p->heap = heap;
+	alloc->heap = heap;
 
 	/* Create vregion for pipeline and its modules if size info is available */
 	if (IS_ENABLED(CONFIG_SOF_VREGIONS) &&
@@ -145,6 +142,16 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 			pipe_cl_err("Failed to create pipeline vregion of %zu bytes, using heap",
 				    pparams->mem_data->heap_bytes);
 	}
+
+	p = sof_ctx_zalloc(alloc, SOF_MEM_FLAG_USER, sizeof(*p), 0);
+	if (!p) {
+		pipe_cl_err("Out of Memory");
+		goto free_alloc;
+	}
+
+	/* init pipeline */
+	p->heap = heap;
+	p->alloc = alloc;
 
 	p->comp_id = comp_id;
 	p->priority = priority;
@@ -178,7 +185,10 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 
 	return p;
 free:
-	sof_heap_free(heap, p);
+	sof_ctx_free(alloc, p);
+free_alloc:
+	vregion_put(alloc->vreg);
+	rfree(alloc);
 	return NULL;
 }
 
@@ -263,6 +273,8 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 /* pipelines must be inactive */
 int pipeline_free(struct pipeline *p)
 {
+	struct mod_alloc_ctx *alloc = p->alloc;
+
 	pipe_dbg(p, "entry");
 
 	/*
@@ -283,7 +295,12 @@ int pipeline_free(struct pipeline *p)
 	pipeline_posn_offset_put(p->posn_offset);
 
 	/* now free the pipeline */
-	sof_heap_free(p->heap, p);
+	sof_ctx_free(alloc, p);
+
+	/* free alloc context and vregion */
+	if (vregion_put(alloc->vreg))
+		pipe_cl_warn("pipeline vregion still in use");
+	rfree(alloc);
 
 	/* show heap status */
 	heap_trace_all(0);
@@ -361,8 +378,8 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	p->source_comp = source;
 	p->sink_comp = sink;
 
-	if (p->vreg)
-		vregion_set_interim(p->vreg);
+	if (p->alloc && p->alloc->vreg)
+		vregion_set_interim(p->alloc->vreg);
 
 	p->status = COMP_STATE_READY;
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -26,6 +26,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <ipc4/module.h>
+#include <ipc4/pipeline.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -135,6 +136,16 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 
 	/* init pipeline */
 	p->heap = heap;
+
+	/* Create vregion for pipeline and its modules if size info is available */
+	if (IS_ENABLED(CONFIG_SOF_VREGIONS) &&
+	    pparams && pparams->mem_data && pparams->mem_data->heap_bytes) {
+		alloc->vreg = vregion_create(pparams->mem_data->heap_bytes);
+		if (!alloc->vreg)
+			pipe_cl_err("Failed to create pipeline vregion of %zu bytes, using heap",
+				    pparams->mem_data->heap_bytes);
+	}
+
 	p->comp_id = comp_id;
 	p->priority = priority;
 	p->pipeline_id = pipeline_id;
@@ -349,6 +360,10 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 
 	p->source_comp = source;
 	p->sink_comp = sink;
+
+	if (p->vreg)
+		vregion_set_interim(p->vreg);
+
 	p->status = COMP_STATE_READY;
 
 	/* show heap status */

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -27,6 +27,7 @@
 #include <ipc/stream.h>
 #include <ipc/topology.h>
 #include <ipc4/module.h>
+#include <ipc4/pipeline.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -195,6 +196,16 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 
 	/* init pipeline */
 	p->heap = heap;
+
+	/* Create vregion for pipeline and its modules if size info is available */
+	if (IS_ENABLED(CONFIG_SOF_VREGIONS) &&
+	    pparams && pparams->mem_data && pparams->mem_data->heap_bytes) {
+		alloc->vreg = vregion_create(pparams->mem_data->heap_bytes);
+		if (!alloc->vreg)
+			pipe_cl_err("Failed to create pipeline vregion of %zu bytes, using heap",
+				    pparams->mem_data->heap_bytes);
+	}
+
 	p->comp_id = comp_id;
 	p->priority = priority;
 	p->pipeline_id = pipeline_id;
@@ -413,6 +424,10 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 
 	p->source_comp = source;
 	p->sink_comp = sink;
+
+	if (p->vreg)
+		vregion_set_interim(p->vreg);
+
 	p->status = COMP_STATE_READY;
 
 	/* show heap status */

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -175,6 +175,7 @@ void pipeline_posn_grant_access(struct k_thread *thread)
 struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_t priority,
 			      uint32_t comp_id, struct create_pipeline_params *pparams)
 {
+	struct mod_alloc_ctx *alloc;
 	struct sof_ipc_stream_posn posn;
 	struct pipeline *p;
 	int ret;
@@ -185,17 +186,13 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 	/* show heap status */
 	heap_trace_all(0);
 
-	/* allocate new pipeline */
-	p = sof_heap_alloc(heap, SOF_MEM_FLAG_USER, sizeof(*p), 0);
-	if (!p) {
-		pipe_cl_err("Out of Memory");
+	alloc = rzalloc(SOF_MEM_FLAG_USER, sizeof(*alloc));
+	if (!alloc) {
+		pipe_cl_err("Failed to allocate pipeline alloc context");
 		return NULL;
 	}
 
-	memset(p, 0, sizeof(*p));
-
-	/* init pipeline */
-	p->heap = heap;
+	alloc->heap = heap;
 
 	/* Create vregion for pipeline and its modules if size info is available */
 	if (IS_ENABLED(CONFIG_SOF_VREGIONS) &&
@@ -205,6 +202,16 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 			pipe_cl_err("Failed to create pipeline vregion of %zu bytes, using heap",
 				    pparams->mem_data->heap_bytes);
 	}
+
+	p = sof_ctx_zalloc(alloc, SOF_MEM_FLAG_USER, sizeof(*p), 0);
+	if (!p) {
+		pipe_cl_err("Out of Memory");
+		goto free_alloc;
+	}
+
+	/* init pipeline */
+	p->heap = heap;
+	p->alloc = alloc;
 
 	p->comp_id = comp_id;
 	p->priority = priority;
@@ -247,7 +254,10 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 
 	return p;
 free:
-	sof_heap_free(heap, p);
+	sof_ctx_free(alloc, p);
+free_alloc:
+	vregion_put(alloc->vreg);
+	rfree(alloc);
 	return NULL;
 }
 
@@ -332,6 +342,8 @@ void pipeline_disconnect(struct comp_dev *comp, struct comp_buffer *buffer, int 
 /* pipelines must be inactive */
 int pipeline_free(struct pipeline *p)
 {
+	struct mod_alloc_ctx *alloc = p->alloc;
+
 	pipe_dbg(p, "entry");
 
 	/*
@@ -347,7 +359,12 @@ int pipeline_free(struct pipeline *p)
 	pipeline_posn_offset_put(p->posn_offset);
 
 	/* now free the pipeline */
-	sof_heap_free(p->heap, p);
+	sof_ctx_free(alloc, p);
+
+	/* free alloc context and vregion */
+	if (vregion_put(alloc->vreg))
+		pipe_cl_warn("pipeline vregion still in use");
+	rfree(alloc);
 
 	/* show heap status */
 	heap_trace_all(0);
@@ -425,8 +442,8 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
 	p->source_comp = source;
 	p->sink_comp = sink;
 
-	if (p->vreg)
-		vregion_set_interim(p->vreg);
+	if (p->alloc && p->alloc->vreg)
+		vregion_set_interim(p->alloc->vreg);
 
 	p->status = COMP_STATE_READY;
 

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -590,6 +590,7 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	/* DP tasks are guaranteed to have a module_adapter */
 	struct processing_module *mod = comp_mod(comp);
+	size_t stack_size = TASK_DP_STACK_SIZE;
 	struct task_ops ops  = {
 		.run		= dp_task_run,
 		.get_deadline	= NULL,
@@ -605,8 +606,17 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 	unsigned int flags = IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0;
 #endif
 
+	if (mod->priv.cfg.ext_data && mod->priv.cfg.ext_data->dp_data &&
+	    mod->priv.cfg.ext_data->dp_data->stack_bytes > 0) {
+		stack_size = MAX(mod->priv.cfg.ext_data->dp_data->stack_bytes,
+				 CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+		comp_info(comp, "stack size set to %zu, %zu requested, min allowed %zu",
+			  stack_size, mod->priv.cfg.ext_data->dp_data->stack_bytes,
+			  CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+	}
+
 	return scheduler_dp_task_init(&comp->task, SOF_UUID(dp_task_uuid), &ops, mod,
-				      comp->ipc_config.core, TASK_DP_STACK_SIZE, flags);
+				      comp->ipc_config.core, stack_size, flags);
 }
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -409,6 +409,7 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 {
 	/* DP tasks are guaranteed to have a module_adapter */
 	struct processing_module *mod = comp_mod(comp);
+	size_t stack_size = TASK_DP_STACK_SIZE;
 	struct task_ops ops  = {
 		.run		= dp_task_run,
 		.get_deadline	= NULL,
@@ -424,8 +425,17 @@ int pipeline_comp_dp_task_init(struct comp_dev *comp)
 	unsigned int flags = IS_ENABLED(CONFIG_USERSPACE) ? K_USER : 0;
 #endif
 
+	if (mod->priv.cfg.ext_data && mod->priv.cfg.ext_data->dp_data &&
+	    mod->priv.cfg.ext_data->dp_data->stack_bytes > 0) {
+		stack_size = MAX(mod->priv.cfg.ext_data->dp_data->stack_bytes,
+				 CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+		comp_info(comp, "stack size set to %zu, %zu requested, min allowed %zu",
+			  stack_size, mod->priv.cfg.ext_data->dp_data->stack_bytes,
+			  CONFIG_ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE);
+	}
+
 	return scheduler_dp_task_init(&comp->task, SOF_UUID(dp_task_uuid), &ops, mod,
-				      comp->ipc_config.core, TASK_DP_STACK_SIZE, flags);
+				      comp->ipc_config.core, stack_size, flags);
 }
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
 

--- a/src/audio/src/src.c
+++ b/src/audio/src/src.c
@@ -34,18 +34,15 @@
 
 LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);
 
-static int src_prepare(struct processing_module *mod,
-		       struct sof_source **sources, int num_of_sources,
-		       struct sof_sink **sinks, int num_of_sinks)
+/* Set rate table pointers, compute rate indices, and copy filter stages.
+ * Must be in src.c because src_table1/2, src_in_fs, etc. come from
+ * the coefficient headers included by this file.
+ */
+static int src_setup_stages(struct processing_module *mod)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct src_param *a = &cd->param;
 	int ret;
-
-	comp_info(mod->dev, "entry");
-
-	if (num_of_sources != 1 || num_of_sinks != 1)
-		return -EINVAL;
 
 	a->in_fs = src_in_fs;
 	a->out_fs = src_out_fs;
@@ -54,27 +51,46 @@ static int src_prepare(struct processing_module *mod,
 	a->max_fir_delay_size_xnch = (PLATFORM_MAX_CHANNELS * MAX_FIR_DELAY_SIZE);
 	a->max_out_delay_size_xnch = (PLATFORM_MAX_CHANNELS * MAX_OUT_DELAY_SIZE);
 
-	src_get_source_sink_params(mod->dev, sources[0], sinks[0]);
-
 	ret = src_param_set(mod->dev, cd);
 	if (ret < 0)
 		return ret;
 
-	ret = src_allocate_copy_stages(mod, a,
-				       src_table1[a->idx_out][a->idx_in],
-				       src_table2[a->idx_out][a->idx_in]);
+	return src_allocate_copy_stages(mod, a,
+					src_table1[a->idx_out][a->idx_in],
+					src_table2[a->idx_out][a->idx_in]);
+}
+
+static int src_do_init(struct processing_module *mod)
+{
+	struct comp_data *cd;
+	int ret;
+
+	ret = src_init(mod);
 	if (ret < 0)
 		return ret;
 
-	ret = src_params_general(mod, sources[0], sinks[0]);
-	if (ret < 0)
-		return ret;
+	cd = module_get_private_data(mod);
+	cd->setup_stages = src_setup_stages;
 
-	return src_prepare_general(mod, sources[0], sinks[0]);
+	return src_init_stages(mod);
+}
+
+static int src_prepare(struct processing_module *mod,
+		       struct sof_source **sources, int num_of_sources,
+		       struct sof_sink **sinks, int num_of_sinks)
+{
+	comp_info(mod->dev, "entry");
+
+	if (num_of_sources != 1 || num_of_sinks != 1)
+		return -EINVAL;
+
+	src_get_source_sink_params(mod->dev, sources[0], sinks[0]);
+
+	return src_do_prepare(mod, sources[0], sinks[0]);
 }
 
 static const struct module_interface src_interface = {
-	.init = src_init,
+	.init = src_do_init,
 	.prepare = src_prepare,
 	.process = src_process,
 	.is_ready_to_process = src_is_ready_to_process,

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -574,6 +574,86 @@ int src_params_general(struct processing_module *mod,
 	return 0;
 }
 
+/* Allocate delay lines and initialize the polyphase SRC filter.
+ * Assumes that cd->param rate table pointers (in_fs, out_fs, etc.)
+ * and stage pointers (stage1, stage2) are already set up via
+ * cd->setup_stages().
+ */
+int src_allocate_delay_lines(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_dev *dev = mod->dev;
+	size_t delay_lines_size;
+	int32_t *buffer_start;
+	int n;
+	int ret;
+
+	/* For LL modules dev->period is already set from the pipeline.
+	 * Compute dev->frames so buffer sizing works.
+	 */
+	if (!dev->frames)
+		component_set_nearest_period_frames(dev, cd->sink_rate);
+
+	if (!cd->sink_rate) {
+		comp_err(dev, "zero sink rate");
+		return -EINVAL;
+	}
+
+	cd->source_frames = dev->frames * cd->source_rate / cd->sink_rate;
+	cd->sink_frames = dev->frames;
+
+	/* Allocate needed memory for delay lines */
+	ret = src_buffer_lengths(dev, cd, cd->channels_count);
+	if (ret < 0) {
+		comp_err(dev, "src_buffer_lengths() failed");
+		return ret;
+	}
+
+	delay_lines_size = ALIGN_UP(sizeof(int32_t) * cd->param.total, 8);
+	if (delay_lines_size == 0) {
+		comp_err(dev, "delay_lines_size = 0");
+		return -EINVAL;
+	}
+
+	mod_free(mod, cd->delay_lines);
+
+	cd->delay_lines = mod_alloc(mod, delay_lines_size);
+	if (!cd->delay_lines) {
+		comp_err(dev, "failed to alloc cd->delay_lines, delay_lines_size = %zu",
+			 delay_lines_size);
+		return -ENOMEM;
+	}
+
+	memset(cd->delay_lines, 0, delay_lines_size);
+	buffer_start = cd->delay_lines + ALIGN_UP(cd->param.sbuf_length, 2);
+
+	/* Initialize SRC for actual sample rate */
+	n = src_polyphase_init(&cd->src, &cd->param, buffer_start);
+
+	/* Reset stage buffer */
+	cd->sbuf_r_ptr = cd->delay_lines;
+	cd->sbuf_w_ptr = cd->delay_lines;
+	cd->sbuf_avail = 0;
+
+	switch (n) {
+	case 0:
+		cd->src_func = src_copy_sxx;
+		break;
+	case 1:
+		cd->src_func = src_1s;
+		break;
+	case 2:
+		cd->src_func = src_2s;
+		break;
+	default:
+		comp_info(dev, "missing coefficients for requested rates combination");
+		cd->src_func = src_fallback;
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
 int src_param_set(struct comp_dev *dev, struct comp_data *cd)
 {
 	struct src_param *a = &cd->param;

--- a/src/audio/src/src_common.c
+++ b/src/audio/src/src_common.c
@@ -755,7 +755,12 @@ int src_reset(struct processing_module *mod)
 	comp_info(mod->dev, "entry");
 
 	cd->src_func = src_fallback;
-	src_polyphase_reset(&cd->src);
+	src_polyphase_reset_state(&cd->src);
+
+	/* Reset stage buffer */
+	cd->sbuf_r_ptr = cd->delay_lines;
+	cd->sbuf_w_ptr = cd->delay_lines;
+	cd->sbuf_avail = 0;
 
 	return 0;
 }

--- a/src/audio/src/src_common.h
+++ b/src/audio/src/src_common.h
@@ -128,6 +128,37 @@ static inline void src_polyphase_reset(struct polyphase_src *src)
 	src_state_reset(&src->state2);
 }
 
+/**
+ * src_polyphase_reset_state - reset filter state while preserving structure
+ *
+ * Zeros the delay line contents and resets read/write pointers to their
+ * initial positions. The filter stage pointers, delay line allocations,
+ * and sizes are preserved.
+ */
+static inline void src_polyphase_reset_state(struct polyphase_src *src)
+{
+	struct src_state *s1 = &src->state1;
+	struct src_state *s2 = &src->state2;
+
+	if (s1->fir_delay && s1->fir_delay_size)
+		memset(s1->fir_delay, 0, sizeof(int32_t) * s1->fir_delay_size);
+
+	if (s1->out_delay && s1->out_delay_size)
+		memset(s1->out_delay, 0, sizeof(int32_t) * s1->out_delay_size);
+
+	s1->fir_wp = s1->fir_delay ? &s1->fir_delay[s1->fir_delay_size - 1] : NULL;
+	s1->out_rp = s1->out_delay;
+
+	if (s2->fir_delay && s2->fir_delay_size)
+		memset(s2->fir_delay, 0, sizeof(int32_t) * s2->fir_delay_size);
+
+	if (s2->out_delay && s2->out_delay_size)
+		memset(s2->out_delay, 0, sizeof(int32_t) * s2->out_delay_size);
+
+	s2->fir_wp = s2->fir_delay ? &s2->fir_delay[s2->fir_delay_size - 1] : NULL;
+	s2->out_rp = s2->out_delay;
+}
+
 int src_polyphase(struct polyphase_src *src, int32_t x[], int32_t y[],
 		  int n_in);
 

--- a/src/audio/src/src_common.h
+++ b/src/audio/src/src_common.h
@@ -167,6 +167,7 @@ struct comp_data {
 	int (*src_func)(struct comp_data *cd, struct sof_source *source,
 			struct sof_sink *sink);
 	void (*polyphase_func)(struct src_stage_prm *s);
+	int (*setup_stages)(struct processing_module *mod);
 };
 
 #if CONFIG_IPC_MAJOR_4
@@ -218,6 +219,7 @@ static inline int src_fallback(struct comp_data *cd,
 int src_allocate_copy_stages(struct processing_module *mod, struct src_param *prm,
 			     const struct src_stage *stage_src1,
 			     const struct src_stage *stage_src2);
+int src_allocate_delay_lines(struct processing_module *mod);
 int src_rate_check(const void *spec);
 int src_set_params(struct processing_module *mod, struct sof_sink *sink);
 
@@ -227,6 +229,9 @@ int src_prepare_general(struct processing_module *mod,
 			struct sof_source *source,
 			struct sof_sink *sink);
 int src_init(struct processing_module *mod);
+int src_init_stages(struct processing_module *mod);
+int src_do_prepare(struct processing_module *mod,
+		   struct sof_source *source, struct sof_sink *sink);
 
 int src_copy_sxx(struct comp_data *cd, struct sof_source *source,
 		 struct sof_sink *sink);

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -195,3 +195,27 @@ int src_init(struct processing_module *mod)
 	return 0;
 }
 
+/* IPC3: No filter allocation at init, change ipc3 behavior as little as possible */
+int src_init_stages(struct processing_module *mod)
+{
+	return 0;
+}
+
+/* IPC3: Full filter setup at prepare time */
+int src_do_prepare(struct processing_module *mod,
+		   struct sof_source *source, struct sof_sink *sink)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	int ret;
+
+	ret = cd->setup_stages(mod);
+	if (ret < 0)
+		return ret;
+
+	ret = src_params_general(mod, source, sink);
+	if (ret < 0)
+		return ret;
+
+	return src_prepare_general(mod, source, sink);
+}
+

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -246,3 +246,66 @@ __cold int src_init(struct processing_module *mod)
 	return 0;
 }
 
+/* Called after src_init() and setup_stages callback is set.
+ * Allocate filter stages and delay lines at init time.
+ */
+int src_init_stages(struct processing_module *mod)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_dev *dev = mod->dev;
+	int ret;
+
+	ret = cd->setup_stages(mod);
+	if (ret < 0)
+		return ret;
+
+	/* For DP modules, dev->period is not yet set at init time (it's
+	 * computed in src_set_params at prepare). Derive it here from the
+	 * IPC config's output buffer size so that delay line allocation
+	 * uses correct buffer sizes.
+	 */
+	if (dev->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_DP && !dev->frames) {
+		uint32_t frame_bytes = cd->channels_count * cd->sample_container_bytes;
+
+		if (frame_bytes && cd->sink_rate) {
+			dev->period = 1000000ULL * cd->ipc_config.base.obs /
+				((uint64_t)frame_bytes * cd->sink_rate);
+			dev->period /= LL_TIMER_PERIOD_US;
+			dev->period *= LL_TIMER_PERIOD_US;
+			component_set_nearest_period_frames(dev, cd->sink_rate);
+		}
+	}
+
+	return src_allocate_delay_lines(mod);
+}
+
+/* At prepare time just verify rates and set downstream params */
+int src_do_prepare(struct processing_module *mod,
+		   struct sof_source *source, struct sof_sink *sink)
+{
+	struct comp_data *cd = module_get_private_data(mod);
+	struct comp_dev *dev = mod->dev;
+	int ret;
+
+	if (cd->source_rate != cd->ipc_config.base.audio_fmt.sampling_frequency ||
+	    cd->sink_rate != cd->ipc_config.sink_rate) {
+		comp_err(mod->dev, "rate mismatch: source %u/%u sink %u/%u",
+			 cd->source_rate,
+			 cd->ipc_config.base.audio_fmt.sampling_frequency,
+			 cd->sink_rate, cd->ipc_config.sink_rate);
+		return -EINVAL;
+	}
+
+	ret = src_set_params(mod, sink);
+	if (ret < 0) {
+		comp_err(mod->dev, "set params failed.");
+		return ret;
+	}
+
+	/* Update frame counts with final dev->frames from src_set_params */
+	cd->source_frames = dev->frames * cd->source_rate / cd->sink_rate;
+	cd->sink_frames = dev->frames;
+
+	return src_prepare_general(mod, source, sink);
+}
+

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -285,14 +285,21 @@ int src_do_prepare(struct processing_module *mod,
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
+	unsigned int source_channels = source_get_channels(source);
+	unsigned int source_rate = source_get_rate(source);
 	int ret;
 
-	if (cd->source_rate != cd->ipc_config.base.audio_fmt.sampling_frequency ||
+	if (cd->source_rate != source_rate ||
 	    cd->sink_rate != cd->ipc_config.sink_rate) {
-		comp_err(mod->dev, "rate mismatch: source %u/%u sink %u/%u",
-			 cd->source_rate,
-			 cd->ipc_config.base.audio_fmt.sampling_frequency,
-			 cd->sink_rate, cd->ipc_config.sink_rate);
+		comp_err(dev, "rate mismatch: init %u/%u, stream %u/%u",
+			 cd->source_rate, cd->sink_rate,
+			 source_rate, cd->ipc_config.sink_rate);
+		return -EINVAL;
+	}
+
+	if (cd->channels_count != (int)source_channels) {
+		comp_err(dev, "channels mismatch: init %d, stream %u",
+			 cd->channels_count, source_channels);
 		return -EINVAL;
 	}
 

--- a/src/audio/src/src_lite.c
+++ b/src/audio/src/src_lite.c
@@ -14,23 +14,15 @@
 
 LOG_MODULE_REGISTER(src_lite, CONFIG_SOF_LOG_LEVEL);
 
-/*
- * This function is 100% identical to src_prepare(), but it's
- * assigning different coefficient arrays because it's including
- * different headers.
+/* Set rate table pointers, compute rate indices, and copy filter stages.
+ * Must be in src_lite.c because src_table1/2, src_in_fs, etc. come from
+ * the coefficient headers included by this file.
  */
-static int src_lite_prepare(struct processing_module *mod,
-			    struct sof_source **sources, int num_of_sources,
-			    struct sof_sink **sinks, int num_of_sinks)
+static int src_lite_setup_stages(struct processing_module *mod)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 	struct src_param *a = &cd->param;
 	int ret;
-
-	comp_info(mod->dev, "entry");
-
-	if (num_of_sources != 1 || num_of_sinks != 1)
-		return -EINVAL;
 
 	a->in_fs = src_in_fs;
 	a->out_fs = src_out_fs;
@@ -43,21 +35,42 @@ static int src_lite_prepare(struct processing_module *mod,
 	if (ret < 0)
 		return ret;
 
-	ret = src_allocate_copy_stages(mod, a,
-				       src_table1[a->idx_out][a->idx_in],
-				       src_table2[a->idx_out][a->idx_in]);
+	return src_allocate_copy_stages(mod, a,
+					src_table1[a->idx_out][a->idx_in],
+					src_table2[a->idx_out][a->idx_in]);
+}
+
+static int src_lite_do_init(struct processing_module *mod)
+{
+	struct comp_data *cd;
+	int ret;
+
+	ret = src_init(mod);
 	if (ret < 0)
 		return ret;
 
-	ret = src_params_general(mod, sources[0], sinks[0]);
-	if (ret < 0)
-		return ret;
+	cd = module_get_private_data(mod);
+	cd->setup_stages = src_lite_setup_stages;
 
-	return src_prepare_general(mod, sources[0], sinks[0]);
+	return src_init_stages(mod);
+}
+
+static int src_lite_prepare(struct processing_module *mod,
+			    struct sof_source **sources, int num_of_sources,
+			    struct sof_sink **sinks, int num_of_sinks)
+{
+	comp_info(mod->dev, "entry");
+
+	if (num_of_sources != 1 || num_of_sinks != 1)
+		return -EINVAL;
+
+	src_get_source_sink_params(mod->dev, sources[0], sinks[0]);
+
+	return src_do_prepare(mod, sources[0], sinks[0]);
 }
 
 const struct module_interface src_lite_interface = {
-	.init = src_init,
+	.init = src_lite_do_init,
 	.prepare = src_lite_prepare,
 	.process = src_process,
 	.is_ready_to_process = src_is_ready_to_process,

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -26,6 +26,7 @@ struct comp_dev;
 struct ipc;
 struct ipc_msg;
 struct k_heap;
+struct vregion;
 
 /*
  * Pipeline status to stop execution of current path, but to keep the
@@ -54,6 +55,7 @@ struct k_heap;
  */
 struct pipeline {
 	struct k_heap *heap;	/**< heap used for allocating this pipeline */
+	struct vregion *vreg;	/**< shared vregion for pipeline modules */
 	uint32_t comp_id;	/**< component id for pipeline */
 	uint32_t pipeline_id;	/**< pipeline id */
 	uint32_t sched_id;	/**< Scheduling component id */

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -26,7 +26,7 @@ struct comp_dev;
 struct ipc;
 struct ipc_msg;
 struct k_heap;
-struct vregion;
+struct mod_alloc_ctx;
 
 /*
  * Pipeline status to stop execution of current path, but to keep the
@@ -55,7 +55,7 @@ struct vregion;
  */
 struct pipeline {
 	struct k_heap *heap;	/**< heap used for allocating this pipeline */
-	struct vregion *vreg;	/**< shared vregion for pipeline modules */
+	struct mod_alloc_ctx *alloc;	/**< shared alloc context for pipeline modules */
 	uint32_t comp_id;	/**< component id for pipeline */
 	uint32_t pipeline_id;	/**< pipeline id */
 	uint32_t sched_id;	/**< Scheduling component id */

--- a/src/include/sof/common.h
+++ b/src/include/sof/common.h
@@ -14,9 +14,7 @@
 /* callers must check/use the return value */
 #define __must_check __attribute__((warn_unused_result))
 
-#ifdef __ZEPHYR__
 #include <zephyr/sys/util.h>
-#endif
 
 /* Align the number to the nearest alignment value */
 #ifndef IS_ALIGNED

--- a/src/include/sof/trace/trace.h
+++ b/src/include/sof/trace/trace.h
@@ -23,8 +23,8 @@
 
 #ifdef __ZEPHYR__
 #include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
 #endif
+#include <zephyr/logging/log.h>
 
 #if !CONFIG_LIBRARY
 #include <platform/trace/trace.h>
@@ -154,13 +154,5 @@ struct tr_ctx {
 		.uuid_p = uuid,					\
 		.level = default_log_level,			\
 	}
-
-/* Only define these two macros for XTOS to avoid the collision with
- * zephyr/include/zephyr/logging/log.h
- */
-#ifndef __ZEPHYR__
-#define LOG_MODULE_REGISTER(ctx, level)
-#define LOG_MODULE_DECLARE(ctx, level)
-#endif
 
 #endif /* __SOF_TRACE_TRACE_H__ */

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -626,11 +626,6 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 		return ret;
 	}
 
-	if (ipc_pipe->pipeline->vreg) {
-		if (vregion_put(ipc_pipe->pipeline->vreg))
-			tr_warn(&ipc_tr, "pipeline vregion still in use");
-	}
-
 	/* free buffer, delete all tasks and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -646,6 +646,11 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 		return ret;
 	}
 
+	if (ipc_pipe->pipeline->vreg) {
+		if (vregion_put(ipc_pipe->pipeline->vreg))
+			tr_warn(&ipc_tr, "pipeline vregion still in use");
+	}
+
 	/* free buffer, delete all tasks and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -646,11 +646,6 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 		return ret;
 	}
 
-	if (ipc_pipe->pipeline->vreg) {
-		if (vregion_put(ipc_pipe->pipeline->vreg))
-			tr_warn(&ipc_tr, "pipeline vregion still in use");
-	}
-
 	/* free buffer, delete all tasks and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -626,6 +626,11 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 		return ret;
 	}
 
+	if (ipc_pipe->pipeline->vreg) {
+		if (vregion_put(ipc_pipe->pipeline->vreg))
+			tr_warn(&ipc_tr, "pipeline vregion still in use");
+	}
+
 	/* free buffer, delete all tasks and remove from list */
 	ret = pipeline_free(ipc_pipe->pipeline);
 	if (ret < 0) {

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -38,6 +38,7 @@ target_compile_options(sof-logger PRIVATE
 
 target_include_directories(sof-logger PRIVATE
 	"${SOF_ROOT_SOURCE_DIRECTORY}/src/include"
+	"${SOF_ROOT_SOURCE_DIRECTORY}/posix/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}/tools/rimage/src/include"
 	"${SOF_ROOT_SOURCE_DIRECTORY}"
 )

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -86,6 +86,15 @@ config SOF_ZEPHYR_HEAP_SIZE
 	 NOTE: Keep in mind that the heap size should not be greater than the physical
 	 memory size of the system defined in DT (and this includes baseFW text/data).
 
+config SOF_USERSPACE_DP_DEFAULT_HEAP_SIZE
+       int "Default heap size for DP userspace threads"
+       default 20480
+       help
+         Defines the default heap size for userspace DP processing
+         threads. The value can be overridden with IPC module init
+         ext_init module payload. The default is derived from what is
+         required for SRC module to produce all supported conversions.
+
 config SOF_USERSPACE_USE_SHARED_HEAP
 	bool "Use shared heap for SOF userspace modules"
 	depends on USERSPACE

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -258,6 +258,15 @@ config ZEPHYR_DP_SCHEDULER
 	  DP modules can be located in dieffrent cores than LL pipeline modules, may have
 	  different tick (i.e. 300ms for speech reccognition, etc.)
 
+config ZEPHYR_DP_SCHEDULER_MIN_STACK_SIZE
+       int "Minimum stack size for DP processing thread"
+       default 512
+       help
+         Defines the minimum stack size allowed for DP processing
+         threads despite what is requested in the module init IPC
+         ext_init payload. If the stack size requested in the IPC is
+         smaller than this, then the value defined here takes over.
+
 config CROSS_CORE_STREAM
 	bool "Enable cross-core connected pipelines"
 	default y if IPC_MAJOR_4

--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -19,14 +19,7 @@
 #include <rtos/symbol.h>
 #include <ipc/topology.h>
 
-#ifdef __ZEPHYR__
 #include <zephyr/logging/log.h>
-#else
-#define LOG_DBG(...) do {} while (0)
-#define LOG_INF(...) do {} while (0)
-#define LOG_WRN(...) do {} while (0)
-#define LOG_ERR(...) do {} while (0)
-#endif
 
 struct sof_fast_get_entry {
 	const void *dram_ptr;
@@ -154,7 +147,7 @@ const void *fast_get(struct mod_alloc_ctx *alloc, const void *dram_ptr, size_t s
 
 	if (entry->sram_ptr) {
 		if (entry->size != size || entry->dram_ptr != dram_ptr) {
-			LOG_ERR("size %u != %u or ptr %p != %p mismatch",
+			LOG_ERR("size %zu != %zu or ptr %p != %p mismatch",
 				entry->size, size, entry->dram_ptr, dram_ptr);
 			ret = NULL;
 			goto out;


### PR DESCRIPTION
This is now more like a proof of concept, rather than a proper mergeable implementation. 

For the time being the vregions is only used for DP modules, but if I have understood the plans correctly, eventually the LL  pipelines should have their own vregions context that is used for all allocation related to the pipeline and modules in it (except the DP modules).

Before this PR the vregions lifetime memory is really  not used at all.  The only place where it could be used is an SRC DP module (SRC being the only DP capable module we have) , and this PR moves throws the balance of lifetime and interim allocs to the other end. After this PR all the allocations for DP SRC module is made from lifetime heap. SRC and DP infrastucture uses heap only for allocating memory for things that are needed for the whole lifetime of the module, and no interim memory is needed.

The things that I still plan to do for DP case:
- Get rid of lifetime and interim concept from anywhere outside vregions code
  - just pass the amount of memory needed
  - implement function to switch the allocations from lifetime to interim
  - call the function from pipeline_complete() instead of from prepare() 
    - this need some more code to pass the pipeline complete info down to DP user thread

As a follow up, take vregions also into use for complete LL pipelines. But before even starting this work we'd better get userspace LL merged.

FYI @lgirdwood , @lyakh , @kv2019i 