### PR TITLE
idc: clear task pointer after free on prepare error

### DIFF
--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -199,6 +199,7 @@ static int idc_prepare(uint32_t comp_id)
 					    dev->ipc_config.core, 0);
 		if (ret < 0) {
 			sof_heap_free(dev->drv->user_heap, dev->task);
+			dev->task = NULL;
 			goto out;
 		}
 	}


### PR DESCRIPTION
On a task init failure in idc_prepare(), the task allocation was freed but
the pointer was left set, so a later comp_free path could free it a second
time. Clear `dev->task` after freeing it.