### PR TITLE
bound control name and value copies in tb_parse_amixer

### DIFF
--- a/tools/testbench/utils.c
+++ b/tools/testbench/utils.c
@@ -368,10 +368,18 @@ static int tb_parse_amixer(struct testbench_prm *tp, char *line)
 	}
 
 	len = end_str - name_str - find_len;
+	if (len < 0 || len >= TB_MAX_CTL_NAME_CHARS) {
+		fprintf(stderr, "error: control name too long in script line: %s\n", line);
+		return -EINVAL;
+	}
 	memcpy(control_name, name_str + find_len, len);
 
 	line_end = line + strlen(line);
 	len = line_end - end_str - find_end_len;
+	if (len < 0 || len >= TB_MAX_CTL_NAME_CHARS) {
+		fprintf(stderr, "error: control value too long in script line: %s\n", line);
+		return -EINVAL;
+	}
 	memcpy(control_params, &end_str[find_end_len], len);
 
 	printf("Info: Setting control name '%s' to value (%s)\n", control_name, control_params);


### PR DESCRIPTION
tb_parse_amixer copies the parsed control name and value into fixed 128-byte stack buffers with no length check on the data read from the control script:
- control_name: len comes from the cset name="..." quote delimiters, never capped to TB_MAX_CTL_NAME_CHARS
- control_params: same unchecked copy for the value after the closing quote
- a name longer than the buffer overflows the stack; the sibling tb_parse_sofctl avoids this by using strndup
Reject over-length fields before each memcpy.