### PR TITLE
topology2: cavs-sdw: add multiband DRC playback pipeline variant

### DIFF
--- a/tools/topology/topology2/cavs-sdw.conf
+++ b/tools/topology/topology2/cavs-sdw.conf
@@ -19,6 +19,7 @@
 <mixout-gain-micsel-eqiir-eqfir-alh-dai-copier-playback.conf>
 <mixout-gain-eqiir-eqfir-drc-alh-dai-copier-playback.conf>
 <mixout-gain-eqiir-eqfir-drc-micsel-eqiir-eqfir-alh-dai-copier-playback.conf>
+<mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback.conf>
 <mixout-gain-eqiir-dts-alh-dai-copier-playback.conf>
 <mixout-gain-eqiir-dts-ctc-alh-dai-copier-playback.conf>
 <dai-copier-gain-eqiir-module-copier-capture.conf>
@@ -115,7 +116,9 @@ Define {
 	SDW_DMIC_ENHANCED_CAPTURE true
 	EFX_SPK_IIR_PARAMS "highpass_100hz_0db_48khz"
 	EFX_SPK_FIR_PARAMS "passthrough"
+	EFX_SPK_DRC_COMPONENT "singleband"
 	EFX_SPK_DRC_PARAMS "speaker_default"
+	EFX_SPK_MBDRC_PARAMS "passthrough"
 	EFX_MIC_IIR_PARAMS "highpass_40hz_0db_48khz"
 	EFX_MIC_TDFB_PARAMS "line2_generic_pm10deg"
 	EFX_MIC_DRC_PARAMS "dmic_default"

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -509,6 +509,15 @@ SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
 SDW_JACK_COMPR_AUDIO_FEATURE_CAPTURE=true,SDW_DMIC_COMPR_AUDIO_FEATURE_CAPTURE=true,\
 MFCC_FRAME_BYTES=76,MFCC_BLOB=ceps"
 
+# Soundwire topologies with multiband-DRC
+"cavs-sdw\;sof-mtl-rt713-l0-rt1316-l12-mbdrc\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,\
+HDMI1_ID=4,HDMI2_ID=5,HDMI3_ID=6,EFX_SPK_DRC_COMPONENT=multiband"
+
+"cavs-sdw\;sof-arl-cs42l43-l0-cs35l56-l23-mbdrc\;PLATFORM=mtl,NUM_SDW_AMP_LINKS=2,SDW_DMIC=1,\
+SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\
+SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack,\
+EFX_SPK_DRC_COMPONENT=multiband"
+
 # Soundwire compressed feature topologies
 "cavs-sdw\;sof-sdca-jack-compr\;SDW_JACK=false,NUM_HDMIS=0,COMPRESSED=true,\
 COMPRESSED_1=true,COMPRESSED_2=false"

--- a/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback.conf
@@ -1,0 +1,137 @@
+#
+# BE playback pipeline: mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier.
+#
+# All attributes defined herein are namespaced by alsatplg to
+# "Object.Pipeline.mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback.N.attribute_name"
+#
+# Usage: mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback pipeline object can be
+# instantiated as:
+#
+# Object.Pipeline.mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback."N" {
+# 	time_domain	"timer"
+# }
+#
+# Where N is the unique pipeline ID within the same alsaconf node.
+#
+
+<include/components/eqiir.conf>
+<include/components/eqfir.conf>
+<include/components/multiband_drc.conf>
+<include/pipelines/cavs/mixout-gain-alh-dai-copier-playback.conf>
+
+Class.Pipeline."mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback" {
+
+	SubTreeCopy.baseclass {
+		# this class extends the mixout-gain-alh-dai-copier-playback pipeline class.
+		source "Class.Pipeline.mixout-gain-alh-dai-copier-playback"
+
+		# target node is not defined which means that the new subtree will be copied to
+		# the parent node containing the SubTreeCopy node i.e in this case the
+		# Class.Pipeline.mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback {} node.
+
+		# default copy type is to extend the base class ie the widgets and routes
+		# will be added to the existing list of widgets/routes in the base class
+
+		tree {
+                        Object.Widget {
+                                eqiir."1" {
+                                        num_input_audio_formats 1
+                                        num_output_audio_formats 1
+
+                                        # 32-bit 48KHz 2ch
+                                        Object.Base.input_audio_format [
+                                                {
+                                                        in_bit_depth		32
+                                                        in_valid_bit_depth	32
+                                                }
+                                        ]
+                                        Object.Base.output_audio_format [
+                                                {
+                                                        out_bit_depth		32
+                                                        out_valid_bit_depth	32
+                                                }
+                                        ]
+
+                                        Object.Control.bytes."1" {
+                                                IncludeByKey.EFX_SPK_IIR_PARAMS {
+                                                        "passthrough" "include/components/eqiir/passthrough.conf"
+                                                        "highpass_20hz_0db_48khz" "include/components/eqiir/highpass_20hz_0db_48khz.conf"
+                                                        "highpass_30hz_0db_48khz" "include/components/eqiir/highpass_30hz_0db_48khz.conf"
+                                                        "highpass_40hz_0db_48khz" "include/components/eqiir/highpass_40hz_0db_48khz.conf"
+                                                        "highpass_50hz_0db_48khz" "include/components/eqiir/highpass_50hz_0db_48khz.conf"
+                                                        "highpass_100hz_0db_48khz" "include/components/eqiir/highpass_100hz_0db_48khz.conf"
+                                                }
+                                        }
+                                }
+
+                                eqfir."1" {
+                                        num_input_audio_formats 1
+                                        num_output_audio_formats 1
+
+                                        # 32-bit 48KHz 2ch
+                                        Object.Base.input_audio_format [
+                                                {
+                                                        in_bit_depth		32
+                                                        in_valid_bit_depth	32
+                                                }
+                                        ]
+                                        Object.Base.output_audio_format [
+                                                {
+                                                        out_bit_depth		32
+                                                        out_valid_bit_depth	32
+                                                }
+                                        ]
+
+                                        Object.Control.bytes."1" {
+                                                IncludeByKey.EFX_SPK_FIR_PARAMS {
+                                                        "passthrough" "include/components/eqfir/passthrough.conf"
+                                                }
+                                        }
+                                }
+
+                                multiband_drc."1" {
+                                        num_input_audio_formats 1
+                                        num_output_audio_formats 1
+
+                                        # 32-bit 48KHz 2ch
+                                        Object.Base.input_audio_format [
+                                                {
+                                                        in_bit_depth		32
+                                                        in_valid_bit_depth	32
+                                                }
+                                        ]
+                                        Object.Base.output_audio_format [
+                                                {
+                                                        out_bit_depth		32
+                                                        out_valid_bit_depth	32
+                                                }
+                                        ]
+
+                                        Object.Control.bytes."1" {
+                                                IncludeByKey.EFX_SPK_MBDRC_PARAMS {
+                                                        "passthrough" "include/components/multiband_drc/passthrough.conf"
+                                                        "default" "include/components/multiband_drc/default.conf"
+                                                }
+                                        }
+                                }
+                        }
+
+			Object.Base {
+				!route [
+					{
+						source  gain.$index.1
+						sink	eqiir.$index.1
+					}
+					{
+						source  eqiir.$index.1
+						sink	eqfir.$index.1
+					}
+					{
+						source  eqfir.$index.1
+						sink	multiband_drc.$index.1
+					}
+				]
+			}
+                }
+        }
+}

--- a/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-amp-generic.conf
@@ -140,66 +140,134 @@ IncludeByKey.PASSTHROUGH {
 
 		IncludeByKey.SDW_SPK_ENHANCED_PLAYBACK {
                         "true" {
-                                mixout-gain-eqiir-eqfir-drc-alh-dai-copier-playback [
-                                        {
-                                                index 21
+                                # multiband and singleband branches differ only in the DRC widget
+                                # and MBDRC/DRC control names; keep both branches in sync.
+                                IncludeByKey.EFX_SPK_DRC_COMPONENT {
+                                        "multiband" {
+                                                mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback [
+                                                        {
+                                                                index 21
 
-                                                Object.Widget.alh-copier.1 {
-                                                        stream_name $SDW_SPK_STREAM
-                                                        node_type $ALH_LINK_OUTPUT_CLASS
-                                                        num_input_audio_formats 3
-                                                        Object.Base.input_audio_format [
-                                                                {
-                                                                        in_bit_depth            16
-                                                                        in_valid_bit_depth      16
+                                                                Object.Widget.alh-copier.1 {
+                                                                        stream_name $SDW_SPK_STREAM
+                                                                        node_type $ALH_LINK_OUTPUT_CLASS
+                                                                        num_input_audio_formats 3
+                                                                        Object.Base.input_audio_format [
+                                                                                {
+                                                                                        in_bit_depth            16
+                                                                                        in_valid_bit_depth      16
+                                                                                }
+                                                                                {
+                                                                                        in_bit_depth            32
+                                                                                        in_valid_bit_depth      24
+                                                                                }
+                                                                                {
+                                                                                        in_bit_depth            32
+                                                                                        in_valid_bit_depth      32
+                                                                                }
+                                                                        ]
+                                                                        num_output_audio_formats 1
+                                                                        Object.Base.output_audio_format [
+                                                                                {
+                                                                                        out_bit_depth           32
+                                                                                        out_valid_bit_depth     $SDW_LINK_VALID_BITS
+                                                                                        out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+                                                                                        out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
+                                                                                }
+                                                                        ]
                                                                 }
-                                                                {
-                                                                        in_bit_depth            32
-                                                                        in_valid_bit_depth      24
+                                                                Object.Widget.gain.1 {
+                                                                        Object.Control.mixer.1 {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME Volume'
+                                                                        }
                                                                 }
-                                                                {
-                                                                        in_bit_depth            32
-                                                                        in_valid_bit_depth      32
-                                                                }
-                                                        ]
-                                                        num_output_audio_formats 1
-                                                        Object.Base.output_audio_format [
-                                                                {
-                                                                        out_bit_depth           32
-                                                                        out_valid_bit_depth     $SDW_LINK_VALID_BITS
-                                                                        out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
-                                                                        out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
-                                                                }
-                                                        ]
-                                                }
-                                                Object.Widget.gain.1 {
-                                                        Object.Control.mixer.1 {
-                                                                name 'Post Mixer $AMP_PLAYBACK_NAME Volume'
-                                                        }
-                                                }
 
-                                                Object.Widget.eqiir.1 {
-                                                        Object.Control.bytes."1" {
-                                                                name 'Post Mixer $AMP_PLAYBACK_NAME IIR Eq bytes'
-                                                        }
-                                                }
-                                                Object.Widget.eqfir.1 {
-                                                        Object.Control.bytes."1" {
-                                                                name 'Post Mixer $AMP_PLAYBACK_NAME FIR Eq bytes'
-                                                        }
-                                                }
-                                                Object.Widget.drc.1 {
-                                                        Object.Control {
-                                                                bytes."1" {
-                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME DRC bytes'
+                                                                Object.Widget.eqiir.1 {
+                                                                        Object.Control.bytes."1" {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME IIR Eq bytes'
+                                                                        }
                                                                 }
-                                                                mixer."1" {
-                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME DRC switch'
+                                                                Object.Widget.eqfir.1 {
+                                                                        Object.Control.bytes."1" {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME FIR Eq bytes'
+                                                                        }
+                                                                }
+                                                                Object.Widget.multiband_drc.1 {
+                                                                        Object.Control {
+                                                                                bytes."1" {
+                                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME MBDRC bytes'
+                                                                                }
+                                                                                mixer."1" {
+                                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME MBDRC switch'
+                                                                                }
+                                                                        }
                                                                 }
                                                         }
-                                                }
+                                                ]
                                         }
-                                ]
+                                        "singleband" {
+                                                mixout-gain-eqiir-eqfir-drc-alh-dai-copier-playback [
+                                                        {
+                                                                index 21
+
+                                                                Object.Widget.alh-copier.1 {
+                                                                        stream_name $SDW_SPK_STREAM
+                                                                        node_type $ALH_LINK_OUTPUT_CLASS
+                                                                        num_input_audio_formats 3
+                                                                        Object.Base.input_audio_format [
+                                                                                {
+                                                                                        in_bit_depth            16
+                                                                                        in_valid_bit_depth      16
+                                                                                }
+                                                                                {
+                                                                                        in_bit_depth            32
+                                                                                        in_valid_bit_depth      24
+                                                                                }
+                                                                                {
+                                                                                        in_bit_depth            32
+                                                                                        in_valid_bit_depth      32
+                                                                                }
+                                                                        ]
+                                                                        num_output_audio_formats 1
+                                                                        Object.Base.output_audio_format [
+                                                                                {
+                                                                                        out_bit_depth           32
+                                                                                        out_valid_bit_depth     $SDW_LINK_VALID_BITS
+                                                                                        out_sample_type		$SAMPLE_TYPE_MSB_INTEGER
+                                                                                        out_fmt_cfg		"$[($out_channels | ($out_valid_bit_depth * 256))]"
+                                                                                }
+                                                                        ]
+                                                                }
+                                                                Object.Widget.gain.1 {
+                                                                        Object.Control.mixer.1 {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME Volume'
+                                                                        }
+                                                                }
+
+                                                                Object.Widget.eqiir.1 {
+                                                                        Object.Control.bytes."1" {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME IIR Eq bytes'
+                                                                        }
+                                                                }
+                                                                Object.Widget.eqfir.1 {
+                                                                        Object.Control.bytes."1" {
+                                                                                name 'Post Mixer $AMP_PLAYBACK_NAME FIR Eq bytes'
+                                                                        }
+                                                                }
+                                                                Object.Widget.drc.1 {
+                                                                        Object.Control {
+                                                                                bytes."1" {
+                                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME DRC bytes'
+                                                                                }
+                                                                                mixer."1" {
+                                                                                        name 'Post Mixer $AMP_PLAYBACK_NAME DRC switch'
+                                                                                }
+                                                                        }
+                                                                }
+                                                        }
+                                                ]
+                                        }
+                                }
                         }
                         "false" {
                                 mixout-gain-alh-dai-copier-playback [
@@ -686,16 +754,34 @@ IncludeByKey.PASSTHROUGH {
 	"false" {
 		IncludeByKey.SDW_SPK_ENHANCED_PLAYBACK {
 			"true" {
-				Object.Base.route [
-					{
-						source	"drc.21.1"
-						sink	"module-copier.21.22"
+				# multiband and singleband branches differ only in the source widget;
+				# keep both branches in sync.
+				IncludeByKey.EFX_SPK_DRC_COMPONENT {
+					"multiband" {
+						Object.Base.route [
+							{
+								source	"multiband_drc.21.1"
+								sink	"module-copier.21.22"
+							}
+							{
+								source	"module-copier.21.22"
+								sink	"alh-copier.$SDW_SPK_STREAM.0"
+							}
+						]
 					}
-					{
-						source	"module-copier.21.22"
-						sink	"alh-copier.$SDW_SPK_STREAM.0"
+					"singleband" {
+						Object.Base.route [
+							{
+								source	"drc.21.1"
+								sink	"module-copier.21.22"
+							}
+							{
+								source	"module-copier.21.22"
+								sink	"alh-copier.$SDW_SPK_STREAM.0"
+							}
+						]
 					}
-				]
+				}
 			}
 			"false" {
 				Object.Base.route [


### PR DESCRIPTION
Add an alternative BE speaker playback pipeline class
mixout-gain-eqiir-eqfir-mbdrc-alh-dai-copier-playback that mirrors the
existing mixout-gain-eqiir-eqfir-drc-alh-dai-copier-playback but uses
the multiband_drc effect in place of the single-band drc.

The SDW enhanced speaker playback path in the sdw-amp-generic platform
partial is now gated by EFX_SPK_DRC_COMPONENT with "multiband"
and "singleband" branches, both in the pipeline instantiation and in
the corresponding route block. The multiband branch selects the new
pipeline class and exposes the multiband_drc bytes and switch as
"Post Mixer <name> MBDRC bytes" / "MBDRC switch" so it does not collide
with the single-band DRC controls.

Two development topology targets are added to exercise the new path:
sof-mtl-rt713-l0-rt1316-l12-mbdrc and
sof-arl-cs42l43-l0-cs35l56-l23-mbdrc.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
