### PR TITLE
audio: module_adapter: remove unnecessary IRQ lock/unlock

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -640,7 +640,6 @@ int module_adapter_prepare(struct comp_dev *dev)
 								  buff_size, memory_flags,
 								  PLATFORM_DCACHE_ALIGN,
 								  BUFFER_USAGE_NOT_SHARED);
-			uint32_t flags;
 
 			if (!buffer) {
 				comp_err(dev, "failed to allocate local buffer");
@@ -650,9 +649,7 @@ int module_adapter_prepare(struct comp_dev *dev)
 
 			vregion_get(md->resources.alloc->vreg);
 
-			irq_local_disable(flags);
 			list_item_prepend(&buffer->buffers_list, &mod->raw_data_buffers_list);
-			irq_local_enable(flags);
 
 			buffer_set_params(buffer, mod->stream_params, BUFFER_UPDATE_FORCE);
 			audio_buffer_reset(&buffer->audio_buffer);
@@ -682,11 +679,8 @@ free:
 	list_for_item_safe(blist, _blist, &mod->raw_data_buffers_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  buffers_list);
-		uint32_t flags;
 
-		irq_local_disable(flags);
 		list_item_del(&buffer->buffers_list);
-		irq_local_enable(flags);
 		buffer_free(buffer);
 	}
 
@@ -1474,11 +1468,7 @@ void module_adapter_free(struct comp_dev *dev)
 	list_for_item_safe(blist, _blist, &mod->raw_data_buffers_list) {
 		struct comp_buffer *buffer = container_of(blist, struct comp_buffer,
 							  buffers_list);
-		uint32_t flags;
-
-		irq_local_disable(flags);
 		list_item_del(&buffer->buffers_list);
-		irq_local_enable(flags);
 		buffer_free(buffer);
 	}
 


### PR DESCRIPTION
In the past, the module adapter prepare and free methods called buffer_attach() and buffer_detach() directly. To call these methods safely, it was required to disable IRQs. See commit 3e3d0cdeab7a ("buffer: prevent cache corruption") for history and rationale.

However, in commit ecc55f81bbb0 ("buf: split sink_list connector to 2 fields") the direct calls to buffer.h were removed. The locks were still kept.

Reviewing the code today, the protected operations work on buffer list maintained in "mod->raw_data_buffers_list". This list is used only by the module adapter itself. External connections go through component "dev->bsink_list" and "dev->bsource_list", which are separate objects and only used in prepare() by the module adapter.

As the pipeline code will ensure module's copy() is not called concurrently with prepare() and free(), it is no longer required to use locks to protect against list operations on the internal list. Removing direct calls to disable interrupts allows to run this code in user-space.