### PR TITLE
audio: kpb: IPC handling hardening

### DIFF
--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2688,6 +2688,15 @@ static int kpb_set_large_config(struct comp_dev *dev, uint32_t param_id,
 		const struct kpb_task_params *cfg = (struct kpb_task_params *)data;
 		uint32_t outpin_id = extended_param_id.part.parameter_instance;
 
+		/* payload must cover the header and all declared dev_ids[] entries */
+		if (!cfg || data_offset < offsetof(struct kpb_task_params, dev_ids))
+			return -EINVAL;
+
+		if (cfg->number_of_modules >
+		    (data_offset - offsetof(struct kpb_task_params, dev_ids)) /
+		    sizeof(cfg->dev_ids[0]))
+			return -EINVAL;
+
 		return configure_fast_mode_task(dev, cfg, outpin_id);
 	}
 #endif

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2459,12 +2459,27 @@ static int kpb_set_micselect(struct comp_dev *dev, const void *data,
 {
 	const struct kpb_micselector_config *mic_sel = data;
 	struct comp_data *kpb = comp_get_drvdata(dev);
-	const size_t mic_cnt = kpb->config.channels - KPB_REFERENCE_SUPPORT_CHANNELS;
-	const uint8_t valid_mask = KPB_COUNT_TO_BITMASK(mic_cnt);
+	size_t mic_cnt;
+	uint8_t valid_mask;
 	size_t i;
 
+	if (max_data_size < (int)sizeof(*mic_sel)) {
+		comp_err(dev, "micselector payload too small: got %d, need %d",
+			 max_data_size, (int)sizeof(*mic_sel));
+		return -EINVAL;
+	}
+
+	if (kpb->config.channels < KPB_REFERENCE_SUPPORT_CHANNELS ||
+	    kpb->config.channels > KPB_MAX_SUPPORTED_CHANNELS) {
+		comp_err(dev, "unsupported channel count %u", kpb->config.channels);
+		return -EINVAL;
+	}
+
+	mic_cnt = kpb->config.channels - KPB_REFERENCE_SUPPORT_CHANNELS;
+	valid_mask = KPB_COUNT_TO_BITMASK(mic_cnt);
+
 	if ((valid_mask & mic_sel->mask) == 0) {
-		comp_err(dev, "error: invalid micselector bit mask");
+		comp_err(dev, "invalid micselector bit mask");
 		return -EINVAL;
 	}
 	 /* selected mics counter */
@@ -2472,6 +2487,10 @@ static int kpb_set_micselect(struct comp_dev *dev, const void *data,
 
 	for (i = 0; i < mic_cnt; i++) {
 		if (KPB_IS_BIT_SET(mic_sel->mask, i)) {
+			if (num_of_sel_mic >= ARRAY_SIZE(kpb->offsets)) {
+				comp_err(dev, "too many selected mics");
+				return -EINVAL;
+			}
 			kpb->offsets[num_of_sel_mic] = i;
 			num_of_sel_mic++;
 		}

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2561,32 +2561,42 @@ static int prepare_fmt_modules_list(struct comp_dev *kpb_dev,
 	struct kpb_fmt_dev_list *fmt_device_list =
 		&((struct comp_data *)comp_get_drvdata(kpb_dev))->fmt_device_list;
 
+	if (outpin_idx >= KPB_MAX_SINK_CNT)
+		return -EINVAL;
+
 	fmt_device_list->kpb_list_item[outpin_idx] = kpb_dev;
 	ret = devicelist_push(&fmt_device_list->device_list[outpin_idx],
 			      &fmt_device_list->kpb_list_item[outpin_idx]);
 	if (ret < 0)
-		return ret;
+		goto err;
 
 	for (size_t mod_idx = 0; mod_idx < modules_to_prepare->number_of_modules; ++mod_idx) {
 		uint32_t comp_id = IPC4_COMP_ID(modules_to_prepare->dev_ids[mod_idx].module_id,
 						modules_to_prepare->dev_ids[mod_idx].instance_id);
 
 		dev = ipc4_get_comp_dev(comp_id);
-		if (!dev)
-			return -EINVAL;
+		if (!dev) {
+			ret = -EINVAL;
+			goto err;
+		}
 
 		struct comp_dev **new_list_item_ptr;
 
 		ret = alloc_fmt_module_list_item(fmt_device_list, dev, &new_list_item_ptr);
 		if (ret < 0)
-			return ret;
+			goto err;
 		*new_list_item_ptr = dev;
 		ret = devicelist_push(&fmt_device_list->device_list[outpin_idx],
 				      new_list_item_ptr);
 		if (ret < 0)
-			return ret;
+			goto err;
 	}
 	return 0;
+
+err:
+	/* drop any entries pushed so far to avoid leaving a half-configured list */
+	clear_fmt_modules_list(fmt_device_list, outpin_idx);
+	return ret;
 }
 
 static int clear_fmt_modules_list(struct kpb_fmt_dev_list *fmt_device_list,


### PR DESCRIPTION
Those commits harden the KPB IPC4 large-config paths: they validate the host-supplied channel count in kpb_set_micselect() (preventing an unsigned underflow and out-of-bounds writes) and validate the FMT module list against the actual payload length in the KP_BUF_CFG_FM_MODULE path (preventing out-of-bounds reads). The third commit makes prepare_fmt_modules_list() roll back partially populated FMT entries on error and adds a defensive outpin_idx bound check, so a failed configuration no longer leaves stale component references.