### PR TITLE
dai: turn dai_get_device() into a syscall

### DIFF
--- a/src/include/sof/lib/dai-zephyr.h
+++ b/src/include/sof/lib/dai-zephyr.h
@@ -309,7 +309,7 @@ void dai_release_llp_slot(struct dai_data *dd);
 /**
  * \brief Retrieve a pointer to the Zephyr device structure for a DAI of a given type and index.
  */
-const struct device *dai_get_device(enum sof_ipc_dai_type type, uint32_t index);
+__syscall const struct device *dai_get_device(enum sof_ipc_dai_type type, uint32_t index);
 
 /**
  * \brief Retrieve the list of all DAI devices.
@@ -318,5 +318,7 @@ const struct device *dai_get_device(enum sof_ipc_dai_type type, uint32_t index);
  */
 const struct device **dai_get_device_list(size_t *count);
 /** @}*/
+
+#include <zephyr/syscalls/dai-zephyr.h>
 
 #endif /* __SOF_LIB_DAI_ZEPHYR_H__ */

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -243,7 +243,7 @@ static int sof_dai_type_to_zephyr(uint32_t type)
 	}
 }
 
-const struct device *dai_get_device(enum sof_ipc_dai_type type, uint32_t index)
+const struct device *z_impl_dai_get_device(enum sof_ipc_dai_type type, uint32_t index)
 {
 	struct dai_config cfg;
 	int z_type;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -622,6 +622,8 @@ zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/audio/module_adapter/module/ge
 zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/lib/fast-get.h)
 zephyr_syscall_header(include/rtos/alloc.h)
 zephyr_library_sources_ifdef(CONFIG_SOF_USERSPACE_INTERFACE_ALLOC syscall/alloc.c)
+zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/lib/dai-zephyr.h)
+zephyr_library_sources_ifdef(CONFIG_USERSPACE syscall/dai.c)
 
 zephyr_library_link_libraries(SOF)
 target_link_libraries(SOF INTERFACE zephyr_interface)

--- a/zephyr/syscall/dai.c
+++ b/zephyr/syscall/dai.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright(c) 2026 Intel Corporation.
+
+#include <sof/lib/dai.h>
+#include <zephyr/kernel.h>
+#include <zephyr/internal/syscall_handler.h>
+
+static inline const struct device *z_vrfy_dai_get_device(enum sof_ipc_dai_type type,
+							 uint32_t index)
+{
+	const struct device *dev = z_impl_dai_get_device(type, index);
+
+	if (dev && !k_object_is_valid(dev, K_OBJ_DRIVER_DAI))
+		return NULL;
+
+	return dev;
+}
+#include <zephyr/syscalls/dai_get_device_mrsh.c>


### PR DESCRIPTION
Make dai_get_device() a syscall, so it can be called from user-space threads.