### PR TITLE
Debug stream text msg improvements

### DIFF
--- a/src/debug/debug_stream/debug_stream_slot.c
+++ b/src/debug/debug_stream/debug_stream_slot.c
@@ -12,6 +12,10 @@
 #include <user/debug_stream_slot.h>
 #include <zephyr/kernel.h>
 
+#ifdef CONFIG_USERSPACE
+#include <zephyr/internal/syscall_handler.h>
+#endif
+
 LOG_MODULE_REGISTER(debug_stream_slot);
 
 struct cpu_mutex {
@@ -66,7 +70,7 @@ debug_stream_get_circular_buffer(struct debug_stream_section_descriptor *desc, u
 	return (struct debug_stream_circular_buf *) (((uint8_t *)hdr) + desc->offset);
 }
 
-int debug_stream_slot_send_record(struct debug_stream_record *rec)
+int z_impl_debug_stream_slot_send_record(struct debug_stream_record *rec)
 {
 	struct debug_stream_section_descriptor desc = { 0 };
 	struct debug_stream_circular_buf *buf =
@@ -118,6 +122,16 @@ int debug_stream_slot_send_record(struct debug_stream_record *rec)
 	LOG_DBG("Record %u id %u len %u sent", rec->seqno, rec->id, record_size);
 	return 0;
 }
+
+#ifdef CONFIG_USERSPACE
+static inline int z_vrfy_debug_stream_slot_send_record(struct debug_stream_record *rec)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(rec, sizeof(*rec)));
+	K_OOPS(K_SYSCALL_MEMORY_READ(rec, rec->size_words * sizeof(uint32_t)));
+	return z_impl_debug_stream_slot_send_record(rec);
+}
+#include <zephyr/syscalls/debug_stream_slot_send_record_mrsh.c>
+#endif
 
 static int debug_stream_slot_init(void)
 {

--- a/src/debug/debug_stream/debug_stream_text_msg.c
+++ b/src/debug/debug_stream/debug_stream_text_msg.c
@@ -43,6 +43,7 @@ void ds_msg(const char *format, ...)
 	ds_vamsg(format, args);
 	va_end(args);
 }
+EXPORT_SYMBOL(ds_msg);
 
 #if defined(CONFIG_EXCEPTION_DUMP_HOOK)
 /* The debug stream debug window slot is 4k, and when it is split

--- a/src/include/user/debug_stream_slot.h
+++ b/src/include/user/debug_stream_slot.h
@@ -127,6 +127,8 @@ struct debug_stream_record;
  *         -ENODEV if debug stream slot is not configured
  *         -ENOMEM if the record is too big
  */
-int debug_stream_slot_send_record(struct debug_stream_record *rec);
+__syscall int debug_stream_slot_send_record(struct debug_stream_record *rec);
+
+#include <zephyr/syscalls/debug_stream_slot.h>
 
 #endif /* __SOC_DEBUG_WINDOW_SLOT_H__ */

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -623,6 +623,8 @@ zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/lib/fast-get.h)
 zephyr_syscall_header(include/rtos/alloc.h)
 zephyr_library_sources_ifdef(CONFIG_SOF_USERSPACE_INTERFACE_ALLOC syscall/alloc.c)
 
+zephyr_syscall_header(${SOF_SRC_PATH}/include/user/debug_stream_slot.h)
+
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)
 


### PR DESCRIPTION
Make ds_send_text_record() a syscall to make userspace debugging easier. And export ds_msg() to allow its usage in module code.