### PR TITLE
tree-wide: remove legacy platform_shared_get()

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -859,8 +859,7 @@ static SHARED_DATA struct comp_driver_info comp_basefw_info = {
 
 UT_STATIC void sys_comp_basefw_init(void)
 {
-	comp_register(platform_shared_get(&comp_basefw_info,
-					  sizeof(comp_basefw_info)));
+	comp_register(&comp_basefw_info);
 }
 
 DECLARE_MODULE(sys_comp_basefw_init);

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -694,8 +694,7 @@ static SHARED_DATA struct comp_driver_info comp_chain_dma_info = {
 
 UT_STATIC void sys_comp_chain_dma_init(void)
 {
-	comp_register(platform_shared_get(&comp_chain_dma_info,
-					  sizeof(comp_chain_dma_info)));
+	comp_register(&comp_chain_dma_info);
 }
 
 DECLARE_MODULE(sys_comp_chain_dma_init);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -187,7 +187,7 @@ EXPORT_SYMBOL(comp_set_state);
 
 void sys_comp_init(struct sof *sof)
 {
-	sof->comp_drivers = platform_shared_get(&cd, sizeof(cd));
+	sof->comp_drivers = &cd;
 
 	list_init(&sof->comp_drivers->list);
 	k_spinlock_init(&sof->comp_drivers->lock);

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -1134,8 +1134,7 @@ static SHARED_DATA struct comp_driver_info comp_dai_info = {
 
 UT_STATIC void sys_comp_dai_init(void)
 {
-	comp_register(platform_shared_get(&comp_dai_info,
-					  sizeof(comp_dai_info)));
+	comp_register(&comp_dai_info);
 }
 
 DECLARE_MODULE(sys_comp_dai_init);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -2065,7 +2065,7 @@ static SHARED_DATA struct comp_driver_info comp_dai_info = {
 
 UT_STATIC void sys_comp_dai_init(void)
 {
-	comp_register(platform_shared_get(&comp_dai_info, sizeof(comp_dai_info)));
+	comp_register(&comp_dai_info);
 }
 
 DECLARE_MODULE(sys_comp_dai_init);

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -472,8 +472,7 @@ static SHARED_DATA struct comp_driver_info ghd_driver_info = {
 
 UT_STATIC void sys_comp_ghd_init(void)
 {
-	comp_register(platform_shared_get(&ghd_driver_info,
-					  sizeof(ghd_driver_info)));
+	comp_register(&ghd_driver_info);
 }
 
 DECLARE_MODULE(sys_comp_ghd_init);

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -1074,8 +1074,7 @@ static SHARED_DATA struct comp_driver_info comp_host_info = {
 
 UT_STATIC void sys_comp_host_init(void)
 {
-	comp_register(platform_shared_get(&comp_host_info,
-					  sizeof(comp_host_info)));
+	comp_register(&comp_host_info);
 }
 
 DECLARE_MODULE(sys_comp_host_init);

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -1338,8 +1338,7 @@ static SHARED_DATA struct comp_driver_info comp_host_info = {
 
 UT_STATIC void sys_comp_host_init(void)
 {
-	comp_register(platform_shared_get(&comp_host_info,
-					  sizeof(comp_host_info)));
+	comp_register(&comp_host_info);
 }
 
 DECLARE_MODULE(sys_comp_host_init);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2748,8 +2748,7 @@ static SHARED_DATA struct comp_driver_info comp_kpb_info = {
 
 UT_STATIC void sys_comp_kpb_init(void)
 {
-	comp_register(platform_shared_get(&comp_kpb_info,
-					  sizeof(comp_kpb_info)));
+	comp_register(&comp_kpb_info);
 }
 
 DECLARE_MODULE(sys_comp_kpb_init);

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -105,8 +105,7 @@ static inline void pipeline_posn_offset_put(uint32_t posn_offset)
 
 void pipeline_posn_init(struct sof *sof)
 {
-	sof->pipeline_posn = platform_shared_get(&pipeline_posn_shared,
-						 sizeof(pipeline_posn_shared));
+	sof->pipeline_posn = &pipeline_posn_shared;
 	k_spinlock_init(&sof->pipeline_posn->lock);
 }
 

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -539,8 +539,7 @@ static SHARED_DATA struct comp_driver_info comp_selector_info = {
 /** \brief Initializes selector component. */
 UT_STATIC void sys_comp_selector_init(void)
 {
-	comp_register(platform_shared_get(&comp_selector_info,
-					  sizeof(comp_selector_info)));
+	comp_register(&comp_selector_info);
 }
 
 DECLARE_MODULE(sys_comp_selector_init);

--- a/src/audio/tone/tone-ipc3.c
+++ b/src/audio/tone/tone-ipc3.c
@@ -401,8 +401,7 @@ static SHARED_DATA struct comp_driver_info comp_tone_info = {
 
 UT_STATIC void sys_comp_tone_init(void)
 {
-	comp_register(platform_shared_get(&comp_tone_info,
-					  sizeof(comp_tone_info)));
+	comp_register(&comp_tone_info);
 }
 
 DECLARE_MODULE(sys_comp_tone_init);

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -168,8 +168,7 @@ struct irq_cascade_desc *interrupt_get_parent(uint32_t irq)
 
 void interrupt_init(struct sof *sof)
 {
-	sof->cascade_root = platform_shared_get(&cascade_root,
-						sizeof(cascade_root));
+	sof->cascade_root = &cascade_root;
 
 	sof->cascade_root->last_irq = PLATFORM_IRQ_FIRST_CHILD - 1;
 	k_spinlock_init(&sof->cascade_root->lock);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -430,7 +430,7 @@ __cold int idc_init(void)
 	tr_dbg(&idc_tr, "entry");
 
 	/* initialize idc data */
-	(*idc)->payload = platform_shared_get(static_payload, sizeof(static_payload));
+	(*idc)->payload = static_payload;
 
 #ifdef CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS
 	struct io_perf_data_item init_data = {IO_PERF_IDC_ID,

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -87,8 +87,7 @@ static SHARED_DATA struct comp_driver_info comp_module_##adapter##_info = { \
 \
 UT_STATIC void sys_comp_module_##adapter##_init(void) \
 { \
-	comp_register(platform_shared_get(&comp_module_##adapter##_info, \
-					  sizeof(comp_module_##adapter##_info))); \
+	comp_register(&comp_module_##adapter##_info); \
 } \
 \
 DECLARE_MODULE(sys_comp_module_##adapter##_init)

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -89,7 +89,6 @@ uint64_t clock_ticks_per_sample(int clock, uint32_t sample_rate)
 	uint32_t ticks_per_msec;
 	uint64_t ticks_per_sample;
 
-	platform_shared_get(clk_info, sizeof(*clk_info));
 	ticks_per_msec = clk_info->freqs[clk_info->current_freq_idx].ticks_per_msec;
 	ticks_per_sample = sample_rate ? ticks_per_msec * 1000 / sample_rate : 0;
 

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -209,8 +209,7 @@ __cold void init_system_notify(struct sof *sof)
 		list_init(&(*notify)->list[i]);
 
 	if (cpu_get_id() == PLATFORM_PRIMARY_CORE_ID)
-		sof->notify_data = platform_shared_get(notify_data_shared,
-						       sizeof(notify_data_shared));
+		sof->notify_data = notify_data_shared;
 }
 
 void free_system_notify(void)

--- a/src/platform/amd/acp_6_3/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_6_3/include/platform/lib/memory.h
@@ -165,11 +165,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/amd/acp_7_0/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_7_0/include/platform/lib/memory.h
@@ -176,11 +176,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/amd/acp_7_x/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_7_x/include/platform/lib/memory.h
@@ -231,11 +231,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/amd/rembrandt/include/platform/lib/memory.h
+++ b/src/platform/amd/rembrandt/include/platform/lib/memory.h
@@ -156,11 +156,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/amd/renoir/include/platform/lib/memory.h
+++ b/src/platform/amd/renoir/include/platform/lib/memory.h
@@ -151,11 +151,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -122,7 +122,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < PLATFORM_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/amd/renoir/lib/memory.c
+++ b/src/platform/amd/renoir/lib/memory.c
@@ -91,5 +91,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -133,7 +133,7 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 
 	/* to view system memory */

--- a/src/platform/amd/vangogh/include/platform/lib/memory.h
+++ b/src/platform/amd/vangogh/include/platform/lib/memory.h
@@ -150,11 +150,6 @@ struct sof;
 #define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 static inline void *platform_rfree_prepare(void *ptr)
 {
 	return ptr;

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -187,11 +187,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define cache_to_uncache_init(address)	address

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -30,7 +30,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -95,5 +95,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -211,11 +211,6 @@ void platform_init_memmap(struct sof *sof);
 #define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -25,7 +25,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8m/lib/memory.c
+++ b/src/platform/imx8m/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/imx8m_cm7/include/platform/lib/memory.h
+++ b/src/platform/imx8m_cm7/include/platform/lib/memory.h
@@ -28,11 +28,6 @@
 /* WAKEUP domain MU1 side B */
 #define MU_BASE 0x30AB0000UL
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/imx8ulp/include/platform/lib/memory.h
+++ b/src/platform/imx8ulp/include/platform/lib/memory.h
@@ -195,11 +195,6 @@ void platform_init_memmap(struct sof *sof);
 #define cache_to_uncache_init(address)	address
 #define is_uncached(address)		0
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.

--- a/src/platform/imx8ulp/lib/clk.c
+++ b/src/platform/imx8ulp/lib/clk.c
@@ -25,7 +25,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info) {

--- a/src/platform/imx8ulp/lib/memory.c
+++ b/src/platform/imx8ulp/lib/memory.c
@@ -96,5 +96,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/imx93_a55/include/platform/lib/memory.h
+++ b/src/platform/imx93_a55/include/platform/lib/memory.h
@@ -58,11 +58,6 @@
 /* WM8962 is connected to SAI3 */
 #define SAI3_BASE 0x42660000
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/imx95/include/platform/lib/memory.h
+++ b/src/platform/imx95/include/platform/lib/memory.h
@@ -28,11 +28,6 @@
 /* WAKEUP domain MU7 side B */
 #define MU_BASE 0x42440000UL
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #endif /* __PLATFORM_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/intel/ace/include/ace/lib/memory.h
+++ b/src/platform/intel/ace/include/ace/lib/memory.h
@@ -33,21 +33,6 @@
 #define cache_to_uncache(address)       sys_cache_uncached_ptr_get(address)
 #define is_uncached(address)            (!sys_cache_is_ptr_cached(address))
 
-/**
- * \brief Returns pointer to the memory shared by multiple cores.
- * \param[in,out] ptr Initial pointer to the allocated memory.
- * \param[in] bytes Size of the allocated memory
- * \return Appropriate pointer to the shared memory.
- *
- * This function is called only once right after allocation of shared memory.
- * Platforms with uncached memory region should return aliased address.
- * On platforms without such region simple invalidate is enough.
- */
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #endif /* __ACE_LIB_MEMORY_H__ */
 
 #else

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -76,26 +76,6 @@ static inline void *cache_to_uncache(void __sparse_cache *address)
 #endif
 
 /**
- * \brief Returns pointer to the memory shared by multiple cores.
- * \param[in,out] ptr Initial pointer to the allocated memory.
- * \param[in] bytes Size of the allocated memory
- * \return Appropriate pointer to the shared memory.
- *
- * This function is called only once right after allocation of shared memory.
- * Platforms with uncached memory region should return aliased address.
- * On platforms without such region simple invalidate is enough.
- */
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-#if CONFIG_CORE_COUNT > 1 && !defined __ZEPHYR__
-	dcache_invalidate_region((__sparse_force void __sparse_cache *)ptr, bytes);
-	return cache_to_uncache(ptr);
-#else
-	return ptr;
-#endif
-}
-
-/**
  * \brief Transforms pointer if necessary before freeing the memory.
  * \param[in,out] ptr Pointer to the allocated memory.
  * \return Appropriate pointer to the memory ready to be freed.

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -37,11 +37,6 @@ uint8_t *get_library_mailbox(void);
 
 #define SHARED_DATA
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8186/include/platform/lib/memory.h
+++ b/src/platform/mt8186/include/platform/lib/memory.h
@@ -192,11 +192,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define cache_to_uncache_init(address)	address

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -135,7 +135,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8186/lib/memory.c
+++ b/src/platform/mt8186/lib/memory.c
@@ -98,5 +98,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -163,7 +163,7 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();

--- a/src/platform/mt8188/include/platform/lib/memory.h
+++ b/src/platform/mt8188/include/platform/lib/memory.h
@@ -192,11 +192,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define cache_to_uncache_init(address)	address

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -123,7 +123,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8188/lib/memory.c
+++ b/src/platform/mt8188/lib/memory.c
@@ -98,5 +98,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/mt8188/platform.c
+++ b/src/platform/mt8188/platform.c
@@ -161,7 +161,7 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();

--- a/src/platform/mt8195/include/platform/lib/memory.h
+++ b/src/platform/mt8195/include/platform/lib/memory.h
@@ -183,11 +183,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
 #define cache_to_uncache_init(address) address

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -177,7 +177,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8195/lib/memory.c
+++ b/src/platform/mt8195/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -182,7 +182,7 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();

--- a/src/platform/mt8196/include/platform/lib/memory.h
+++ b/src/platform/mt8196/include/platform/lib/memory.h
@@ -191,11 +191,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address)	address
 #define cache_to_uncache(address)	address
 #define cache_to_uncache_init(address)	address

--- a/src/platform/mt8196/lib/clk.c
+++ b/src/platform/mt8196/lib/clk.c
@@ -37,7 +37,7 @@ void platform_clock_init(struct sof *sof)
 	int i;
 
 	tr_dbg(&clkdrv_tr, "clock init\n");
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	/* When the system is in an active state, the DSP clock operates at 800MHz (0.75V).
 	 * In a low power scenario, the DSP enters WFI state, and the clock reduces to 26MHz.

--- a/src/platform/mt8196/lib/memory.c
+++ b/src/platform/mt8196/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/mt8196/platform.c
+++ b/src/platform/mt8196/platform.c
@@ -162,7 +162,7 @@ int platform_init(struct sof *sof)
 {
 	int ret;
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 	platform_interrupt_init();
 	platform_clock_init(sof);

--- a/src/platform/mt8365/include/platform/lib/memory.h
+++ b/src/platform/mt8365/include/platform/lib/memory.h
@@ -206,11 +206,6 @@ struct sof;
 
 void platform_init_memmap(struct sof *sof);
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
 #define cache_to_uncache_init(address) address

--- a/src/platform/mt8365/lib/clk.c
+++ b/src/platform/mt8365/lib/clk.c
@@ -168,7 +168,7 @@ void platform_clock_init(struct sof *sof)
 {
 	int i;
 
-	sof->clocks = platform_shared_get(platform_clocks_info, sizeof(platform_clocks_info));
+	sof->clocks = platform_clocks_info;
 
 	for (i = 0; i < CONFIG_CORE_COUNT; i++) {
 		sof->clocks[i] = (struct clock_info){

--- a/src/platform/mt8365/lib/memory.c
+++ b/src/platform/mt8365/lib/memory.c
@@ -97,5 +97,5 @@ static SHARED_DATA struct mm memmap = {
 void platform_init_memmap(struct sof *sof)
 {
 	/* memmap has been initialized statically as a part of .data */
-	sof->memory_map = platform_shared_get(&memmap, sizeof(memmap));
+	sof->memory_map = &memmap;
 }

--- a/src/platform/mt8365/platform.c
+++ b/src/platform/mt8365/platform.c
@@ -164,7 +164,7 @@ int platform_init(struct sof *sof)
 	mailbox_sw_reg_write(SRAM_REG_OP_CPU2DSP, 0);
 	mailbox_sw_reg_write(SRAM_REG_OP_DSP2CPU, 0);
 
-	sof->platform_timer = platform_shared_get(&timer_shared, sizeof(timer_shared));
+	sof->platform_timer = &timer_shared;
 	sof->cpu_timers = sof->platform_timer;
 
 	platform_interrupt_init();

--- a/src/platform/mtk/include/platform/lib/memory.h
+++ b/src/platform/mtk/include/platform/lib/memory.h
@@ -16,11 +16,6 @@ BUILD_ASSERT(PLATFORM_DCACHE_ALIGN == XCHAL_DCACHE_LINESIZE);
 #define uncache_to_cache(addr) (addr)
 #define cache_to_uncache(addr) (addr)
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define host_to_local(addr) (addr)
 
 #define PLATFORM_HEAP_SYSTEM 1

--- a/src/platform/posix/include/platform/lib/memory.h
+++ b/src/platform/posix/include/platform/lib/memory.h
@@ -47,11 +47,6 @@ extern uint32_t posix_trace[];
 
 #define host_to_local(addr) (addr)
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define SHARED_DATA /**/
 
 #endif /* PLATFORM_HOST_PLATFORM_MEMORY_H */

--- a/src/platform/qemu_xtensa/include/platform/lib/memory.h
+++ b/src/platform/qemu_xtensa/include/platform/lib/memory.h
@@ -8,11 +8,6 @@
 
 /* Dummy memory header for qemu_xtensa */
 
-static inline void *platform_shared_get(void *ptr, int bytes)
-{
-	return ptr;
-}
-
 #define PLATFORM_DCACHE_ALIGN sizeof(void *)
 #define HOST_PAGE_SIZE 4096
 #define SHARED_DATA

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -1113,8 +1113,7 @@ static SHARED_DATA struct comp_driver_info comp_keyword_info = {
 
 UT_STATIC void sys_comp_keyword_init(void)
 {
-	comp_register(platform_shared_get(&comp_keyword_info,
-					  sizeof(comp_keyword_info)));
+	comp_register(&comp_keyword_info);
 }
 
 DECLARE_MODULE(sys_comp_keyword_init);

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -555,8 +555,7 @@ static SHARED_DATA struct comp_driver_info comp_smart_amp_info = {
 
 UT_STATIC void sys_comp_smart_amp_test_init(void)
 {
-	comp_register(platform_shared_get(&comp_smart_amp_info,
-					  sizeof(comp_smart_amp_info)));
+	comp_register(&comp_smart_amp_info);
 }
 
 DECLARE_MODULE(sys_comp_smart_amp_test_init);


### PR DESCRIPTION
platform_shared_get() was returning its first argument and not doing anything else in all int implementation but one - cAVS with multicore but with no Zephyr. And such builds haven't been supported in SOF for a long time. Remove platform_shared_get() completely.