### PR TITLE
base_fw: reject undersized system time payload

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -277,6 +277,9 @@ __cold static uint32_t basefw_set_system_time(uint32_t param_id, bool first_bloc
 	if (!(first_block && last_block))
 		return IPC4_INVALID_REQUEST;
 
+	if (data_offset < sizeof(struct ipc4_system_time))
+		return IPC4_ERROR_INVALID_PARAM;
+
 	global_system_time_info.host_time.val_l = ((const struct ipc4_system_time *)data)->val_l;
 	global_system_time_info.host_time.val_u = ((const struct ipc4_system_time *)data)->val_u;
 


### PR DESCRIPTION
The SYSTEM_TIME large-config handler dereferenced the payload as a fixed
struct without checking the supplied size, reading past the mailbox for a
short payload. Reject a payload smaller than `struct ipc4_system_time`.

No functional change for valid configurations.