### PR TITLE
IPC4 error code corrections

### DIFF
--- a/src/audio/base_fw_intel.c
+++ b/src/audio/base_fw_intel.c
@@ -424,7 +424,7 @@ __cold int basefw_vendor_get_large_config(struct comp_dev *dev, uint32_t param_i
 
 	extended_param_id.full = param_id;
 
-	uint32_t ret = IPC4_ERROR_INVALID_PARAM;
+	uint32_t ret = IPC4_INVALID_REQUEST;
 
 	switch (extended_param_id.part.parameter_type) {
 	case IPC4_MEMORY_STATE_INFO_GET:
@@ -560,7 +560,7 @@ __cold int basefw_vendor_set_large_config(struct comp_dev *dev, uint32_t param_i
 		break;
 	}
 
-	return IPC4_UNKNOWN_MESSAGE_TYPE;
+	return IPC4_INVALID_REQUEST;
 }
 
 __cold int basefw_vendor_dma_control(uint32_t node_id, const char *config_data, size_t data_size)

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -817,6 +817,10 @@ static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4
 		if (!cpu_is_me(dev->ipc_config.core))
 			return ipc4_process_on_core(dev->ipc_config.core, false);
 	} else {
+		/* BaseFW module has only 0th instance */
+		if (config->primary.r.instance_id)
+			return IPC4_INVALID_RESOURCE_ID;
+
 		drv = ipc4_get_comp_drv(config->primary.r.module_id);
 	}
 
@@ -1004,6 +1008,10 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 		if (!cpu_is_me(dev->ipc_config.core))
 			return ipc4_process_on_core(dev->ipc_config.core, false);
 	} else {
+		/* BaseFW module has only 0th instance */
+		if (config.primary.r.instance_id)
+			return IPC4_INVALID_RESOURCE_ID;
+
 		drv = ipc4_get_comp_drv(config.primary.r.module_id);
 	}
 
@@ -1173,6 +1181,10 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 		if (!cpu_is_me(dev->ipc_config.core))
 			return ipc4_process_on_core(dev->ipc_config.core, false);
 	} else {
+		/* BaseFW module has only 0th instance */
+		if (config.primary.r.instance_id)
+			return IPC4_INVALID_RESOURCE_ID;
+
 		drv = ipc4_get_comp_drv(config.primary.r.module_id);
 	}
 

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -1281,7 +1281,7 @@ __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 		ret = IPC4_UNAVAILABLE;
 		break;
 	default:
-		ret = IPC4_UNAVAILABLE;
+		ret = IPC4_UNKNOWN_MESSAGE_TYPE;
 		break;
 	}
 

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -809,7 +809,7 @@ static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4
 		comp_id = IPC4_COMP_ID(config->primary.r.module_id, config->primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
-			return IPC4_MOD_INVALID_ID;
+			return IPC4_INVALID_RESOURCE_ID;
 
 		drv = dev->drv;
 
@@ -821,7 +821,7 @@ static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4
 	}
 
 	if (!drv)
-		return IPC4_MOD_INVALID_ID;
+		return IPC4_INVALID_RESOURCE_ID;
 
 	function = set ? drv->ops.set_attribute : drv->ops.get_attribute;
 	if (!function)
@@ -996,7 +996,7 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 				       config.primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
-			return IPC4_MOD_INVALID_ID;
+			return IPC4_INVALID_RESOURCE_ID;
 
 		drv = dev->drv;
 
@@ -1008,7 +1008,7 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 	}
 
 	if (!drv)
-		return IPC4_MOD_INVALID_ID;
+		return IPC4_INVALID_RESOURCE_ID;
 
 	if (!drv->ops.get_large_config)
 		return IPC4_INVALID_REQUEST;
@@ -1041,7 +1041,7 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 
 	/* set up ipc4 error code for reply data */
 	if (ret < 0)
-		ret = IPC4_MOD_INVALID_ID;
+		ret = IPC4_INVALID_RESOURCE_ID;
 
 	/* Copy host config and overwrite */
 	reply.extension.dat = config.extension.dat;
@@ -1165,7 +1165,7 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 		comp_id = IPC4_COMP_ID(config.primary.r.module_id, config.primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
-			return IPC4_MOD_INVALID_ID;
+			return IPC4_INVALID_RESOURCE_ID;
 
 		drv = dev->drv;
 
@@ -1177,7 +1177,7 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 	}
 
 	if (!drv)
-		return IPC4_MOD_INVALID_ID;
+		return IPC4_INVALID_RESOURCE_ID;
 
 	if (!drv->ops.set_large_config)
 		return IPC4_INVALID_REQUEST;


### PR DESCRIPTION
These commits correct a bunch of error codes to improve compliance with the IPC4 protocol. This allows me to re-enable older tests that are shared with the reference firmware. Some of the fixes seem sound, while others seem more arbitrary, especially the change from MOD_INVALID_ID to INVALID_RESOURCE_ID. Those may reflect the reference firmware's design or implementation rather than an intentional protocol decision. Therefore, if any of these changes are unacceptable or incompatible with the driver, please let me know. I will try to address those issues elsewhere.