### PR TITLE
topology2: sdw-dmic-generic: raise TDFB bytes control max size

### DIFF
--- a/tools/topology/topology2/include/pipelines/cavs/host-gateway-tdfb-drc-capture.conf
+++ b/tools/topology/topology2/include/pipelines/cavs/host-gateway-tdfb-drc-capture.conf
@@ -37,7 +37,6 @@ Class.Pipeline."host-gateway-tdfb-drc-capture" {
                                 tdfb."1" {
                                         Object.Control {
                                                 bytes."1" {
-                                                        max 16384
                                                         IncludeByKey.EFX_MIC_TDFB_PARAMS {
                                                                 "line2_pass" "include/components/tdfb/line2_pass.conf"
                                                                 "line2_generic_pm10deg" "include/components/tdfb/line2_generic_pm10deg_48khz.conf"

--- a/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-dmic-generic.conf
@@ -88,6 +88,7 @@ IncludeByKey.SDW_DMIC_ENHANCED_CAPTURE {
                                                 Object.Control {
                                                         bytes."1" {
                                                                 name '$SDW_DMIC_CAPTURE_PCM_NAME Capture TDFB bytes'
+                                                                max 16384
                                                         }
                                                         mixer."1" {
                                                                 name '$SDW_DMIC_CAPTURE_PCM_NAME Capture TDFB beam switch'


### PR DESCRIPTION
Setting the bytes control max inside the host-gateway-tdfb-drc-capture pipeline class had no effect: alsatplg leaves the widget control at the default 1024, so pushing a larger TDFB blob with sof-ctl failed.

Move the max to the widget instantiation in sdw-dmic-generic.conf where it is honored, and keep the original 16384 headroom so the setting also covers larger beamformer blobs that may be added later.