### PR TITLE
topology2: production: cav2.5: Add sof-adl-rt711-l0-rt1316-l23-rt714-l1

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-cavs25.cmake
+++ b/tools/topology/topology2/production/tplg-targets-cavs25.cmake
@@ -10,6 +10,10 @@ list(APPEND TPLGS
 "cavs-sdw\;sof-adl-rt711-l0-rt1316-l13-rt714-l2\;NUM_SDW_AMP_LINKS=2,\
 SDW_DMIC=1,SDW_DMIC_STREAM=SDW2-Capture"
 
+"cavs-sdw\;sof-adl-rt711-l0-rt1316-l23-rt714-l1\;NUM_SDW_AMP_LINKS=2,\
+SDW_SPK_STREAM=SDW2-Playback,SDW_SPK_IN_STREAM=SDW2-Capture,\
+SDW_DMIC=1,SDW_DMIC_STREAM=SDW1-Capture"
+
 # IPC4 topology for TGL/ADL rt711 Headset + rt1308 Amplifier + rt715 DMIC
 "cavs-sdw\;sof-tgl-rt711-rt1308-rt715\;NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,SDW_AMP_FEEDBACK=false"
 


### PR DESCRIPTION
The same configuration as
    sof-mtl-rt711-l0-rt1316-l23-rt714-l1
    sof-lnl-rt711-l0-rt1316-l23-rt714-l1
