### PR TITLE
app: debug_stream_overlay.conf: Remove XTENSA_BACKTRACE_EXCEPTION_DUMP

### DIFF
--- a/app/debug_stream_overlay.conf
+++ b/app/debug_stream_overlay.conf
@@ -37,5 +37,4 @@ CONFIG_SOF_TELEMETRY_IO_PERFORMANCE_MEASUREMENTS=n
 CONFIG_EXCEPTION_DUMP_HOOK=y
 # Do not try to send exception prints through logs; this causes problems on PTL with mtrace
 CONFIG_EXCEPTION_DUMP_HOOK_ONLY=y
-# Print also backtrace through the exception hook
-CONFIG_XTENSA_BACKTRACE_EXCEPTION_DUMP_HOOK=y
+


### PR DESCRIPTION
Remove XTENSA_BACKTRACE_EXCEPTION_DUMP option from debug_stream_overlay.conf since its removed from Zephyr in commit:

ba8bb9a20f97 arch: xtensa: change backtrace to use EXCEPTION_DUMP