### PR TITLE
workflows: add zizmor GitHub Actions security scan

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+---
+name: "Zizmor GitHub Actions Analysis"
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+permissions: {}
+
+# Specifies group name that stops previous workflows if the name matches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Analyze workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # Required to upload SARIF results to the Security tab
+      actions: read           # Required to read workflow information
+      contents: read          # Required to checkout repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          inputs: .github/workflows/


### PR DESCRIPTION
Add zizmor.yml GitHub Actions workflow that runs zizmor static analysis against all SOF workflow files on every push to main and on every pull request targeting main.

zizmor audits GitHub Actions workflows for security misconfigurations: unpinned action references, credential persistence, template injection, excessive permissions, pull_request_target misuse, poisoned pipeline attacks, and other supply-chain risks.

While SOF already runs CodeQL analysis on workflows, zizmor covers a complementary and broader set of GitHub Actions-specific attack patterns that CodeQL does not detect. The two tools find different classes of issues and running both gives better coverage than either alone.

A one-off manual scan (zizmor v1.25.2) of the existing SOF workflows found no exploitable vulnerabilities. The primary findings were 31 cases of actions referenced by mutable version tags instead of SHA hashes, and 22 checkouts missing `persist-credentials: false`. This workflow will prevent new regressions of this kind from being merged.

The workflow follows the same conventions as the existing codeql.yml:
- top-level `permissions: {}` with only required grants at job level
- `actions/checkout` and `zizmorcore/zizmor-action` pinned to SHAs
- `persist-credentials: false` on the checkout step
- concurrency group that cancels superseded runs

Findings are uploaded as SARIF to the GitHub Security tab via GitHub Advanced Security (SOF is a public repository). The run does not fail on findings; use a GitHub Ruleset to make it a blocking merge gate.