### PR TITLE
tools: ctl: drop build-tree RUNPATH from sof-ctl

### DIFF
--- a/tools/ctl/CMakeLists.txt
+++ b/tools/ctl/CMakeLists.txt
@@ -11,6 +11,16 @@ target_link_libraries(sof-ctl PRIVATE
 	"-lasound"
 )
 
+# tools/lib is only needed as a -L link path for a locally built ALSA.
+# Do not let CMake also embed it as an ELF RPATH/RUNPATH: it points into
+# the build tree and, once stripped to empty on install, leaves an empty
+# DT_RUNPATH tag that trips distro ELF security scanners (scanelf reports
+# "NULL DT_RUNPATH"). Skip the build RPATH and keep the install RPATH
+# empty so no DT_RUNPATH tag is emitted. See thesofproject/sof#10070.
+set_target_properties(sof-ctl PROPERTIES
+	SKIP_BUILD_RPATH TRUE
+	INSTALL_RPATH "")
+
 target_compile_options(sof-ctl PRIVATE
 	-Wall -Werror
 )


### PR DESCRIPTION
## Problem

`sof-ctl` ships with an empty/NULL `DT_RUNPATH` ELF entry, which distro
ELF security scanners reject. Reported downstream (Gentoo) via scanelf:

```
scanelf: rpath_security_checks(): Security problem NULL DT_RUNPATH in .../usr/bin/sof-ctl
```

This appeared in v2025.05 when the tools started linking against a
locally built ALSA.

## Cause

`tools/ctl/CMakeLists.txt` adds `tools/lib` as a link directory (`-L`) so
`sof-ctl` can link a locally built `libasound`. CMake also embeds that
directory in the binary's `RPATH`/`RUNPATH`, pointing into the build
tree. At install time CMake strips the path to an empty string, leaving
an empty `DT_RUNPATH` tag — the "NULL DT_RUNPATH" scanelf flags.

## Fix

Keep `tools/lib` as a `-L` link path only. Set `SKIP_BUILD_RPATH TRUE`
and an empty `INSTALL_RPATH` on the `sof-ctl` target so no `DT_RUNPATH`
tag is emitted at all. The installed binary resolves `libasound` through
the normal loader search path.

## Verification

Clean build of `tools/` before/after:

- **Before:** `readelf -d sof-ctl` → `RUNPATH [.../tools/lib:]`
- **After:** `readelf -d sof-ctl` → no `RPATH`/`RUNPATH` tag

`sof-ctl` still links and runs against system `libasound`.

Closes #10070