### PR TITLE
schedule: allocate the scheduler objects with sof_heap_alloc()

### DIFF
--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -180,6 +180,10 @@ struct schedulers {
  */
 struct schedulers **arch_schedulers_get(void);
 
+struct schedulers **arch_user_schedulers_get(void);
+
+struct schedulers **arch_user_schedulers_get_for_core(int core);
+
 /**
  * Retrieves scheduler's data.
  * @param type SOF_SCHEDULE_ type.
@@ -322,17 +326,13 @@ static inline void schedule_free(uint32_t flags)
 /** See scheduler_ops::scheduler_init_context */
 static inline struct k_thread *scheduler_init_context(struct task *task)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
-	assert(schedulers);
+	assert(task && task->sch);
+	sch = task->sch;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type && sch->ops->scheduler_init_context)
-			return sch->ops->scheduler_init_context(sch->data, task);
-	}
+	if (sch->ops->scheduler_init_context)
+		return sch->ops->scheduler_init_context(sch->data, task);
 
 	return NULL;
 }

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -84,18 +84,21 @@ int schedule_task_init(struct task *task,
 static void scheduler_register(struct schedule_data *scheduler)
 {
 	struct schedulers **sch = arch_schedulers_get();
+	struct k_heap *heap = NULL;
 
-	if (IS_ENABLED(CONFIG_SOF_USERSPACE_LL) && scheduler_is_user(scheduler->type))
+	if (IS_ENABLED(CONFIG_SOF_USERSPACE_LL) && scheduler_is_user(scheduler->type)) {
 		sch = arch_user_schedulers_get();
+		heap = sof_sys_user_heap_get();
+	}
 
 	if (!*sch) {
 		/* init schedulers list */
-		*sch = rzalloc(SOF_MEM_FLAG_KERNEL,
-			       sizeof(**sch));
+		*sch = sof_heap_alloc(heap, 0, sizeof(**sch), 0);
 		if (!*sch) {
 			tr_err(&sch_tr, "allocation failed");
 			return;
 		}
+		memset(*sch, 0, sizeof(**sch));
 		list_init(&(*sch)->list);
 	}
 
@@ -105,16 +108,21 @@ static void scheduler_register(struct schedule_data *scheduler)
 void scheduler_init(int type, const struct scheduler_ops *ops, void *data)
 {
 	struct schedule_data *sch;
+	struct k_heap *heap = NULL;
+
+	if (IS_ENABLED(CONFIG_SOF_USERSPACE_LL) && scheduler_is_user(type))
+		heap = sof_sys_user_heap_get();
 
 	if (!ops || !ops->schedule_task || !ops->schedule_task_cancel ||
 	    !ops->schedule_task_free)
 		return;
 
-	sch = rzalloc(SOF_MEM_FLAG_KERNEL, sizeof(*sch));
+	sch = sof_heap_alloc(heap, SOF_MEM_FLAG_KERNEL, sizeof(*sch), 0);
 	if (!sch) {
 		tr_err(&sch_tr, "allocation failed");
 		sof_panic(SOF_IPC_PANIC_IPC);
 	}
+	memset(sch, 0, sizeof(*sch));
 	list_init(&sch->list);
 	sch->type = type;
 	sch->ops = ops;

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -22,12 +22,23 @@ SOF_DEFINE_REG_UUID(schedule);
 
 DECLARE_TR_CTX(sch_tr, SOF_UUID(schedule_uuid), LOG_LEVEL_INFO);
 
+static inline bool scheduler_is_user(int type)
+{
+	/*
+	 * currently only LL managed in user-space, but longterm
+	 * goal is to move all audio application level scheduling
+	 * to user-space and only keep Zephyr scheduler logic in
+	 * kernel
+	 */
+	return type == SOF_SCHEDULE_LL_TIMER;
+}
+
 int schedule_task_init(struct task *task,
 		       const struct sof_uuid_entry *uid, uint16_t type,
 		       uint16_t priority, enum task_state (*run)(void *data),
 		       void *data, uint16_t core, uint32_t flags)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
+	struct schedulers *schedulers;
 	struct schedule_data *sch = NULL;
 	struct list_item *slist;
 
@@ -35,6 +46,11 @@ int schedule_task_init(struct task *task,
 		tr_err(&sch_tr, "invalid task type");
 		return -EINVAL;
 	}
+
+	if (IS_ENABLED(CONFIG_SOF_USERSPACE_LL) && scheduler_is_user(type))
+		schedulers = *arch_user_schedulers_get_for_core(core);
+	else
+		schedulers = *arch_schedulers_get();
 
 	if (!schedulers)
 		return -ENODEV;
@@ -68,6 +84,9 @@ int schedule_task_init(struct task *task,
 static void scheduler_register(struct schedule_data *scheduler)
 {
 	struct schedulers **sch = arch_schedulers_get();
+
+	if (IS_ENABLED(CONFIG_SOF_USERSPACE_LL) && scheduler_is_user(scheduler->type))
+		sch = arch_user_schedulers_get();
 
 	if (!*sch) {
 		/* init schedulers list */

--- a/zephyr/schedule.c
+++ b/zephyr/schedule.c
@@ -14,7 +14,18 @@
 #include <sof/lib/cpu.h>
 #include <ipc/topology.h>
 
-static APP_SYSUSER_BSS struct schedulers *_schedulers[CONFIG_CORE_COUNT];
+/* Kernel-only scheduler list — depending on how SOF is built,
+ * either holds all or subset of scheduler types.
+ * Not accessible from user-space threads.
+ */
+static struct schedulers *_k_schedulers[CONFIG_CORE_COUNT];
+
+#if CONFIG_SOF_USERSPACE_LL
+/* User-accessible scheduler list — holds the subset of scheduler
+ * types that are managed in user-space
+ */
+static APP_SYSUSER_BSS struct schedulers *_u_schedulers[CONFIG_CORE_COUNT];
+#endif
 
 /**
  * Retrieves registered schedulers.
@@ -22,6 +33,45 @@ static APP_SYSUSER_BSS struct schedulers *_schedulers[CONFIG_CORE_COUNT];
  */
 struct schedulers **arch_schedulers_get(void)
 {
-	return _schedulers + cpu_get_id();
+#if CONFIG_SOF_USERSPACE_LL
+	/* user-space callers must use arch_user_schedulers_get() */
+	assert(!k_is_user_context());
+#endif
+	return _k_schedulers + cpu_get_id();
 }
 EXPORT_SYMBOL(arch_schedulers_get);
+
+/**
+ * Retrieves registered user schedulers for the current core.
+ *
+ * Relies on cpu_get_id(), so it may invoke privileged functions and
+ * must not be called from a user-space context. User-space callers
+ * should use arch_user_schedulers_get_for_core() instead.
+ *
+ * @return List of registered schedulers.
+ */
+struct schedulers **arch_user_schedulers_get(void)
+{
+#ifdef CONFIG_SOF_USERSPACE_LL
+	return _u_schedulers + cpu_get_id();
+#else
+	return NULL;
+#endif
+}
+
+/**
+ * Retrieves registered user schedulers for the given core.
+ *
+ * Unlike arch_user_schedulers_get(), this takes the core explicitly and
+ * is therefore safe to call from a user-space context.
+ *
+ * @return List of registered schedulers.
+ */
+struct schedulers **arch_user_schedulers_get_for_core(int core)
+{
+#ifdef CONFIG_SOF_USERSPACE_LL
+	return _u_schedulers + core;
+#else
+	return NULL;
+#endif
+}


### PR DESCRIPTION
Ensure the scheduler objects and lists of schedulers are allocated such that they can be used with both kernel and user-space LL scheduler implementations.

The SOF_MEM_FLAG_KERNEL flag is remevod. This flag has been a no-op for a while, and given scheduler list is not always in kernel anymore, it would be highly confusing to keep it.

When CONFIG_SOF_USERSPACE_LL is set, the context of all schedulers is managed in the LL user-space domain.