### PR TITLE
ipc4: large_config: log rejected data_off_size validation failures

### DIFF
--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -1107,10 +1107,16 @@ __cold static int ipc4_set_vendor_config_module_instance(struct comp_dev *dev,
 	assert_can_be_cold();
 
 	/* Validate host-controlled payload size before any use or arithmetic. */
-	if (data_off_size > MAILBOX_HOSTBOX_SIZE)
+	if (data_off_size > MAILBOX_HOSTBOX_SIZE) {
+		tr_err(&ipc_tr, "data_off_size greater than mailbox %u > %u",
+		       data_off_size, (uint32_t)MAILBOX_HOSTBOX_SIZE);
 		return IPC4_INVALID_CONFIG_DATA_STRUCT;
-	if (init_block && data_off_size < sizeof(struct sof_tlv))
+	}
+	if (init_block && data_off_size < sizeof(struct sof_tlv)) {
+		tr_err(&ipc_tr, "init_block data_off_size too small %u < %zu",
+		       data_off_size, sizeof(struct sof_tlv));
 		return IPC4_INVALID_CONFIG_DATA_STRUCT;
+	}
 
 	/* Old FW comment: bursted configs */
 	if (init_block && final_block) {


### PR DESCRIPTION
The data_off_size bounds checks in ipc4_set_vendor_config_module_instance() silently returned IPC4_INVALID_CONFIG_DATA_STRUCT, giving no clue why a MOD_LARGE_CONFIG_SET request was rejected. This makes diagnosing malformed or malicious topologies/host requests harder.

Add tr_dbg() traces to both rejection paths reporting the offending data_off_size together with the limit it violated (the mailbox size for the upper bound, and sizeof(struct sof_tlv) for the init_block lower bound). No functional change to the validation itself.