### PR TITLE
module: passthrough: rework module to use sink/source api

### DIFF
--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -63,18 +63,23 @@ static int passthrough_codec_init_process(struct processing_module *mod)
 	return 0;
 }
 
-static int
-passthrough_codec_process(struct processing_module *mod,
-			  struct input_stream_buffer *input_buffers, int num_input_buffers,
-			  struct output_stream_buffer *output_buffers, int num_output_buffers)
+static int passthrough_codec_process(struct processing_module *mod,
+				     struct sof_source **sources, int num_of_sources,
+				     struct sof_sink **sinks, int num_of_sinks)
 {
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
+	const void *src_ptr, *src_buf_start;
+	void *snk_ptr, *snk_buf_start;
+	size_t src_buf_size, snk_buf_size;
+	size_t n_bytes = codec->mpd.in_buff_size;
+	size_t size_to_wrap;
+	int err;
 
 	comp_dbg(dev, "entry");
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
-	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+	if (source_get_data_available(sources[0]) < n_bytes) {
 		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
@@ -82,19 +87,38 @@ passthrough_codec_process(struct processing_module *mod,
 	if (!codec->mpd.init_done)
 		passthrough_codec_init_process(mod);
 
-	memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size,
-		 input_buffers[0].data, codec->mpd.in_buff_size);
+	err = source_get_data(sources[0], n_bytes, &src_ptr, &src_buf_start, &src_buf_size);
+	if (err)
+		return err;
 
-	memcpy_s(codec->mpd.out_buff, codec->mpd.out_buff_size,
-		 codec->mpd.in_buff, codec->mpd.in_buff_size);
-	codec->mpd.produced = mod->period_bytes;
-	codec->mpd.consumed = mod->period_bytes;
-	input_buffers[0].consumed = codec->mpd.consumed;
+	/* src_buf_size is the total ring buffer size; handle wrap when copying to in_buff */
+	size_to_wrap = (const uint8_t *)src_buf_start + src_buf_size - (const uint8_t *)src_ptr;
+	if (n_bytes <= size_to_wrap) {
+		memcpy_s(codec->mpd.in_buff, n_bytes, src_ptr, n_bytes);
+	} else {
+		memcpy_s(codec->mpd.in_buff, n_bytes, src_ptr, size_to_wrap);
+		memcpy_s((uint8_t *)codec->mpd.in_buff + size_to_wrap, n_bytes - size_to_wrap,
+			 src_buf_start, n_bytes - size_to_wrap);
+	}
+	source_release_data(sources[0], n_bytes);
 
-	/* copy the produced samples into the output buffer */
-	memcpy_s(output_buffers[0].data, codec->mpd.produced, codec->mpd.out_buff,
-		 codec->mpd.produced);
-	output_buffers[0].size = codec->mpd.produced;
+	memcpy_s(codec->mpd.out_buff, codec->mpd.out_buff_size, codec->mpd.in_buff, n_bytes);
+
+	err = sink_get_buffer(sinks[0], n_bytes, &snk_ptr, &snk_buf_start, &snk_buf_size);
+	if (err)
+		return err;
+
+	/* snk_buf_size is the total ring buffer size; handle wrap when copying from out_buff */
+	size_to_wrap = (uint8_t *)snk_buf_start + snk_buf_size - (uint8_t *)snk_ptr;
+	if (n_bytes <= size_to_wrap) {
+		memcpy_s(snk_ptr, n_bytes, codec->mpd.out_buff, n_bytes);
+	} else {
+		memcpy_s(snk_ptr, n_bytes, codec->mpd.out_buff, size_to_wrap);
+		memcpy_s(snk_buf_start, n_bytes - size_to_wrap,
+			 (const uint8_t *)codec->mpd.out_buff + size_to_wrap,
+			 n_bytes - size_to_wrap);
+	}
+	sink_commit_buffer(sinks[0], n_bytes);
 
 	return 0;
 }
@@ -121,7 +145,7 @@ static int passthrough_codec_free(struct processing_module *mod)
 static const struct module_interface passthrough_interface = {
 	.init = passthrough_codec_init,
 	.prepare = passthrough_codec_prepare,
-	.process_raw_data = passthrough_codec_process,
+	.process = passthrough_codec_process,
 	.reset = passthrough_codec_reset,
 	.free = passthrough_codec_free
 };


### PR DESCRIPTION
Rework the passthrough module to only use the sink/source api to prepare sof for the full transition to pipeline 2.0.