### PR TITLE
drc: validate host config blob sizes (dcblock, drc, multiband_drc)

### DIFF
--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -205,7 +205,11 @@ static int dcblock_prepare(struct processing_module *mod,
 		  cd->source_format, cd->sink_format);
 
 	cd->config = comp_get_data_blob(cd->model_handler, &data_size, NULL);
-	if (cd->config && data_size > 0)
+	/* dcblock_copy_coefficients() copies sizeof(R_coeffs) from the blob, so
+	 * require the blob to actually hold that many bytes; fall back to
+	 * passthrough otherwise instead of over-reading the blob
+	 */
+	if (cd->config && data_size >= sizeof(cd->R_coeffs))
 		dcblock_copy_coefficients(mod);
 	else
 		dcblock_set_passthrough(mod);

--- a/src/audio/drc/drc.c
+++ b/src/audio/drc/drc.c
@@ -353,7 +353,10 @@ static int drc_prepare(struct processing_module *mod,
 	/* Initialize DRC */
 	comp_info(dev, "source_format=%d", cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, &data_size, NULL);
-	if (cd->config && data_size > 0) {
+	/* the blob is dereferenced as a struct sof_drc_config below and in
+	 * drc_setup(), so require it to be at least that large
+	 */
+	if (cd->config && data_size >= sizeof(struct sof_drc_config)) {
 		ret = drc_setup(mod, channels, rate);
 		if (ret < 0) {
 			comp_err(dev, "error: drc_setup failed.");

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -369,7 +369,14 @@ static int multiband_drc_prepare(struct processing_module *mod,
 	comp_dbg(dev, "source_format=%d, sink_format=%d",
 		 cd->source_format, cd->source_format);
 	cd->config = comp_get_data_blob(cd->model_handler, &data_size, NULL);
-	if (cd->config && data_size > 0) {
+	/* the blob holds a base struct followed by num_bands variable-length
+	 * band coefficients; require the base struct first, then the full
+	 * per-band payload, so setup cannot read past the blob
+	 */
+	if (cd->config && data_size >= sizeof(struct sof_multiband_drc_config) &&
+	    cd->config->num_bands <= SOF_MULTIBAND_DRC_MAX_BANDS &&
+	    data_size >= sizeof(struct sof_multiband_drc_config) +
+		    (size_t)cd->config->num_bands * sizeof(struct sof_drc_params)) {
 		ret = multiband_drc_setup(mod, channels, rate);
 		if (ret < 0) {
 			comp_err(dev, "error: multiband_drc_setup failed.");


### PR DESCRIPTION
Hardening of the DRC-family components against host config blobs that are
smaller than the structures read out of them (out-of-bounds reads of
adjacent heap otherwise):

- dcblock: require the blob to cover the coefficient array before copying it
- drc: require the blob to be at least `sizeof(struct sof_drc_config)`
- multiband_drc: require the blob to cover the base config and all
  `num_bands` per-band coefficient entries

No functional change for valid configurations.