### PR TITLE
 audio: module-adapter: make generic code compatible with user-space

### DIFF
--- a/src/audio/data_blob.c
+++ b/src/audio/data_blob.c
@@ -624,12 +624,13 @@ EXPORT_SYMBOL(comp_data_blob_get_cmd);
 
 static void *default_alloc(size_t size)
 {
-	return rballoc(SOF_MEM_FLAG_USER, size);
+	return sof_heap_alloc(sof_sys_user_heap_get(),
+			      SOF_MEM_FLAG_USER | SOF_MEM_FLAG_LARGE_BUFFER, size, 0);
 }
 
 static void default_free(void *buf)
 {
-	rfree(buf);
+	sof_heap_free(sof_sys_user_heap_get(), buf);
 }
 
 struct comp_data_blob_handler *
@@ -641,10 +642,11 @@ comp_data_blob_handler_new_ext(struct comp_dev *dev, bool single_blob,
 
 	comp_dbg(dev, "entry");
 
-	handler = rzalloc(SOF_MEM_FLAG_USER,
-			  sizeof(struct comp_data_blob_handler));
+	handler = sof_heap_alloc(sof_sys_user_heap_get(), SOF_MEM_FLAG_USER,
+				 sizeof(struct comp_data_blob_handler), 0);
 
 	if (handler) {
+		memset(handler, 0, sizeof(*handler));
 		handler->dev = dev;
 		handler->single_blob = single_blob;
 		handler->alloc = alloc ? alloc : default_alloc;
@@ -662,6 +664,6 @@ void comp_data_blob_handler_free(struct comp_data_blob_handler *blob_handler)
 
 	comp_free_data_blob(blob_handler);
 
-	rfree(blob_handler);
+	sof_heap_free(sof_sys_user_heap_get(), blob_handler);
 }
 EXPORT_SYMBOL(comp_data_blob_handler_free);

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -57,13 +57,15 @@ int module_load_config(struct comp_dev *dev, const void *cfg, size_t size)
 
 	if (!dst->data) {
 		/* No space for config available yet, allocate now */
-		dst->data = rballoc(SOF_MEM_FLAG_USER, size);
+		dst->data = sof_heap_alloc(sof_sys_user_heap_get(),
+					   SOF_MEM_FLAG_USER | SOF_MEM_FLAG_LARGE_BUFFER, size, 0);
 	} else if (dst->size != size) {
 		/* The size allocated for previous config doesn't match the new one.
 		 * Free old container and allocate new one.
 		 */
-		rfree(dst->data);
-		dst->data = rballoc(SOF_MEM_FLAG_USER, size);
+		sof_heap_free(sof_sys_user_heap_get(), dst->data);
+		dst->data = sof_heap_alloc(sof_sys_user_heap_get(),
+					   SOF_MEM_FLAG_USER | SOF_MEM_FLAG_LARGE_BUFFER, size, 0);
 	}
 	if (!dst->data) {
 		comp_err(dev, "failed to allocate space for setup config.");
@@ -538,7 +540,7 @@ int module_prepare(struct processing_module *mod,
 	 * as it has been applied during the procedure - it is safe to
 	 * free it.
 	 */
-	rfree(md->cfg.data);
+	sof_heap_free(sof_sys_user_heap_get(), md->cfg.data);
 
 	md->cfg.avail = false;
 	md->cfg.data = NULL;
@@ -673,7 +675,7 @@ int module_reset(struct processing_module *mod)
 
 	md->cfg.avail = false;
 	md->cfg.size = 0;
-	rfree(md->cfg.data);
+	sof_heap_free(sof_sys_user_heap_get(), md->cfg.data);
 	md->cfg.data = NULL;
 
 #if CONFIG_IPC_MAJOR_3
@@ -724,10 +726,10 @@ int module_free(struct processing_module *mod)
 	/* Free all memory shared by module_adapter & module */
 	md->cfg.avail = false;
 	md->cfg.size = 0;
-	rfree(md->cfg.data);
+	sof_heap_free(sof_sys_user_heap_get(), md->cfg.data);
 	md->cfg.data = NULL;
 	if (md->runtime_params) {
-		rfree(md->runtime_params);
+		sof_heap_free(sof_sys_user_heap_get(), md->runtime_params);
 		md->runtime_params = NULL;
 	}
 #if CONFIG_IPC_MAJOR_3
@@ -794,7 +796,9 @@ int module_set_configuration(struct processing_module *mod,
 		}
 
 		/* Allocate buffer for new params */
-		md->runtime_params = rballoc(SOF_MEM_FLAG_USER, md->new_cfg_size);
+		md->runtime_params = sof_heap_alloc(sof_sys_user_heap_get(),
+						    SOF_MEM_FLAG_USER | SOF_MEM_FLAG_LARGE_BUFFER,
+						    md->new_cfg_size, 0);
 		if (!md->runtime_params) {
 			comp_err(dev, "space allocation for new params failed");
 			return -ENOMEM;
@@ -835,7 +839,7 @@ int module_set_configuration(struct processing_module *mod,
 	md->new_cfg_size = 0;
 
 	if (md->runtime_params)
-		rfree(md->runtime_params);
+		sof_heap_free(sof_sys_user_heap_get(), md->runtime_params);
 	md->runtime_params = NULL;
 
 	return ret;

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -631,11 +631,26 @@ EXPORT_SYMBOL(rfree);
 void *z_impl_sof_heap_alloc(struct k_heap *heap, uint32_t flags, size_t bytes,
 			    size_t alignment)
 {
-	if (flags & (SOF_MEM_FLAG_LARGE_BUFFER | SOF_MEM_FLAG_USER_SHARED_BUFFER))
+#if CONFIG_SOF_USERSPACE_USE_SHARED_HEAP
+	/*
+	 * FLAG_USER_SHARED_BUFFER maps to a specific heap, so
+	 * the passed 'heap' can be ignored
+	 */
+	if (flags & SOF_MEM_FLAG_USER_SHARED_BUFFER)
 		return rballoc_align(flags, bytes, alignment);
+#endif
 
-	if (!heap)
+	if (!heap) {
+		/*
+		 * Ensure virtual heap is utilized for large buffers
+		 * if no heap is explicitly passed. rballoc_align()
+		 * has this logic.
+		 */
+		if (flags & SOF_MEM_FLAG_LARGE_BUFFER)
+			return rballoc_align(flags, bytes, alignment);
+
 		heap = &sof_heap;
+	}
 
 	if (flags & SOF_MEM_FLAG_COHERENT)
 		return heap_alloc_aligned(heap, alignment, bytes);

--- a/zephyr/syscall/alloc.c
+++ b/zephyr/syscall/alloc.c
@@ -12,7 +12,8 @@ static inline void *z_vrfy_sof_heap_alloc(struct k_heap *heap, uint32_t flags,
 {
 	/* only allow flags that are safe for user-space heap isolation */
 	static const uint32_t allowed_flags =
-		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT | SOF_MEM_FLAG_DMA;
+		SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT | SOF_MEM_FLAG_DMA |
+		SOF_MEM_FLAG_LARGE_BUFFER;
 
 	K_OOPS(flags & ~allowed_flags);
 


### PR DESCRIPTION
Series of patches to make generic module code safe to use from user-space.