### PR TITLE
audio: data_blob: fix memcpy_s bounds in ipc4_comp_data_blob_set

### DIFF
--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -628,6 +628,18 @@ int comp_data_blob_get_cmd(struct comp_data_blob_handler *blob_handler,
 			return -EINVAL;
 		}
 
+		/* Bound data_pos against data_size: host-controlled num_elems
+		 * advances it per fragment and could leak adjacent heap.
+		 */
+		if (blob_handler->data_pos >= blob_handler->data_size ||
+		    cdata->num_elems > blob_handler->data_size - blob_handler->data_pos) {
+			comp_err(blob_handler->dev,
+				 "out of bounds read: pos %u elems %u size %u",
+				 blob_handler->data_pos, cdata->num_elems,
+				 blob_handler->data_size);
+			return -EINVAL;
+		}
+
 		/* copy required size of data */
 		ret = memcpy_s(cdata->data->data, size,
 			       (char *)blob_handler->data + blob_handler->data_pos,

--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -365,8 +365,16 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		valid_data_size = last_block ? data_offset : MAILBOX_DSPBOX_SIZE;
 
 		ret = memcpy_s((char *)blob_handler->data_new,
-			       valid_data_size, data, valid_data_size);
-		assert(!ret);
+			       blob_handler->new_data_size, data, valid_data_size);
+		if (ret) {
+			comp_err(blob_handler->dev, "failed to copy fragment");
+			blob_handler->free(blob_handler->data_new);
+			blob_handler->data_new = NULL;
+			blob_handler->new_data_size = 0;
+			blob_handler->data_pos = 0;
+			blob_handler->data_ready = false;
+			return ret;
+		}
 
 		blob_handler->data_pos += valid_data_size;
 	} else {
@@ -391,8 +399,17 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 			valid_data_size = blob_handler->new_data_size - data_offset;
 
 		ret = memcpy_s((char *)blob_handler->data_new + data_offset,
-			       valid_data_size, data, valid_data_size);
-		assert(!ret);
+			       blob_handler->new_data_size - data_offset,
+			       data, valid_data_size);
+		if (ret) {
+			comp_err(blob_handler->dev, "failed to copy fragment");
+			blob_handler->free(blob_handler->data_new);
+			blob_handler->data_new = NULL;
+			blob_handler->new_data_size = 0;
+			blob_handler->data_pos = 0;
+			blob_handler->data_ready = false;
+			return ret;
+		}
 
 		blob_handler->data_pos += valid_data_size;
 	}

--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -330,6 +330,14 @@ int ipc4_comp_data_blob_set(struct comp_data_blob_handler *blob_handler,
 		 "data_offset = %d",
 		 data_offset);
 
+	/* Reject a new first_block mid-transfer: reusing stale data_new while
+	 * overwriting new_data_size defeats the memcpy_s bound (heap overflow).
+	 */
+	if (blob_handler->data_new && first_block) {
+		comp_err(blob_handler->dev, "busy with previous request");
+		return -EBUSY;
+	}
+
 	/* in case when the current package is the first, we should allocate
 	 * memory for whole model data
 	 */


### PR DESCRIPTION
Pass the real destination capacity instead of the copy count so the size check is effective, preventing
a host-controlled heap overflow of data_new.