### PR TITLE
audio: make comp_drivers_get() accessible from user-space

### DIFF
--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -38,6 +38,13 @@ LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 
 static APP_SYSUSER_BSS SHARED_DATA struct comp_driver_list cd;
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+struct comp_driver_list *comp_drivers_get(void)
+{
+	return &cd;
+}
+#endif
+
 SOF_DEFINE_REG_UUID(component);
 
 DECLARE_TR_CTX(comp_tr, SOF_UUID(component_uuid), LOG_LEVEL_INFO);

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -424,10 +424,18 @@ static inline void comp_make_shared(struct comp_dev *dev)
 	dev->is_shared = true;
 }
 
+/**
+ * Get the global component driver list.
+ * @return Pointer to the component driver list.
+ */
+#ifdef CONFIG_SOF_USERSPACE_LL
+struct comp_driver_list *comp_drivers_get(void);
+#else
 static inline struct comp_driver_list *comp_drivers_get(void)
 {
 	return sof_get()->comp_drivers;
 }
+#endif
 
 #if CONFIG_IPC_MAJOR_4
 static inline int comp_ipc4_bind_remote(struct comp_dev *dev, struct bind_info *bind_data)


### PR DESCRIPTION
Make comp_drivers_get() usable from user-space when SOF is built with CONFIG_SOF_USERSPACE_LL.