### PR TITLE
west.yml: update zephyr to 3841a72452ec

### DIFF
--- a/src/init/init.c
+++ b/src/init/init.c
@@ -41,7 +41,7 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <user/abi_dbg.h>
 #include <sof_versions.h>
-#include <version.h>
+#include <zephyr/version.h>
 #endif
 #include <sof/lib/ams.h>
 

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -330,10 +330,12 @@ __cold int ipc_init(struct sof *sof)
 #endif
 
 #ifdef __ZEPHYR__
-	struct k_thread *thread = &sof->ipc->ipc_send_wq.thread;
+	k_tid_t thread;
 
 	k_work_queue_start(&sof->ipc->ipc_send_wq, ipc_send_wq_stack,
 			   K_THREAD_STACK_SIZEOF(ipc_send_wq_stack), 1, NULL);
+
+	thread = k_work_queue_thread_get(&sof->ipc->ipc_send_wq);
 
 	k_thread_suspend(thread);
 

--- a/src/ipc/ipc-zephyr.c
+++ b/src/ipc/ipc-zephyr.c
@@ -9,7 +9,7 @@
 //         Andrey Borisovich <andrey.borisovich@intel.com>
 //         Adrian Warecki <adrian.warecki@intel.com>
 
-#include <autoconf.h>
+#include <zephyr/autoconf.h>
 
 #include <zephyr/kernel.h>
 #include <zephyr/ipc/ipc_service.h>

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -30,7 +30,7 @@
 #include <sof_versions.h>
 
 #ifdef __ZEPHYR__
-#include <version.h>
+#include <zephyr/version.h>
 #endif
 
 #include <errno.h>

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: ee13f80fd5ede26838d461914858b9cc8cdb652f
+      revision: 3841a72452ec13ff7a0a5df14f514e7870b71817
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -102,7 +102,7 @@ static struct scheduler_ops schedule_edf_ops = {
 
 __cold int scheduler_init_edf(void)
 {
-	struct k_thread *thread = &edf_workq.thread;
+	k_tid_t thread;
 
 	assert_can_be_cold();
 
@@ -113,6 +113,7 @@ __cold int scheduler_init_edf(void)
 		       K_THREAD_STACK_SIZEOF(edf_workq_stack),
 		       CONFIG_EDF_THREAD_PRIORITY, NULL);
 
+	thread = k_work_queue_thread_get(&edf_workq);
 	k_thread_suspend(thread);
 
 	k_thread_heap_assign(thread, sof_sys_heap_get());

--- a/zephyr/lib/alloc.c
+++ b/zephyr/lib/alloc.c
@@ -37,7 +37,7 @@ struct vmh_heap *virtual_buffers_heap;
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/cache.h>
 

--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -27,7 +27,7 @@ static uint32_t mic_disable_status;
 #include "../audio/copier/copier.h"
 
 /* Zephyr includes */
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel/smp.h>
 #include <zephyr/device.h>

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -33,7 +33,7 @@
 #include <zephyr/kernel_structs.h>
 #include <zephyr/kernel.h>
 #include <zephyr/pm/policy.h>
-#include <version.h>
+#include <zephyr/version.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Total of 2048 commits.

Changes include:

940b0f0e7f54 soc: intel_adsp: fix xtensa gdbstub include guard check
e7893844b769 xtensa: remove dead z_arch_irq_connect_dynamic
c21da807a929 arch: replace SEMIHOST arch allowlist with capability
2fbba5e3e434 arch: replace IRQ_OFFLOAD_NESTED arch allowlist with capability
ab77c8c5e520 soc intel ace: Add missing type in kconfig option
46c81149a9f8 drivers: dai: amd: tdm: add ACP 7.X TDM DAI support
22ed52d7b05d drivers: clock_control: mcxw7x: fix OSC32K load cap and coarse gain
c5581fa077cf boards: nxp: imx9: sort supported list in alphabetical order
995e7184b438 dts: arm: nxp: imx952: Add #address-cells to IRQSTEER masters
8a7d57090d4b dts: nxp: imx952: add and enable SAR ADC node
266e2d074ce3 dts: nxp: fix TSTMR clock-frequency to 24 MHz on i.MX93/943/95/952
a6771bc5b1db boards: nxp: imx943_evk: disable tstmr1 on M33
5295cb345bd7 llext: support word granular access instr mem for xtensa
704582eaf665 boards: imx952_evk: add A55 and A55 SMP platform
9e5b1b7292e2 dts: arm64: imx952: add SoC dts for A55
2d3595e069ad soc: imx952: add A55 CPU Core support
3e8cfffcbc67 logging: Do not enable CONFIG_LOG_PRINTK_STATIC by default
e9515593ac48 boards: imx91/imx93: change to use fixed cache line size
458f4942893b logging: Add option to process printk using static macros
2e12489176e3 dts: nxp: mcx: add EQDC and INPUTMUX nodes for MCXA
6e7ecd679171 soc: nxp: imxrt6xx: use zephyr/ prefix for autoconf.h include
0f25a5b270df boards: imx95_evk: m7: fix PTP clock using for ENETC
1cb78d368a1b drivers: timer: add NXP RTC (rtc_jdp) system timer
218392538cb1 soc: intel: Fix missing zephyr/ include path
255fe93214f5 soc: intel_adsp: include DATA_SECTIONS linker snippet
217e2913a1c0 lib: heap: kasan: lightweight heap write sanitizer for sys_heap
aa014f60b5d3 lib: heap: use single evaluation min
a4b895017c06 boards: nxp: frdm_mcxaxx6: add lpdac support
ba8bb9a20f97 arch: xtensa: change backtrace to use EXCEPTION_DUMP
7037755650ea boards: mcx_nx4x_evk: enable lpcmp for mcx_n5xx_evk
c0f0fed6eef1 boards: nxp: mimxrt1180_evk: fix cm7 dtcm/itcm region overlap
a85e1787bfc1 logging: mtrace: add support for multi slot logging
b0b25c35c945 drivers: use <> to include Zephyr headers instead of ""
b9c925c8e6ee drivers: counter: native_sim: add capture emulator
6a68a214a9a9 logging: frontends: stmesp_demux: Increase robustness
e3c6b5340d77 logging: frontend: stmesp: Add flag indicating presence of hexdump data
bc594b461c28 arch: xtensa: extend syscall helper to invoke levels 0-3
5cba4b75e82d lib: heap: add ASAN poisoning backend for sys_heap
f82e45c6d375 lib: heap: add sanitizer hook for sys_heap
1824b00efda5 lib: heap: use uppercase MIN macro in realloc paths
751e074ab9fe include: logging: backends: complete coverage and tidy titles
21958f13cf1a dts: amd: acp_7_x: add TDM DAI and DMA device tree nodes
a445f3183076 soc: amd: acp_7_x: add TDM register definitions and context struct
96b0ba14d97d manifest: hal_nxp: update revision for FW blob update
d33280510ab7 kernel: timeout: add bucketed delta-list backend
e0244d279b47 kernel: timeout: add timer-wheel backend
5188d5009b02 kernel: timeout: add min-heap backend
e4b928ef193c sys: min_heap: add reference (handle-based) min-heap variant
b381345043fc kernel: timeout: factor delta-list queue into a pluggable backend
b04eb25b7865 include: zephyr: toolchain: Rename header file guard macros
fd451c283dde tracing: user: expose kernel-object hooks as weak callbacks
cb01fb4245b8 boards: *: dmic: add dmic-dev alias
1e265cf77632 kernel: kheap: keep static heap init as a PRE_KERNEL_1 SYS_INIT
3a1d70f4509a kernel: kheap, mem_slab, mailbox: use kernel init hooks
ec46c494a9e8 drivers: sdhc: imx_usdhc: revert Zephyr-side cache maintenance
662334aca482 west.yml: update hal_nxp for imx952 a55
fe025522fe64 manifest: hal_nxp: update revision for raw scan result support
11ebcf851a62 drivers: timer: simplify skip/inverted K_TICKS_FOREVER guards
bbf9caf996d7 drivers: timer: drop dead K_TICKS_FOREVER tick clamps
4ee67656ba2f dts: xtensa: use diamond include for non-local header files
7fd275e80093 drivers: clock_control: mcux_syscon: fix I3C freq for MCXAXX7
b25b70cec710 drivers: counter: add NXP TSTMR counter driver
43140f1760f5 doc: security: Disclose CVE-2026-10635
5e1afeaad6d3 modules: hal_nxp: add RPMSG-Lite build integration
b6fe144fb9f4 ipc: service: backends: add RPMSG-Lite backend
a78111b4d85d manifest: hal_nxp: update revision to fix PM3 entry failure