### PR TITLE
zephyr: remove k_thread_cpu_mask_clear() calls

### DIFF
--- a/src/schedule/zephyr_dma_domain.c
+++ b/src/schedule/zephyr_dma_domain.c
@@ -462,8 +462,7 @@ static int zephyr_dma_domain_register(struct ll_schedule_domain *domain,
 				 K_FOREVER);
 
 #ifdef CONFIG_SCHED_CPU_MASK
-	k_thread_cpu_mask_clear(thread);
-	k_thread_cpu_mask_enable(thread, core);
+	k_thread_cpu_pin(thread, core);
 #endif
 	k_thread_name_set(thread, thread_name);
 

--- a/src/schedule/zephyr_domain.c
+++ b/src/schedule/zephyr_domain.c
@@ -218,8 +218,7 @@ static int zephyr_domain_register(struct ll_schedule_domain *domain,
 				 NULL, CONFIG_LL_THREAD_PRIORITY, 0, K_FOREVER);
 
 #ifdef CONFIG_SCHED_CPU_MASK
-	k_thread_cpu_mask_clear(thread);
-	k_thread_cpu_mask_enable(thread, core);
+	k_thread_cpu_pin(thread, core);
 #endif
 	k_thread_name_set(thread, thread_name);
 
@@ -345,8 +344,7 @@ static int zephyr_domain_thread_init(struct ll_schedule_domain *domain,
 				 K_USER, K_FOREVER);
 
 #ifdef CONFIG_SCHED_CPU_MASK
-	k_thread_cpu_mask_clear(thread);
-	k_thread_cpu_mask_enable(thread, core);
+	k_thread_cpu_pin(thread, core);
 #endif
 	k_thread_name_set(thread, thread_name);
 

--- a/zephyr/edf_schedule.c
+++ b/zephyr/edf_schedule.c
@@ -117,8 +117,7 @@ __cold int scheduler_init_edf(void)
 
 	k_thread_heap_assign(thread, sof_sys_heap_get());
 #ifdef CONFIG_SCHED_CPU_MASK
-	k_thread_cpu_mask_clear(thread);
-	k_thread_cpu_mask_enable(thread, PLATFORM_PRIMARY_CORE_ID);
+	k_thread_cpu_pin(thread, PLATFORM_PRIMARY_CORE_ID);
 #endif
 	k_thread_name_set(thread, "edf_workq");
 


### PR DESCRIPTION
When CONFIG_SCHED_CPU_MASK_PIN_ONLY is enabled, an empty CPU mask is not allowed. Calling k_thread_cpu_mask_clear() triggers an assertion, which causes firmware boot failure when CONFIG_ASSERT is enabled.

Use k_thread_cpu_pin() instead.