### PR TITLE
smart_amp: bound host-supplied frame, channel and config sizes

### DIFF
--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -521,8 +521,15 @@ static int smart_amp_ff_process(struct processing_module *mod,
 		return 0;
 	}
 
-	if (frames > SMART_AMP_FF_BUF_DB_SZ) {
-		comp_err(dev, "feed forward frame size overflow: %u", frames);
+	/*
+	 * The remap functions write frames * ff_mod.channels samples into
+	 * ff_mod.buf, which holds SMART_AMP_FF_BUF_DB_SZ samples. Bound the
+	 * total sample count, not just the frame count, so an unexpected
+	 * channel count cannot overflow the buffer.
+	 */
+	if ((uint64_t)frames * sad->ff_mod.channels > SMART_AMP_FF_BUF_DB_SZ) {
+		comp_err(dev, "feed forward frame size overflow: %u frames, %u ch",
+			 frames, sad->ff_mod.channels);
 		sad->ff_mod.consumed = frames;
 		return -EINVAL;
 	}
@@ -556,8 +563,10 @@ static int smart_amp_fb_process(struct processing_module *mod,
 		return 0;
 	}
 
-	if (frames > SMART_AMP_FB_BUF_DB_SZ) {
-		comp_err(dev, "feedback frame size overflow: %u", frames);
+	/* bound total samples (frames * channels) against the buffer size */
+	if ((uint64_t)frames * sad->fb_mod.channels > SMART_AMP_FB_BUF_DB_SZ) {
+		comp_err(dev, "feedback frame size overflow: %u frames, %u ch",
+			 frames, sad->fb_mod.channels);
 		sad->fb_mod.consumed = frames;
 		return -EINVAL;
 	}

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -289,7 +289,11 @@ static int smart_amp_get_config(struct processing_module *mod,
 	comp_dbg(dev, "actual blob size = %zu, expected blob size = %zu",
 		 bs, sizeof(struct sof_smart_amp_config));
 
-	if (bs == 0 || bs > size)
+	/* bs is the host-set config.size and is used as the memcpy source
+	 * length from the fixed-size sad->config, so bound it by the struct
+	 * size. memcpy_s() below already bounds it against the destination.
+	 */
+	if (bs == 0 || bs > sizeof(struct sof_smart_amp_config))
 		return -EINVAL;
 
 	ret = memcpy_s(cdata->data->data, size, &sad->config, bs);

--- a/src/audio/smart_amp/smart_amp_generic.c
+++ b/src/audio/smart_amp/smart_amp_generic.c
@@ -35,7 +35,11 @@ static void remap_s32_to_s32(struct smart_amp_mod_stream *src_mod, uint32_t fram
 		n = MIN(num_samples_remaining, nmax);
 
 		for (ch = 0; ch < src_mod->channels; ch++) {
-			if (chan_map[ch] == -1)
+			/* skip unmapped (-1) and out-of-range source channels;
+			 * the uint8_t cast folds the negative case into the
+			 * single upper-bound check (-1 becomes 255 >= src_ch)
+			 */
+			if ((uint8_t)chan_map[ch] >= src_ch)
 				continue;
 
 			mod_ptr = mod_ptr_base + ch;
@@ -103,7 +107,11 @@ static void remap_s16_to_s16(struct smart_amp_mod_stream *src_mod, uint32_t fram
 		n = MIN(num_samples_remaining, nmax);
 
 		for (ch = 0; ch < src_mod->channels; ch++) {
-			if (chan_map[ch] == -1)
+			/* skip unmapped (-1) and out-of-range source channels;
+			 * the uint8_t cast folds the negative case into the
+			 * single upper-bound check (-1 becomes 255 >= src_ch)
+			 */
+			if ((uint8_t)chan_map[ch] >= src_ch)
 				continue;
 
 			mod_ptr = mod_ptr_base + ch;
@@ -147,7 +155,11 @@ static void remap_s16_to_b32(struct smart_amp_mod_stream *src_mod, uint32_t fram
 		n = MIN(num_samples_remaining, nmax);
 
 		for (ch = 0; ch < src_mod->channels; ch++) {
-			if (chan_map[ch] == -1)
+			/* skip unmapped (-1) and out-of-range source channels;
+			 * the uint8_t cast folds the negative case into the
+			 * single upper-bound check (-1 becomes 255 >= src_ch)
+			 */
+			if ((uint8_t)chan_map[ch] >= src_ch)
 				continue;
 
 			mod_ptr = mod_ptr_base + ch;

--- a/src/audio/smart_amp/smart_amp_maxim_dsm.c
+++ b/src/audio/smart_amp/smart_amp_maxim_dsm.c
@@ -321,7 +321,18 @@ static int maxim_dsm_get_param(struct smart_amp_mod_struct_t *hspk,
 		 * required size
 		 */
 		if (bs > size) {
-			comp_err(dev, "[DSM] invalid size %d", bs);
+			comp_err(dev, "[DSM] invalid size %zu", bs);
+			return -EINVAL;
+		}
+
+		/* Host controls msg_index and therefore data_pos; make sure the
+		 * fragment stays inside caldata->data to avoid leaking adjacent
+		 * heap back to the host.
+		 */
+		if (caldata->data_pos >= caldata->data_size ||
+		    bs > caldata->data_size - caldata->data_pos) {
+			comp_err(dev, "[DSM] invalid data_pos %u, size %zu, total %u",
+				 caldata->data_pos, bs, caldata->data_size);
 			return -EINVAL;
 		}
 

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -518,6 +518,16 @@ static int smart_amp_prepare(struct comp_dev *dev)
 
 	sad->in_channels = audio_stream_get_channels(&sad->source_buf->stream);
 
+	/* out_channels bounds the processing loop that indexes the
+	 * PLATFORM_MAX_CHANNELS-sized channel map, so reject a larger count
+	 */
+	if (sad->out_channels > PLATFORM_MAX_CHANNELS ||
+	    sad->in_channels > PLATFORM_MAX_CHANNELS) {
+		comp_err(dev, "invalid channel count, in %u out %u",
+			 sad->in_channels, sad->out_channels);
+		return -EINVAL;
+	}
+
 	if (sad->feedback_buf) {
 		audio_stream_set_channels(&sad->feedback_buf->stream,
 					  sad->config.feedback_channels);


### PR DESCRIPTION
Hardening of host-supplied fields in smart_amp so a compromised host cannot
drive out-of-bounds access in the DSP:

- bound the processed sample count (frames * channels) against the buffer
  capacity, not just the frame count
- skip out-of-range source channel-map entries instead of indexing past the
  source frame
- bound the calibration read offset against the calibration data size
- bound the get-config copy length by the config struct size
- (sample component) reject channel counts above the platform maximum

No functional change for valid configurations.