### PR TITLE
audio: copier: avoid IRQ lock/unlock in chmap code

### DIFF
--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -13,6 +13,7 @@
 #include <rtos/interrupt.h>
 #include <sof/ipc/msg.h>
 #include <sof/ipc/topology.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <rtos/interrupt.h>
 #include <rtos/timer.h>
 #include <rtos/cache.h>
@@ -838,7 +839,9 @@ __cold static int set_chmap(struct comp_dev *dev, const void *data, size_t data_
 	pcm_converter_func process;
 	pcm_converter_func converters[IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT];
 	int i;
+#ifndef CONFIG_SOF_USERSPACE_LL
 	uint32_t irq_flags;
+#endif
 
 	assert_can_be_cold();
 
@@ -892,15 +895,26 @@ __cold static int set_chmap(struct comp_dev *dev, const void *data, size_t data_
 		}
 	}
 
-	/* Atomically update chmap, process and converters */
+	/* Atomically update chmap, process and converters.
+	 * In user-space builds irq_local_disable() is privileged,
+	 * use the LL scheduler lock instead.
+	 */
+#ifdef CONFIG_SOF_USERSPACE_LL
+	user_ll_lock_sched(dev->pipeline->core);
+#else
 	irq_local_disable(irq_flags);
+#endif
 
 	cd->dd[0]->chmap = chmap_cfg->channel_map;
 	cd->dd[0]->process = process;
 	for (i = 0; i < IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT; i++)
 		cd->converter[i] = converters[i];
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+	user_ll_unlock_sched(dev->pipeline->core);
+#else
 	irq_local_enable(irq_flags);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
Copier set_chmap() blocks IRQs to atomically update the converters. This code is not safe to be moved to user-space, so replace the locks with calls to block LL scheduler execution.