### PR TITLE
lib: vregion: lazy interim heap creation from remaining lifetime space

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -65,13 +65,7 @@ static struct vregion *module_adapter_dp_heap_new(const struct comp_ipc_config *
 	/* FIXME: the size will be derived from configuration */
 	const size_t buf_size = 28 * 1024;
 
-	/*
-	 * A 1-to-1 replacement of the original heap implementation would be to
-	 * have "lifetime size" equal to 0. But (1) this is invalid for
-	 * vregion_create() and (2) we gradually move objects, that are simple
-	 * to move to the lifetime buffer. Make it 4k for the beginning.
-	 */
-	return vregion_create(4096, buf_size - 4096);
+	return vregion_create(buf_size);
 }
 
 static struct processing_module *module_adapter_mem_alloc(const struct comp_driver *drv,
@@ -109,9 +103,9 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	if (!mod_vreg)
 		mod = sof_heap_alloc(mod_heap, flags, sizeof(*mod), 0);
 	else if (flags & SOF_MEM_FLAG_COHERENT)
-		mod = vregion_alloc_coherent(mod_vreg, VREGION_MEM_TYPE_LIFETIME, sizeof(*mod));
+		mod = vregion_alloc_coherent(mod_vreg, sizeof(*mod));
 	else
-		mod = vregion_alloc(mod_vreg, VREGION_MEM_TYPE_LIFETIME, sizeof(*mod));
+		mod = vregion_alloc(mod_vreg, sizeof(*mod));
 
 	if (!mod) {
 		comp_cl_err(drv, "failed to allocate memory for module");
@@ -136,7 +130,7 @@ static struct processing_module *module_adapter_mem_alloc(const struct comp_driv
 	 * single-core configurations.
 	 */
 	if (mod_vreg)
-		dev = vregion_alloc_coherent(mod_vreg, VREGION_MEM_TYPE_LIFETIME, sizeof(*dev));
+		dev = vregion_alloc_coherent(mod_vreg, sizeof(*dev));
 	else
 		dev = sof_heap_alloc(mod_heap, SOF_MEM_FLAG_COHERENT, sizeof(*dev), 0);
 

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -7,8 +7,10 @@
 
 #include <sof/audio/buffer.h>
 #include <sof/audio/component_ext.h>
+#include <sof/audio/module_adapter/module/generic.h>
 #include <sof/audio/pipeline.h>
 #include <sof/ipc/msg.h>
+#include <sof/lib/vregion.h>
 #include <rtos/interrupt.h>
 #include <rtos/symbol.h>
 #include <rtos/alloc.h>
@@ -294,8 +296,14 @@ static int pipeline_comp_complete(struct comp_dev *current,
 	 * It will be calculated during module prepare operation
 	 * either by the module or to default value based on module's OBS
 	 */
-	if (current->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL)
+	if (current->ipc_config.proc_domain == COMP_PROCESSING_DOMAIN_LL) {
 		current->period = ppl_data->p->period;
+	} else {
+		struct processing_module *mod = comp_mod(current);
+
+		if (mod && mod->priv.resources.alloc)
+			vregion_set_interim(mod->priv.resources.alloc->vreg);
+	}
 
 	current->priority = ppl_data->p->priority;
 

--- a/src/include/sof/lib/vregion.h
+++ b/src/include/sof/lib/vregion.h
@@ -24,6 +24,7 @@ struct vregion;
 enum vregion_mem_type {
 	VREGION_MEM_TYPE_INTERIM,		/* interim allocation that can be freed */
 	VREGION_MEM_TYPE_LIFETIME,		/* lifetime allocation */
+	VREGION_MEM_TYPE_INVALID,		/* Interim heap initialization failed */
 };
 
 #if CONFIG_SOF_VREGIONS
@@ -31,14 +32,24 @@ enum vregion_mem_type {
 /**
  * @brief Create a new virtual region instance.
  *
- * Create a new virtual region instance with specified static and dynamic partitions.
- * Total size is the sum of static and dynamic sizes.
+ * Create a new virtual region instance with specified memory size.
+ * Allocations start in LIFETIME mode.
  *
- * @param[in] lifetime_size Size of the virtual region lifetime partition.
- * @param[in] interim_size Size of the virtual region interim partition.
+ * @param[in] memsize Total size of the virtual region memory.
  * @return struct vregion* Pointer to the new virtual region instance, or NULL on failure.
  */
-struct vregion *vregion_create(size_t lifetime_size, size_t interim_size);
+struct vregion *vregion_create(size_t memsize);
+
+/**
+ * @brief Switch virtual region allocations to interim mode.
+ *
+ * After this call, all allocations from this vregion will use the interim
+ * heap. The interim heap is created lazily from remaining lifetime space.
+ * Multiple calls are allowed but log a warning.
+ *
+ * @param[in] vr Pointer to the virtual region instance.
+ */
+void vregion_set_interim(struct vregion *vr);
 
 /**
  * @brief Increment virtual region's user count.
@@ -66,36 +77,33 @@ struct vregion *vregion_put(struct vregion *vr);
  * @brief Allocate memory from the specified virtual region.
  *
  * @param[in] vr Pointer to the virtual region instance.
- * @param[in] type Type of memory to allocate (lifetime or interim).
  * @param[in] size Size of memory to allocate in bytes.
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-void *vregion_alloc(struct vregion *vr, enum vregion_mem_type type, size_t size);
+void *vregion_alloc(struct vregion *vr, size_t size);
 
 /**
  * @brief like vregion_alloc() but allocates coherent memory
  */
-void *vregion_alloc_coherent(struct vregion *vr, enum vregion_mem_type type, size_t size);
+void *vregion_alloc_coherent(struct vregion *vr, size_t size);
 
 /**
  * @brief Allocate aligned memory from the specified virtual region.
  *
- * Allocate aligned memory from the specified virtual region based on the memory type.
+ * Allocate aligned memory from the specified virtual region using the
+ * current allocation mode (lifetime or interim).
  *
  * @param[in] vr Pointer to the virtual region instance.
- * @param[in] type Type of memory to allocate (lifetime or interim).
  * @param[in] size Size of memory to allocate in bytes.
  * @param[in] alignment Alignment of memory to allocate in bytes.
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-void *vregion_alloc_align(struct vregion *vr, enum vregion_mem_type type,
-			  size_t size, size_t alignment);
+void *vregion_alloc_align(struct vregion *vr, size_t size, size_t alignment);
 
 /**
  * @brief like vregion_alloc_align() but allocates coherent memory
  */
-void *vregion_alloc_coherent_align(struct vregion *vr, enum vregion_mem_type type,
-				   size_t size, size_t alignment);
+void *vregion_alloc_coherent_align(struct vregion *vr, size_t size, size_t alignment);
 
 /**
  * @brief Free memory allocated from the specified virtual region.
@@ -129,10 +137,11 @@ struct vregion {
 	unsigned int use_count;
 };
 
-static inline struct vregion *vregion_create(size_t lifetime_size, size_t interim_size)
+static inline struct vregion *vregion_create(size_t memsize)
 {
 	return NULL;
 }
+static inline void vregion_set_interim(struct vregion *vr) {}
 static inline struct vregion *vregion_get(struct vregion *vr)
 {
 	return vr;
@@ -141,22 +150,20 @@ static inline struct vregion *vregion_put(struct vregion *vr)
 {
 	return vr;
 }
-static inline void *vregion_alloc(struct vregion *vr, enum vregion_mem_type type, size_t size)
+static inline void *vregion_alloc(struct vregion *vr, size_t size)
 {
 	return NULL;
 }
-static inline void *vregion_alloc_coherent(struct vregion *vr, enum vregion_mem_type type,
-					   size_t size)
+static inline void *vregion_alloc_coherent(struct vregion *vr, size_t size)
 {
 	return NULL;
 }
-static inline void *vregion_alloc_align(struct vregion *vr, enum vregion_mem_type type,
-					size_t size, size_t alignment)
+static inline void *vregion_alloc_align(struct vregion *vr, size_t size, size_t alignment)
 {
 	return NULL;
 }
-static inline void *vregion_alloc_coherent_align(struct vregion *vr, enum vregion_mem_type type,
-						 size_t size, size_t alignment)
+static inline void *vregion_alloc_coherent_align(struct vregion *vr, size_t size,
+						 size_t alignment)
 {
 	return NULL;
 }

--- a/src/lib/objpool.c
+++ b/src/lib/objpool.c
@@ -44,10 +44,10 @@ static int objpool_add(struct objpool_head *head, unsigned int n, size_t size, u
 		pobjpool = sof_heap_alloc(head->heap, flags,
 					  aligned_size + sizeof(*pobjpool), 0);
 	else if (flags & SOF_MEM_FLAG_COHERENT)
-		pobjpool = vregion_alloc_coherent(head->vreg, VREGION_MEM_TYPE_INTERIM,
+		pobjpool = vregion_alloc_coherent(head->vreg,
 						  aligned_size + sizeof(*pobjpool));
 	else
-		pobjpool = vregion_alloc(head->vreg, VREGION_MEM_TYPE_INTERIM,
+		pobjpool = vregion_alloc(head->vreg,
 					 aligned_size + sizeof(*pobjpool));
 
 	if (!pobjpool)

--- a/zephyr/include/rtos/alloc.h
+++ b/zephyr/include/rtos/alloc.h
@@ -189,10 +189,9 @@ static inline void *sof_ctx_alloc(struct mod_alloc_ctx *ctx, uint32_t flags,
 		return sof_heap_alloc(ctx ? ctx->heap : NULL, flags, size, alignment);
 
 	if (flags & SOF_MEM_FLAG_COHERENT)
-		return vregion_alloc_coherent_align(ctx->vreg, VREGION_MEM_TYPE_INTERIM,
-						    size, alignment);
+		return vregion_alloc_coherent_align(ctx->vreg, size, alignment);
 
-	return vregion_alloc_align(ctx->vreg, VREGION_MEM_TYPE_INTERIM, size, alignment);
+	return vregion_alloc_align(ctx->vreg, size, alignment);
 }
 
 /**

--- a/zephyr/lib/fast-get.c
+++ b/zephyr/lib/fast-get.c
@@ -203,7 +203,7 @@ const void *fast_get(struct mod_alloc_ctx *alloc, const void *dram_ptr, size_t s
 
 	if (alloc && alloc->vreg && size <= FAST_GET_MAX_COPY_SIZE)
 		/* A userspace allocation, that won't be shared */
-		ret = vregion_alloc_align(alloc->vreg, VREGION_MEM_TYPE_INTERIM, alloc_size,
+		ret = vregion_alloc_align(alloc->vreg, alloc_size,
 					  alloc_align);
 	else
 		ret = sof_heap_alloc(heap, alloc_flags, alloc_size, alloc_align);

--- a/zephyr/lib/vregion.c
+++ b/zephyr/lib/vregion.c
@@ -5,6 +5,7 @@
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
  */
 
+#include <sys/types.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -87,7 +88,10 @@ struct vregion {
 	struct k_mutex lock;		/* protect vregion heaps and use-count */
 	unsigned int use_count;
 
-	/* interim heap */
+	/* current allocation mode */
+	enum vregion_mem_type type;	/* LIFETIME at creation, switch to INTERIM */
+
+	/* interim heap - created lazily on first interim allocation */
 	struct interim_heap interim;	/* interim heap */
 
 	/* lifetime heap */
@@ -97,30 +101,31 @@ struct vregion {
 /**
  * @brief Create a new virtual region instance.
  *
- * Create a new VIRTUAL REGION instance with specified static and dynamic
- * sizes. Total size is their sum.
+ * Create a new VIRTUAL REGION instance with specified memory size.
+ * Allocations start in LIFETIME mode.
  *
- * @param[in] lifetime_size Size of the virtual region lifetime partition.
- * @param[in] interim_size Size of the virtual region interim partition.
+ * @param[in] memsize Total size of the virtual region memory.
  * @return struct vregion* Pointer to the new virtual region instance, or NULL on failure.
  */
-struct vregion *vregion_create(size_t lifetime_size, size_t interim_size)
+struct vregion *vregion_create(size_t memsize)
 {
 	struct vregion *vr;
 	unsigned int pages;
 	size_t total_size;
 	uint8_t *vregion_base;
 
-	if (!lifetime_size || !interim_size) {
-		LOG_ERR("error: invalid vregion lifetime size %zu or interim size %zu",
-			lifetime_size, interim_size);
+	if (!memsize) {
+		LOG_ERR("error: invalid vregion memsize %zu", memsize);
 		return NULL;
 	}
 
-	/* Align up lifetime sizes and interim sizes to nearest page */
-	lifetime_size = ALIGN_UP(lifetime_size, CONFIG_MM_DRV_PAGE_SIZE);
-	interim_size = ALIGN_UP(interim_size, CONFIG_MM_DRV_PAGE_SIZE);
-	total_size = lifetime_size + interim_size;
+	/*
+	 * Align up the memory size to nearest page. Lifetime
+	 * allocations growing upward from the base. The interim
+	 * k_heap is created lazily from the remaining space when
+	 * initialization phase is ready.
+	 */
+	total_size = ALIGN_UP(memsize, CONFIG_MM_DRV_PAGE_SIZE);
 
 	/* allocate vregion metadata separately to keep it inaccessible to the user */
 	vr = rmalloc(0, sizeof(*vr));
@@ -140,31 +145,23 @@ struct vregion *vregion_create(size_t lifetime_size, size_t interim_size)
 	vr->size = total_size;
 	vr->pages = pages;
 
-	/* set partition sizes */
-	vr->interim.heap.heap.init_bytes = interim_size;
-	vr->lifetime.size = lifetime_size;
-
-	/* set base addresses for partitions */
-	vr->interim.heap.heap.init_mem = vr->base;
-	vr->lifetime.base = vr->base + interim_size;
-
-	/* set alloc ptr addresses for lifetime linear partitions */
-	vr->lifetime.ptr = vr->lifetime.base;
+	/* lifetime linear allocator starts at the beginning of the vregion memory */
+	vr->lifetime.base = vregion_base;
+	vr->lifetime.size = total_size;
+	vr->lifetime.ptr = vregion_base;
 	vr->lifetime.used = 0;
 	vr->lifetime.free_count = 0;
 
-	/* init interim heaps */
-	k_heap_init(&vr->interim.heap, vr->interim.heap.heap.init_mem, interim_size);
+	/* start in lifetime allocation mode */
+	vr->type = VREGION_MEM_TYPE_LIFETIME;
 
 	k_mutex_init(&vr->lock);
 	/* The creator is the first user */
 	vr->use_count = 1;
 
 	/* log the new vregion */
-	LOG_INF("new at base %p size %#zx pages %u struct embedded at %p",
+	LOG_INF("new at base %p size %#zx pages %u metadata at %p",
 		(void *)vr->base, total_size, pages, (void *)vr);
-	LOG_DBG(" interim size %#zx at %p", interim_size, (void *)vr->interim.heap.heap.init_mem);
-	LOG_DBG(" lifetime size %#zx at %p", lifetime_size, (void *)vr->lifetime.base);
 
 	return vr;
 }
@@ -213,6 +210,68 @@ struct vregion *vregion_put(struct vregion *vr)
 }
 
 /**
+ * @brief Initialize the interim heap from remaining vregion space.
+ *
+ * Called on first interim allocation. Creates the k_heap from all buffer
+ * space not yet consumed by lifetime allocations.
+ *
+ * @param[in] vr Pointer to the virtual region instance.
+ */
+static void interim_heap_init(struct vregion *vr)
+{
+	uint8_t *interim_base;
+	ssize_t interim_size;
+
+	if (vr->type == VREGION_MEM_TYPE_INTERIM) {
+		LOG_WRN("vregion %p already in interim mode", (void *)vr);
+		return;
+	}
+
+	/* interim heap starts right after current lifetime pointer, page-aligned */
+	interim_base = UINT_TO_POINTER(ALIGN_UP(POINTER_TO_UINT(vr->lifetime.ptr),
+						CONFIG_DCACHE_LINE_SIZE));
+	interim_size = (vr->base + vr->size) - interim_base;
+	/*
+	 * Calling k_heap_init() with too small size causes an assert
+	 * failure. Exact limit is hard to deduce from sys_heap_init()
+	 * code, but 1024 seems to be enough.
+	 */
+	if (interim_size < 1024) {
+		LOG_WRN("Too little memory, %zd bytes, left for interim heap", interim_size);
+		vr->type = VREGION_MEM_TYPE_INVALID;
+		return;
+	}
+
+	LOG_INF("creating interim heap: lifetime used %zu, interim available %zu at %p",
+		vr->lifetime.used, interim_size, (void *)interim_base);
+
+	/* cap lifetime so no more lifetime allocs can grow into interim */
+	vr->lifetime.size = interim_base - vr->base;
+
+	vr->interim.heap.heap.init_mem = interim_base;
+	vr->interim.heap.heap.init_bytes = interim_size;
+
+	k_heap_init(&vr->interim.heap, interim_base, interim_size);
+	vr->type = VREGION_MEM_TYPE_INTERIM;
+
+	/* Update lifetime heap with the interim heap usage. */
+	vr->lifetime.ptr = (void *)(interim_base + interim_size);
+	vr->lifetime.used = (uint8_t *)vr->lifetime.ptr - (uint8_t *)vr->lifetime.base;
+}
+
+void vregion_set_interim(struct vregion *vr)
+{
+	if (!vr)
+		return;
+
+	k_mutex_lock(&vr->lock, K_FOREVER);
+
+	interim_heap_init(vr);
+
+	k_mutex_unlock(&vr->lock);
+}
+
+/**
  * @brief Allocate memory with alignment from the virtual region dynamic heap.
  *
  * @param[in] heap Pointer to the heap to use.
@@ -220,8 +279,7 @@ struct vregion *vregion_put(struct vregion *vr)
  * @param[in] align Alignment of the allocation.
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-static void *interim_alloc(struct interim_heap *heap,
-			   size_t size, size_t align)
+static void *interim_alloc(struct interim_heap *heap, size_t size, size_t align)
 {
 	void *ptr;
 
@@ -247,14 +305,16 @@ static void interim_free(struct interim_heap *heap, void *ptr)
 /**
  * @brief Allocate memory from the virtual region lifetime allocator.
  *
+ * If the interim heap has already been created (i.e., an interim allocation
+ * was made), log a warning and fall back to interim allocation.
+ *
  * @param[in] heap Pointer to the linear heap to use.
  * @param[in] size Size of the allocation.
  * @param[in] align Alignment of the allocation.
  *
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-static void *lifetime_alloc(struct vlinear_heap *heap,
-			    size_t size, size_t align)
+static void *lifetime_alloc(struct vlinear_heap *heap, size_t size, size_t align)
 {
 	void *ptr;
 	uint8_t *aligned_ptr;
@@ -315,14 +375,15 @@ void vregion_free(struct vregion *vr, void *ptr)
 	if (sys_cache_is_ptr_uncached(ptr))
 		ptr = sys_cache_cached_ptr_get(ptr);
 
-	if (ptr >= (void *)vr->interim.heap.heap.init_mem &&
+	/* Check if pointer is in interim heap (if initialized) */
+	if (vr->type == VREGION_MEM_TYPE_INTERIM &&
+	    ptr >= (void *)vr->interim.heap.heap.init_mem &&
 	    ptr < (void *)((uint8_t *)vr->interim.heap.heap.init_mem +
 			   vr->interim.heap.heap.init_bytes))
-		/* pointer is in interim heap */
 		interim_free(&vr->interim, ptr);
 	else if (ptr >= (void *)vr->lifetime.base &&
 		   ptr < (void *)(vr->lifetime.base + vr->lifetime.size))
-		/* pointer is in lifetime heap */
+		/* pointer is in lifetime area - no-op free */
 		lifetime_free(&vr->lifetime, ptr);
 	else
 		LOG_ERR("error: vregion free invalid pointer %p", ptr);
@@ -332,17 +393,15 @@ void vregion_free(struct vregion *vr, void *ptr)
 EXPORT_SYMBOL(vregion_free);
 
 /**
- * @brief Allocate memory type from the virtual region.
+ * @brief Allocate memory from the virtual region.
  *
  * @param[in] vr Pointer to the virtual region instance.
- * @param[in] type Memory type to allocate.
  * @param[in] size Size of the allocation.
  * @param[in] alignment Alignment of the allocation.
  *
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-void *vregion_alloc_align(struct vregion *vr, enum vregion_mem_type type,
-			  size_t size, size_t alignment)
+void *vregion_alloc_align(struct vregion *vr, size_t size, size_t alignment)
 {
 	void *p;
 
@@ -354,7 +413,7 @@ void *vregion_alloc_align(struct vregion *vr, enum vregion_mem_type type,
 
 	k_mutex_lock(&vr->lock, K_FOREVER);
 
-	switch (type) {
+	switch (vr->type) {
 	case VREGION_MEM_TYPE_INTERIM:
 		p = interim_alloc(&vr->interim, size, alignment);
 		break;
@@ -362,7 +421,7 @@ void *vregion_alloc_align(struct vregion *vr, enum vregion_mem_type type,
 		p = lifetime_alloc(&vr->lifetime, size, alignment);
 		break;
 	default:
-		LOG_ERR("error: invalid memory type %d", type);
+		LOG_ERR("error: invalid memory type %d", vr->type);
 		p = NULL;
 	}
 
@@ -375,21 +434,20 @@ EXPORT_SYMBOL(vregion_alloc_align);
 /**
  * @brief Allocate memory from the virtual region.
  * @param[in] vr Pointer to the virtual region instance.
- * @param[in] type Memory type to allocate.
  * @param[in] size Size of the allocation.
  * @return void* Pointer to the allocated memory, or NULL on failure.
  */
-void *vregion_alloc(struct vregion *vr, enum vregion_mem_type type, size_t size)
+void *vregion_alloc(struct vregion *vr, size_t size)
 {
-	return vregion_alloc_align(vr, type, size, 0);
+	return vregion_alloc_align(vr, size, 0);
 }
 EXPORT_SYMBOL(vregion_alloc);
 
-void *vregion_alloc_coherent(struct vregion *vr, enum vregion_mem_type type, size_t size)
+void *vregion_alloc_coherent(struct vregion *vr, size_t size)
 {
 	size = ALIGN_UP(size, CONFIG_DCACHE_LINE_SIZE);
 
-	void *p = vregion_alloc_align(vr, type, size, CONFIG_DCACHE_LINE_SIZE);
+	void *p = vregion_alloc_align(vr, size, CONFIG_DCACHE_LINE_SIZE);
 
 	if (!p)
 		return NULL;
@@ -399,14 +457,13 @@ void *vregion_alloc_coherent(struct vregion *vr, enum vregion_mem_type type, siz
 	return sys_cache_uncached_ptr_get(p);
 }
 
-void *vregion_alloc_coherent_align(struct vregion *vr, enum vregion_mem_type type,
-				   size_t size, size_t alignment)
+void *vregion_alloc_coherent_align(struct vregion *vr, size_t size, size_t alignment)
 {
 	if (alignment < CONFIG_DCACHE_LINE_SIZE)
 		alignment = CONFIG_DCACHE_LINE_SIZE;
 	size = ALIGN_UP(size, CONFIG_DCACHE_LINE_SIZE);
 
-	void *p = vregion_alloc_align(vr, type, size, alignment);
+	void *p = vregion_alloc_align(vr, size, alignment);
 
 	if (!p)
 		return NULL;

--- a/zephyr/test/vregion.c
+++ b/zephyr/test/vregion.c
@@ -17,8 +17,11 @@ LOG_MODULE_DECLARE(sof_boot_test, CONFIG_SOF_LOG_LEVEL);
 
 static struct vregion *test_vreg_create(void)
 {
-	struct vregion *vreg = vregion_create(CONFIG_MM_DRV_PAGE_SIZE - 100,
-					      CONFIG_MM_DRV_PAGE_SIZE);
+	/*
+	 * Use a 3-page vregion so that after two lifetime allocations there is still
+	 * enough remaining space to initialize and exercise the interim heap.
+	 */
+	struct vregion *vreg = vregion_create(3 * CONFIG_MM_DRV_PAGE_SIZE);
 
 	zassert_not_null(vreg);
 
@@ -27,40 +30,46 @@ static struct vregion *test_vreg_create(void)
 
 static void test_vreg_alloc_lifet(struct vregion *vreg)
 {
-	void *ptr = vregion_alloc(vreg, VREGION_MEM_TYPE_LIFETIME, 2000);
+	void *ptr = vregion_alloc(vreg, 6000);
 
 	zassert_not_null(ptr);
 
-	void *ptr_align = vregion_alloc_align(vreg, VREGION_MEM_TYPE_LIFETIME, 1600, 16);
+	void *ptr_align = vregion_alloc_align(vreg, 5000, 16);
 
 	zassert_not_null(ptr_align);
 	zassert_equal((uintptr_t)ptr_align & 15, 0);
 
-	void *ptr_nomem = vregion_alloc(vreg, VREGION_MEM_TYPE_LIFETIME, 2000);
+	/*
+	 * Seal lifetime, switch to interim. The interim heap is created
+	 * lazily from the remaining ~1 page, so a 6000-byte alloc won't fit.
+	 */
+	vregion_set_interim(vreg);
+
+	void *ptr_nomem = vregion_alloc(vreg, 6000);
 
 	zassert_is_null(ptr_nomem);
 
+	/* Lifetime frees are no-ops; re-alloc from interim still fails */
 	vregion_free(vreg, ptr_align);
 	vregion_free(vreg, ptr);
 
-	/* Freeing isn't possible with LIFETIME */
-	ptr_nomem = vregion_alloc(vreg, VREGION_MEM_TYPE_LIFETIME, 2000);
+	ptr_nomem = vregion_alloc(vreg, 6000);
 
 	zassert_is_null(ptr_nomem);
 }
 
 static void test_vreg_alloc_tmp(struct vregion *vreg)
 {
-	void *ptr = vregion_alloc(vreg, VREGION_MEM_TYPE_INTERIM, 20);
+	void *ptr = vregion_alloc(vreg, 20);
 
 	zassert_not_null(ptr);
 
-	void *ptr_align = vregion_alloc_align(vreg, VREGION_MEM_TYPE_INTERIM, 2000, 16);
+	void *ptr_align = vregion_alloc_align(vreg, 1000, 16);
 
 	zassert_not_null(ptr_align);
 	zassert_equal((uintptr_t)ptr_align & 15, 0);
 
-	void *ptr_nomem = vregion_alloc(vreg, VREGION_MEM_TYPE_INTERIM, 2000);
+	void *ptr_nomem = vregion_alloc(vreg, 2000);
 
 	zassert_is_null(ptr_nomem);
 
@@ -68,7 +77,7 @@ static void test_vreg_alloc_tmp(struct vregion *vreg)
 	vregion_free(vreg, ptr);
 
 	/* Should be possible to allocate again */
-	ptr = vregion_alloc(vreg, VREGION_MEM_TYPE_INTERIM, 2000);
+	ptr = vregion_alloc(vreg, 1000);
 
 	zassert_not_null(ptr);
 }
@@ -83,10 +92,10 @@ ZTEST(sof_boot, vregion)
 {
 	struct vregion *vreg = test_vreg_create();
 
-	/* Test interim allocations */
-	test_vreg_alloc_tmp(vreg);
-	/* Test lifetime allocations */
+	/* Test lifetime allocations (initial mode), then seal */
 	test_vreg_alloc_lifet(vreg);
+	/* Test interim allocations (already switched by lifet test) */
+	test_vreg_alloc_tmp(vreg);
 
 	test_vreg_destroy(vreg);
 }


### PR DESCRIPTION
Refactor the vregion memory layout to use a single contiguous buffer instead of two separately page-aligned partitions. The vregion lifetime allocations start at the base and growing upward. The interim k_heap is created lazily when vregion_set_interim() is called for whatever space remains after lifetime allocations.

This eliminates the rigid partition boundary that previously wasted memory when lifetime usage was smaller or larger than pre-configured. The interim heap creation is deferred until actually needed, at which point the lifetime region is sealed and any further allocation requests are redirected to the interim.

The vregion tracks internal allocation mode (lifetime or interim). All allocations start in lifetime mode. The vregion_set_interim() function switches to interim mode. The enum vregion_mem_type parameter has been removed from the vregion_alloc*() API since the mode is now internal state.

vregion_set_interim() is called in pipeline_comp_complete() in case the component's processing domain is Data Processing. The DP components are so far the only place where vregions are used at the moment.

Add a guard to skip k_heap_init() in interim_heap_init() if the remaining interim size is too small (< 1024 bytes), which would otherwise trigger an assert failure in sys_heap_init(). Mark the vregion type to VREGION_MEM_TYPE_INVALID if that happens.

Key changes:
- vregion_create(): Takes single memsize argument instead of separate lifetime_size and interim_size
- New vregion_set_interim(): Switches allocation mode from lifetime to interim, warns on repeated calls
- vregion_alloc*(): No longer take enum vregion_mem_type parameter, use internal state instead
- New interim_heap_init(): Called lazily, page-aligns interim start, logs lifetime used and interim available at INFO level
- vregion_free(): Guards interim pointer range
- pipeline_comp_completee(): Calls vregion_set_interim() to switch mode