### PR TITLE
audio: igo_nr: bound host active_channel_idx before adopting config

### DIFF
--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -719,9 +719,9 @@ static void igo_nr_set_igo_params(struct processing_module *mod)
 	struct comp_dev *dev = mod->dev;
 
 	comp_info(dev, "entry");
-	igo_nr_check_config_validity(dev, cd);
 
-	if (p_config) {
+	/* Adopt the host blob only when new config is valid */
+	if (p_config && igo_nr_check_config_validity(dev, cd) == 0) {
 		comp_info(dev, "New config detected.");
 		cd->config = *p_config;
 		igo_nr_print_config(mod);


### PR DESCRIPTION
Adopt the blob only when igo_nr_check_config_validity() passes so a host index past process_enable[] cannot reach prepare/process.