### PR TITLE
module_adapter: validate connection count against module capacity

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -506,6 +506,14 @@ int module_adapter_prepare(struct comp_dev *dev)
 		return -EINVAL;
 	}
 
+	if (mod->num_of_sources > mod->max_sources ||
+	    mod->num_of_sinks > mod->max_sinks) {
+		comp_err(dev, "connected sources %d (max %d) or sinks %d (max %d) exceed module capacity",
+			 mod->num_of_sources, mod->max_sources,
+			 mod->num_of_sinks, mod->max_sinks);
+		return -EINVAL;
+	}
+
 	/* check processing mode */
 	if (IS_PROCESSING_MODE_AUDIO_STREAM(mod) && mod->max_sources > 1 && mod->max_sinks > 1) {
 		comp_err(dev, "Invalid use of simple_copy");


### PR DESCRIPTION
Add a bounds check in module_adapter_prepare() to reject topologies where the actual number of connected sources or sinks exceeds the module-declared capacity (max_sources / max_sinks).

Without this check, a misconfigured topology binding more sources than a module supports leads to out-of-bounds writes into the input_buffers or output_buffers arrays allocated for max_sources/max_sinks entries.

The audio_stream copy path already validates this (in module_adapter_audio_stream_type_copy), but the raw-data path had no equivalent guard in either prepare or copy.