### PR TITLE
chain-dma: fix NULL dereference

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -132,7 +132,7 @@ static void zephyr_ll_task_done(struct zephyr_ll *sch,
 
 	task->state = SOF_TASK_STATE_FREE;
 
-	if (pdata->freeing)
+	if (pdata && pdata->freeing)
 		/*
 		 * zephyr_ll_task_free() is trying to free this task. Complete
 		 * it and signal the semaphore to let the function proceed
@@ -258,7 +258,7 @@ static void zephyr_ll_run(void *data)
 		task = container_of(list, struct task, list);
 		pdata = task->priv_data;
 
-		if (task->state == SOF_TASK_STATE_CANCEL) {
+		if (!pdata || task->state == SOF_TASK_STATE_CANCEL) {
 			list = list->next;
 			zephyr_ll_task_done(sch, task);
 			continue;


### PR DESCRIPTION
Fix a NULL dereference when terminating a chain-dma stream after schedule_task_free() has been called from chain_task_pause().

If somebody can fix chain DMA instead to not leave the task running after it's freed, that might be a preferred solution