### PR TITLE
pipeline: reject double-connect of already-attached buffer

### DIFF
--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -635,12 +635,20 @@ static inline struct list_item *buffer_comp_list(struct comp_buffer *buffer,
  * from racing attach / detach calls, but the scheduler can interrupt the IPC
  * thread and begin using the buffer for streaming. FIXME: this is still a
  * problem with different cores.
+ *
+ * Returns -EALREADY if the buffer is already attached in this direction.
+ * Attaching the same buffer twice would corrupt the list (list_item_prepend
+ * on an already-linked node creates a self-loop), so callers must propagate
+ * the error.
  */
-void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)
+int buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir)
 {
 	struct list_item *list = buffer_comp_list(buffer, dir);
 	CORE_CHECK_STRUCT(&buffer->audio_buffer);
+	if (!list_is_empty(list))
+		return -EALREADY;
 	list_item_prepend(list, head);
+	return 0;
 }
 
 /*

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -198,6 +198,7 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 		     int dir)
 {
 	struct list_item *comp_list;
+	int ret;
 	PPL_LOCK_DECLARE;
 
 	if (dir == PPL_CONN_DIR_COMP_TO_BUFFER)
@@ -208,7 +209,13 @@ int pipeline_connect(struct comp_dev *comp, struct comp_buffer *buffer,
 	PPL_LOCK();
 
 	comp_list = comp_buffer_list(comp, dir);
-	buffer_attach(buffer, comp_list, dir);
+	ret = buffer_attach(buffer, comp_list, dir);
+	if (ret < 0) {
+		comp_err(comp, "buffer %d already connected dir %d",
+			 buf_get_id(buffer), dir);
+		PPL_UNLOCK();
+		return ret;
+	}
 	buffer_set_comp(buffer, comp, dir);
 
 	PPL_UNLOCK();

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -289,8 +289,11 @@ static inline void buffer_stream_writeback(struct comp_buffer *buffer, uint32_t 
  * really be the head of the list, not a list head within another buffer. We
  * don't synchronise its cache, so it must not be embedded in an object, using
  * the coherent API. The caller takes care to protect list heads.
+ *
+ * Returns -EINVAL if the buffer is already linked in this direction
+ * (re-attaching would create a self-loop and corrupt the list).
  */
-void buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir);
+int buffer_attach(struct comp_buffer *buffer, struct list_item *head, int dir);
 
 /*
  * Detach a buffer from anywhere in the list. "head" is again the head of the


### PR DESCRIPTION
pipeline_connect() had no guard against being called twice for the same buffer-component pair. Calling list_item_prepend() on a node that is already in a doubly-linked list corrupts the list by creating a self-loop where node->next points back to itself instead of to the list head.

The corruption was discovered through IPC3 fuzzing in persistent mode. Without per-testcase topology teardown, components and buffers created by testcase N survive into testcase N+1. When N+1 sends a TPLG_COMP_CONNECT for IDs that N already connected, ipc_comp_connect() finds the surviving objects and calls pipeline_connect() a second time. The same sequence can also be triggered within a single testcase by two CONNECT messages for the same pair.

The self-loop causes ipc_comp_free() to hang indefinitely. The function walks bsource_list / bsink_list with comp_dev_for_each_producer_safe() whose termination condition checks node->next == &comp->bsource_list. With the self-loop that check is always false. The walk runs inside irq_local_disable(), so the native_sim timer cannot preempt the thread and nsi_exec_for() never returns, making libFuzzer's max_total_time limit unreachable.

A second failure mode arises when ipc_buffer_free() calls pipeline_disconnect() on the corrupted buffer. list_item_del() updates comp->bsource_list.next to node->next, which due to the self-loop is the node itself — leaving the component's list head pointing into the freed buffer memory. When that memory is reused by a later allocation and overwritten, the next walk of bsource_list dereferences an invalid pointer, crashing with a null dereference or a corrupt-pointer access.

Add an early-exit guard in pipeline_connect() before buffer_attach(): if the buffer's relevant list node (source_list for COMP_TO_BUFFER, sink_list for BUFFER_TO_COMP) is not a self-loop singleton, the buffer is already attached and the connect is rejected with -EINVAL. list_is_empty() returns true only for a freshly created or correctly disconnected buffer, so no valid use case is rejected.

Verified with -s address on the full IPC3 corpus (~66K inputs, 75 s): zero crashes, zero hangs, ~2800 exec/s. The unfixed build stalled indefinitely on the same run.