### PR TITLE
fix off-by-one scanf width in filter_parse_component_name

### DIFF
--- a/tools/logger/filter.c
+++ b/tools/logger/filter.c
@@ -104,7 +104,7 @@ static char *filter_parse_component_name(char *input_str, struct filter_element 
 	 */
 	if (strlen(scan_format_string) == 0) {
 		ret = snprintf(scan_format_string, sizeof(scan_format_string),
-				"%%%d[^0-9* ]s", UUID_NAME_MAX_LEN);
+				"%%%d[^0-9* ]s", UUID_NAME_MAX_LEN - 1);
 		if (ret <= 0)
 			return NULL;
 	}


### PR DESCRIPTION
sscanf writes one byte past comp_name when parsing a -F component name:
- the format width is set to UUID_NAME_MAX_LEN, but a %N[...] conversion writes up to N characters plus a NUL
- comp_name is only UUID_NAME_MAX_LEN bytes, so a name of that length overflows the stack buffer by one byte
Capped the scan width at UUID_NAME_MAX_LEN - 1.