### PR TITLE
boards: nvl: add Google RTC Audio Processing to NVL configs

### DIFF
--- a/app/boards/intel_adsp_ace40_nvl.conf
+++ b/app/boards/intel_adsp_ace40_nvl.conf
@@ -12,6 +12,12 @@ CONFIG_COMP_SRC_IPC4_FULL_MATRIX=y
 CONFIG_COMP_TESTER=y
 CONFIG_FORMAT_CONVERT_HIFI3=n
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_PROBE=y
 CONFIG_PROBE_DMA_MAX=2

--- a/app/boards/intel_adsp_ace40_nvls.conf
+++ b/app/boards/intel_adsp_ace40_nvls.conf
@@ -12,6 +12,12 @@ CONFIG_COMP_SRC_IPC4_FULL_MATRIX=y
 CONFIG_COMP_TESTER=y
 CONFIG_FORMAT_CONVERT_HIFI3=n
 
+# SOF / audio modules / mocks
+# This mock is part of official sof-bin releases because the CI that
+# tests it can't use extra CONFIGs. See #9410, #8722 and #9386
+CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m
+CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y
+
 # SOF / infrastructure
 CONFIG_PROBE=y
 CONFIG_PROBE_DMA_MAX=2


### PR DESCRIPTION
Enable the Google RTC Audio Processing component as a loadable module for NVL and NVL-S boards.

This change adds CONFIG_COMP_GOOGLE_RTC_AUDIO_PROCESSING=m and CONFIG_GOOGLE_RTC_AUDIO_PROCESSING_MOCK=y to both board config files.

(This is to just unblock some test cases on NVL platforms)