### PR TITLE
audio: base_fw: validate host core_id in KCPS allocation request

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -341,6 +341,12 @@ __cold static int basefw_kcps_allocation_request(struct ipc4_resource_kcps *requ
 	assert_can_be_cold();
 
 #if CONFIG_KCPS_DYNAMIC_CLOCK_CONTROL
+	if (request->core_id >= CONFIG_CORE_COUNT) {
+		tr_err(&ipc_tr, "invalid core_id %u",
+		       request->core_id);
+		return IPC4_ERROR_INVALID_PARAM;
+	}
+
 	if (core_kcps_adjust(request->core_id, request->kcps))
 		return IPC4_ERROR_INVALID_PARAM;
 #endif


### PR DESCRIPTION
basefw_kcps_allocation_request() passed request->core_id from the host IPC payload straight into core_kcps_adjust(), which uses it to index kcps_consumption[CONFIG_CORE_COUNT]. An out-of-range core_id turns the add-assign into an arbitrary relative write into DSP .bss.

Reject core_id >= CONFIG_CORE_COUNT at the IPC boundary, mirroring the existing check in schedulers_info_get().