### PR TITLE
chain-dma: fix potential NULL dereference #10955

### DIFF
--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -79,6 +79,12 @@ static int chain_host_start(struct comp_dev *dev)
 	struct chain_dma_data *cd = comp_get_drvdata(dev);
 	int err;
 
+	if (!cd->chan_host || !cd->chan_host->dma) {
+		comp_err(dev, "incomplete initialization detected, aborting host %p",
+			 cd->chan_host);
+		return -ENODEV;
+	}
+
 	err = dma_start(cd->chan_host->dma->z_dev, cd->chan_host->index);
 	if (err < 0)
 		return err;


### PR DESCRIPTION
It has been reported that upon resume certain userspace software tries to use chain DMA without proper initialisation. Prevent DSP exceptions by checking for such cases.

Link: https://github.com/thesofproject/sof/issues/10955