### PR TITLE
doc: Add zephyr/include to the Doxygen input

### DIFF
--- a/doc/sof.doxygen.in
+++ b/doc/sof.doxygen.in
@@ -10,7 +10,8 @@ INPUT            = @top_srcdir@/src/include/ipc \
                    @top_srcdir@/src/include/kernel \
 		   @top_srcdir@/src/include/user \
                    @top_srcdir@/src/include/sof \
-                   @top_srcdir@/xtos/include
+                   @top_srcdir@/xtos/include \
+                   @top_srcdir@/zephyr/include
 # Exlude some 3rd party codec headers with external references
 EXCLUDE		 = @top_srcdir@/src/include/sof/audio/MaxxEffect
 RECURSIVE	 = YES

--- a/zephyr/include/rtos/userspace_helper.h
+++ b/zephyr/include/rtos/userspace_helper.h
@@ -95,7 +95,7 @@ int user_stack_free(void *p_stack);
 
 /**
  * Free private processing module heap.
- * @param sys_heap pointer to the sys_heap structure.
+ * @param mod_drv_heap pointer to the k_heap structure.
  *
  * @note
  * Function used only when CONFIG_USERSPACE is set.

--- a/zephyr/include/sof/lib/regions_mm.h
+++ b/zephyr/include/sof/lib/regions_mm.h
@@ -49,17 +49,9 @@
  */
 #define DEFAULT_CONFIG_ALOCATORS_COUNT 5
 
-/** @struct vmh_block_bundle_descriptor
- *
- *  @brief This is a struct describing one bundle of blocks
- *  used as base for allocators blocks.
- *
- *  @var block_size size of memory block.
- *  @var number_of_blocks number of memory blocks.
- */
 struct vmh_block_bundle_descriptor {
-	size_t block_size;
-	size_t number_of_blocks;
+	size_t block_size; /**< size of memory block. */
+	size_t number_of_blocks; /**< number of memory blocks. */
 };
 
 /*
@@ -75,8 +67,6 @@ struct vmh_block_bundle_descriptor {
  *  Provided config size must be physical page aligned so it
  *  will not overlap in physical space with other heaps during mapping.
  *  So every block has to have its overall size aligned to CONFIG_MM_DRV_PAGE_SIZE
- *
- *  @vmh_block_bundle_descriptor[] aggregation of bundle descriptors.
  */
 struct vmh_heap_config {
 	struct vmh_block_bundle_descriptor block_bundles_table[MAX_MEMORY_ALLOCATORS_COUNT];


### PR DESCRIPTION
## What

Add `zephyr/include` to the Doxygen `INPUT` in `doc/sof.doxygen.in`.

## Why

The Memory Allocation (`alloc_api`), PM Runtime (`pm_runtime`) and DMA
(`sof_dma_drivers`, `sof_dma_copy_func`) API doc groups stopped appearing in the
generated documentation when their headers were decoupled into `zephyr/include/`
during the RTOS split. The Doxygen `INPUT` still listed only `src/include` and
`xtos/include`, so those Zephyr-era headers were no longer scanned, and sof-docs
reported `Cannot find group` for all four.

These headers declare exactly those four groups and no others, with no
group-name overlap with `xtos/include`, so adding the directory recovers the
missing API docs without introducing duplicates.

## Testing

Regenerated the Doxygen XML and rebuilt sof-docs against it: all four groups now
render, and the sof-docs warning count drops from 6 to 2 (the remaining two are
a pre-existing breathe limitation, unrelated to this change).

## Companion PR

Supports thesofproject/sof-docs#520, whose strict (`-W`) documentation build
turns these `Cannot find group` warnings into errors. That PR's build stays red
until this change is merged; the two should land together.
