### PR TITLE
west.yml: update zephyr to 9885b002c1bd

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 3841a72452ec13ff7a0a5df14f514e7870b71817
+      revision: 9885b002c1bdfd520355de44daa34edefc86f9e6
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Total of 821 commits.

Changes include:

21a30f3f9a62 llext: correct got entry reads in xtensa elf
e0f04c284729 Revert "kernel: timeout: add sys_clock_idle_enter() for low-power idle handoff"
7d0bb85adc29 kernel: timeout: add sys_clock_idle_enter() for low-power idle handoff
3e93f462ac41 soc: nxp: use diamond include for non-local header files
a77fc1e6e870 boards: nxp: use diamond include for non-local header files
eec6a8f52a63 arch: x86, xtensa: support the idle-hook CPU load backend
25d08114e92e arch: gate idle notification hooks on SYS_IDLE_HOOKS
b8585ef254c1 soc: intel: use diamond include for non-local header files
715e6c494266 dts: arm: use diamond include for non-local header files
6e245d5d3704 lib/sys: add sys prefix to word granular access functions
439718a59814 xtensa: remove CPU mask pin only special code path
539fec76a346 logging: widen raw timestamp format to full uint width
c1c448133b57 modules: hal_nxp: fix i.MX943 Cortex-A device build
5c1758aed791 west.yml: remove unused files from hal_nxp
11b534905147 drivers: timer: declare 64-bit counter widths to the generic core
0bbd4843faa3 drivers: timer: fix the equality-match compare catch-up livelock
72d14283bda2 drivers: timer: intel_adsp_timer: use the generic timer core
e8163a10525e drivers: timer: native_sim_timer: use the generic timer core
4b0877cebe95 drivers: timer: xtensa_sys_timer: use the generic timer core
945af04840a2 lib: os: cpu_load: close the idle window at ISR entry
3244b759ddf3 Revert "west.yml: update hal nxp to the latest version"
a9f8e1a2391f west.yml: update hal nxp to the latest version