### PR TITLE
cold: add multiple `__cold` annotations

### DIFF
--- a/src/audio/mic_privacy_manager/mic_privacy_manager_intel.c
+++ b/src/audio/mic_privacy_manager/mic_privacy_manager_intel.c
@@ -10,6 +10,7 @@
 #include <sof/audio/audio_stream.h>
 #include <sof/audio/buffer.h>
 #include <sof/audio/mic_privacy_manager.h>
+#include <sof/lib/memory.h>
 
 const struct device *mic_priv_dev;
 
@@ -88,9 +89,11 @@ void mic_privacy_enable_dmic_irq(bool enable_irq)
 	}
 }
 
-int mic_privacy_manager_init(void)
+__cold int mic_privacy_manager_init(void)
 {
 	mic_priv_dev = DEVICE_DT_GET(DT_NODELABEL(mic_privacy));
+
+	assert_can_be_cold();
 
 	if (!mic_priv_dev)
 		return -EINVAL;

--- a/src/debug/telemetry/performance_monitor.c
+++ b/src/debug/telemetry/performance_monitor.c
@@ -8,6 +8,7 @@
 #include <sof/debug/telemetry/performance_monitor.h>
 #include <sof/debug/telemetry/telemetry.h>
 #include <sof/lib/cpu.h>
+#include <sof/lib/memory.h>
 #include <sof/lib_manager.h>
 
 #include <zephyr/sys/bitarray.h>
@@ -427,10 +428,12 @@ SYS_BITARRAY_DEFINE_STATIC(io_performance_data_bit_array, PERFORMANCE_DATA_ENTRI
 static struct io_perf_monitor_ctx perf_monitor_ctx;
 static struct io_perf_data_item io_perf_data_items[IO_PERFORMANCE_MAX_ENTRIES];
 
-int io_perf_monitor_init(void)
+__cold int io_perf_monitor_init(void)
 {
 	int ret;
 	struct io_perf_monitor_ctx *self = &perf_monitor_ctx;
+
+	assert_can_be_cold();
 
 	k_spinlock_init(&self->lock);
 	k_spinlock_key_t key = k_spin_lock(&self->lock);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -15,6 +15,7 @@
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
 #include <sof/lib/cpu.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
@@ -419,9 +420,11 @@ void idc_cmd(struct idc_msg *msg)
 }
 
 /* Runs on each CPU */
-int idc_init(void)
+__cold int idc_init(void)
 {
 	struct idc **idc = idc_get();
+
+	assert_can_be_cold();
 
 	tr_dbg(&idc_tr, "entry");
 

--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -196,10 +196,12 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	return ret;
 }
 
-void idc_init_thread(void)
+__cold void idc_init_thread(void)
 {
 	char thread_name[] = "idc_p4wq0";
 	int cpu = cpu_get_id();
+
+	assert_can_be_cold();
 
 	k_p4wq_enable_static_thread(q_zephyr_idc + cpu,
 				    _p4threads_q_zephyr_idc + cpu, BIT(cpu));

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -110,6 +110,8 @@ __cold int secondary_core_init(struct sof *sof)
 	int err;
 	struct ll_schedule_domain *dma_domain;
 
+	assert_can_be_cold();
+
 	/* check whether we are in a cold boot process or not (e.g. D0->D0ix
 	 * flow when primary core disables all secondary cores). If not, we do
 	 * not have allocate basic structures like e.g. schedulers, notifier,
@@ -163,6 +165,8 @@ __cold int secondary_core_init(struct sof *sof)
 
 __cold static void print_version_banner(void)
 {
+	assert_can_be_cold();
+
 	/*
 	 * Non-Zephyr builds emit the version banner in DMA-trace
 	 * init and this is done at a later time as otherwise the
@@ -193,6 +197,8 @@ static log_timestamp_t default_get_timestamp(void)
 
 __cold static int primary_core_init(int argc, char *argv[], struct sof *sof)
 {
+	assert_can_be_cold();
+
 	/* setup context */
 	sof->argc = argc;
 	sof->argv = argv;

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -93,9 +93,11 @@ static enum task_state validate(void *data)
 	return SOF_TASK_STATE_RESCHEDULE;
 }
 
-void sa_init(struct sof *sof, uint64_t timeout)
+__cold void sa_init(struct sof *sof, uint64_t timeout)
 {
 	uint64_t ticks;
+
+	assert_can_be_cold();
 
 	if (timeout > UINT_MAX)
 		tr_warn(&sa_tr, "timeout > %u", UINT_MAX);

--- a/src/lib/ams.c
+++ b/src/lib/ams.c
@@ -16,7 +16,6 @@
 #include <sof/ipc/topology.h>
 #include <rtos/idc.h>
 #include <rtos/alloc.h>
-#include <sof/lib/memory.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -578,12 +577,14 @@ static int ams_create_shared_context(struct ams_shared_context *ctx)
 	return 0;
 }
 
-int ams_init(void)
+__cold int ams_init(void)
 {
 	struct ams_shared_context *ams_shared_ctx;
 	struct async_message_service **ams = arch_ams_get();
 	struct sof *sof;
 	int ret = 0;
+
+	assert_can_be_cold();
 
 	*ams = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 		       sizeof(**ams));

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -190,10 +190,13 @@ void notifier_event(const void *caller, enum notify_id type, uint32_t core_mask,
 	}
 }
 
-void init_system_notify(struct sof *sof)
+__cold void init_system_notify(struct sof *sof)
 {
 	struct notify **notify = arch_notify_get();
 	int i;
+
+	assert_can_be_cold();
+
 	*notify = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
 			  sizeof(**notify));
 	if (!*notify) {

--- a/src/platform/intel/ace/lib/watchdog.c
+++ b/src/platform/intel/ace/lib/watchdog.c
@@ -5,6 +5,7 @@
  * Author: Adrian Warecki <adrian.warecki@intel.com>
  */
 
+#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <rtos/idc.h>
 #include <sof/schedule/ll_schedule_domain.h>
@@ -72,13 +73,15 @@ static void watchdog_timeout(const struct device *dev, int core)
 		watchdog_secondary_core_action_on_timeout();
 }
 
-void watchdog_init(void)
+__cold void watchdog_init(void)
 {
 	int i, ret;
 	const struct wdt_timeout_cfg watchdog_config = {
 		.window.max = LL_WATCHDOG_TIMEOUT_US / 1000,
 		.callback = watchdog_timeout,
 	};
+
+	assert_can_be_cold();
 
 	secondary_timeout_ipc.tx_data = NULL;
 	secondary_timeout_ipc.tx_size = 0;

--- a/src/platform/intel/ace/platform.c
+++ b/src/platform/intel/ace/platform.c
@@ -65,6 +65,8 @@ __cold int platform_boot_complete(uint32_t boot_message)
 {
 	struct ipc_cmd_hdr header;
 
+	assert_can_be_cold();
+
 	/* get any IPC specific boot message and optional data */
 	ipc_boot_complete_msg(&header, 0);
 	header.pri |= boot_message;
@@ -91,6 +93,8 @@ static struct pm_notifier pm_state_notifier = {
 __cold int platform_init(struct sof *sof)
 {
 	int ret;
+
+	assert_can_be_cold();
 
 	trace_point(TRACE_BOOT_PLATFORM_CLOCK);
 	platform_clock_init(sof);

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -21,6 +21,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/sys/sem.h>
 #include <zephyr/sys/mutex.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <ipc4/base_fw.h>
 
@@ -346,9 +347,12 @@ static struct scheduler_ops schedule_dp_ops = {
 	.schedule_task_free	= scheduler_dp_task_free,
 };
 
-int scheduler_dp_init(void)
+__cold int scheduler_dp_init(void)
 {
 	int ret;
+
+	assert_can_be_cold();
+
 	struct scheduler_dp_data *dp_sch = rzalloc(SOF_MEM_FLAG_KERNEL,
 						   sizeof(struct scheduler_dp_data));
 	if (!dp_sch)

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -9,6 +9,7 @@
 #include <rtos/symbol.h>
 #include <sof/audio/component.h>
 #include <rtos/interrupt.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/notifier.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
@@ -604,12 +605,14 @@ EXPORT_SYMBOL(zephyr_ll_task_init);
 
 /* TODO: low-power mode clock support */
 /* Runs on each core during initialisation with the same domain argument */
-int zephyr_ll_scheduler_init(struct ll_schedule_domain *domain)
+__cold int zephyr_ll_scheduler_init(struct ll_schedule_domain *domain)
 {
 	struct zephyr_ll *sch;
 	int core = cpu_get_id();
 	struct k_heap *heap = sof_sys_heap_get();
 	int flags = SOF_MEM_FLAG_KERNEL | SOF_MEM_FLAG_COHERENT;
+
+	assert_can_be_cold();
 
 #if CONFIG_SOF_USERSPACE_LL
 	heap = zephyr_ll_user_heap();

--- a/src/schedule/zephyr_twb_schedule.c
+++ b/src/schedule/zephyr_twb_schedule.c
@@ -7,6 +7,7 @@
 
 #include <rtos/task.h>
 #include <stdint.h>
+#include <sof/lib/memory.h>
 #include <sof/lib/uuid.h>
 #include <sof/schedule/schedule.h>
 #include <sof/schedule/ll_schedule.h>
@@ -348,11 +349,13 @@ static struct scheduler_ops schedule_twb_ops = {
 	.schedule_task_free	= scheduler_twb_task_free,
 };
 
-int scheduler_twb_init(void)
+__cold int scheduler_twb_init(void)
 {
 	struct scheduler_twb_data *twb_sch = rzalloc(SOF_MEM_FLAG_KERNEL,
 						   sizeof(struct scheduler_twb_data));
 	int ret;
+
+	assert_can_be_cold();
 
 	if (!twb_sch)
 		return -ENOMEM;

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -5,6 +5,7 @@
 // Author: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>
 
 #include <sof/audio/component.h>
+#include <sof/lib/memory.h>
 #include <rtos/alloc.h>
 #include <rtos/task.h>
 #include <stdint.h>
@@ -99,9 +100,11 @@ static struct scheduler_ops schedule_edf_ops = {
 	.schedule_task_free	= schedule_edf_task_free,
 };
 
-int scheduler_init_edf(void)
+__cold int scheduler_init_edf(void)
 {
 	struct k_thread *thread = &edf_workq.thread;
+
+	assert_can_be_cold();
 
 	scheduler_init(SOF_SCHEDULE_EDF, &schedule_edf_ops, NULL);
 

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -270,9 +270,11 @@ const struct dma_info lib_dma = {
 };
 
 /* Initialize all platform DMAC's */
-int dmac_init(struct sof *sof)
+__cold int dmac_init(struct sof *sof)
 {
 	int i;
+
+	assert_can_be_cold();
 
 	sof->dma_info = &lib_dma;
 


### PR DESCRIPTION
make multiple initialisation functions, called from `platform_init()`, `primary_core_init()` and `secondary_core_init()` "cold"