### PR TITLE
topology2: Add sof-ptl-rt713-l3-rt1320-l2 for MSI Prestige 14/16 Flip AI+ (D3MTG/C3MTG)

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -174,6 +174,13 @@ SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=SDW1-Playback,\
 SDW_JACK_OUT_STREAM=SDW3-Playback,SDW_JACK_IN_STREAM=SDW3-Capture,\
 PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt713-l3-rt1320-l1.bin"
 
+# MSI Prestige 14/16 Flip AI+ (D3MTG/C3MTG) with RT713 on link 3 and double stereo RT1320 on link 2
+"cavs-sdw\;sof-ptl-rt713-l3-rt1320-l2\;PLATFORM=ptl,SDW_DMIC=1,NUM_SDW_AMP_LINKS=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=SDW2-Playback,\
+SDW_JACK_OUT_STREAM=SDW3-Playback,SDW_JACK_IN_STREAM=SDW3-Capture,\
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt713-l3-rt1320-l2.bin,\
+DEEPBUFFER_FW_DMA_MS=10,DEEP_BUF_SPK=true"
+
 "cavs-sdw\;sof-ptl-cs42l43-l2-cs35l56x6-l13\;NUM_SDW_AMP_LINKS=3,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"


### PR DESCRIPTION
## Summary

I add a new SOF topology build target for MSI Prestige 14/16 Flip AI+ (D3MTG/C3MTG) (They share the same hardware but in different size), which use a unusual SoundWire configurations

- RT713 jack/headset codec on link 3
- Dual stereos RT1320 SmartAmp on the same link 2
- 1 SoundWire DMIC

## Why?

Existing rt713-rt1320 boards have two RT1320 amps on different links, But MSI makes the RT1320 amps on the same link 2

```
[   13.220268] sof-audio-pci-intel-ptl 0000:00:1f.3: No SoundWire machine driver found for the ACPI-reported configuration:
[   13.220270] sof-audio-pci-intel-ptl 0000:00:1f.3: link 2 mfg_id 0x025d part_id 0x1320 version 0x3
[   13.220271] sof-audio-pci-intel-ptl 0000:00:1f.3: link 2 mfg_id 0x025d part_id 0x1320 version 0x3
[   13.220272] sof-audio-pci-intel-ptl 0000:00:1f.3: link 3 mfg_id 0x025d part_id 0x0713 version 0x3
```

## Dependencies

This topology requires a matching kernel SoundWire machine table entry that I will submit separately to the the sof `linux` fork repository.

- `sound/soc/intel/common/soc-acpi-intel-ptl-match.c`
    - adds `rt1320_2_group2_lr_adr` for the two RT1320 which on the same link 2
    - adds `link_mask = BIT(2) | BIT(3)` entry referencing `sof-ptl-rt713-l3-rt1320-l2.tplg`

## Test

- [x] Built tplg + nhlt bin succeed
- [x] Loaded on real hardware (MSI Prestige 16 Flip AI+ C3MTG, kernel 7.1.1-2-cachyos with the kernel patch applied)
- [x] Speaker (RT1320 stereo) plays both channels
- [x] Internal DMIC stereo capture works
- [x] HDMI 1/2/3 output devices exposed but **haven't** verified on monitor with audio (I don't have such monitor on hand)
- [x] PipeWire UCM HiFi profile auto-activates and exposes proper sinks/sources