### PR TITLE
platform: intel: ace: fix is_uncached() definition

### DIFF
--- a/src/platform/intel/ace/include/ace/lib/memory.h
+++ b/src/platform/intel/ace/include/ace/lib/memory.h
@@ -31,7 +31,7 @@
 
 #define uncache_to_cache(address)       sys_cache_cached_ptr_get(address)
 #define cache_to_uncache(address)       sys_cache_uncached_ptr_get(address)
-#define is_uncached(address)            sys_cache_is_ptr_cached(address)
+#define is_uncached(address)            (!sys_cache_is_ptr_cached(address))
 
 /**
  * \brief Returns pointer to the memory shared by multiple cores.


### PR DESCRIPTION
Fixes is_uncached() implementation for Intel ACE platforms.