### PR TITLE
module_adapter: ipc4: validate pin counts against IPC4 maximum

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -20,6 +20,7 @@
 #include <sof/ut.h>
 #include <rtos/interrupt.h>
 #include <rtos/symbol.h>
+#include <ipc4/base_fw.h>
 #include <limits.h>
 #include <stdint.h>
 
@@ -145,6 +146,9 @@ int module_adapter_init_data(struct comp_dev *dev,
 			     + (n_out * sizeof(*dst->output_pins));
 
 		if (cfgsz == (sizeof(*cfg) + pinsz)) {
+			if (n_in > IPC4_MAX_SRC_QUEUE || n_out > IPC4_MAX_DST_QUEUE)
+				return -EINVAL;
+
 			dst->nb_input_pins = n_in;
 			dst->nb_output_pins = n_out;
 			dst->input_pins = sof_heap_alloc(dev->mod->priv.resources.alloc->heap,

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -23,7 +23,7 @@
  */
 #define IPC4_MAX_CLK_STATES 0
 
-/* Max src queue count count supported by ipc4 */
+/* Max src queue count supported by ipc4 */
 #define IPC4_MAX_SRC_QUEUE 8
 
 /* Max module instance for single module count supported by ipc4 */

--- a/src/include/ipc4/base_fw.h
+++ b/src/include/ipc4/base_fw.h
@@ -26,6 +26,9 @@
 /* Max src queue count supported by ipc4 */
 #define IPC4_MAX_SRC_QUEUE 8
 
+/* Max dst queue count supported by ipc4 */
+#define IPC4_MAX_DST_QUEUE 8
+
 /* Max module instance for single module count supported by ipc4 */
 #define IPC4_MAX_MODULE_INSTANCES 256
 


### PR DESCRIPTION
Reject IPC4 module init payloads where nb_input_pins or nb_output_pins
exceed the protocol maximum (IPC4_MAX_SRC_QUEUE / IPC4_MAX_DST_QUEUE = 8).

The existing cfgsz equality check ensures the immediate pointer
arithmetic is in-bounds, but it does not prevent unsupported pin counts
from being stored in dst->nb_input_pins / dst->nb_output_pins and used
by downstream module code. Add explicit upper-bound validation before
computing pinsz, matching the IPC4 ABI contract advertised via
IPC4_MAX_MODULE_PIN_COUNT_FW_CFG.