### PR TITLE
lib-manager: fix a NULL dereference

### DIFF
--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -1165,7 +1165,7 @@ cleanup:
 	uint32_t module_id = lib_id << LIB_MANAGER_LIB_ID_SHIFT;
 	const struct sof_man_module *mod = lib_manager_get_module_manifest(module_id);
 
-	if (!ret && module_is_llext(mod))
+	if (!ret && mod && module_is_llext(mod))
 		/* Auxiliary LLEXT libraries need to be linked upon loading */
 		ret = llext_manager_add_library(module_id);
 


### PR DESCRIPTION
lib_manager_get_module_manifest() can return NULL, if it is then passed to module_is_llext() as an argument, it will lead to an exception. Check for NULL before calling module_is_llext().