### PR TITLE
ipc4: harden IPC4 pipeline triggering logic

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -369,7 +369,7 @@ static int pipeline_comp_reset(struct comp_dev *current,
 	 * scheduled together, except for IPC4, where each pipeline receives
 	 * commands from the host separately
 	 */
-	if (!is_single_ppl && IPC4_MOD_ID(current->ipc_config.id))
+	if (!is_single_ppl && IS_ENABLED(CONFIG_IPC_MAJOR_4))
 		return 0;
 
 	/* Propagate reset across pipelines only in the same direction

--- a/src/audio/pipeline/pipeline-params.c
+++ b/src/audio/pipeline/pipeline-params.c
@@ -267,7 +267,7 @@ static int pipeline_comp_prepare(struct comp_dev *current,
 
 	if (!comp_is_single_pipeline(current, ppl_data->start)) {
 		/* ipc4 module is only prepared in its parent pipeline */
-		if (IPC4_MOD_ID(current->ipc_config.id))
+		if (IS_ENABLED(CONFIG_IPC_MAJOR_4))
 			return 0;
 
 		/* Propagate prepare only to pipelines in the same direction */

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -140,7 +140,7 @@ static enum task_state pipeline_task_cmd(struct pipeline *p,
 			err = SOF_TASK_STATE_RESCHEDULE;
 		} else if (p->status == COMP_STATE_PAUSED) {
 			/* reset the pipeline components for IPC4 after the STOP trigger */
-			if (cmd == COMP_TRIGGER_STOP && IPC4_MOD_ID(host->ipc_config.id)) {
+			if (cmd == COMP_TRIGGER_STOP && IS_ENABLED(CONFIG_IPC_MAJOR_4)) {
 				err = pipeline_reset(host->pipeline, host);
 				if (err < 0)
 					reply->error = err;

--- a/src/audio/pipeline/pipeline-schedule.c
+++ b/src/audio/pipeline/pipeline-schedule.c
@@ -284,6 +284,16 @@ void pipeline_schedule_triggered(struct pipeline_walk_context *ctx,
 	struct pipeline *p;
 	uint32_t flags;
 
+#ifdef CONFIG_IPC_MAJOR_4
+	/*
+	 * With IPC4, each pipeline is triggered separately. Exactly 1 pipeline
+	 * is expected in the pipelines list (it's unclear whether an empty list
+	 * should be tolerated).
+	 */
+	assert(list_is_empty(&ctx->pipelines) ||
+	       list_item_is_last(ctx->pipelines.next, &ctx->pipelines));
+#endif
+
 	/*
 	 * Interrupts have to be disabled while adding tasks to or removing them
 	 * from the scheduler list. Without that scheduling can begin

--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -229,7 +229,7 @@ static int pipeline_comp_list(struct comp_dev *current,
 	 * component and we aren't using IPC4. With IPC4 each pipeline receives
 	 * commands separately so we don't need to trigger them together
 	 */
-	if (!is_single_ppl && (!is_same_sched || IPC4_MOD_ID(current->ipc_config.id))) {
+	if (!is_single_ppl && (!is_same_sched || IS_ENABLED(CONFIG_IPC_MAJOR_4))) {
 		pipe_dbg(current->pipeline,
 			 "current is from another pipeline");
 		return 0;


### PR DESCRIPTION
Move two commits out of https://github.com/thesofproject/sof/pull/10868 as it's not yet clear what to do with the revert there.

ipc4: harden IPC4 pipeline triggering logic
Using IPC4_MOD_ID() is not the best way to check if IPC4 is enabled. For module ID == 0, IPC4_MOD_ID() returns 0 for both IPC3 and IPC4. Module ID 0 is a valid IPC4 BASEFW ID. Since BASEFW is never added to a pipeline, this change doesn't fix any real problem. However, it's just more appropriate and safer to use IS_ENABLED(CONFIG_IPC_MAJOR_4): if module ID data becomes corrupted (zeroed) at runtime, this shouldn't make debugging even harder by causing unexpected pipeline behavior.

ipc4: assert IPC4 pipeline triggering logic
With IPC4, each pipeline is triggered separately. Exactly 1 pipeline is expected in the pipelines list in pipeline_schedule_triggered(). Unfortunately, we still have considerable complex IPC3 pipeline triggering code being used with IPC4. This assertion ensures that the code works correctly for the IPC4 case.