### PR TITLE
fix: Hifi stack arrays

### DIFF
--- a/src/audio/drc/drc_hifi4.c
+++ b/src/audio/drc/drc_hifi4.c
@@ -116,7 +116,7 @@ void drc_update_detector_average(struct drc_state *state,
 				 int nch)
 {
 	ae_f32 detector_average = state->detector_average; /* Q2.30 */
-	ae_int32 abs_input_array[DRC_DIVISION_FRAMES]; /* Q1.31 */
+	ae_int32 abs_input_array[DRC_DIVISION_FRAMES] __attribute__((aligned(8))); /* Q1.31 */
 	ae_int32 *abs_input_array_p;
 	int div_start, i, ch;
 	ae_int16 *sample16_p; /* for s16 format case */

--- a/src/audio/up_down_mixer/up_down_mixer_hifi3.c
+++ b/src/audio/up_down_mixer/up_down_mixer_hifi3.c
@@ -1247,7 +1247,7 @@ void downmix16bit_4ch_mono(struct up_down_mixer_data *cd, const uint8_t * const 
 	uint32_t idx3 = get_channel_index(cd->in_channel_map, 2);
 	uint32_t idx4 = get_channel_index(cd->in_channel_map, 3);
 
-	uint16_t coeffs[4] = {cd->downmix_coefficients[idx1],
+	uint16_t coeffs[4] __attribute__((aligned(8))) = {cd->downmix_coefficients[idx1],
 			      cd->downmix_coefficients[idx2],
 			      cd->downmix_coefficients[idx3],
 			      cd->downmix_coefficients[idx4]


### PR DESCRIPTION
Some arrays of hifi objects are on the stack, these should always be vector aligned since they can be consumed directly (passed via pointer) in SIMD operations. Enforce. 