### PR TITLE
platform: ace: watchdog: send primary timeout via ipc_service critica…

### DIFF
--- a/src/platform/intel/ace/lib/watchdog.c
+++ b/src/platform/intel/ace/lib/watchdog.c
@@ -9,6 +9,7 @@
 #include <sof/lib/uuid.h>
 #include <rtos/idc.h>
 #include <sof/schedule/ll_schedule_domain.h>
+#include <sof/ipc/driver.h>
 #include <sof/ipc/msg.h>
 #include <ipc4/notification.h>
 
@@ -17,8 +18,6 @@
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adsp_watchdog), okay)
 #include <adsp_watchdog.h>
-#include <intel_adsp_ipc.h>
-#include <intel_adsp_ipc_devtree.h>
 
 LOG_MODULE_REGISTER(wdt, CONFIG_SOF_LOG_LEVEL);
 
@@ -27,6 +26,7 @@ SOF_DEFINE_REG_UUID(wdt);
 DECLARE_TR_CTX(wdt_tr, SOF_UUID(wdt_uuid), LOG_LEVEL_INFO);
 
 static const struct device *const watchdog = DEVICE_DT_GET(DT_NODELABEL(adsp_watchdog));
+static struct ipc_msg primary_timeout_ipc;
 static struct ipc_msg secondary_timeout_ipc;
 
 static void watchdog_primary_core_action_on_timeout(void)
@@ -35,8 +35,15 @@ static void watchdog_primary_core_action_on_timeout(void)
 
 	/* Send Watchdog Timeout IPC notification */
 	ipc4_notification_watchdog_init(&notif, cpu_get_id(), true);
-	intel_adsp_ipc_send_message_emergency(INTEL_ADSP_IPC_HOST_DEV,
-					      notif.primary.dat, notif.extension.dat);
+	primary_timeout_ipc.header = notif.primary.dat;
+	primary_timeout_ipc.extension = notif.extension.dat;
+
+	/*
+	 * The primary core low latency scheduler is stalled, so bypass the IPC
+	 * queue and push the notification straight to the host using the direct
+	 * (critical) send path.
+	 */
+	ipc_platform_send_msg_direct(&primary_timeout_ipc);
 }
 
 static void watchdog_secondary_core_action_on_timeout(void)
@@ -82,6 +89,10 @@ __cold void watchdog_init(void)
 	};
 
 	assert_can_be_cold();
+
+	primary_timeout_ipc.tx_data = NULL;
+	primary_timeout_ipc.tx_size = 0;
+	list_init(&primary_timeout_ipc.list);
 
 	secondary_timeout_ipc.tx_data = NULL;
 	secondary_timeout_ipc.tx_size = 0;


### PR DESCRIPTION
…l send

The primary-core watchdog timeout notification used the deprecated old-interface call intel_adsp_ipc_send_message_emergency() together with the Intel-specific INTEL_ADSP_IPC_HOST_DEV device handle.

Route it instead through the generic ipc_platform_send_msg_direct(), which maps to ipc_service_send_critical() and the backend critical/emergency send, identical register behaviour (busy-wait, no ack, bypasses flow control), but expressed with the backend-agnostic ipc_service API and a struct ipc_msg, mirroring the secondary-core path.

This removes the watchdog's dependency on the old interface and on the Intel host IPC device macro, dropping the intel_adsp_ipc*.h includes.