### PR TITLE
ipc: add support for userspace IPC handling

### DIFF
--- a/src/include/ipc4/handler.h
+++ b/src/include/ipc4/handler.h
@@ -17,12 +17,49 @@ struct ipc4_message_request;
 int ipc4_user_process_module_message(struct ipc4_message_request *ipc4, struct ipc_msg *reply);
 
 /**
+ * @brief Process MOD_CONFIG_GET or MOD_CONFIG_SET in any execution context.
+ * @param[in] ipc4 IPC4 message request.
+ * @param[in] set true for CONFIG_SET, false for CONFIG_GET.
+ * @param[out] reply_ext Receives extension value for CONFIG_GET (may be NULL).
+ * @return IPC4 status code (0 on success).
+ */
+int ipc4_process_module_config(struct ipc4_message_request *ipc4,
+			       bool set, uint32_t *reply_ext);
+
+/**
+ * @brief Process MOD_LARGE_CONFIG_GET in any execution context.
+ * @param[in] ipc4 IPC4 message request.
+ * @param[out] reply_ext Receives extension value for reply.
+ * @param[out] reply_tx_size Receives TX data size for reply.
+ * @param[out] reply_tx_data Receives TX data pointer for reply.
+ * @return IPC4 status code (0 on success).
+ */
+int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
+				  uint32_t *reply_ext,
+				  uint32_t *reply_tx_size,
+				  void **reply_tx_data);
+
+/**
+ * @brief Process MOD_LARGE_CONFIG_SET in any execution context.
+ * @param[in] ipc4 IPC4 message request.
+ * @return IPC4 status code (0 on success).
+ */
+int ipc4_process_large_config_set(struct ipc4_message_request *ipc4);
+
+/**
  * \brief Processes IPC4 userspace global message.
  * @param[in] ipc4 IPC4 message request.
  * @param[in] reply IPC message reply structure.
  * @return IPC4_SUCCESS on success, error code otherwise.
  */
 int ipc4_user_process_glb_message(struct ipc4_message_request *ipc4, struct ipc_msg *reply);
+
+/**
+ * \brief Process SET_PIPELINE_STATE IPC4 message (prepare + trigger phases).
+ * @param[in] ipc4 IPC4 message request.
+ * @return 0 on success, IPC4 error code otherwise.
+ */
+int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4);
 
 /**
  * \brief Increment the IPC compound message pre-start counter.

--- a/src/include/ipc4/handler.h
+++ b/src/include/ipc4/handler.h
@@ -62,10 +62,18 @@ int ipc4_user_process_glb_message(struct ipc4_message_request *ipc4, struct ipc_
 int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4);
 
 /**
+ * \brief Complete the IPC compound message.
+ * @param[in] msg_id IPC message ID.
+ * @param[in] error Error code of the IPC command.
+ */
+void ipc_compound_msg_done(uint32_t msg_id, int error);
+
+#if defined(__ZEPHYR__) && defined(CONFIG_SOF_FULL_ZEPHYR_APPLICATION)
+/**
  * \brief Increment the IPC compound message pre-start counter.
  * @param[in] msg_id IPC message ID.
  */
-void ipc_compound_pre_start(int msg_id);
+__syscall void ipc_compound_pre_start(int msg_id);
 
 /**
  * \brief Decrement the IPC compound message pre-start counter on return value status.
@@ -73,19 +81,22 @@ void ipc_compound_pre_start(int msg_id);
  * @param[in] ret Return value of the IPC command.
  * @param[in] delayed True if the reply is delayed.
  */
-void ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed);
-
-/**
- * \brief Complete the IPC compound message.
- * @param[in] msg_id IPC message ID.
- * @param[in] error Error code of the IPC command.
- */
-void ipc_compound_msg_done(uint32_t msg_id, int error);
+__syscall void ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed);
 
 /**
  * \brief Wait for the IPC compound message to complete.
  * @return 0 on success, error code otherwise on timeout.
  */
-int ipc_wait_for_compound_msg(void);
+__syscall int ipc_wait_for_compound_msg(void);
+
+#include <zephyr/syscalls/handler.h>
+#else
+void z_impl_ipc_compound_pre_start(int msg_id);
+#define ipc_compound_pre_start z_impl_ipc_compound_pre_start
+void z_impl_ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed);
+#define ipc_compound_post_start z_impl_ipc_compound_post_start
+int z_impl_ipc_wait_for_compound_msg(void);
+#define ipc_wait_for_compound_msg z_impl_ipc_wait_for_compound_msg
+#endif
 
 #endif /* __SOF_IPC4_HANDLER_H__ */

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -74,6 +74,10 @@ struct ipc {
 	struct task ipc_task;
 #endif
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+	struct mod_alloc_ctx *ll_alloc;
+#endif
+
 #ifdef CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS
 	/* io performance measurement */
 	struct io_perf_data_item *io_perf_in_msg_count;
@@ -95,6 +99,12 @@ struct ipc {
 
 extern struct task_ops ipc_task_ops;
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+
+struct ipc *ipc_get(void);
+
+#else
+
 /**
  * \brief Get the IPC global context.
  * @return The global IPC context.
@@ -103,6 +113,8 @@ static inline struct ipc *ipc_get(void)
 {
 	return sof_get()->ipc;
 }
+
+#endif /* CONFIG_SOF_USERSPACE_LL */
 
 /**
  * \brief Initialise global IPC context.

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -18,6 +18,7 @@
 #include <user/trace.h>
 #include <ipc/header.h>
 #include <ipc/stream.h>
+#include <sof/ipc/ipc_reply.h>
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -25,6 +26,7 @@
 struct comp_driver;
 struct dma_sg_elem_array;
 struct ipc_msg;
+struct ipc4_message_request;
 
 /* validates internal non tail structures within IPC command structure */
 #define IPC_IS_SIZE_INVALID(object)					\
@@ -212,6 +214,29 @@ struct dai_data;
 int ipc_dai_data_config(struct dai_data *dd, struct comp_dev *dev);
 
 /**
+ * \brief Processes IPC4 userspace module message.
+ * @param[in] ipc4 IPC4 message request.
+ * @param[in] reply IPC message reply structure.
+ * @return IPC4_SUCCESS on success, error code otherwise.
+ */
+int ipc4_user_process_module_message(struct ipc4_message_request *ipc4, struct ipc_msg *reply);
+
+/**
+ * \brief Processes IPC4 userspace global message.
+ * @param[in] ipc4 IPC4 message request.
+ * @param[in] reply IPC message reply structure.
+ * @return IPC4_SUCCESS on success, error code otherwise.
+ */
+int ipc4_user_process_glb_message(struct ipc4_message_request *ipc4, struct ipc_msg *reply);
+
+/**
+ * \brief Complete the IPC compound message.
+ * @param[in] msg_id IPC message ID.
+ * @param[in] error Error code of the IPC command.
+ */
+void ipc_compound_msg_done(uint32_t msg_id, int error);
+
+/**
  * \brief create a IPC boot complete message.
  * @param[in] header header.
  * @param[in] data data.
@@ -280,12 +305,6 @@ void ipc_cmd(struct ipc_cmd_hdr *_hdr);
  * @return 1 if successful (reply sent by other core), error code otherwise.
  */
 int ipc_process_on_core(uint32_t core, bool blocking);
-
-/**
- * \brief reply to an IPC message.
- * @param[in] reply pointer to the reply structure.
- */
-void ipc_msg_reply(struct sof_ipc_reply *reply);
 
 /**
  * \brief Call platform-specific IPC completion function.

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+struct comp_driver;
 struct dma_sg_elem_array;
 struct ipc_msg;
 
@@ -53,6 +54,37 @@ extern struct tr_ctx ipc_tr;
 #define IPC_TASK_SECONDARY_CORE	BIT(2)
 #define IPC_TASK_POWERDOWN      BIT(3)
 
+struct ipc_user {
+	struct k_thread *thread;
+	struct k_sem *sem;
+	struct k_event *event;
+	/** @brief Copy of IPC4 message primary word forwarded to user thread */
+	uint32_t ipc_msg_pri;
+	/** @brief Copy of IPC4 message extension word forwarded to user thread */
+	uint32_t ipc_msg_ext;
+	/** @brief Result code from user thread processing */
+	int result;
+	/** @brief Reply extension word from user thread (e.g. CONFIG_GET result) */
+	uint32_t reply_ext;
+	/** @brief Reply TX data size from user thread (e.g. LARGE_CONFIG_GET result) */
+	uint32_t reply_tx_size;
+	/** @brief Reply TX data pointer from user thread (e.g. LARGE_CONFIG_GET result) */
+	void *reply_tx_data;
+	struct ipc *ipc;
+	struct k_thread *audio_thread;
+	/** @brief Original kernel driver pointer for restoring dev->drv after create */
+	const struct comp_driver *init_drv;
+	/**
+	 * @brief User-accessible copy of comp_driver + tr_ctx for create().
+	 *
+	 * The comp_driver and tr_ctx structs reside in kernel memory
+	 * (.rodata/.data) which is not user-readable. The kernel handler
+	 * copies them here before forwarding to the user thread.
+	 * Size verified by BUILD_ASSERT in handler-user.c.
+	 */
+	uint8_t init_drv_data[160] __aligned(4);
+};
+
 struct ipc {
 	struct k_spinlock lock;	/* locking mechanism */
 	void *comp_data;
@@ -75,6 +107,7 @@ struct ipc {
 #endif
 
 #ifdef CONFIG_SOF_USERSPACE_LL
+	struct ipc_user *ipc_user_pdata;
 	struct mod_alloc_ctx *ll_alloc;
 #endif
 

--- a/src/include/sof/ipc/common.h
+++ b/src/include/sof/ipc/common.h
@@ -314,4 +314,30 @@ void ipc_complete_cmd(struct ipc *ipc);
 /* GDB stub: should enter GDB after completing the IPC processing */
 extern bool ipc_enter_gdb;
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+/**
+ * @brief Forward an IPC command to the user-space thread and wait for it.
+ *
+ * Protocol-agnostic: only the two raw message words are handed across the
+ * kernel/user boundary. The active IPC major's ipc_user_thread_dispatch()
+ * interprets them in the user thread.
+ *
+ * @param primary   Primary message word
+ * @param extension Extension message word
+ * @return Result code from user thread processing
+ */
+int ipc_user_forward_cmd(uint32_t primary, uint32_t extension);
+
+/**
+ * @brief Protocol-specific dispatch of a forwarded IPC command.
+ *
+ * Runs in the user-space IPC thread. A __weak default returns -ENOSYS;
+ * the active IPC major (e.g. IPC4) provides the real implementation.
+ *
+ * @param ipc_user User IPC context holding the forwarded message words
+ * @return Result code to report back to the host
+ */
+int ipc_user_thread_dispatch(struct ipc_user *ipc_user);
+#endif
+
 #endif /* __SOF_DRIVERS_IPC_H__ */

--- a/src/include/sof/ipc/ipc_reply.h
+++ b/src/include/sof/ipc/ipc_reply.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright(c) 2026 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOF_IPC_IPC_REPLY_H__
+#define __SOF_IPC_IPC_REPLY_H__
+
+#include <ipc/header.h>
+
+struct sof_ipc_reply;
+
+/**
+ * \brief reply to an IPC message.
+ * @param[in] reply pointer to the reply structure.
+ */
+#if defined(__ZEPHYR__) && defined(CONFIG_SOF_FULL_ZEPHYR_APPLICATION)
+__syscall void ipc_msg_reply(struct sof_ipc_reply *reply);
+
+#include <zephyr/syscalls/ipc_reply.h>
+#else
+void z_impl_ipc_msg_reply(struct sof_ipc_reply *reply);
+#define ipc_msg_reply z_impl_ipc_msg_reply
+#endif
+
+#endif /* __SOF_IPC_IPC_REPLY_H__ */

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -50,6 +50,12 @@ struct ipc_comp_dev;
 const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id);
 struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id);
 int ipc4_add_comp_dev(struct comp_dev *dev);
+#ifdef CONFIG_SOF_USERSPACE_LL
+struct ipc4_message_request;
+struct comp_driver;
+struct comp_dev *comp_new_ipc4_user(struct ipc4_message_request *ipc4,
+				    const struct comp_driver *drv);
+#endif
 int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma);
 int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -49,6 +49,7 @@ typedef uint32_t ipc_comp;
 struct ipc_comp_dev;
 const struct comp_driver *ipc4_get_comp_drv(uint32_t module_id);
 struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id);
+int ipc4_add_comp_dev(struct comp_dev *dev);
 int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma);
 int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);

--- a/src/include/sof/schedule/ll_schedule_domain.h
+++ b/src/include/sof/schedule/ll_schedule_domain.h
@@ -120,6 +120,7 @@ struct task *zephyr_ll_task_alloc(void);
 struct k_heap *zephyr_ll_user_heap(void);
 bool zephyr_ll_user_heap_verify(struct k_heap *heap);
 void zephyr_ll_user_resources_init(void);
+void user_ll_grant_access(struct k_thread *thread, int core);
 void user_ll_lock_sched(int core);
 void user_ll_unlock_sched(int core);
 #ifdef CONFIG_ASSERT

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -506,11 +506,6 @@ __cold int ipc_init(struct sof *sof)
 
 	tr_dbg(&ipc_tr, "entry");
 
-#if CONFIG_SOF_BOOT_TEST_STANDALONE
-	LOG_INF("SOF_BOOT_TEST_STANDALONE, skipping platform IPC init.");
-	return 0;
-#endif
-
 #ifdef CONFIG_SOF_USERSPACE_LL
 	heap = zephyr_ll_user_heap();
 
@@ -558,6 +553,11 @@ __cold int ipc_init(struct sof *sof)
 	io_perf_monitor_init_data(&ipc->io_perf_in_msg_count, &init_data);
 	init_data.direction = IO_PERF_OUTPUT_DIRECTION;
 	io_perf_monitor_init_data(&ipc->io_perf_out_msg_count, &init_data);
+#endif
+
+#if CONFIG_SOF_BOOT_TEST_STANDALONE
+	LOG_INF("SOF_BOOT_TEST_STANDALONE, disabling IPC.");
+	return 0;
 #endif
 
 #ifdef __ZEPHYR__

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -356,7 +356,7 @@ int ipc_user_forward_cmd(uint32_t primary, uint32_t extension)
 	k_event_set(pdata->event, IPC_USER_EVENT_CMD);
 
 	/* Wait for user thread to complete */
-	ret = k_sem_take(pdata->sem, K_MSEC(10));
+	ret = k_sem_take(pdata->sem, K_MSEC(100));
 	if (ret) {
 		LOG_ERR("IPC user: sem error %d\n", ret);
 		/* fall through to complete the cmd */

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -24,6 +24,8 @@
 #include <sof/lib/memory.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/ll_schedule.h>
+#include <sof/schedule/ll_schedule_domain.h>
 #include <rtos/sof.h>
 #include <rtos/spinlock.h>
 #include <ipc/dai.h>
@@ -35,6 +37,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#endif
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+#include <rtos/userspace_helper.h>
+#endif
+
 #include <sof/debug/telemetry/performance_monitor.h>
 
 LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
@@ -42,6 +52,17 @@ LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(ipc);
 
 DECLARE_TR_CTX(ipc_tr, SOF_UUID(ipc_uuid), LOG_LEVEL_INFO);
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+K_APPMEM_PARTITION_DEFINE(ipc_context_part);
+
+K_APP_BMEM(ipc_context_part) static struct ipc ipc_context;
+
+struct ipc *ipc_get(void)
+{
+	return &ipc_context;
+}
+#endif
 
 int ipc_process_on_core(uint32_t core, bool blocking)
 {
@@ -288,34 +309,60 @@ void ipc_schedule_process(struct ipc *ipc)
 #endif
 }
 
+static void ipc_user_init(void)
+{
+}
+
 __cold int ipc_init(struct sof *sof)
 {
+	struct k_heap *heap;
+	struct ipc *ipc;
+
 	assert_can_be_cold();
 
 	tr_dbg(&ipc_tr, "entry");
 
 #if CONFIG_SOF_BOOT_TEST_STANDALONE
-	LOG_INF("SOF_BOOT_TEST_STANDALONE, disabling IPC.");
+	LOG_INF("SOF_BOOT_TEST_STANDALONE, skipping platform IPC init.");
 	return 0;
 #endif
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+	heap = zephyr_ll_user_heap();
+
+	ipc = ipc_get();
+	memset(ipc, 0, sizeof(*ipc));
+	ipc->ll_alloc = sof_heap_alloc(heap, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
+				       sizeof(*ipc->ll_alloc), 0);
+	if (!ipc->ll_alloc) {
+		tr_err(&ipc_tr, "Unable to allocate IPC ll_alloc");
+		sof_panic(SOF_IPC_PANIC_IPC);
+	}
+	ipc->ll_alloc->heap = heap;
+	ipc->ll_alloc->vreg = NULL;
+#else
+	heap = NULL;
+
 	/* init ipc data */
-	sof->ipc = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, sizeof(*sof->ipc));
-	if (!sof->ipc) {
+	ipc = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT, sizeof(*ipc));
+	if (!ipc) {
 		tr_err(&ipc_tr, "Unable to allocate IPC data");
 		return -ENOMEM;
 	}
-	sof->ipc->comp_data = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
-				      SOF_IPC_MSG_MAX_SIZE);
-	if (!sof->ipc->comp_data) {
-		tr_err(&ipc_tr, "Unable to allocate IPC component data");
-		rfree(sof->ipc);
-		return -ENOMEM;
-	}
+	sof->ipc = ipc;
+#endif
 
-	k_spinlock_init(&sof->ipc->lock);
-	list_init(&sof->ipc->msg_list);
-	list_init(&sof->ipc->comp_list);
+	ipc->comp_data = sof_heap_alloc(heap, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
+					SOF_IPC_MSG_MAX_SIZE, 0);
+	if (!ipc->comp_data) {
+		tr_err(&ipc_tr, "Unable to allocate IPC component data");
+		sof_panic(SOF_IPC_PANIC_IPC);
+	}
+	memset(ipc->comp_data, 0, SOF_IPC_MSG_MAX_SIZE);
+
+	k_spinlock_init(&ipc->lock);
+	list_init(&ipc->msg_list);
+	list_init(&ipc->comp_list);
 
 #ifdef CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS
 	struct io_perf_data_item init_data = {IO_PERF_IPC_ID,
@@ -324,18 +371,19 @@ __cold int ipc_init(struct sof *sof)
 					      IO_PERF_POWERED_UP_ENABLED,
 					      IO_PERF_D0IX_POWER_MODE,
 					      0, 0, 0 };
-	io_perf_monitor_init_data(&sof->ipc->io_perf_in_msg_count, &init_data);
+	io_perf_monitor_init_data(&ipc->io_perf_in_msg_count, &init_data);
 	init_data.direction = IO_PERF_OUTPUT_DIRECTION;
-	io_perf_monitor_init_data(&sof->ipc->io_perf_out_msg_count, &init_data);
+	io_perf_monitor_init_data(&ipc->io_perf_out_msg_count, &init_data);
 #endif
 
 #ifdef __ZEPHYR__
 	k_tid_t thread;
 
-	k_work_queue_start(&sof->ipc->ipc_send_wq, ipc_send_wq_stack,
+	k_work_queue_init(&ipc->ipc_send_wq);
+	k_work_queue_start(&ipc->ipc_send_wq, ipc_send_wq_stack,
 			   K_THREAD_STACK_SIZEOF(ipc_send_wq_stack), 1, NULL);
 
-	thread = k_work_queue_thread_get(&sof->ipc->ipc_send_wq);
+	thread = k_work_queue_thread_get(&ipc->ipc_send_wq);
 
 	k_thread_suspend(thread);
 
@@ -346,10 +394,12 @@ __cold int ipc_init(struct sof *sof)
 
 	k_thread_resume(thread);
 
-	k_work_init_delayable(&sof->ipc->z_delayed_work, ipc_work_handler);
+	k_work_init_delayable(&ipc->z_delayed_work, ipc_work_handler);
 #endif
 
-	return platform_ipc_init(sof->ipc);
+	ipc_user_init();
+
+	return platform_ipc_init(ipc);
 }
 
 /* Locking: call with ipc->lock held and interrupts disabled */

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -309,9 +309,193 @@ void ipc_schedule_process(struct ipc *ipc)
 #endif
 }
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+/* Generic user-space IPC handling thread infrastructure. Protocol-specific
+ * command interpretation lives in ipc_user_thread_dispatch(), implemented by
+ * the active IPC major (see src/ipc/ipc4/).
+ */
+
+#define IPC_USER_EVENT_CMD      BIT(0)
+#define IPC_USER_EVENT_STOP     BIT(1)
+
+static struct k_thread ipc_user_thread;
+static K_THREAD_STACK_DEFINE(ipc_user_stack, CONFIG_SOF_IPC_USER_THREAD_STACK_SIZE);
+
+/**
+ * @brief Forward an IPC command to the user-space thread.
+ *
+ * Called from kernel context (IPC EDF task) to forward the message words
+ * to the user-space thread for processing. Sets IPC_TASK_IN_THREAD in
+ * task_mask so the host is not signaled until the user thread completes.
+ * Blocks until the user thread finishes processing and returns the result.
+ *
+ * @param primary   Primary message word
+ * @param extension Extension message word
+ * @return Result from user thread processing
+ */
+int ipc_user_forward_cmd(uint32_t primary, uint32_t extension)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_user *pdata = ipc->ipc_user_pdata;
+	k_spinlock_key_t key;
+	int ret;
+
+	LOG_DBG("IPC: forward cmd %08x", primary);
+
+	/* Copy message words — original buffer may be reused */
+	pdata->ipc_msg_pri = primary;
+	pdata->ipc_msg_ext = extension;
+	pdata->ipc = ipc;
+
+	/* Prevent host completion until user thread finishes */
+	key = k_spin_lock(&ipc->lock);
+	ipc->task_mask |= IPC_TASK_IN_THREAD;
+	k_spin_unlock(&ipc->lock, key);
+
+	/* Wake the user thread */
+	k_event_set(pdata->event, IPC_USER_EVENT_CMD);
+
+	/* Wait for user thread to complete */
+	ret = k_sem_take(pdata->sem, K_MSEC(10));
+	if (ret) {
+		LOG_ERR("IPC user: sem error %d\n", ret);
+		/* fall through to complete the cmd */
+	}
+
+	/* Clear the task mask bit and check for completion */
+	key = k_spin_lock(&ipc->lock);
+	ipc->task_mask &= ~IPC_TASK_IN_THREAD;
+	ipc_complete_cmd(ipc);
+	k_spin_unlock(&ipc->lock, key);
+
+	return !ret ? pdata->result : ret;
+}
+
+/**
+ * @brief Protocol-specific dispatch of a forwarded IPC command.
+ *
+ * Weak default; the active IPC major overrides this. Runs in the user
+ * thread context with the forwarded message words in @p ipc_user.
+ */
+__weak int ipc_user_thread_dispatch(struct ipc_user *ipc_user)
+{
+	ARG_UNUSED(ipc_user);
+	return -ENOSYS;
+}
+
+/**
+ * User-space IPC thread entry point. p1 points to the ipc_user context
+ * shared with the kernel launcher.
+ */
+static void ipc_user_thread_fn(void *p1, void *p2, void *p3)
+{
+	struct ipc_user *ipc_user = p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	__ASSERT(k_is_user_context(), "expected user context");
+
+	/* Signal startup complete — unblocks init waiting on semaphore */
+	k_sem_give(ipc_user->sem);
+	LOG_INF("IPC user-space thread started");
+
+	for (;;) {
+		uint32_t mask = k_event_wait_safe(ipc_user->event,
+						  IPC_USER_EVENT_CMD | IPC_USER_EVENT_STOP,
+						  false, K_FOREVER);
+
+		LOG_DBG("IPC user wake, mask %u", mask);
+
+		if (mask & IPC_USER_EVENT_CMD) {
+			ipc_user->result = ipc_user_thread_dispatch(ipc_user);
+
+			/* Signal completion — kernel side will finish IPC */
+			k_sem_give(ipc_user->sem);
+		}
+
+		if (mask & IPC_USER_EVENT_STOP)
+			break;
+	}
+}
+
+__cold static void ipc_user_init(void)
+{
+	struct ipc *ipc = ipc_get();
+	struct ipc_user *ipc_user = sof_heap_alloc(sof_sys_user_heap_get(), SOF_MEM_FLAG_USER,
+						   sizeof(*ipc_user), 0);
+	int ret;
+
+	if (!ipc_user) {
+		LOG_ERR("user IPC pdata alloc failed");
+		sof_panic(SOF_IPC_PANIC_IPC);
+	}
+
+	ipc_user->sem = k_object_alloc(K_OBJ_SEM);
+	if (!ipc_user->sem) {
+		LOG_ERR("user IPC sem alloc failed");
+		k_panic();
+	}
+
+	ret = k_mem_domain_add_partition(zephyr_ll_mem_domain(), &ipc_context_part);
+	if (ret < 0)
+		LOG_WRN("ipc context partition add failed: %d", ret);
+
+	k_sem_init(ipc_user->sem, 0, 1);
+
+	/* Allocate kernel objects for the user-space thread */
+	ipc_user->event = k_object_alloc(K_OBJ_EVENT);
+	if (!ipc_user->event) {
+		LOG_ERR("user IPC event alloc failed");
+		sof_panic(SOF_IPC_PANIC_IPC);
+	}
+	k_event_init(ipc_user->event);
+
+	k_thread_create(&ipc_user_thread, ipc_user_stack,
+			CONFIG_SOF_IPC_USER_THREAD_STACK_SIZE,
+			ipc_user_thread_fn, ipc_user, NULL, NULL,
+			-1, K_USER, K_FOREVER);
+
+	ipc_user->thread = &ipc_user_thread;
+	k_thread_access_grant(&ipc_user_thread, ipc_user->sem, ipc_user->event);
+	user_grant_dai_access_all(&ipc_user_thread);
+	user_grant_dma_access_all(&ipc_user_thread);
+	ret = user_access_to_mailbox(zephyr_ll_mem_domain(), &ipc_user_thread);
+	if (ret < 0) {
+		LOG_ERR("ipc user: mailbox access grant failed: %d", ret);
+		sof_panic(SOF_IPC_PANIC_IPC);
+	}
+	user_ll_grant_access(&ipc_user_thread, PLATFORM_PRIMARY_CORE_ID);
+	k_mem_domain_add_thread(zephyr_ll_mem_domain(), &ipc_user_thread);
+
+	k_thread_cpu_pin(&ipc_user_thread, PLATFORM_PRIMARY_CORE_ID);
+	k_thread_name_set(&ipc_user_thread, "ipc_user");
+
+	/* Store references in ipc struct so kernel handler can forward commands */
+	ipc->ipc_user_pdata = ipc_user;
+
+	k_thread_start(&ipc_user_thread);
+
+	struct task *task = zephyr_ll_task_alloc();
+
+	schedule_task_init_ll(task, SOF_UUID(ipc_uuid), SOF_SCHEDULE_LL_TIMER,
+			0, NULL, NULL, cpu_get_id(), 0);
+	ipc_user->audio_thread = scheduler_init_context(task);
+
+	/* Grant ipc_user thread permission on the audio thread object.
+	 * Needed so user-space dai_common_new() can call
+	 * k_thread_access_grant(audio_thread, dai_mutex) from user context.
+	 */
+	k_thread_access_grant(&ipc_user_thread, ipc_user->audio_thread);
+
+	/* Wait for user thread startup — consumes the initial k_sem_give from thread */
+	k_sem_take(ipc->ipc_user_pdata->sem, K_FOREVER);
+}
+#else
 static void ipc_user_init(void)
 {
 }
+#endif /* CONFIG_SOF_USERSPACE_LL */
 
 __cold int ipc_init(struct sof *sof)
 {

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -89,8 +89,10 @@ __cold struct comp_buffer *buffer_new(struct mod_alloc_ctx *alloc,
 		buffer->stream.runtime_stream_params.pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
 
+#if !defined(CONFIG_SOF_USERSPACE_LL)
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
 			 &buffer_tr, sizeof(struct tr_ctx));
+#endif
 	}
 
 	return buffer;
@@ -388,7 +390,7 @@ __cold int ipc_comp_free(struct ipc *ipc, uint32_t comp_id)
 	icd->cd = NULL;
 
 	list_item_del(&icd->list);
-	rfree(icd);
+	sof_heap_free(sof_sys_user_heap_get(), icd);
 
 	return 0;
 }

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -727,7 +727,7 @@ int ipc_comp_new(struct ipc *ipc, ipc_comp *_comp)
 	return 0;
 }
 
-void ipc_msg_reply(struct sof_ipc_reply *reply)
+void z_impl_ipc_msg_reply(struct sof_ipc_reply *reply)
 {
 	struct ipc *ipc = ipc_get();
 	k_spinlock_key_t key;

--- a/src/ipc/ipc4/handler-kernel.c
+++ b/src/ipc/ipc4/handler-kernel.c
@@ -40,6 +40,11 @@
 #include <rtos/string.h>
 #include <sof/lib_manager.h>
 
+#ifdef __ZEPHYR__
+#include <zephyr/kernel.h>
+#include <zephyr/internal/syscall_handler.h>
+#endif
+
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -128,7 +133,7 @@ __cold static bool is_any_ppl_active(void)
 	return false;
 }
 
-void ipc_compound_pre_start(int msg_id)
+void z_impl_ipc_compound_pre_start(int msg_id)
 {
 	/* ipc thread will wait for all scheduled tasks to be complete
 	 * Use a reference count to check status of these tasks.
@@ -136,7 +141,23 @@ void ipc_compound_pre_start(int msg_id)
 	atomic_add(&msg_data.delayed_reply, 1);
 }
 
-void ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed)
+#ifdef CONFIG_USERSPACE
+/**
+ * \brief Userspace verification wrapper for ipc_compound_pre_start().
+ *
+ * Forwards the call to z_impl_ipc_compound_pre_start(). No pointer
+ * validation is needed as only primitive types are passed.
+ *
+ * @param[in] msg_id IPC message ID.
+ */
+void z_vrfy_ipc_compound_pre_start(int msg_id)
+{
+	z_impl_ipc_compound_pre_start(msg_id);
+}
+#include <zephyr/syscalls/ipc_compound_pre_start_mrsh.c>
+#endif
+
+void z_impl_ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed)
 {
 	if (ret) {
 		ipc_cmd_err(&ipc_tr, "failed to process msg %d status %d", msg_id, ret);
@@ -148,6 +169,24 @@ void ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed)
 	if (!delayed)
 		atomic_sub(&msg_data.delayed_reply, 1);
 }
+
+#ifdef CONFIG_USERSPACE
+/**
+ * \brief Userspace verification wrapper for ipc_compound_post_start().
+ *
+ * Forwards the call to z_impl_ipc_compound_post_start(). No pointer
+ * validation is needed as only primitive types are passed.
+ *
+ * @param[in] msg_id IPC message ID.
+ * @param[in] ret Return value of the IPC command.
+ * @param[in] delayed True if the reply is delayed.
+ */
+void z_vrfy_ipc_compound_post_start(uint32_t msg_id, int ret, bool delayed)
+{
+	z_impl_ipc_compound_post_start(msg_id, ret, delayed);
+}
+#include <zephyr/syscalls/ipc_compound_post_start_mrsh.c>
+#endif
 
 void ipc_compound_msg_done(uint32_t msg_id, int error)
 {
@@ -170,13 +209,13 @@ void ipc_compound_msg_done(uint32_t msg_id, int error)
  * be always IPC4_FAILURE. Therefore the compound messages handling is simplified. The pipeline
  * triggers will require an explicit scheduler call to get the components to desired state.
  */
-int ipc_wait_for_compound_msg(void)
+int z_impl_ipc_wait_for_compound_msg(void)
 {
 	atomic_set(&msg_data.delayed_reply, 0);
 	return IPC4_SUCCESS;
 }
 #else
-int ipc_wait_for_compound_msg(void)
+int z_impl_ipc_wait_for_compound_msg(void)
 {
 	int try_count = 30;
 
@@ -192,6 +231,22 @@ int ipc_wait_for_compound_msg(void)
 
 	return IPC4_SUCCESS;
 }
+
+#ifdef CONFIG_USERSPACE
+/**
+ * \brief Userspace verification wrapper for ipc_wait_for_compound_msg().
+ *
+ * Forwards the call to z_impl_ipc_wait_for_compound_msg(). No pointer
+ * validation is needed as no pointers are passed.
+ *
+ * @return IPC4_SUCCESS on success, IPC4_FAILURE on timeout.
+ */
+int z_vrfy_ipc_wait_for_compound_msg(void)
+{
+	return z_impl_ipc_wait_for_compound_msg();
+}
+#include <zephyr/syscalls/ipc_wait_for_compound_msg_mrsh.c>
+#endif
 #endif
 
 #if CONFIG_LIBRARY_MANAGER
@@ -509,13 +564,22 @@ void ipc_send_buffer_status_notify(void)
 }
 #endif
 
-void ipc_msg_reply(struct sof_ipc_reply *reply)
+void z_impl_ipc_msg_reply(struct sof_ipc_reply *reply)
 {
 	struct ipc4_message_request in;
 
 	in.primary.dat = msg_data.msg_in.pri;
 	ipc_compound_msg_done(in.primary.r.type, reply->error);
 }
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy_ipc_msg_reply(struct sof_ipc_reply *reply)
+{
+	K_OOPS(K_SYSCALL_MEMORY_READ(reply, sizeof(*reply)));
+	z_impl_ipc_msg_reply(reply);
+}
+#include <zephyr/syscalls/ipc_msg_reply_mrsh.c>
+#endif
 
 void ipc_cmd(struct ipc_cmd_hdr *_hdr)
 {

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -424,8 +424,12 @@ __cold const struct ipc4_pipeline_set_state_data *ipc4_get_pipeline_data_wrapper
 	return ipc4_get_pipeline_data();
 }
 
-/* Entry point for ipc4_pipeline_trigger(), therefore cannot be cold */
-static int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
+/**
+ * \brief Process SET_PIPELINE_STATE IPC4 message (prepare + trigger phases).
+ * @param[in] ipc4 IPC4 message request.
+ * @return 0 on success, IPC4 error code otherwise.
+ */
+int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4)
 {
 	const struct ipc4_pipeline_set_state_data *ppl_data;
 	struct ipc4_pipeline_set_state state;
@@ -809,7 +813,22 @@ __cold static int ipc4_unbind_module_instance(struct ipc4_message_request *ipc4)
 	return ipc_comp_disconnect(ipc, (ipc_pipe_comp_connect *)&bu);
 }
 
-static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4, bool set)
+/**
+ * @brief Process MOD_CONFIG_GET or MOD_CONFIG_SET in any execution context.
+ *
+ * Looks up the target component by module_id:instance_id, verifies the
+ * driver supports get_attribute/set_attribute, and dispatches the
+ * operation. For GET, the retrieved value is written to @p reply_ext.
+ *
+ * Callable from both the IPC kernel task and the IPC user thread.
+ *
+ * @param ipc4      Pointer to the IPC4 message request (primary + extension)
+ * @param set       true for CONFIG_SET, false for CONFIG_GET
+ * @param reply_ext Output: receives the extension value for CONFIG_GET (may be NULL for SET)
+ * @return IPC4 status code (0 on success)
+ */
+__cold int ipc4_process_module_config(struct ipc4_message_request *ipc4,
+				      bool set, uint32_t *reply_ext)
 {
 	struct ipc4_module_config *config = (struct ipc4_module_config *)ipc4;
 	int (*function)(struct comp_dev *dev, uint32_t type, void *value);
@@ -859,8 +878,21 @@ static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4
 		ret = IPC4_INVALID_CONFIG_PARAM_ID;
 	}
 
+	if (!set && reply_ext)
+		*reply_ext = config->extension.dat;
+
+	return ret;
+}
+
+static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4, bool set)
+{
+	uint32_t reply_ext;
+	int ret;
+
+	ret = ipc4_process_module_config(ipc4, set, &reply_ext);
+
 	if (!set)
-		msg_reply->extension = config->extension.dat;
+		msg_reply->extension = reply_ext;
 
 	return ret;
 }
@@ -988,6 +1020,108 @@ __cold static int ipc4_get_vendor_config_module_instance(struct comp_dev *dev,
 		}
 	}
 	return IPC4_SUCCESS;
+}
+
+__cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
+					uint32_t *reply_ext,
+					uint32_t *reply_tx_size,
+					void **reply_tx_data)
+{
+	struct ipc4_module_large_config_reply reply;
+	struct ipc4_module_large_config config;
+	char *data = ipc_get()->comp_data;
+	const struct comp_driver *drv;
+	struct comp_dev *dev = NULL;
+	uint32_t data_offset;
+
+	assert_can_be_cold();
+
+	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
+
+	if (ret < 0)
+		return IPC4_FAILURE;
+
+	tr_dbg(&ipc_tr, "%x : %x",
+	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+
+	/* get component dev for non-basefw since there is no
+	 * component dev for basefw
+	 */
+	if (config.primary.r.module_id) {
+		uint32_t comp_id;
+
+		comp_id = IPC4_COMP_ID(config.primary.r.module_id,
+				       config.primary.r.instance_id);
+		dev = ipc4_get_comp_dev(comp_id);
+		if (!dev)
+			return IPC4_MOD_INVALID_ID;
+
+		drv = dev->drv;
+
+		/* Multicore disabled for userspace forwarding;
+		 * non-userspace path retains ipc4_process_on_core()
+		 */
+	} else {
+		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+	}
+
+	if (!drv)
+		return IPC4_MOD_INVALID_ID;
+
+	if (!drv->ops.get_large_config)
+		return IPC4_INVALID_REQUEST;
+
+	data_offset = config.extension.r.data_off_size;
+
+	/* check for vendor param first */
+	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+		/* For now only vendor_config case uses payload from hostbox */
+		dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+					 config.extension.r.data_off_size);
+		ret = ipc4_get_vendor_config_module_instance(dev, drv,
+							     config.extension.r.init_block,
+							     config.extension.r.final_block,
+							     &data_offset,
+							     data,
+							     (const char *)MAILBOX_HOSTBOX_BASE);
+	} else {
+#if CONFIG_LIBRARY
+		data += sizeof(reply);
+#endif
+		ipc4_prepare_for_kcontrol_get(dev, config.extension.r.large_param_id,
+					      data, data_offset);
+
+		ret = drv->ops.get_large_config(dev, config.extension.r.large_param_id,
+						config.extension.r.init_block,
+						config.extension.r.final_block,
+						&data_offset, data);
+	}
+
+	/* set up ipc4 error code for reply data */
+	if (ret < 0)
+		ret = IPC4_MOD_INVALID_ID;
+
+	/* Copy host config and overwrite */
+	reply.extension.dat = config.extension.dat;
+	reply.extension.r.data_off_size = data_offset;
+
+	/* The last block, no more data */
+	if (!config.extension.r.final_block && data_offset < SOF_IPC_MSG_MAX_SIZE)
+		reply.extension.r.final_block = 1;
+
+	/* Indicate last block if error occurs */
+	if (ret)
+		reply.extension.r.final_block = 1;
+
+	/* no need to allocate memory for reply msg */
+	if (ret)
+		return ret;
+
+	/* Output via parameters instead of msg_reply */
+	*reply_ext = reply.extension.dat;
+	*reply_tx_size = data_offset;
+	*reply_tx_data = data;
+	return ret;
 }
 
 __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_request *ipc4)
@@ -1180,6 +1314,77 @@ __cold static int ipc4_set_vendor_config_module_instance(struct comp_dev *dev,
 	}
 	return drv->ops.set_large_config(dev, param_id, init_block, final_block,
 					 data_off_size, data);
+}
+
+__cold int ipc4_process_large_config_set(struct ipc4_message_request *ipc4)
+{
+	struct ipc4_module_large_config config;
+	struct comp_dev *dev = NULL;
+	const struct comp_driver *drv;
+
+	assert_can_be_cold();
+
+	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
+
+	if (ret < 0)
+		return IPC4_FAILURE;
+
+	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+				 config.extension.r.data_off_size);
+	tr_dbg(&ipc_tr, "%x : %x",
+	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+
+	if (config.primary.r.module_id) {
+		uint32_t comp_id;
+
+		comp_id = IPC4_COMP_ID(config.primary.r.module_id, config.primary.r.instance_id);
+		dev = ipc4_get_comp_dev(comp_id);
+		if (!dev)
+			return IPC4_MOD_INVALID_ID;
+
+		drv = dev->drv;
+
+		/* Multicore disabled for userspace forwarding;
+		 * non-userspace path retains ipc4_process_on_core()
+		 */
+	} else {
+		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+	}
+
+	if (!drv)
+		return IPC4_MOD_INVALID_ID;
+
+	if (!drv->ops.set_large_config)
+		return IPC4_INVALID_REQUEST;
+
+	/* check for vendor param first */
+	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+		ret = ipc4_set_vendor_config_module_instance(dev, drv,
+							     (uint32_t)config.primary.r.module_id,
+							     (uint32_t)config.primary.r.instance_id,
+							     config.extension.r.init_block,
+							     config.extension.r.final_block,
+							     config.extension.r.data_off_size,
+							     (const char *)MAILBOX_HOSTBOX_BASE);
+	} else {
+#if CONFIG_LIBRARY
+		struct ipc *ipc = ipc_get();
+		const char *data = (const char *)ipc->comp_data + sizeof(config);
+#else
+		const char *data = (const char *)MAILBOX_HOSTBOX_BASE;
+#endif
+		ret = drv->ops.set_large_config(dev, config.extension.r.large_param_id,
+			config.extension.r.init_block, config.extension.r.final_block,
+			config.extension.r.data_off_size, data);
+		if (ret < 0) {
+			ipc_cmd_err(&ipc_tr, "failed to set large_config_module_instance %x : %x",
+				    (uint32_t)config.primary.r.module_id,
+				    (uint32_t)config.primary.r.instance_id);
+			ret = IPC4_INVALID_RESOURCE_ID;
+		}
+	}
+
+	return ret;
 }
 
 __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ipc4)

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -90,6 +90,7 @@ static inline const struct ipc4_pipeline_set_state_data *ipc4_get_pipeline_data(
 /*
  * Global IPC Operations.
  */
+#ifndef CONFIG_SOF_USERSPACE_LL
 __cold static int ipc4_new_pipeline(struct ipc4_message_request *ipc4)
 {
 	struct ipc *ipc = ipc_get();
@@ -98,7 +99,9 @@ __cold static int ipc4_new_pipeline(struct ipc4_message_request *ipc4)
 
 	return ipc_pipeline_new(ipc, (ipc_pipe_new *)ipc4);
 }
+#endif
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 __cold static int ipc4_delete_pipeline(struct ipc4_message_request *ipc4)
 {
 	struct ipc4_pipeline_delete *pipe;
@@ -111,6 +114,7 @@ __cold static int ipc4_delete_pipeline(struct ipc4_message_request *ipc4)
 
 	return ipc_pipeline_free(ipc, pipe->primary.r.instance_id);
 }
+#endif
 
 static int ipc4_pcm_params(struct ipc_comp_dev *pcm_dev)
 {
@@ -689,13 +693,25 @@ int ipc4_user_process_glb_message(struct ipc4_message_request *ipc4,
 
 	/* pipeline settings */
 	case SOF_IPC4_GLB_CREATE_PIPELINE:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_new_pipeline(ipc4);
+#endif
 		break;
 	case SOF_IPC4_GLB_DELETE_PIPELINE:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_delete_pipeline(ipc4);
+#endif
 		break;
 	case SOF_IPC4_GLB_SET_PIPELINE_STATE:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_set_pipeline_state(ipc4);
+#endif
 		break;
 
 	case SOF_IPC4_GLB_GET_PIPELINE_STATE:
@@ -775,6 +791,7 @@ __cold static int ipc4_init_module_instance(struct ipc4_message_request *ipc4)
 	return 0;
 }
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 __cold static int ipc4_bind_module_instance(struct ipc4_message_request *ipc4)
 {
 	struct ipc4_module_bind_unbind bu;
@@ -812,6 +829,7 @@ __cold static int ipc4_unbind_module_instance(struct ipc4_message_request *ipc4)
 
 	return ipc_comp_disconnect(ipc, (ipc_pipe_comp_connect *)&bu);
 }
+#endif /* !CONFIG_SOF_USERSPACE_LL */
 
 /**
  * @brief Process MOD_CONFIG_GET or MOD_CONFIG_SET in any execution context.
@@ -884,6 +902,7 @@ __cold int ipc4_process_module_config(struct ipc4_message_request *ipc4,
 	return ret;
 }
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4, bool set)
 {
 	uint32_t reply_ext;
@@ -896,6 +915,7 @@ static int ipc4_set_get_config_module_instance(struct ipc4_message_request *ipc4
 
 	return ret;
 }
+#endif /* !CONFIG_SOF_USERSPACE_LL */
 
 __cold static void ipc4_prepare_for_kcontrol_get(struct comp_dev *dev, uint8_t param_id,
 						 char *data_out, uint32_t data_size)
@@ -1462,6 +1482,7 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 	return ret;
 }
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 __cold static int ipc4_delete_module_instance(struct ipc4_message_request *ipc4)
 {
 	struct ipc4_module_delete_instance module;
@@ -1489,6 +1510,7 @@ __cold static int ipc4_delete_module_instance(struct ipc4_message_request *ipc4)
 
 	return ret;
 }
+#endif /* !CONFIG_SOF_USERSPACE_LL */
 
 __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 					    struct ipc_msg *reply)
@@ -1503,28 +1525,155 @@ __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 
 	switch (type) {
 	case SOF_IPC4_MOD_INIT_INSTANCE:
+#ifdef CONFIG_SOF_USERSPACE_LL
+	{
+		/* User-space init: kernel does driver lookup only (requires
+		 * access to IMR manifest and driver list in kernel memory).
+		 * Component creation (drv->ops.create) runs in user thread
+		 * so untrusted module code does not execute in kernel context.
+		 * Cross-core creation stays fully in kernel.
+		 */
+		struct ipc4_module_init_instance mi;
+
+		BUILD_ASSERT(sizeof(struct comp_driver) + sizeof(struct tr_ctx) <=
+			     sizeof(((struct ipc_user *)0)->init_drv_data),
+			     "ipc_user.init_drv_data too small for driver copy");
+
+		ret = memcpy_s(&mi, sizeof(mi), ipc4, sizeof(*ipc4));
+		if (ret < 0)
+			break;
+
+		if (!cpu_is_me(mi.extension.r.core_id)) {
+			ret = ipc4_init_module_instance(ipc4);
+		} else {
+			struct ipc *ipc = ipc_get();
+			uint32_t comp_id = IPC4_COMP_ID(mi.primary.r.module_id,
+							mi.primary.r.instance_id);
+			const struct comp_driver *drv = ipc4_get_comp_drv(
+				IPC4_MOD_ID(comp_id));
+			struct ipc_user *pdata = ipc->ipc_user_pdata;
+
+			if (!drv) {
+				ret = IPC4_MOD_NOT_INITIALIZED;
+				break;
+			}
+
+			/* Copy comp_driver and tr_ctx into user-accessible ipc_user buffer
+			 * originals are in kernel .rodata/.data and not readable from user mode.
+			 */
+			struct comp_driver *drv_copy = (struct comp_driver *)pdata->init_drv_data;
+			struct tr_ctx *tctx_copy =
+				(struct tr_ctx *)(pdata->init_drv_data +
+						sizeof(struct comp_driver));
+
+			ret = memcpy_s(drv_copy, sizeof(*drv_copy), drv, sizeof(*drv));
+			if (!ret && drv->tctx) {
+				ret = memcpy_s(tctx_copy, sizeof(*tctx_copy),
+					       drv->tctx, sizeof(*drv->tctx));
+				drv_copy->tctx = tctx_copy;
+			}
+
+			if (ret < 0)
+				break;
+
+			pdata->init_drv = drv;
+			ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+		}
+	}
+#else
 		ret = ipc4_init_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_CONFIG_GET:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		/* Forward to user thread for privilege-separated execution */
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+		if (!ret) {
+			struct ipc *ipc = ipc_get();
+			struct ipc_user *pdata = ipc->ipc_user_pdata;
+
+			msg_reply->extension = pdata->reply_ext;
+		}
+#else
 		ret = ipc4_set_get_config_module_instance(ipc4, false);
+#endif
 		break;
 	case SOF_IPC4_MOD_CONFIG_SET:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		/* Forward to user thread for privilege-separated execution */
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_set_get_config_module_instance(ipc4, true);
+#endif
 		break;
 	case SOF_IPC4_MOD_LARGE_CONFIG_GET:
+#ifdef CONFIG_SOF_USERSPACE_LL
+	{
+		struct ipc4_module_large_config config;
+
+		memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
+		if (config.primary.r.module_id) {
+			/* Module case: forward to user thread */
+			ret = ipc_user_forward_cmd(ipc4->primary.dat,
+						   ipc4->extension.dat);
+			if (!ret) {
+				struct ipc *ipc = ipc_get();
+				struct ipc_user *pdata = ipc->ipc_user_pdata;
+
+				msg_reply->extension = pdata->reply_ext;
+				msg_reply->tx_size = pdata->reply_tx_size;
+				msg_reply->tx_data = pdata->reply_tx_data;
+			}
+		} else {
+			/* Base firmware (module_id==0): keep in kernel —
+			 * ipc4_get_comp_drv() accesses IMR manifest which
+			 * has no user-space partition.
+			 */
+			ret = ipc4_get_large_config_module_instance(ipc4);
+		}
+	}
+#else
 		ret = ipc4_get_large_config_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_LARGE_CONFIG_SET:
+#ifdef CONFIG_SOF_USERSPACE_LL
+	{
+		struct ipc4_module_large_config config;
+
+		memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
+		if (config.primary.r.module_id) {
+			ret = ipc_user_forward_cmd(ipc4->primary.dat,
+						   ipc4->extension.dat);
+		} else {
+			/* Base firmware: keep in kernel (IMR access) */
+			ret = ipc4_set_large_config_module_instance(ipc4);
+		}
+	}
+#else
 		ret = ipc4_set_large_config_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_BIND:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_bind_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_UNBIND:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_unbind_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_DELETE_INSTANCE:
+#ifdef CONFIG_SOF_USERSPACE_LL
+		ret = ipc_user_forward_cmd(ipc4->primary.dat, ipc4->extension.dat);
+#else
 		ret = ipc4_delete_module_instance(ipc4);
+#endif
 		break;
 	case SOF_IPC4_MOD_ENTER_MODULE_RESTORE:
 	case SOF_IPC4_MOD_EXIT_MODULE_RESTORE:

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -1537,3 +1537,148 @@ __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 
 	return ret;
 }
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+/*
+ * IPC4 implementation of the user-thread dispatch hook. Runs in the
+ * user-space IPC thread; reconstructs the IPC4 message from the forwarded
+ * words and executes the privilege-separated part of each command.
+ */
+int ipc_user_thread_dispatch(struct ipc_user *ipc_user)
+{
+	struct ipc4_message_request msg;
+	int result = -EINVAL;
+
+	/* Reconstruct the IPC4 message from copied words */
+	msg.primary.dat = ipc_user->ipc_msg_pri;
+	msg.extension.dat = ipc_user->ipc_msg_ext;
+
+	ipc_user->reply_ext = 0;
+
+	if (msg.primary.r.msg_tgt == SOF_IPC4_MESSAGE_TARGET_MODULE_MSG) {
+		/* Module message dispatch */
+		switch (msg.primary.r.type) {
+		case SOF_IPC4_MOD_CONFIG_GET:
+			result = ipc4_process_module_config(&msg, false,
+							    &ipc_user->reply_ext);
+			break;
+		case SOF_IPC4_MOD_CONFIG_SET:
+			result = ipc4_process_module_config(&msg, true, NULL);
+			break;
+		case SOF_IPC4_MOD_BIND: {
+			struct ipc4_module_bind_unbind bu;
+
+			result = memcpy_s(&bu, sizeof(bu), &msg, sizeof(msg));
+			if (result < 0)
+				break;
+
+			result = ipc_comp_connect(ipc_user->ipc,
+						  (ipc_pipe_comp_connect *)&bu);
+			break;
+		}
+		case SOF_IPC4_MOD_UNBIND: {
+			struct ipc4_module_bind_unbind bu;
+
+			result = memcpy_s(&bu, sizeof(bu), &msg, sizeof(msg));
+			if (result < 0)
+				break;
+
+			result = ipc_comp_disconnect(ipc_user->ipc,
+						     (ipc_pipe_comp_connect *)&bu);
+			break;
+		}
+		case SOF_IPC4_MOD_INIT_INSTANCE: {
+			/* User thread creates the component —
+			 * drv->ops.create() runs in user-space so untrusted
+			 * module code does not execute with kernel privileges.
+			 *
+			 * init_drv = original kernel pointer
+			 * init_drv_data = user-accessible copy
+			 */
+			const struct comp_driver *orig_drv = ipc_user->init_drv;
+			const struct comp_driver *drv_copy =
+				(const struct comp_driver *)ipc_user->init_drv_data;
+			struct comp_dev *dev;
+
+			ipc_user->init_drv = NULL;
+			if (!orig_drv) {
+				result = IPC4_MOD_NOT_INITIALIZED;
+				break;
+			}
+
+			dev = comp_new_ipc4_user(&msg, drv_copy);
+			if (!dev) {
+				result = IPC4_MOD_NOT_INITIALIZED;
+				break;
+			}
+
+			/* Restore original kernel driver pointer. comp_init()
+			 * set dev->drv to the copy; runtime code expects the
+			 * canonical kernel address.
+			 */
+			dev->drv = orig_drv;
+
+			result = ipc4_add_comp_dev(dev);
+			if (result != IPC4_SUCCESS)
+				break;
+
+			comp_update_ibs_obs_cpc(dev);
+			result = 0;
+			break;
+		}
+		case SOF_IPC4_MOD_DELETE_INSTANCE: {
+			struct ipc4_module_delete_instance module;
+			uint32_t comp_id;
+
+			memcpy_s(&module, sizeof(module), &msg, sizeof(msg));
+			comp_id = IPC4_COMP_ID(module.primary.r.module_id,
+					       module.primary.r.instance_id);
+			result = ipc_comp_free(ipc_user->ipc, comp_id);
+			if (result < 0)
+				result = IPC4_INVALID_RESOURCE_ID;
+			break;
+		}
+		case SOF_IPC4_MOD_LARGE_CONFIG_GET:
+			result = ipc4_process_large_config_get(&msg,
+							       &ipc_user->reply_ext,
+							       &ipc_user->reply_tx_size,
+							       &ipc_user->reply_tx_data);
+			break;
+		case SOF_IPC4_MOD_LARGE_CONFIG_SET:
+			result = ipc4_process_large_config_set(&msg);
+			break;
+		default:
+			LOG_ERR("IPC user: unsupported module cmd type %d",
+				msg.primary.r.type);
+			result = -EINVAL;
+			break;
+		}
+	} else {
+		/* Global message dispatch */
+		switch (msg.primary.r.type) {
+		case SOF_IPC4_GLB_CREATE_PIPELINE:
+			result = ipc_pipeline_new(ipc_user->ipc,
+						  (ipc_pipe_new *)&msg);
+			break;
+		case SOF_IPC4_GLB_DELETE_PIPELINE: {
+			struct ipc4_pipeline_delete *pipe =
+				(struct ipc4_pipeline_delete *)&msg;
+
+			result = ipc_pipeline_free(ipc_user->ipc,
+						   pipe->primary.r.instance_id);
+			break;
+		}
+		case SOF_IPC4_GLB_SET_PIPELINE_STATE:
+			result = ipc4_set_pipeline_state(&msg);
+			break;
+		default:
+			LOG_ERR("IPC user: unsupported glb cmd type %d",
+				msg.primary.r.type);
+			result = -EINVAL;
+			break;
+		}
+	}
+
+	return result;
+}
+#endif /* CONFIG_SOF_USERSPACE_LL */

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -572,7 +572,10 @@ __cold static struct comp_buffer *ipc4_create_buffer(struct comp_dev *src, bool 
 	ipc_buf.size = buf_size;
 	ipc_buf.comp.id = IPC4_COMP_ID(src_queue, dst_queue);
 	ipc_buf.comp.pipeline_id = src->ipc_config.pipeline_id;
-	ipc_buf.comp.core = cpu_get_id();
+
+	assert(IS_ENABLED(CONFIG_SOF_USERSPACE_LL) || src->ipc_config.core == cpu_get_id());
+	ipc_buf.comp.core = src->ipc_config.core;
+
 	return buffer_new(alloc, &ipc_buf, is_shared);
 }
 
@@ -715,6 +718,11 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 #else
 	alloc = NULL;
 #endif /* CONFIG_ZEPHYR_DP_SCHEDULER */
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+	if (!alloc)
+		alloc = ipc->ll_alloc;
+#endif
 	bool cross_core_bind = source->ipc_config.core != sink->ipc_config.core;
 
 	/* If both components are on same core -- process IPC on that core,

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -64,7 +64,6 @@ LOG_MODULE_DECLARE(ipc, CONFIG_SOF_LOG_LEVEL);
 extern struct tr_ctx comp_tr;
 
 static const struct comp_driver *ipc4_get_drv(const void *uuid);
-static int ipc4_add_comp_dev(struct comp_dev *dev);
 
 void ipc_build_stream_posn(struct sof_ipc_stream_posn *posn, uint32_t type,
 			   uint32_t id)
@@ -355,6 +354,7 @@ __cold static int ipc4_create_pipeline(struct ipc4_pipeline_create *pipe_desc,
 	struct ipc_comp_dev *ipc_pipe;
 	struct pipeline *pipe;
 	struct ipc *ipc = ipc_get();
+	struct k_heap *heap = sof_sys_user_heap_get();
 
 	assert_can_be_cold();
 
@@ -367,7 +367,7 @@ __cold static int ipc4_create_pipeline(struct ipc4_pipeline_create *pipe_desc,
 	}
 
 	/* create the pipeline */
-	pipe = pipeline_new(NULL, pipe_desc->primary.r.instance_id,
+	pipe = pipeline_new(heap, pipe_desc->primary.r.instance_id,
 			    pipe_desc->primary.r.ppl_priority, 0, pparams);
 	if (!pipe) {
 		tr_err(&ipc_tr, "ipc: pipeline_new() failed");
@@ -383,12 +383,13 @@ __cold static int ipc4_create_pipeline(struct ipc4_pipeline_create *pipe_desc,
 	pipe->core = pipe_desc->extension.r.core_id;
 
 	/* allocate the IPC pipeline container */
-	ipc_pipe = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
-			   sizeof(struct ipc_comp_dev));
+	ipc_pipe = sof_heap_alloc(heap, SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
+				  sizeof(struct ipc_comp_dev), 0);
 	if (!ipc_pipe) {
 		pipeline_free(pipe);
 		return IPC4_OUT_OF_MEMORY;
 	}
+	memset(ipc_pipe, 0, sizeof(*ipc_pipe));
 
 	ipc_pipe->pipeline = pipe;
 	ipc_pipe->type = COMP_TYPE_PIPELINE;
@@ -555,7 +556,7 @@ __cold int ipc_pipeline_free(struct ipc *ipc, uint32_t comp_id)
 
 	ipc_pipe->pipeline = NULL;
 	list_item_del(&ipc_pipe->list);
-	rfree(ipc_pipe);
+	sof_heap_free(sof_sys_user_heap_get(), ipc_pipe);
 
 	return IPC4_SUCCESS;
 }
@@ -1103,7 +1104,7 @@ __cold int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdm
 			if (icd->cd != dev)
 				continue;
 			list_item_del(&icd->list);
-			rfree(icd);
+			sof_heap_free(sof_sys_user_heap_get(), icd);
 			break;
 		}
 		comp_free(dev);
@@ -1319,7 +1320,7 @@ struct comp_dev *ipc4_get_comp_dev(uint32_t comp_id)
 }
 EXPORT_SYMBOL(ipc4_get_comp_dev);
 
-__cold static int ipc4_add_comp_dev(struct comp_dev *dev)
+__cold int ipc4_add_comp_dev(struct comp_dev *dev)
 {
 	struct ipc *ipc = ipc_get();
 	struct ipc_comp_dev *icd;
@@ -1334,12 +1335,13 @@ __cold static int ipc4_add_comp_dev(struct comp_dev *dev)
 	}
 
 	/* allocate the IPC component container */
-	icd = rzalloc(SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
-		      sizeof(struct ipc_comp_dev));
+	icd = sof_heap_alloc(sof_sys_user_heap_get(), SOF_MEM_FLAG_USER | SOF_MEM_FLAG_COHERENT,
+			     sizeof(struct ipc_comp_dev), 0);
 	if (!icd) {
 		tr_err(&ipc_tr, "alloc failed");
 		return IPC4_OUT_OF_MEMORY;
 	}
+	memset(icd, 0, sizeof(*icd));
 
 	icd->cd = dev;
 	icd->type = COMP_TYPE_COMPONENT;

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -222,6 +222,105 @@ __cold struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_i
 	return dev;
 }
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+/**
+ * comp_new_ipc4_user - Create component in user-space IPC thread context.
+ *
+ * Called from the user-space IPC thread. Receives a pre-resolved driver
+ * pointer from the kernel handler. Performs IPC4 message parsing, HOSTBOX
+ * data read, and calls drv->ops.create() in user-space context.
+ *
+ * @param ipc4 IPC4 message request (reconstructed from ipc_user pri/ext words)
+ * @param drv  Component driver resolved by kernel via ipc4_get_comp_drv()
+ * @return Created component device, or NULL on failure
+ */
+__cold struct comp_dev *comp_new_ipc4_user(struct ipc4_message_request *ipc4,
+					   const struct comp_driver *drv)
+{
+	struct ipc4_module_init_instance module_init;
+	struct comp_ipc_config ipc_config;
+	struct comp_dev *dev;
+	uint32_t comp_id;
+	char *data;
+	int ret;
+
+	assert_can_be_cold();
+
+	ret = memcpy_s(&module_init, sizeof(module_init), ipc4, sizeof(*ipc4));
+	if (ret < 0)
+		return NULL;
+
+	comp_id = IPC4_COMP_ID(module_init.primary.r.module_id,
+			       module_init.primary.r.instance_id);
+
+	if (ipc4_get_comp_dev(comp_id)) {
+		tr_err(&ipc_tr, "comp 0x%x exists", comp_id);
+		return NULL;
+	}
+
+	if (module_init.extension.r.core_id >= CONFIG_CORE_COUNT) {
+		tr_err(&ipc_tr, "ipc: comp->core = %u",
+		       (uint32_t)module_init.extension.r.core_id);
+		return NULL;
+	}
+
+	memset(&ipc_config, 0, sizeof(ipc_config));
+	ipc_config.id = comp_id;
+	ipc_config.pipeline_id = module_init.extension.r.ppl_instance_id;
+	ipc_config.core = module_init.extension.r.core_id;
+	ipc_config.ipc_config_size =
+		module_init.extension.r.param_block_size * sizeof(uint32_t);
+	ipc_config.ipc_extended_init = module_init.extension.r.extended_init;
+	if (ipc_config.ipc_config_size > MAILBOX_HOSTBOX_SIZE) {
+		tr_err(&ipc_tr,
+		       "IPC payload size %u too big for the message window",
+		       ipc_config.ipc_config_size);
+		return NULL;
+	}
+#ifdef CONFIG_DCACHE_LINE_SIZE
+	if (!IS_ENABLED(CONFIG_LIBRARY))
+		sys_cache_data_invd_range(
+			(__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
+			ALIGN_UP(ipc_config.ipc_config_size,
+				 CONFIG_DCACHE_LINE_SIZE));
+#endif
+	data = ipc4_get_comp_new_data();
+
+#if CONFIG_ZEPHYR_DP_SCHEDULER
+	if (module_init.extension.r.proc_domain)
+		ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_DP;
+	else
+		ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
+#else
+	if (module_init.extension.r.proc_domain) {
+		tr_err(&ipc_tr,
+		       "ipc: DP scheduling is disabled, cannot create comp 0x%x",
+		       comp_id);
+		return NULL;
+	}
+	ipc_config.proc_domain = COMP_PROCESSING_DOMAIN_LL;
+#endif
+
+	if (drv->type == SOF_COMP_MODULE_ADAPTER) {
+		const struct ipc_config_process spec = {
+			.data = (const unsigned char *)data,
+			.size = ipc_config.ipc_config_size,
+		};
+
+		dev = drv->ops.create(drv, &ipc_config, (const void *)&spec);
+	} else {
+		dev = drv->ops.create(drv, &ipc_config, (const void *)data);
+	}
+	if (!dev)
+		return NULL;
+
+	list_init(&dev->bsource_list);
+	list_init(&dev->bsink_list);
+
+	return dev;
+}
+#endif /* CONFIG_SOF_USERSPACE_LL */
+
 /* Called from ipc4_set_pipeline_state(), so cannot be cold */
 struct ipc_comp_dev *ipc_get_comp_by_ppl_id(struct ipc *ipc, uint16_t type,
 					    uint32_t ppl_id,

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -625,6 +625,13 @@ struct task *zephyr_ll_task_alloc(void)
 	return task;
 }
 
+void user_ll_grant_access(struct k_thread *thread, int core)
+{
+	assert(core < CONFIG_CORE_COUNT && zephyr_ll_locks[core] != NULL);
+
+	k_thread_access_grant(thread, zephyr_ll_locks[core]);
+}
+
 /**
  * Lock the LL scheduler to prevent it from processing tasks.
  *

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -622,6 +622,8 @@ zephyr_library_sources_ifdef(CONFIG_SHELL
 
 zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/audio/module_adapter/module/generic.h)
 zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/lib/fast-get.h)
+zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/ipc/ipc_reply.h)
+zephyr_syscall_header(${SOF_SRC_PATH}/include/ipc4/handler.h)
 zephyr_syscall_header(include/rtos/alloc.h)
 zephyr_library_sources_ifdef(CONFIG_SOF_USERSPACE_INTERFACE_ALLOC syscall/alloc.c)
 zephyr_syscall_header(${SOF_SRC_PATH}/include/sof/lib/dai-zephyr.h)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -327,3 +327,11 @@ config STACK_SIZE_IPC_TX
 	default 2048
 	help
 	  IPC sender work-queue thread stack size. Keep a power of 2.
+
+config SOF_IPC_USER_THREAD_STACK_SIZE
+	int "IPC user thread stack size"
+	default 8192
+	depends on SOF_USERSPACE_LL
+	help
+	  Stack size for the userspace IPC thread.
+	  Keep a power of 2.

--- a/zephyr/include/rtos/sof.h
+++ b/zephyr/include/rtos/sof.h
@@ -46,8 +46,10 @@ struct sof {
 	int argc;
 	char **argv;
 
+#ifndef CONFIG_SOF_USERSPACE_LL
 	/* ipc */
 	struct ipc *ipc;
+#endif
 
 	/* system agent */
 	struct sa *sa;

--- a/zephyr/lib/userspace_helper.c
+++ b/zephyr/lib/userspace_helper.c
@@ -110,6 +110,39 @@ int user_access_to_mailbox(struct k_mem_domain *domain, k_tid_t thread_id)
 	if (ret < 0)
 		return ret;
 
+#if defined(CONFIG_SOF_USERSPACE_LL) && defined(CONFIG_IPC_MAJOR_4)
+	/* HOSTBOX partitions for IPC4 module init parameter block reads.
+	 * comp_new_ipc4() accesses MAILBOX_HOSTBOX_BASE directly to get
+	 * the module configuration data sent by the host.
+	 */
+	struct k_mem_partition hostbox_partition;
+
+	/* Uncached HOSTBOX partition */
+	hostbox_partition.start =
+		(uintptr_t)sys_cache_uncached_ptr_get((void __sparse_cache *)MAILBOX_HOSTBOX_BASE);
+	hostbox_partition.size = ALIGN_UP(MAILBOX_HOSTBOX_SIZE,
+					  CONFIG_MMU_PAGE_SIZE);
+	hostbox_partition.attr = K_MEM_PARTITION_P_RO_U_RO;
+
+	ret = k_mem_domain_add_partition(domain, &hostbox_partition);
+	if (ret < 0)
+		return ret;
+
+	/* Cached HOSTBOX partition for cache invalidation path.
+	 * sys_cache_data_invd_range() syscall verification requires
+	 * write access to the region, so use RW instead of RO.
+	 */
+	hostbox_partition.start =
+		(uintptr_t)sys_cache_cached_ptr_get((void *)MAILBOX_HOSTBOX_BASE);
+	hostbox_partition.size = ALIGN_UP(MAILBOX_HOSTBOX_SIZE,
+					  CONFIG_MMU_PAGE_SIZE);
+	hostbox_partition.attr = K_MEM_PARTITION_P_RW_U_RW;
+
+	ret = k_mem_domain_add_partition(domain, &hostbox_partition);
+	if (ret < 0)
+		return ret;
+#endif /* CONFIG_IPC_MAJOR_4 */
+
 #ifndef CONFIG_IPC_MAJOR_4
 	/*
 	 * Next mailbox_stream (not available in IPC4). Stream access is cached,


### PR DESCRIPTION
This PR contains one of the remaining big subsets from https://github.com/thesofproject/sof/pull/10558 and implements ability to handle a subset of IPC in a Zephyr user-space thread. This is an important enabler for running the SOF audio pipelines in user-space and allows us to run all audio module code in user context (including the module initialization and configuration functions).

This PR has no impact to default SOF builds where LL audio pipelines are run in kernel space.