### PR TITLE
app: boards: imx95: Disable edma1 node

### DIFF
--- a/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
+++ b/app/boards/imx95_evk_mimx9596_m7_ddr.overlay
@@ -26,6 +26,10 @@
 	status = "okay";
 };
 
+&edma1 {
+	status = "disabled";
+};
+
 &edma2 {
 	compatible = "nxp,edma";
 	reg = <0x42000000 (DT_SIZE_K(64) * 33)>;


### PR DESCRIPTION
Zephyr commit 58e859c5dd37b88 ("boards: nxp: imx95_evk: enable EDMA1 for M7 core") enables EDMA1 node which in turn enables dma_mcux_edma.c driver.

dma_mcux_edma.c requires some attention w.r.t cache configuration options.

SOF doesnt use EDMA1 nodes but inherits edma1 node which selects DMA_MCUX_EDMA and causes the following compilation errors:

dma_mcux_edma.c:1225:2: error: #error Unexpected or disallowed cache situation for dma descriptors

So disable edma1 node as we don't use it.