### PR TITLE
logger: bound uuid pointer to include the entry size

### DIFF
--- a/tools/logger/convert.c
+++ b/tools/logger/convert.c
@@ -126,8 +126,14 @@ static const char *format_uid(uint32_t uid_ptr, int use_colors, bool be, bool up
 	const struct sof_uuid_entry *uid_entry;
 	char *str;
 
+	/*
+	 * The whole struct sof_uuid_entry is read at uid_ptr, so require that
+	 * many bytes to remain in the uids region; a bare ">=" upper bound
+	 * would accept a pointer whose entry straddles the end of the buffer.
+	 */
 	if (uid_ptr < uids_dict->base_address ||
-	    uid_ptr >= uids_dict->base_address + uids_dict->data_length) {
+	    uid_ptr + sizeof(struct sof_uuid_entry) >
+		uids_dict->base_address + uids_dict->data_length) {
 		str = calloc(1, strlen(BAD_PTR_STR) + 1 + 6);
 		if (!str) {
 			log_err("can't allocate memory\n");


### PR DESCRIPTION
The UUID-pointer bounds check in sof-logger only required the pointer to be
below the end of the uids region, not that a whole `struct sof_uuid_entry`
fits. A crafted .ldc dictionary with a UUID pointer near the end of the region
could make the logger read an entry straddling the buffer end. Include the
entry size in the upper-bound check.