### PR TITLE
app: overlays: ptl: add ll_usespace_overlay.conf

### DIFF
--- a/app/overlays/ptl/ll_userspace_overlay.conf
+++ b/app/overlays/ptl/ll_userspace_overlay.conf
@@ -1,0 +1,38 @@
+# This is overlay configuration file to enable user-space LL audio
+# pipeline support. This overlay is intended for development
+# purposes. If user-space LL is enabled for some build target by
+# default, the settings should be made in the SOF board file directly.
+
+# Enable user-space LL support in SOF
+# -----------------------------------
+
+CONFIG_SOF_USERSPACE_LL=y
+
+# make the drivers work in user-space
+CONFIG_SOF_USERSPACE_INTERFACE_DMA=y
+CONFIG_DAI_USERSPACE=y
+
+# Temporary settings that are needed currently to enable user-space LL
+# --------------------------------------------------------------------
+
+# problem with DSP panics due to illegal instruction hit in user-space if cold
+# store execution is enabled. Disable it for now until rootcause is found.
+CONFIG_COLD_STORE_EXECUTE_DRAM=n
+CONFIG_COLD_STORE_EXECUTE_DEBUG=n
+
+# telemetry not yet user-space compatible
+CONFIG_SOF_TELEMETRY_PERFORMANCE_MEASUREMENTS=n
+CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS=n
+
+# disable loadable modules (hits privilege issues in user-space now)
+CONFIG_LLEXT_STORAGE_WRITABLE=n
+CONFIG_LLEXT_EXPERIMENTAL=n
+CONFIG_MODULES=n
+
+# some of current boot tests interfere with user-space setup
+CONFIG_SOF_BOOT_TEST_ALLOWED=n
+
+# misc features not yet compatible with user-space
+CONFIG_CROSS_CORE_STREAM=n
+CONFIG_INTEL_ADSP_MIC_PRIVACY=n
+CONFIG_XRUN_NOTIFICATIONS_ENABLE=n


### PR DESCRIPTION
Add an overlay for Intel 'ptl' target that allows to build SOF with all audio pipeline code running in Zephyr user-space.

Some features are disabled in the overlay as the feature is not working in user-space configuration. This list will be adjusted as more features are made compatible with user-space.