### PR TITLE
Expose static objects used by audio pipeline framework to LL user thread

### DIFF
--- a/posix/include/rtos/userspace_helper.h
+++ b/posix/include/rtos/userspace_helper.h
@@ -19,6 +19,8 @@
 
 #define APP_TASK_BSS
 #define APP_TASK_DATA
+#define APP_SYSUSER_BSS
+#define APP_SYSUSER_DATA
 
 struct sys_heap;
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -36,7 +36,7 @@
 
 LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 
-static SHARED_DATA struct comp_driver_list cd;
+static APP_SYSUSER_BSS SHARED_DATA struct comp_driver_list cd;
 
 SOF_DEFINE_REG_UUID(component);
 

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -17,6 +17,7 @@
 #include <rtos/timer.h>
 #include <rtos/cache.h>
 #include <rtos/init.h>
+#include <rtos/userspace_helper.h>
 #include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -1189,7 +1190,7 @@ __cold static int copier_unbind(struct processing_module *mod, struct bind_info 
 	return 0;
 }
 
-static struct module_endpoint_ops copier_endpoint_ops = {
+static APP_SYSUSER_DATA const struct module_endpoint_ops copier_endpoint_ops = {
 	.get_total_data_processed = copier_get_processed_data,
 	.position = copier_position,
 	.dai_ts_config = copier_dai_ts_config_op,
@@ -1200,7 +1201,7 @@ static struct module_endpoint_ops copier_endpoint_ops = {
 	.trigger = copier_comp_trigger
 };
 
-static const struct module_interface copier_interface = {
+static APP_SYSUSER_DATA const struct module_interface copier_interface = {
 	.init = copier_init,
 	.prepare = copier_prepare,
 	.process_audio_stream = copier_process,

--- a/src/audio/copier/copier_host.c
+++ b/src/audio/copier/copier_host.c
@@ -9,6 +9,7 @@
 #include <sof/tlv.h>
 #include <sof/trace/trace.h>
 #include <sof/audio/module_adapter/module/generic.h>
+#include <rtos/userspace_helper.h>
 #include "copier.h"
 #include "host_copier.h"
 
@@ -27,7 +28,7 @@ struct fpi_sync_group {
 	struct list_item item;
 };
 
-static struct list_item group_list_head = LIST_INIT(group_list_head);
+static APP_SYSUSER_DATA struct list_item group_list_head = LIST_INIT(group_list_head);
 
 __cold static struct fpi_sync_group *find_group_by_id(uint32_t id)
 {

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -34,8 +34,7 @@
 
 LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 
-/* Protects IPC4 LLP reading-slot firmware registers used by DAI code. */
-static SYS_MUTEX_DEFINE(llp_reading_slots_lock);
+static APP_SYSUSER_BSS SYS_MUTEX_DEFINE(llp_reading_slots_lock);
 
 void dai_set_link_hda_config(uint16_t *link_config,
 			     struct ipc_config_dai *common_config,

--- a/zephyr/include/rtos/userspace_helper.h
+++ b/zephyr/include/rtos/userspace_helper.h
@@ -17,6 +17,8 @@
 #ifndef CONFIG_USERSPACE
 #define APP_TASK_BSS
 #define APP_TASK_DATA
+#define APP_SYSUSER_BSS
+#define APP_SYSUSER_DATA
 #else
 #include <zephyr/cache.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -15,12 +15,13 @@
 #include <sof/lib/memory.h>
 #include <rtos/sof.h>
 #include <rtos/spinlock.h>
+#include <rtos/userspace_helper.h>
 #include <zephyr/device.h>
 
 #define DW_DMA_BUFFER_PERIOD_COUNT	0x4
 #define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
-SHARED_DATA struct sof_dma dma[] = {
+APP_SYSUSER_DATA SHARED_DATA struct sof_dma dma[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {

--- a/zephyr/schedule.c
+++ b/zephyr/schedule.c
@@ -10,10 +10,11 @@
 #include <sof/schedule/ll_schedule.h>
 #include <rtos/alloc.h>
 #include <rtos/symbol.h>
+#include <rtos/userspace_helper.h>
 #include <sof/lib/cpu.h>
 #include <ipc/topology.h>
 
-static struct schedulers *_schedulers[CONFIG_CORE_COUNT];
+static APP_SYSUSER_BSS struct schedulers *_schedulers[CONFIG_CORE_COUNT];
 
 /**
  * Retrieves registered schedulers.


### PR DESCRIPTION
The audio application code has some uses of global objects. Expose all these objects with APP_SYSUSER_BSS/APP_SYSUSER_DATA so that the objects are accessible to the LL audio thread when SOF is built with CONFIG_SOF_USERSPACE_LL. In other builds, these macros are no-ops, so no functional change to other builds.