### PR TITLE
scripts: reset LLEXT VMA accumulators before each west build

### DIFF
--- a/scripts/xtensa-build-zephyr.py
+++ b/scripts/xtensa-build-zephyr.py
@@ -979,6 +979,22 @@ def build_platforms():
 				env=platf_build_environ, sof_log_env=True)
 		print()
 
+		# Delete the LLEXT VMA accumulator file before every build.
+		# llext_offset_calc.py uses module_size as a persistent counter
+		# across cmake custom-command invocations.  If ninja is invoked
+		# more than once without a pristine rebuild this counter keeps
+		# accumulating, pushing pre-linked VMAs beyond the valid LLEXT
+		# virtual region and causing sys_mm_drv_map_region() to fail
+		# silently at runtime (IPC4_MOD_NOT_INITIALIZED error 104).
+		# llext_offset_calc.py already handles a missing file as size=0,
+		# so deletion is the simplest and most reliable reset.
+		zephyr_build_dir = pathlib.Path(abs_build_dir) / "zephyr"
+		if zephyr_build_dir.is_dir():
+			acc_path = zephyr_build_dir / "module_size"
+			if acc_path.is_file():
+				acc_path.unlink()
+				print(f"Deleted LLEXT VMA accumulator: {acc_path}")
+
 		# Build
 		try:
 			execute_command(build_cmd, cwd=west_top, env=platf_build_environ, sof_log_env=True)


### PR DESCRIPTION
llext_link_helper.py uses openmod_module_size and module_size as persistent counters to assign pre-linked VMAs to LLEXT ELFs.  Running ninja more than once without a pristine build causes these files to accumulate across invocations.  The second run doubles the counter values, placing all ELF VMAs outside the valid LLEXT virtual region [CONFIG_LIBRARY_BASE_ADDRESS, +CONFIG_LIBRARY_REGION_SIZE).

When pre_located=true the LLEXT loader uses the ELF sh_addr VMAs directly as physical load addresses.  sys_mm_drv_map_region() silently fails for out-of-range addresses, so the module is never registered. The kernel then receives IPC4_MOD_NOT_INITIALIZED (error 104) for every module init IPC.

Reset both accumulator files to 0 before every west build invocation so VMA assignment always starts from CONFIG_LIBRARY_BASE_ADDRESS.