### PR TITLE
audio: copier: reject ALH multi-gateway config with zero count

### DIFF
--- a/src/audio/copier/copier_dai.c
+++ b/src/audio/copier/copier_dai.c
@@ -108,7 +108,7 @@ static int copier_alh_assign_dai_index(struct comp_dev *dev,
 		}
 
 		dai_num = alh_blob->alh_cfg.count;
-		if (dai_num > IPC4_ALH_MAX_NUMBER_OF_GTW || dai_num < 0) {
+		if (dai_num > IPC4_ALH_MAX_NUMBER_OF_GTW || dai_num <= 0) {
 			comp_err(mod->dev, "Invalid dai_count: %d", dai_num);
 			return -EINVAL;
 		}
@@ -138,7 +138,7 @@ static int copier_alh_assign_dai_index(struct comp_dev *dev,
 		}
 
 		dai_num = alh_blob->alh_cfg.count;
-		if (dai_num > IPC4_ALH_MAX_NUMBER_OF_GTW || dai_num < 0) {
+		if (dai_num > IPC4_ALH_MAX_NUMBER_OF_GTW || dai_num <= 0) {
 			comp_err(mod->dev, "Invalid dai_count: %d", dai_num);
 			return -EINVAL;
 		}


### PR DESCRIPTION
copier_alh_assign_dai_index() rejected only count > MAX and count < 0, letting count == 0 pass. A zero count creates a DAI copier with endpoint_num == 0 (the dai-creation loop never runs), which later makes copier_position() return -EINVAL before writing posn.

Reject count <= 0, matching ref fw flow.