### PR TITLE
audio: smart_amp: validate DSM parameter id before db write

### DIFF
--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -385,6 +385,13 @@ static int maxim_dsm_set_param(struct smart_amp_mod_struct_t *hspk,
 			id = DSM_CH_MASK(param->param.id);
 			ch = (param->param.id & DSM_CH1_BITMASK) ? 0 : 1;
 
+			/* id indexes the model database; reject values past its size */
+			if (id >= hspk->param.max_param) {
+				comp_err(dev, "[DSM] invalid param id:%x max:%d",
+					 id, hspk->param.max_param);
+				return -EINVAL;
+			}
+
 			/* 2nd channel has (hspk->param.max_param * DSM_PARAM_MAX) sized offset */
 			db[(id + ch * hspk->param.max_param) * DSM_PARAM_MAX + DSM_PARAM_VALUE] =
 				param->param.value;


### PR DESCRIPTION
maxim_dsm_set_param() masks the host-supplied parameter id with DSM_CH_MASK() and uses the result directly as an index into the model database db[], which is sized for hspk->param.max_param parameters. A larger id leads to an out-of-bounds write.

Reject id values that are not below max_param before indexing db[].