### PR TITLE
lib_manager: align auth result checks with newer API

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -110,15 +110,16 @@ static int lib_manager_auth_proc(const void *buffer_data, size_t buffer_size,
 	while (auth_api_busy(auth_ctx))
 		;
 
+	if (phase != AUTH_PHASE_LAST)
+		return 0;
+
 	ret = auth_api_result(auth_ctx);
+	auth_api_cleanup(auth_ctx);
 
 	if (ret != AUTH_IMAGE_TRUSTED) {
 		tr_err(&lib_manager_tr, "Untrusted library!");
 		return -EACCES;
 	}
-
-	if (phase == AUTH_PHASE_LAST)
-		auth_api_cleanup(auth_ctx);
 
 	return 0;
 }


### PR DESCRIPTION
With newer authentication API of ROM_EXT, the authentication result is provided only after the last phase. This change aligns SOF FW to this behavior. The change is backward compatible with older API versions.

I tested this with both old and new ROM_EXT as well as with valid and invalid keys.