### PR TITLE
audio: phase vocoder: fix module name mismatch with TOML manifest

### DIFF
--- a/src/audio/phase_vocoder/phase_vocoder.c
+++ b/src/audio/phase_vocoder/phase_vocoder.c
@@ -271,7 +271,7 @@ static const struct module_interface phase_vocoder_interface = {
 #include <rimage/sof/user/manifest.h>
 
 static const struct sof_man_module_manifest mod_manifest __section(".module") __used =
-	SOF_LLEXT_MODULE_MANIFEST("PHASE_VOCODER", &phase_vocoder_interface, 1,
+	SOF_LLEXT_MODULE_MANIFEST("PHASEVOC", &phase_vocoder_interface, 1,
 				  SOF_REG_UUID(phase_vocoder), 40);
 
 SOF_LLEXT_BUILDINFO;

--- a/tools/rimage/config/nvl.toml.h
+++ b/tools/rimage/config/nvl.toml.h
@@ -154,5 +154,9 @@ index = __COUNTER__
 #include <audio/stft_process/stft_process.toml>
 #endif
 
+#if defined(CONFIG_COMP_PHASE_VOCODER) || defined(LLEXT_FORCE_ALL_MODULAR)
+#include <audio/phase_vocoder/phase_vocoder.toml>
+#endif
+
 [module]
 count = __COUNTER__


### PR DESCRIPTION
The LLEXT manifest declared the module name as "PHASE_VOCODER", which rimage truncates to "PHASE_VO" (SOF_MAN_MOD_NAME_LEN is 8), while phase_vocoder.toml uses "PHASEVOC". The names do not match, so rimage fails to package modular builds with the error "Module PHASE_VO not found in TOML." on platforms that build the component as loadable module (e.g. PTL).

Use "PHASEVOC" in the manifest to match the TOML entry.

Fixes #10541 