### PR TITLE
audio: aria: reject zero sample group size in init

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -123,6 +123,13 @@ static int aria_init(struct processing_module *mod)
 	list_init(&dev->bsource_list);
 	list_init(&dev->bsink_list);
 
+	/* sample group size is used as a divisor below, reject configs that make it zero */
+	if (!base_cfg->audio_fmt.channels_count || base_cfg->audio_fmt.depth < 8) {
+		comp_err(dev, "invalid channels:%u depth:%d",
+			 base_cfg->audio_fmt.channels_count, base_cfg->audio_fmt.depth);
+		return -EINVAL;
+	}
+
 	cd = mod_zalloc(mod, sizeof(*cd));
 	if (!cd) {
 		return -ENOMEM;


### PR DESCRIPTION
aria_init() computes sgs = (depth >> 3) * channels_count and then divides ibs by sgs. A host-supplied base config with channels_count of 0 or depth below 8 makes sgs zero, causing a divide-by-zero.

Validate channels_count and depth before the division.