### PR TITLE
west.yml: update zephyr to 2826b08

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: c162980efd9ad8616d0e2fe886ca917d8d8d240a
+      revision: 2826b086d1355e9ae0b034c4dd391555c1e11074
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update west.yml to bring in Zephyr support
for AMD ACP 7X.