### PR TITLE
scheduler: zephyr_ll: misc fixes to make scheduler run in user-space

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -412,10 +412,12 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 
 	zephyr_ll_assert_core(sch);
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 	if (k_is_in_isr()) {
 		tr_err(&ll_tr, "cannot free tasks from interrupt context!");
 		return -EDEADLK;
 	}
+#endif
 
 	zephyr_ll_lock(sch, &flags);
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -257,15 +257,24 @@ void platform_dai_timestamp(struct comp_dev *dai,
 		posn->flags |= SOF_TIME_DAI_VALID;
 
 	/* get SSP wallclock - DAI sets this to stream start value */
+#ifndef CONFIG_SOF_USERSPACE_LL
 	posn->wallclock = sof_cycle_get_64() - posn->wallclock;
 	posn->wallclock_hz = sys_cycle_get_64_rate();
+#else
+	posn->wallclock = k_uptime_ticks() - posn->wallclock;
+	posn->wallclock_hz = CONFIG_SYS_CLOCK_TICKS_PER_SEC;
+#endif
 	posn->flags |= SOF_TIME_WALL_VALID;
 }
 
 /* get current wallclock for componnent */
 void platform_dai_wallclock(struct comp_dev *dai, uint64_t *wallclock)
 {
+#ifndef CONFIG_SOF_USERSPACE_LL
 	*wallclock = sof_cycle_get_64();
+#else
+	*wallclock = k_uptime_ticks();
+#endif
 }
 
 /*


### PR DESCRIPTION
A few standalone changes to make LL scheduler code user-space safe.