### PR TITLE
zephyr: schedule: allow user-space to access scheduler list

### DIFF
--- a/zephyr/schedule.c
+++ b/zephyr/schedule.c
@@ -10,10 +10,11 @@
 #include <sof/schedule/ll_schedule.h>
 #include <rtos/alloc.h>
 #include <rtos/symbol.h>
+#include <rtos/userspace_helper.h>
 #include <sof/lib/cpu.h>
 #include <ipc/topology.h>
 
-static struct schedulers *_schedulers[CONFIG_CORE_COUNT];
+static APP_SYSUSER_BSS struct schedulers *_schedulers[CONFIG_CORE_COUNT];
 
 /**
  * Retrieves registered schedulers.


### PR DESCRIPTION
Make the scheduler list available to system user-space threads.