### PR TITLE
audio: mixin_mixout: Correct underrun notification parameter

### DIFF
--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -270,7 +270,7 @@ static void mixin_check_notify_underrun(struct comp_dev *dev, struct mixin_data 
 		    (eos_detected && mixin_data->eos_delay_periods == 0)) {
 			mixin_data->last_reported_underrun = 0;
 
-			send_mixer_underrun_notif_msg(dev->ipc_config.id, eos_detected,
+			send_mixer_underrun_notif_msg(dev->pipeline->pipeline_id, eos_detected,
 						      source_avail, sinks_free);
 		}
 	}


### PR DESCRIPTION
The MIXER_UNDERRUN_DETECTED notification is initialized to carry the pipeline_id (SOF_IPC4_PIPELINE) as resource, not the module_id.