### PR TITLE
debug: breadcrumbs in kernel dmesg for IPC timeouts..

### DIFF
--- a/app/debug_overlay.conf
+++ b/app/debug_overlay.conf
@@ -31,3 +31,8 @@ CONFIG_GDBSTUB_ENTER_IMMEDIATELY=n
 # Testing with runtime filtering enabled ensures the same feature set is validated.
 # Note: This setting has no effect if CONFIG_LOG_RUNTIME_FILTERING is disabled.
 CONFIG_LOG_RUNTIME_DEFAULT_LEVEL=3
+
+# Record fatal exception breadcrumbs (PC/cause/vaddr) in HP-SRAM window0 so the
+# crash is visible in the host dmesg "Firmware state" line when no console or
+# mtrace output is available.
+CONFIG_XTENSA_ADSP_FATAL_BREADCRUMB=y

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 53c5faa286d011acc635a6d98b7ab41648a0b379
+      revision: 12358fe4e7656c86790ffed482f38bd7d8235ea4
       remote: lgirdwood
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 7b5a4415767d3a953478c3a3c467107a3f5d4d69
+      revision: 110264b6b6a3c1a6c93a58378ef0b2f1bc916ee8
       remote: lgirdwood
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -45,7 +45,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 12358fe4e7656c86790ffed482f38bd7d8235ea4
+      revision: 7b5a4415767d3a953478c3a3c467107a3f5d4d69
       remote: lgirdwood
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/west.yml
+++ b/west.yml
@@ -11,6 +11,8 @@ manifest:
       url-base: https://github.com/thesofproject
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos
+    - name: lgirdwood
+      url-base: https://github.com/lgirdwood
 
   # When upgrading projects here please run git log --oneline in the
   # project and if not too long then include the output in your commit
@@ -43,8 +45,8 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: ee13f80fd5ede26838d461914858b9cc8cdb652f
-      remote: zephyrproject
+      revision: 53c5faa286d011acc635a6d98b7ab41648a0b379
+      remote: lgirdwood
 
       # Import some projects listed in zephyr/west.yml@revision
       #


### PR DESCRIPTION
Very useful for agents, links into double and triple fault handlers and on Intel HW will insert exception data into SoC "SW registers" that are always printed in dmesg for IPC timeouts.

Zephyr PR pending.