### PR TITLE
Only heap size attribute

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -81,10 +81,9 @@ int module_ext_init_decode(const struct comp_driver *drv, struct module_ext_init
 			}
 			ext_data->dp_data = dp_data;
 			comp_cl_info(drv,
-				     "init_ext_obj_dp_data domain %u stack %u interim %u lifetime %u shared %u",
+				     "init_ext_obj_dp_data domain %u stack %u heap %u",
 				     dp_data->domain_id, dp_data->stack_bytes,
-				     dp_data->interim_heap_bytes, dp_data->lifetime_heap_bytes,
-				     dp_data->shared_bytes);
+				     dp_data->heap_bytes);
 			break;
 		}
 		case IPC4_MOD_INIT_DATA_ID_MODULE_DATA:

--- a/src/include/ipc4/module.h
+++ b/src/include/ipc4/module.h
@@ -93,9 +93,7 @@ struct ipc4_module_init_ext_object {
 struct ipc4_module_init_ext_obj_dp_data {
 	uint32_t domain_id;		/* userspace domain ID */
 	uint32_t stack_bytes;		/* required stack size in bytes */
-	uint32_t interim_heap_bytes;	/* required interim heap size in bytes */
-	uint32_t lifetime_heap_bytes;	/* required lifetime heap size in bytes */
-	uint32_t shared_bytes;		/* required shared memory size in bytes */
+	uint32_t heap_bytes;			/* required heap size in bytes */
 } __attribute__((packed, aligned(4)));
 
 /*

--- a/src/include/ipc4/pipeline.h
+++ b/src/include/ipc4/pipeline.h
@@ -88,9 +88,7 @@ struct ipc4_pipeline_ext_object {
 struct ipc4_pipeline_ext_obj_mem_data {
 	uint32_t domain_id;		/* userspace domain ID */
 	uint32_t stack_bytes;		/* required stack size in bytes */
-	uint32_t interim_heap_bytes;	/* required interim heap size in bytes */
-	uint32_t lifetime_heap_bytes;	/* required lifetime heap size in bytes */
-	uint32_t shared_bytes;		/* required shared memory in bytes */
+	uint32_t heap_bytes;			/* required heap size in bytes */
 } __packed __aligned(4);
 
 /*

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -317,10 +317,9 @@ __cold static int ipc4_create_pipeline_payload_decode(char *data,
 			}
 			pparams->mem_data = mem_data;
 			tr_info(&ipc_tr,
-				"init_ext_obj_mem_data domain %u stack %u interim %u lifetime %u shared %u",
+				"init_ext_obj_mem_data domain %u stack %u heap %u",
 				mem_data->domain_id, mem_data->stack_bytes,
-				mem_data->interim_heap_bytes, mem_data->lifetime_heap_bytes,
-				mem_data->shared_bytes);
+				mem_data->heap_bytes);
 			break;
 		}
 		default:


### PR DESCRIPTION
This PR is base on https://github.com/thesofproject/sof/pull/10831 and should go in after it. It is also an integral part of soon to be pushed new version https://github.com/thesofproject/sof/pull/10783 and should go in only after we are convinced of #10783 changes, automating division between vregion lifetime and interim allocations, and in effect moving most of allocations to lifetime linear part of the vregion heap.

This is a separate PR because this should go in before we tag the next SOF release, to not to let our IPC and topology attribute wandering to contaminate our SOF releases. That is if we get convinced of #10783  approach.

This is a pair with the soon to be pushed new version of https://github.com/thesofproject/linux/pull/5537
