### PR TITLE
plugin: tplg: bound pipeline_list against TPLG_MAX_PCM_PIPELINES

### DIFF
--- a/tools/plugin/alsaplug/tplg.c
+++ b/tools/plugin/alsaplug/tplg.c
@@ -999,6 +999,12 @@ static int plug_prepare_widget(snd_sof_plug_t *plug, struct tplg_pcm_info *pcm_i
 	}
 
 	if (i == pipeline_list->count) {
+		if (pipeline_list->count >= TPLG_MAX_PCM_PIPELINES) {
+			SNDERR("error: too many pipelines for PCM, max %d\n",
+			       TPLG_MAX_PCM_PIPELINES);
+			return -EINVAL;
+		}
+
 		pipeline_list->pipelines[pipeline_list->count] = comp_info->pipe_info;
 		pipeline_list->count++;
 	}


### PR DESCRIPTION
plug_prepare_widget() appends each new pipeline referenced by a PCM into the fixed-size pipeline_list->pipelines[] array:

	pipeline_list->pipelines[pipeline_list->count] = comp_info->pipe_info;
	pipeline_list->count++;

The array has only TPLG_MAX_PCM_PIPELINES entries, but the number of pipelines bound to a PCM is dictated by the topology graph, which comes from the .tplg file loaded by the SOF ALSA plugin. With no upper-bound check, a topology that binds more than TPLG_MAX_PCM_PIPELINES pipelines to a single PCM writes past the end of the array.

Reject the store with -EINVAL once the list is full, before writing past the end of the array.