### PR TITLE
audio: base_fw: validate dma control payload length before subtract

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -770,6 +770,13 @@ __cold static int basefw_dma_control(bool first_block, bool last_block, uint32_t
 	}
 
 	dma_control = (struct ipc4_dma_control *)data;
+
+	/* data_offset must cover the fixed header before computing the payload size */
+	if (data_offset < sizeof(struct ipc4_dma_control)) {
+		tr_err(&ipc_tr, "DMA Control message too short: %u", data_offset);
+		return IPC4_ERROR_INVALID_PARAM;
+	}
+
 	data_size = data_offset - sizeof(struct ipc4_dma_control);
 
 	if (data_size < (dma_control->config_length * sizeof(uint32_t))) {


### PR DESCRIPTION
basefw_dma_control() computes data_size = data_offset - sizeof(struct ipc4_dma_control) where data_offset is the host-supplied payload length. When data_offset is smaller than the header the unsigned subtraction wraps to a huge value that passes the length check and is forwarded as the payload size, leading to an out-of-bounds read.

Reject data_offset values smaller than the fixed header before the subtraction.