### PR TITLE
module: waves: rework module to use sink/source api

### DIFF
--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -753,18 +753,25 @@ static int waves_codec_init_process(struct processing_module *mod)
 	return 0;
 }
 
-static int
-waves_codec_process(struct processing_module *mod,
-		    struct input_stream_buffer *input_buffers, int num_input_buffers,
-		    struct output_stream_buffer *output_buffers, int num_output_buffers)
+static int waves_codec_process(struct processing_module *mod,
+			       struct sof_source **sources, int num_of_sources,
+			       struct sof_sink **sinks, int num_of_sinks)
 {
 	int ret;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
 	struct waves_codec_data *waves_codec = codec->private;
+	const void *src_ptr;
+	const void *src_buf_start;
+	size_t src_buf_size;
+	void *snk_ptr;
+	void *snk_buf_start;
+	size_t snk_buf_size;
+	size_t n_bytes = codec->mpd.in_buff_size;
+	size_t size_to_wrap;
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
-	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+	if (source_get_data_available(sources[0]) < n_bytes) {
 		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
@@ -772,9 +779,20 @@ waves_codec_process(struct processing_module *mod,
 	if (!codec->mpd.init_done)
 		waves_codec_init_process(mod);
 
-	memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size,
-		 input_buffers[0].data, codec->mpd.in_buff_size);
-	codec->mpd.avail = codec->mpd.in_buff_size;
+	ret = source_get_data(sources[0], n_bytes, &src_ptr, &src_buf_start, &src_buf_size);
+	if (ret)
+		return ret;
+
+	/* src_buf_size is the total ring buffer size; handle wrap when copying to in_buff */
+	size_to_wrap = (const uint8_t *)src_buf_start + src_buf_size - (const uint8_t *)src_ptr;
+	if (n_bytes <= size_to_wrap) {
+		memcpy_s(codec->mpd.in_buff, n_bytes, src_ptr, n_bytes);
+	} else {
+		memcpy_s(codec->mpd.in_buff, n_bytes, src_ptr, size_to_wrap);
+		memcpy_s((uint8_t *)codec->mpd.in_buff + size_to_wrap, n_bytes - size_to_wrap,
+			 src_buf_start, n_bytes - size_to_wrap);
+	}
+	codec->mpd.avail = n_bytes;
 
 	comp_dbg(dev, "start");
 
@@ -806,18 +824,34 @@ waves_codec_process(struct processing_module *mod,
 
 	status = MaxxEffect_Process(waves_codec->effect, i_streams, o_streams);
 	if (status) {
+		source_release_data(sources[0], 0);
 		comp_err(dev, "MaxxEffect_Process returned %d", status);
 		ret = -EINVAL;
 	} else {
 		codec->mpd.produced = waves_codec->o_stream.numAvailableSamples *
 			waves_codec->o_format.numChannels * waves_codec->sample_size_in_bytes;
 		codec->mpd.consumed = codec->mpd.produced;
-		input_buffers[0].consumed = codec->mpd.consumed;
-		ret = 0;
-		/* copy the produced samples into the output buffer */
-		memcpy_s(output_buffers[0].data, codec->mpd.produced, codec->mpd.out_buff,
-			 codec->mpd.produced);
-		output_buffers[0].size = codec->mpd.produced;
+
+		source_release_data(sources[0], codec->mpd.consumed);
+
+		ret = sink_get_buffer(sinks[0], codec->mpd.produced,
+				      &snk_ptr, &snk_buf_start, &snk_buf_size);
+		if (!ret) {
+			/* snk_buf_size is the total ring buffer size; handle wrap */
+			size_to_wrap = (uint8_t *)snk_buf_start + snk_buf_size -
+				       (uint8_t *)snk_ptr;
+			if (codec->mpd.produced <= size_to_wrap) {
+				memcpy_s(snk_ptr, codec->mpd.produced,
+					 codec->mpd.out_buff, codec->mpd.produced);
+			} else {
+				memcpy_s(snk_ptr, codec->mpd.produced,
+					 codec->mpd.out_buff, size_to_wrap);
+				memcpy_s(snk_buf_start, codec->mpd.produced - size_to_wrap,
+					 (const uint8_t *)codec->mpd.out_buff + size_to_wrap,
+					 codec->mpd.produced - size_to_wrap);
+			}
+			sink_commit_buffer(sinks[0], codec->mpd.produced);
+		}
 	}
 
 	if (ret)
@@ -899,7 +933,7 @@ waves_codec_set_configuration(struct processing_module *mod, uint32_t config_id,
 static const struct module_interface waves_interface = {
 	.init = waves_codec_init,
 	.prepare = waves_codec_prepare,
-	.process_raw_data = waves_codec_process,
+	.process = waves_codec_process,
 	.set_configuration = waves_codec_set_configuration,
 	.reset = waves_codec_reset,
 	.free = waves_codec_free


### PR DESCRIPTION
Rework the waves module to only use the sink/source api to prepare sof for the full transition to pipeline 2.0.