### PR TITLE
tplg_parser: reject process priv blob smaller than abi header

### DIFF
--- a/tools/tplg_parser/process.c
+++ b/tools/tplg_parser/process.c
@@ -151,6 +151,10 @@ static int process_append_data3(void *_process_ipc,
 
 	/* Size is process IPC plus private data minus ABI header */
 	bytes_ctl = (struct snd_soc_tplg_bytes_control *)ctl;
+	if (bytes_ctl->priv.size < sizeof(struct sof_abi_hdr)) {
+		fprintf(stderr, "error: process priv data smaller than ABI header\n");
+		return -EINVAL;
+	}
 	size = bytes_ctl->priv.size - sizeof(struct sof_abi_hdr);
 	ipc_size = sizeof(struct sof_ipc_comp_process) + UUID_SIZE +
 			process_ipc->size + size;


### PR DESCRIPTION
Integer underflow in the topology process-widget parser:
- process_append_data3 subtracts the 32-byte ABI header from the host-supplied priv.size as a size_t
- a bytes control with priv.size below that underflows size; the ipc_size check wraps along with it and passes, so the memcpy overruns process_ipc
- process_append_data4 right below is unaffected, it bounds the subtracted size directly

Reject priv.size below sizeof(struct sof_abi_hdr) before the subtraction.