### PR TITLE
tplg: reject zero-size arrays and undersized private data

### DIFF
--- a/tools/tplg_parser/object.c
+++ b/tools/tplg_parser/object.c
@@ -62,6 +62,14 @@ int tplg_create_object(struct tplg_context *ctx,
 			return -EINVAL;
 		}
 
+		/* a zero-size array never advances the cursor below: bail out
+		 * instead of looping forever on a malformed topology
+		 */
+		if (array->size == 0) {
+			fprintf(stderr, "error: load %s zero-size array\n", name);
+			return -EINVAL;
+		}
+
 		for (i = 0; i < ipc->num_groups; i++) {
 			const struct sof_topology_token *tokens = ipc->grp[i].tokens;
 			int num_tokens = ipc->grp[i].num_tokens;

--- a/tools/tplg_parser/process.c
+++ b/tools/tplg_parser/process.c
@@ -151,6 +151,11 @@ static int process_append_data3(void *_process_ipc,
 
 	/* Size is process IPC plus private data minus ABI header */
 	bytes_ctl = (struct snd_soc_tplg_bytes_control *)ctl;
+	if (bytes_ctl->priv.size < sizeof(struct sof_abi_hdr)) {
+		fprintf(stderr, "error: process priv data too small: %u\n",
+			bytes_ctl->priv.size);
+		return -EINVAL;
+	}
 	size = bytes_ctl->priv.size - sizeof(struct sof_abi_hdr);
 	ipc_size = sizeof(struct sof_ipc_comp_process) + UUID_SIZE +
 			process_ipc->size + size;
@@ -184,6 +189,11 @@ static int process_append_data4(void *_process_ipc,
 
 	/* Size is process IPC plus private data minus ABI header */
 	bytes_ctl = (struct snd_soc_tplg_bytes_control *)ctl;
+	if (bytes_ctl->priv.size < sizeof(struct sof_abi_hdr)) {
+		fprintf(stderr, "error: process priv data too small: %u\n",
+			bytes_ctl->priv.size);
+		return -EINVAL;
+	}
 	size = bytes_ctl->priv.size - sizeof(struct sof_abi_hdr);
 
 	/* validate if everything will fit */


### PR DESCRIPTION
Two robustness fixes in the host-side topology parser (testbench/plugin)
against crafted .tplg input:

- reject a zero-size vendor array, which otherwise never advances the parse
  cursor and loops forever
- reject process-widget private data smaller than the ABI header before
  subtracting, which otherwise underflows the remaining-size computation