### PR TITLE
audio: module_adapter_ipc4: add range check to module_get_large_config()

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -263,10 +263,16 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 		else
 			fragment_size = SOF_IPC_MSG_MAX_SIZE;
 	} else {
-		if (!last_block)
+		if (!last_block) {
 			fragment_size = SOF_IPC_MSG_MAX_SIZE;
-		else
+		} else {
+			if (*data_offset_size > md->cfg.size) {
+				comp_err(dev, "invalid data_offset_size %u > cfg size %zu",
+					 *data_offset_size, md->cfg.size);
+				return -EINVAL;
+			}
 			fragment_size = md->cfg.size - *data_offset_size;
+		}
 	}
 
 	if (interface->get_configuration)


### PR DESCRIPTION
In a multi-block get case, if the host sends data_off_size > md->cfg.size, the calculation of the last fragment size is incorrect if a sufficiently large value is passed.

Add validation to catch this case and return an error data_off_size is too large.