### PR TITLE
zephyr: syscall: sof_dma: fixes to dma_config syscall verification

### DIFF
--- a/zephyr/syscall/sof_dma.c
+++ b/zephyr/syscall/sof_dma.c
@@ -190,7 +190,8 @@ static inline int z_vrfy_sof_dma_config(struct sof_dma *dma, uint32_t channel,
 					struct dma_config *config)
 {
 	struct dma_block_config *blk_cfgs;
-	struct dma_config kern_cfg, user_cfg;
+	struct dma_config kern_cfg = { 0 };
+	struct dma_config user_cfg;
 	int ret;
 
 	K_OOPS(!sof_dma_is_valid(dma));

--- a/zephyr/syscall/sof_dma.c
+++ b/zephyr/syscall/sof_dma.c
@@ -5,6 +5,7 @@
 #include <sof/lib/dma.h>
 #include <zephyr/kernel.h>
 #include <zephyr/internal/syscall_handler.h>
+#include <zephyr/sys/math_extras.h>
 
 #ifdef CONFIG_SOF_USERSPACE_INTERFACE_DMA
 
@@ -111,12 +112,22 @@ static inline struct dma_block_config *deep_copy_dma_blk_cfg_list(struct dma_con
 {
 	struct dma_block_config *kern_cfg;
 	struct dma_block_config *kern_prev = NULL, *kern_next, *user_next;
+	size_t alloc_size;
 	int i = 0;
 
 	if (!cfg->block_count)
 		return NULL;
 
-	kern_cfg = rmalloc(0, sizeof(*kern_cfg) * cfg->block_count);
+	/*
+	 * block_count is user-controlled, so compute the allocation size
+	 * with an overflow check. Without it, a large block_count would
+	 * wrap the product on 32-bit size_t, yield an undersized buffer,
+	 * and let the copy loop below overflow the kernel heap.
+	 */
+	if (size_mul_overflow(sizeof(*kern_cfg), cfg->block_count, &alloc_size))
+		return NULL;
+
+	kern_cfg = rmalloc(0, alloc_size);
 	if (!kern_cfg)
 		return NULL;
 

--- a/zephyr/syscall/sof_dma.c
+++ b/zephyr/syscall/sof_dma.c
@@ -111,9 +111,9 @@ static inline void z_vrfy_sof_dma_release_channel(struct sof_dma *dma,
 static inline struct dma_block_config *deep_copy_dma_blk_cfg_list(struct dma_config *cfg)
 {
 	struct dma_block_config *kern_cfg;
-	struct dma_block_config *kern_prev = NULL, *kern_next, *user_next;
+	struct dma_block_config *kern_next, *user_next;
 	size_t alloc_size;
-	int i = 0;
+	uint32_t i;
 
 	if (!cfg->block_count)
 		return NULL;
@@ -131,17 +131,16 @@ static inline struct dma_block_config *deep_copy_dma_blk_cfg_list(struct dma_con
 	if (!kern_cfg)
 		return NULL;
 
-	for (user_next = cfg->head_block, kern_next = kern_cfg;
-	     user_next;
-	     user_next = user_next->next_block, kern_next++, i++) {
-		if (i == cfg->block_count) {
-			/* last block can point to first one */
-			if (user_next != cfg->head_block)
-				goto err;
-
-			kern_prev->next_block = kern_cfg;
-			break;
-		}
+	user_next = cfg->head_block;
+	for (i = 0, kern_next = kern_cfg; i < cfg->block_count; i++, kern_next++) {
+		/*
+		 * The user list must contain exactly block_count entries.
+		 * A list that terminates early (NULL before the count is
+		 * reached) is rejected so the kernel copy and block_count
+		 * stay consistent and the driver never walks past the copy.
+		 */
+		if (!user_next)
+			goto err;
 
 		if (k_usermode_from_copy(kern_next, user_next, sizeof(*kern_next)))
 			goto err;
@@ -169,10 +168,29 @@ static inline struct dma_block_config *deep_copy_dma_blk_cfg_list(struct dma_con
 			goto err;
 		}
 
-		if (kern_prev)
-			kern_prev->next_block = kern_next;
+		/*
+		 * kern_next->next_block now holds the untrusted user-space
+		 * pointer copied above. Never let the kernel walk it: relink
+		 * every block to the kernel copy so the list can never point
+		 * outside the kern_cfg array.
+		 */
+		user_next = kern_next->next_block;
 
-		kern_prev = kern_next;
+		if (i + 1 < cfg->block_count) {
+			/* link to the next kernel block */
+			kern_next->next_block = kern_next + 1;
+		} else {
+			/*
+			 * Last block: the user list must end here, either
+			 * NULL-terminated or cyclic back to the first block.
+			 */
+			if (user_next == cfg->head_block)
+				kern_next->next_block = kern_cfg;
+			else if (!user_next)
+				kern_next->next_block = NULL;
+			else
+				goto err;
+		}
 	}
 
 	/* set transfer list to point to first kernel transfer config object */


### PR DESCRIPTION
Series of fixes to sof_dma dma_config syscall verification.

Note that this interface is not yet enabled in any product configuration, so exposure is currently limited.