### PR TITLE
idc: zephyr_idc: check target core before taking idc_mutex

### DIFF
--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -135,6 +135,11 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	int ret;
 	int idc_send_memcpy_err __unused;
 
+	if (!cpu_is_core_enabled(target_cpu)) {
+		tr_err(&zephyr_idc_tr, "Core %u is down, cannot send IDC message", target_cpu);
+		return -EACCES;
+	}
+
 	k_mutex_lock(&idc_mutex, K_FOREVER);
 
 	if (unlikely(work->thread)) {
@@ -153,10 +158,6 @@ int idc_send_msg(struct idc_msg *msg, uint32_t mode)
 	work->handler = idc_handler;
 	work->sync = mode == IDC_BLOCKING;
 
-	if (!cpu_is_core_enabled(target_cpu)) {
-		tr_err(&zephyr_idc_tr, "Core %u is down, cannot sent IDC message", target_cpu);
-		return -EACCES;
-	}
 	if (msg->payload) {
 		idc_send_memcpy_err = memcpy_s(payload->data, sizeof(payload->data),
 					       msg->payload, msg->size);


### PR DESCRIPTION
idc_send_msg() acquired idc_mutex and then returned -EACCES on the disabled-core path without unlocking, leaking the mutex and blocking all later cross-core IDC sends.

Move the cpu_is_core_enabled() check ahead of the lock so the early return no longer holds the mutex and the per-core work slot is not touched for a disabled core.