### PR TITLE
topology2: fix HDMI link IDs for sof-lnl-rt713-l0-rt1318-l1

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace2.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace2.cmake
@@ -28,7 +28,8 @@ SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 "cavs-sdw\;sof-lnl-rt713-l0-rt1318-l1\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,\
-SDW_SPK_STREAM=SDW1-Playback,SDW_AMP_FEEDBACK=false"
+SDW_SPK_STREAM=SDW1-Playback,SDW_AMP_FEEDBACK=false,\
+HDMI1_ID=4,HDMI2_ID=5,HDMI3_ID=6"
 
 "cavs-sdw\;sof-lnl-rt713-l0-rt1318-l1-2ch\;PLATFORM=lnl,NUM_SDW_AMP_LINKS=1,\
 SDW_SPK_STREAM=SDW1-Playback,SDW_AMP_FEEDBACK=false,\


### PR DESCRIPTION
Hi, I disabled my mic in my bios (lenovo lunar lake laptop) and my speaker stopped working. This PR fixed it. 

I don't quite follow the fix but AI says it's the following:

This topology has no DMIC backend, but inherits the default HDMI backend-link IDs of 5/6/7 from hdmi-default.conf. Those defaults assume a DMIC link occupies ID 4, so they start HDMI at 5.

The sof_sdw machine driver assigns backend-link IDs compactly. For this board the SoundWire jack and rt1318 amplifier links take IDs 0-3, and with no DMIC the iDisp links follow at 4/5/6. The topology's iDisp1 at ID 5 then matches no card link and the probe fails:

  ASoC: physical link iDisp1 (id 5) not exist
  error: failed to load DSP topology -22
  sof_sdw: ASoC: failed to instantiate card -22

so the whole card, including speaker playback, is lost.

Set HDMI1_ID/HDMI2_ID/HDMI3_ID to 4/5/6 to match the IDs the driver creates for the no-DMIC case. This mirrors the -2ch variant, which adds two DMIC links at IDs 4/5 and correspondingly places HDMI at 6/7/8.