### PR TITLE
fft: free the plan on the invalid word length path

### DIFF
--- a/src/math/fft/fft_common.c
+++ b/src/math/fft/fft_common.c
@@ -53,6 +53,7 @@ struct fft_plan *fft_plan_common_new(struct processing_module *mod, void *inb,
 		break;
 	default:
 		comp_cl_err(mod->dev, "Invalid word length.");
+		mod_free(mod, plan);
 		return NULL;
 	}
 


### PR DESCRIPTION
fft_plan_common_new() allocated the plan before the word-length switch and
leaked it when the default case rejected an unsupported length. Free the
plan before returning NULL on that path.