### PR TITLE
module_adapter: fix memory API debug check for DP modules

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -28,8 +28,10 @@
 /* The __ZEPHYR__ condition is to keep cmocka tests working */
 #if CONFIG_MODULE_MEMORY_API_DEBUG && defined(__ZEPHYR__)
 #define MEM_API_CHECK_THREAD(res) do { \
-	if ((res)->rsrc_mngr != k_current_get()) \
-		LOG_WRN("mngr %p != cur %p", (res)->rsrc_mngr, k_current_get()); \
+	k_tid_t tid = k_current_get(); \
+	if (((res)->rsrc_mngr != NULL || (res)->dp_thread != NULL) &&	\
+	    (res)->rsrc_mngr != tid && (res)->dp_thread != tid)		\
+		LOG_WRN("cur %p != mngr %p or dp %p", tid, (res)->rsrc_mngr, (res)->dp_thread); \
 } while (0)
 #else
 #define MEM_API_CHECK_THREAD(res)

--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -118,7 +118,7 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 		goto emod;
 	}
 
-	struct mod_alloc_ctx *alloc = rmalloc(flags, sizeof(*alloc));
+	struct mod_alloc_ctx *alloc = rzalloc(flags, sizeof(*alloc));
 
 	if (!alloc)
 		goto ealloc;

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -135,6 +135,7 @@ struct module_resources {
 	struct mod_alloc_ctx *alloc;
 #if CONFIG_MODULE_MEMORY_API_DEBUG && defined(__ZEPHYR__)
 	k_tid_t rsrc_mngr;
+	k_tid_t dp_thread;
 #endif
 };
 

--- a/src/schedule/zephyr_dp_schedule_application.c
+++ b/src/schedule/zephyr_dp_schedule_application.c
@@ -504,6 +504,10 @@ int scheduler_dp_task_init(struct task **task, const struct sof_uuid_entry *uid,
 					   stack_size, dp_thread_fn, ptask, NULL, NULL,
 					   CONFIG_DP_THREAD_PRIORITY, ptask->flags, K_FOREVER);
 	scheduler_dp_thread_name_set(pdata->thread_id, mod);
+#if CONFIG_MODULE_MEMORY_API_DEBUG
+	/* For a DP module the resource manager can also be the DP thread */
+	mod->priv.resources.dp_thread = pdata->thread_id;
+#endif
 
 	unsigned int pidx;
 	size_t size;


### PR DESCRIPTION
Add dp_thread field to module_resources so that the memory API debug check accepts allocations from both the IPC thread (rsrc_mngr) and the DP thread. Update MEM_API_CHECK_THREAD to check both thread IDs.

Also change mod_alloc_ctx allocation from rmalloc to rzalloc to zero-initialize the structure. The code assumes the dp_thread member is NULL in case of a non-DP module.

Both threads using the memory tracking features is not a problem since the memory operations are synchronized with semaphores and events so that both threads are never doing resource operations at the same time.