### PR TITLE
ipc: remove unnecessary comp_driver_list spinlock

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -45,23 +45,22 @@ DECLARE_TR_CTX(comp_tr, SOF_UUID(component_uuid), LOG_LEVEL_INFO);
 int comp_register(struct comp_driver_info *drv)
 {
 	struct comp_driver_list *drivers = comp_drivers_get();
-	k_spinlock_key_t key;
 
-	key = k_spin_lock(&drivers->lock);
+	/*
+	 * No locking needed: the driver list is only modified at FW boot,
+	 * where module init runs serially on the primary core, and at
+	 * runtime from the serialized IPC thread (library load). These
+	 * never overlap, so concurrent modification is not possible.
+	 */
 	list_item_prepend(&drv->list, &drivers->list);
-	k_spin_unlock(&drivers->lock, key);
 
 	return 0;
 }
 
 void comp_unregister(struct comp_driver_info *drv)
 {
-	struct comp_driver_list *drivers = comp_drivers_get();
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&drivers->lock);
+	/* see comp_register() on why no locking is needed */
 	list_item_del(&drv->list);
-	k_spin_unlock(&drivers->lock, key);
 }
 
 int comp_set_adapter_ops(const struct comp_driver *drv, const struct module_interface *ops)
@@ -190,7 +189,6 @@ void sys_comp_init(struct sof *sof)
 	sof->comp_drivers = platform_shared_get(&cd, sizeof(cd));
 
 	list_init(&sof->comp_drivers->list);
-	k_spinlock_init(&sof->comp_drivers->lock);
 }
 
 void comp_get_copy_limits(struct comp_buffer *source,

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -26,7 +26,6 @@
 /** \brief Holds list of registered components' drivers */
 struct comp_driver_list {
 	struct list_item list;	/**< list of component drivers */
-	struct k_spinlock lock;	/**< list lock */
 };
 
 /** \brief Retrieves the component device buffer list. */

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -81,7 +81,6 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 	struct comp_driver_info *info;
 	struct sof_ipc_comp_ext *comp_ext;
 	uintptr_t offset;
-	k_spinlock_key_t key;
 
 	/* do we have extended data ? */
 	if (!comp->ext_data_length) {
@@ -127,9 +126,10 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 		goto out;
 	}
 
-	/* search driver list with UUID */
-	key = k_spin_lock(&drivers->lock);
-
+	/*
+	 * search driver list with UUID; no locking needed as the driver
+	 * list is only modified at boot and from the serialized IPC thread
+	 */
 	list_for_item(clist, &drivers->list) {
 		info = container_of(clist, struct comp_driver_info,
 				    list);
@@ -147,8 +147,6 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 		       *(uint32_t *)(&comp_ext->uuid[4]),
 		       *(uint32_t *)(&comp_ext->uuid[8]),
 		       *(uint32_t *)(&comp_ext->uuid[12]));
-
-	k_spin_unlock(&drivers->lock, key);
 
 out:
 	if (drv)

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1142,11 +1142,8 @@ __cold static const struct comp_driver *ipc4_search_for_drv(const void *uuid)
 	struct list_item *clist;
 	const struct comp_driver *drv = NULL;
 	struct comp_driver_info *info;
-	uint32_t flags;
 
 	assert_can_be_cold();
-
-	irq_local_disable(flags);
 
 	/* search driver list with UUID */
 	list_for_item(clist, &drivers->list) {
@@ -1162,7 +1159,6 @@ __cold static const struct comp_driver *ipc4_search_for_drv(const void *uuid)
 		}
 	}
 
-	irq_local_enable(flags);
 	return drv;
 }
 


### PR DESCRIPTION
Drop the IRQ disable/enable in ipc4_search_for_drv(). The driver list is only modified at FW boot and when a new driver is registered at runtime via SOF_IPC4_GLB_LOAD_LIBRARY IPC. ipc4_search_for_drv() is only used when processing IPC messages. As IPC processing is serialized, it is not possible for the driver list to be modified concurrently with a call to ipc4_search_for_drv().