### PR TITLE
audio: init align to avoid uninitialized read in error log

### DIFF
--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -467,7 +467,7 @@ int dai_common_params(struct dai_data *dd, struct comp_dev *dev,
 	uint32_t period_bytes;
 	uint32_t buffer_size;
 	uint32_t addr_align;
-	uint32_t align;
+	uint32_t align = 0;
 	int err;
 
 	comp_dbg(dev, "dai_params()");

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -977,7 +977,7 @@ static int dai_set_dma_buffer(struct dai_data *dd, struct comp_dev *dev,
 	uint32_t buffer_size;
 	uint32_t buffer_size_preferred;
 	uint32_t addr_align;
-	uint32_t align;
+	uint32_t align = 0;
 	int err;
 
 	comp_dbg(dev, "entry");

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -686,7 +686,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	uint32_t period_bytes;
 	uint32_t buffer_size;
 	uint32_t addr_align;
-	uint32_t align;
+	uint32_t align = 0;
 	int err;
 
 	/* host params always installed by pipeline IPC */

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -887,7 +887,7 @@ int host_common_params(struct host_data *hd, struct comp_dev *dev,
 	uint32_t buffer_size;
 	uint32_t buffer_size_preferred;
 	uint32_t addr_align;
-	uint32_t align;
+	uint32_t align = 0;
 	int i, err;
 	bool is_scheduling_source = dev == dev->pipeline->sched_comp;
 	uint32_t round_up_size;


### PR DESCRIPTION
sof_dma_get_attribute() can return an error without writing its output parameter, so logging align on that path read an uninitialized value. Initialize align to 0 in the host/dai zephyr and legacy params paths.