### PR TITLE
schedule: bind scheduler to a task at task init time

### DIFF
--- a/posix/include/rtos/task.h
+++ b/posix/include/rtos/task.h
@@ -18,6 +18,7 @@
 
 struct comp_dev;
 struct sof;
+struct schedule_data;
 
 /** \brief Predefined LL task priorities. */
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
@@ -60,6 +61,7 @@ struct task {
 	uint16_t priority;	/**< priority of the task (used by LL) */
 	uint16_t core;		/**< execution core */
 	uint16_t flags;		/**< custom flags */
+	struct schedule_data *sch;	/**< scheduler bound to task */
 	enum task_state state;	/**< current state */
 	void *data;		/**< custom data passed to all ops */
 	struct list_item list;	/**< used by schedulers to hold tasks */

--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -202,149 +202,106 @@ static inline void *scheduler_get_data(uint16_t type)
 /** See scheduler_ops::schedule_task_running */
 static inline int schedule_task_running(struct task *task)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type) {
-			/* optional operation */
-			if (!sch->ops->schedule_task_running)
-				return 0;
+	assert(task);
+	sch = task->sch;
 
-			return sch->ops->schedule_task_running(sch->data, task);
-		}
-	}
+	if (!sch->ops->schedule_task_running)
+		return 0;
 
-	return -ENODEV;
+	return sch->ops->schedule_task_running(sch->data, task);
 }
 
 /** See scheduler_ops::schedule_task */
 static inline int schedule_task(struct task *task, uint64_t start,
 				uint64_t period)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
 	if (!task)
 		return -EINVAL;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type)
-			return sch->ops->schedule_task(sch->data, task, start,
-						       period);
-	}
+	sch = task->sch;
 
-	return -ENODEV;
+	return sch->ops->schedule_task(sch->data, task, start, period);
 }
 
 /** See scheduler_ops::schedule_task_before */
 static inline int schedule_task_before(struct task *task, uint64_t start,
 				       uint64_t period, struct task *before)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
 	if (!task || !before)
 		return -EINVAL;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type) {
-			if (sch->ops->schedule_task_before)
-				return sch->ops->schedule_task_before(sch->data, task, start,
-								      period, before);
+	sch = task->sch;
 
-			return sch->ops->schedule_task(sch->data, task, start,
-						       period);
-		}
-	}
+	if (sch->ops->schedule_task_before)
+		return sch->ops->schedule_task_before(sch->data, task, start,
+						      period, before);
 
-	return -ENODEV;
+	return sch->ops->schedule_task(sch->data, task, start, period);
 }
 
 /** See scheduler_ops::schedule_task_after */
 static inline int schedule_task_after(struct task *task, uint64_t start,
 				      uint64_t period, struct task *after)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
 	if (!task || !after)
 		return -EINVAL;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type) {
-			if (sch->ops->schedule_task_after)
-				return sch->ops->schedule_task_after(sch->data, task, start,
-								     period, after);
+	sch = task->sch;
 
-			return sch->ops->schedule_task(sch->data, task, start,
-						       period);
-		}
-	}
+	if (sch->ops->schedule_task_after)
+		return sch->ops->schedule_task_after(sch->data, task, start,
+						     period, after);
 
-	return -ENODEV;
+	return sch->ops->schedule_task(sch->data, task, start, period);
 }
 
 /** See scheduler_ops::reschedule_task */
 static inline int reschedule_task(struct task *task, uint64_t start)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type) {
-			/* optional operation */
-			if (!sch->ops->reschedule_task)
-				return 0;
+	assert(task);
+	sch = task->sch;
 
-			return sch->ops->reschedule_task(sch->data, task,
-							 start);
-		}
-	}
+	/* optional operation */
+	if (!sch->ops->reschedule_task)
+		return 0;
 
-	return -ENODEV;
+	return sch->ops->reschedule_task(sch->data, task, start);
 }
 
 /** See scheduler_ops::schedule_task_cancel */
 static inline int schedule_task_cancel(struct task *task)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type)
-			return sch->ops->schedule_task_cancel(sch->data, task);
-	}
+	if (!task || !task->sch)
+		return -EINVAL;
 
-	return -ENODEV;
+	sch = task->sch;
+
+	return sch->ops->schedule_task_cancel(sch->data, task);
 }
 
 /** See scheduler_ops::schedule_task_free */
 static inline int schedule_task_free(struct task *task)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
-	struct list_item *slist;
 
-	list_for_item(slist, &schedulers->list) {
-		sch = container_of(slist, struct schedule_data, list);
-		if (task->type == sch->type)
-			return sch->ops->schedule_task_free(sch->data, task);
-	}
+	if (!task || !task->sch)
+		return -EINVAL;
 
-	return -ENODEV;
+	sch = task->sch;
+
+	return sch->ops->schedule_task_free(sch->data, task);
 }
 
 /** See scheduler_ops::scheduler_free */

--- a/src/platform/library/schedule/schedule.c
+++ b/src/platform/library/schedule/schedule.c
@@ -25,8 +25,28 @@ int schedule_task_init(struct task *task,
 		       uint16_t priority, enum task_state (*run)(void *data),
 		       void *data, uint16_t core, uint32_t flags)
 {
+	struct schedulers *schedulers = *arch_schedulers_get();
+	struct schedule_data *sch = NULL;
+	struct list_item *slist;
+
 	if (type >= SOF_SCHEDULE_COUNT)
 		return -EINVAL;
+
+	if (!schedulers)
+		return -ENODEV;
+
+	task->sch = NULL;
+	list_for_item(slist, &schedulers->list) {
+		sch = container_of(slist, struct schedule_data, list);
+		if (type == sch->type) {
+			task->sch = sch;
+			break;
+		}
+	}
+
+	if (!task->sch) {
+		return -ENODEV;
+	}
 
 	task->uid = uid;
 	task->type = type;

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -27,9 +27,30 @@ int schedule_task_init(struct task *task,
 		       uint16_t priority, enum task_state (*run)(void *data),
 		       void *data, uint16_t core, uint32_t flags)
 {
+	struct schedulers *schedulers = *arch_schedulers_get();
+	struct schedule_data *sch = NULL;
+	struct list_item *slist;
+
 	if (type >= SOF_SCHEDULE_COUNT) {
 		tr_err(&sch_tr, "invalid task type");
 		return -EINVAL;
+	}
+
+	if (!schedulers)
+		return -ENODEV;
+
+	task->sch = NULL;
+	list_for_item(slist, &schedulers->list) {
+		sch = container_of(slist, struct schedule_data, list);
+		if (type == sch->type) {
+			task->sch = sch;
+			break;
+		}
+	}
+
+	if (!task->sch) {
+		tr_err(&sch_tr, "unable to bind scheduler to task %p (type %d)", task, type);
+		return -ENODEV;
 	}
 
 	task->uid = uid;

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -543,6 +543,12 @@ int zephyr_ll_task_init(struct task *task,
 	if (task->priv_data)
 		return -EEXIST;
 
+	/*
+	 * schedule_task_init() must be run on target core, see
+	 * sof/zephyr/schedule.c:arch_schedulers_get()
+	 */
+	assert(cpu_get_id() == core);
+
 	ret = schedule_task_init(task, uid, type, priority, run, data, core,
 				 flags);
 	if (ret < 0)

--- a/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
+++ b/test/cmocka/src/audio/pipeline/pipeline_connection_mocks.c
@@ -49,6 +49,9 @@ struct pipeline_connect_data *get_standard_connect_objects(void)
 	sch->ops = &schedule_mock_ops;
 	list_item_append(&sch->list, &schedulers->list);
 
+	/* Bind the scheduler to the task, as schedule_task_init() would */
+	pipe->pipe_task->sch = sch;
+
 	struct comp_dev *first = calloc(sizeof(struct comp_dev), 1);
 	struct comp_ipc_config *first_comp = &first->ipc_config;
 

--- a/zephyr/include/rtos/task.h
+++ b/zephyr/include/rtos/task.h
@@ -17,6 +17,7 @@
 
 struct comp_dev;
 struct sof;
+struct schedule_data;
 
 /** \brief Predefined LL task priorities. */
 #define SOF_TASK_PRI_HIGH	0	/* priority level 0 - high */
@@ -59,6 +60,7 @@ struct task {
 	uint16_t priority;	/**< priority of the task (used by LL) */
 	uint16_t core;		/**< execution core */
 	uint16_t flags;		/**< custom flags */
+	struct schedule_data *sch;	/**< scheduler bound to task */
 	enum task_state state;	/**< current state */
 	void *data;		/**< custom data passed to all ops */
 	struct list_item list;	/**< used by schedulers to hold tasks */


### PR DESCRIPTION
Change the operation model of schedule.h such that a task is bound to a scheduler instance at task init time. In the past, the scheduler instance has been looked up at each task scheduling invocation. The old model assume all schedule.h callers have access to all scheduler objects in the system. This complicates implementation of user-space support in SOF.

Store a pointer to the matching schedule_data in the task struct at schedule_task_init() time. This allows all schedule API functions (schedule_task, schedule_task_before, schedule_task_after, reschedule_task, schedule_task_cancel, schedule_task_free, and schedule_task_running) to use the cached scheduler reference directly from task->sch, instead of iterating the global scheduler list on every call.

This reduces runtime overhead and simplifies the inline functions in schedule.h, removing the repeated list traversal and type matching logic. The scheduler binding is validated at init time, so subsequent operations can assume a valid task->sch pointer.

Note: in Zephyr builds, arch_schedulers_get() is sensitive on which core it is executed on, so add an assert to ensure schedule_task_init() is called on the target core.