### PR TITLE
 ipc: ipc4: fixes to DMA driver use in user-space builds

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -450,7 +450,7 @@ void dai_dma_position_update(struct dai_data *dd, struct comp_dev *dev)
 	if (!dd->slot_info.node_id)
 		return;
 
-	ret = dma_get_status(dd->dma->z_dev, dd->chan_index, &status);
+	ret = sof_dma_get_status(dd->dma, dd->chan_index, &status);
 	if (ret < 0)
 		return;
 

--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -236,9 +236,9 @@ void dai_dma_release(struct dai_data *dd, struct comp_dev *dev)
 		 * TODO: refine power management when stream is paused
 		 */
 		/* if reset is after pause dma has already been stopped */
-		dma_stop(dd->dma->z_dev, dd->chan_index);
+		sof_dma_stop(dd->dma, dd->chan_index);
 
-		dma_release_channel(dd->dma->z_dev, dd->chan_index);
+		sof_dma_release_channel(dd->dma, dd->chan_index);
 		dd->chan_index = -EINVAL;
 	}
 }


### PR DESCRIPTION
A set of small fixes to how IPC4 code uses DMA driver and driver look-up interfaces.

Patches part of feature development done in https://github.com/thesofproject/sof/pull/10558 