### PR TITLE
module: cadence: rework module to use sink/source api

### DIFF
--- a/src/audio/module_adapter/module/cadence.c
+++ b/src/audio/module_adapter/module/cadence.c
@@ -221,7 +221,7 @@ size_t cadence_api_table_size(void)
 	return ARRAY_SIZE(cadence_api_table);
 }
 
-int cadence_codec_get_samples(struct processing_module *mod)
+unsigned int cadence_codec_get_samples(struct processing_module *mod)
 {
 	struct cadence_codec_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;
@@ -572,4 +572,41 @@ int cadence_codec_process_data(struct processing_module *mod,
 	}
 
 	return 0;
+}
+
+void cadence_copy_data_from_buffer(void *dest, const void *buffer_ptr, size_t bytes_to_copy,
+				   size_t buffer_size, void const *buffer_start)
+{
+	size_t bytes_to_end = (size_t)((const uint8_t *)buffer_start +
+				       buffer_size - (const uint8_t *)buffer_ptr);
+
+	if (bytes_to_end >= bytes_to_copy) {
+		/* No wrap, copy directly */
+		memcpy_s(dest, bytes_to_copy, buffer_ptr, bytes_to_copy);
+		return;
+	}
+
+	/* Wrap occurs, copy in two parts */
+	memcpy_s(dest, bytes_to_end, buffer_ptr, bytes_to_end);
+	memcpy_s((uint8_t *)dest + bytes_to_end, bytes_to_copy - bytes_to_end,
+		 buffer_start, bytes_to_copy - bytes_to_end);
+}
+
+void cadence_copy_data_to_buffer(void *buffer_ptr, size_t bytes_to_copy,
+				 size_t buffer_size, void *buffer_start,
+				 const void *src)
+{
+	size_t bytes_to_end = (size_t)((uint8_t *)buffer_start +
+				       buffer_size - (uint8_t *)buffer_ptr);
+
+	if (bytes_to_end >= bytes_to_copy) {
+		/* No wrap, copy directly */
+		memcpy_s(buffer_ptr, bytes_to_copy, src, bytes_to_copy);
+		return;
+	}
+
+	/* Wrap occurs, copy in two parts */
+	memcpy_s(buffer_ptr, bytes_to_end, src, bytes_to_end);
+	memcpy_s(buffer_start, bytes_to_copy - bytes_to_end,
+		 (const uint8_t *)src + bytes_to_end, bytes_to_copy - bytes_to_end);
 }

--- a/src/audio/module_adapter/module/cadence_ipc3.c
+++ b/src/audio/module_adapter/module/cadence_ipc3.c
@@ -211,71 +211,93 @@ free:
 	return ret;
 }
 
-static int
-cadence_codec_process(struct processing_module *mod,
-		      struct input_stream_buffer *input_buffers, int num_input_buffers,
-		      struct output_stream_buffer *output_buffers, int num_output_buffers)
+static int cadence_codec_process(struct processing_module *mod,
+				 struct sof_source **sources, int num_of_sources,
+				 struct sof_sink **sinks, int num_of_sinks)
 {
-	struct comp_buffer *local_buff;
 	struct comp_dev *dev = mod->dev;
 	struct module_data *codec = &mod->priv;
-	int free_bytes, output_bytes = cadence_codec_get_samples(mod) *
+	size_t output_bytes = cadence_codec_get_samples(mod) *
 				mod->stream_params->sample_container_bytes *
 				mod->stream_params->channels;
-	uint32_t remaining = input_buffers[0].size;
+	size_t remaining = source_get_data_available(sources[0]);
+	const void *source_buffer_start, *src_ptr;
+	void *sink_ptr, *sink_buffer_start;
+	size_t src_bytes, sink_bytes;
 	int ret;
 
 	if (!cadence_codec_deep_buff_allowed(mod))
 		mod->deep_buff_bytes = 0;
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
-	if (input_buffers[0].size < codec->mpd.in_buff_size) {
+	if (remaining < codec->mpd.in_buff_size) {
 		comp_dbg(dev, "not enough data to process");
 		return -ENODATA;
 	}
 
 	if (!codec->mpd.init_done) {
-		memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size, input_buffers[0].data,
-			 codec->mpd.in_buff_size);
+		ret = source_get_data(sources[0], codec->mpd.in_buff_size, &src_ptr,
+				      &source_buffer_start, &src_bytes);
+		if (ret) {
+			comp_err(dev, "cannot get data from source buffer");
+			return ret;
+		}
+
+		cadence_copy_data_from_buffer(codec->mpd.in_buff, src_ptr,
+					      codec->mpd.in_buff_size, src_bytes,
+					      source_buffer_start);
 		codec->mpd.avail = codec->mpd.in_buff_size;
 
 		ret = cadence_codec_init_process(mod);
-		if (ret)
+		if (ret) {
+			source_release_data(sources[0], 0);
 			return ret;
+		}
 
 		remaining -= codec->mpd.consumed;
-		input_buffers[0].consumed = codec->mpd.consumed;
+		source_release_data(sources[0], codec->mpd.consumed);
 	}
 
-	/* do not proceed with processing if not enough free space left in the local buffer */
-	local_buff = list_first_item(&mod->raw_data_buffers_list, struct comp_buffer, buffers_list);
-	free_bytes = audio_stream_get_free(&local_buff->stream);
-	if (free_bytes < output_bytes)
+	/* do not proceed with processing if not enough free space left in the sink buffer */
+	if (sink_get_free_size(sinks[0]) < output_bytes)
 		return -ENOSPC;
 
 	/* Proceed only if we have enough data to fill the module buffer completely */
 	if (remaining < codec->mpd.in_buff_size)
 		return -ENODATA;
 
-	memcpy_s(codec->mpd.in_buff, codec->mpd.in_buff_size,
-		 (uint8_t *)input_buffers[0].data + input_buffers[0].consumed,
-		 codec->mpd.in_buff_size);
+	ret = source_get_data(sources[0], codec->mpd.in_buff_size, &src_ptr, &source_buffer_start,
+			      &src_bytes);
+	if (ret)
+		return ret;
+
+	cadence_copy_data_from_buffer(codec->mpd.in_buff, src_ptr,
+				      codec->mpd.in_buff_size, src_bytes,
+				      source_buffer_start);
 	codec->mpd.avail = codec->mpd.in_buff_size;
 
 	comp_dbg(dev, "cadence_codec_process() start");
 
 	ret = cadence_codec_process_data(mod, NULL);
-	if (ret)
+	if (ret) {
+		source_release_data(sources[0], 0);
 		return ret;
+	}
 
-	/* update consumed with the number of samples consumed during init */
-	input_buffers[0].consumed += codec->mpd.consumed;
-	codec->mpd.consumed = input_buffers[0].consumed;
+	source_release_data(sources[0], codec->mpd.consumed);
 
-	/* copy the produced samples into the output buffer */
-	memcpy_s(output_buffers[0].data, codec->mpd.produced, codec->mpd.out_buff,
-		 codec->mpd.produced);
-	output_buffers[0].size = codec->mpd.produced;
+	ret = sink_get_buffer(sinks[0], codec->mpd.produced, &sink_ptr, &sink_buffer_start,
+			      &sink_bytes);
+	if (ret) {
+		comp_err(dev, "cannot get sink buffer");
+		return ret;
+	}
+
+	/* Copy the produced samples into the output buffer */
+	cadence_copy_data_to_buffer(sink_ptr, codec->mpd.produced, sink_bytes,
+				    sink_buffer_start, codec->mpd.out_buff);
+
+	sink_commit_buffer(sinks[0], codec->mpd.produced);
 
 	comp_dbg(dev, "cadence_codec_process() done");
 
@@ -307,7 +329,7 @@ static int cadence_codec_reset(struct processing_module *mod)
 static const struct module_interface cadence_codec_interface = {
 	.init = cadence_codec_init,
 	.prepare = cadence_codec_prepare,
-	.process_raw_data = cadence_codec_process,
+	.process = cadence_codec_process,
 	.set_configuration = cadence_codec_set_configuration,
 	.reset = cadence_codec_reset,
 	.free = cadence_codec_free

--- a/src/audio/module_adapter/module/cadence_ipc4.c
+++ b/src/audio/module_adapter/module/cadence_ipc4.c
@@ -395,24 +395,6 @@ static int cadence_codec_prepare(struct processing_module *mod,
 	return 0;
 }
 
-static void cadence_copy_data_from_buffer(void *dest, const void *buffer_ptr, size_t bytes_to_copy,
-					  size_t buffer_size, uint8_t const *buffer_start)
-{
-	size_t bytes_to_end = (size_t)((uint8_t *)buffer_start +
-				       buffer_size - (uint8_t *)buffer_ptr);
-
-	if (bytes_to_end >= bytes_to_copy) {
-		/* No wrap, copy directly */
-		memcpy_s(dest, bytes_to_copy, buffer_ptr, bytes_to_copy);
-		return;
-	}
-
-	/* Wrap occurs, copy in two parts */
-	memcpy_s(dest, bytes_to_end, buffer_ptr, bytes_to_end);
-	memcpy_s((uint8_t *)dest + bytes_to_end, bytes_to_copy - bytes_to_end,
-		 buffer_start, bytes_to_copy - bytes_to_end);
-}
-
 static int cadence_codec_process(struct processing_module *mod, struct sof_source **sources,
 				 int num_of_sources, struct sof_sink **sinks, int num_of_sinks)
 {
@@ -420,11 +402,10 @@ static int cadence_codec_process(struct processing_module *mod, struct sof_sourc
 	struct module_data *codec = &mod->priv;
 	size_t in_size = source_get_data_available(sources[0]);
 	size_t out_space = sink_get_free_size(sinks[0]);
-	uint8_t const *source_buffer_start;
-	int consumed_during_init = 0;
+	const void *source_buffer_start, *src_ptr;
+	void *sink_buffer_start, *sink_ptr;
+	size_t src_bytes, sink_bytes;
 	uint32_t remaining = in_size;
-	const void *src_ptr;
-	size_t src_bytes;
 	int ret;
 
 	if (!codec->mpd.init_done) {
@@ -446,7 +427,6 @@ static int cadence_codec_process(struct processing_module *mod, struct sof_sourc
 
 		remaining -= codec->mpd.consumed;
 		source_release_data(sources[0], codec->mpd.consumed);
-		consumed_during_init = codec->mpd.consumed;
 	}
 
 	codec->mpd.consumed = 0;
@@ -456,8 +436,8 @@ static int cadence_codec_process(struct processing_module *mod, struct sof_sourc
 		return -ENODATA;
 
 	/* Acquire data from the source buffer */
-	ret = source_get_data(sources[0], codec->mpd.in_buff_size, &src_ptr,
-			      (const void **)&source_buffer_start, &src_bytes);
+	ret = source_get_data(sources[0], codec->mpd.in_buff_size, &src_ptr, &source_buffer_start,
+			      &src_bytes);
 
 	cadence_copy_data_from_buffer(codec->mpd.in_buff, src_ptr, codec->mpd.in_buff_size,
 				      src_bytes, source_buffer_start);
@@ -507,32 +487,16 @@ static int cadence_codec_process(struct processing_module *mod, struct sof_sourc
 		return -ENOSPC;
 	}
 
-	void *sink_ptr;
-	size_t sink_bytes;
-	uint8_t const *sink_buffer_start;
-
-	ret = sink_get_buffer(sinks[0], codec->mpd.produced, &sink_ptr,
-			      (void **)&sink_buffer_start, &sink_bytes);
+	ret = sink_get_buffer(sinks[0], codec->mpd.produced, &sink_ptr, &sink_buffer_start,
+			      &sink_bytes);
 	if (ret) {
 		comp_err(dev, "cannot get sink buffer");
 		return ret;
 	}
 
 	/* Copy the produced samples into the output buffer */
-	size_t bytes_to_end = (size_t)((uint8_t *)sink_buffer_start +
-				       sink_bytes - (uint8_t *)sink_ptr);
-
-	if (bytes_to_end >= codec->mpd.produced) {
-		/* No wrap, copy directly */
-		memcpy_s(sink_ptr, codec->mpd.produced, codec->mpd.out_buff,
-			 codec->mpd.produced);
-	} else {
-		/* Wrap occurs, copy in two parts */
-		memcpy_s(sink_ptr, bytes_to_end, codec->mpd.out_buff, bytes_to_end);
-		memcpy_s((uint8_t *)sink_buffer_start, codec->mpd.produced - bytes_to_end,
-			 (uint8_t *)codec->mpd.out_buff + bytes_to_end,
-			 codec->mpd.produced - bytes_to_end);
-	}
+	cadence_copy_data_to_buffer(sink_ptr, codec->mpd.produced, sink_bytes,
+				    sink_buffer_start, codec->mpd.out_buff);
 
 	source_release_data(sources[0], codec->mpd.consumed);
 	sink_commit_buffer(sinks[0], codec->mpd.produced);

--- a/src/include/sof/audio/module_adapter/module/cadence.h
+++ b/src/include/sof/audio/module_adapter/module/cadence.h
@@ -101,11 +101,16 @@ int cadence_codec_process_data(struct processing_module *mod,
 int cadence_codec_apply_config(struct processing_module *mod);
 void cadence_codec_free_memory_tables(struct processing_module *mod);
 int cadence_codec_init_memory_tables(struct processing_module *mod);
-int cadence_codec_get_samples(struct processing_module *mod);
+unsigned int cadence_codec_get_samples(struct processing_module *mod);
 int cadence_codec_init_process(struct processing_module *mod);
 int cadence_init_codec_object(struct processing_module *mod);
 int cadence_codec_resolve_api(struct processing_module *mod);
 int cadence_codec_free(struct processing_module *mod);
 size_t cadence_api_table_size(void);
+void cadence_copy_data_from_buffer(void *dest, const void *buffer_ptr, size_t bytes_to_copy,
+				   size_t buffer_size, void const *buffer_start);
+void cadence_copy_data_to_buffer(void *buffer_ptr, size_t bytes_to_copy,
+				 size_t buffer_size, void *buffer_start,
+				 const void *src);
 
 #endif /* __SOF_AUDIO_CADENCE_CODEC__ */


### PR DESCRIPTION
Rework the cadence ipc3 module variant to only use the sink/source api to prepare sof for the full transition to pipeline 2.0.

Make cadence_copy_data_from_buffer() shared across both ipc3 and ipc4 variants. Add a common cadence_copy_data_to_buffer() function. Remove the unnecessary const modifier from sink_buffer_start and eliminate redundant type casts.