### PR TITLE
intel: platform: use Kconfig for IDC stack size

### DIFF
--- a/src/platform/ace30/include/platform/lib/memory.h
+++ b/src/platform/ace30/include/platform/lib/memory.h
@@ -42,7 +42,7 @@
 #define SRAM_STREAM_SIZE		0x1000
 
 /* Stack configuration */
-#define SOF_STACK_SIZE			0x1000
+#define SOF_STACK_SIZE			CONFIG_SOF_STACK_SIZE
 
 #define PLATFORM_HEAP_SYSTEM		CONFIG_CORE_COUNT /* one per core */
 #define PLATFORM_HEAP_SYSTEM_RUNTIME	CONFIG_CORE_COUNT /* one per core */

--- a/src/platform/lunarlake/include/platform/lib/memory.h
+++ b/src/platform/lunarlake/include/platform/lib/memory.h
@@ -44,7 +44,7 @@
 #define SRAM_STREAM_SIZE		0x1000
 
 /* Stack configuration */
-#define SOF_STACK_SIZE			0x1000
+#define SOF_STACK_SIZE			CONFIG_SOF_STACK_SIZE
 
 #define PLATFORM_HEAP_SYSTEM		CONFIG_CORE_COUNT /* one per core */
 #define PLATFORM_HEAP_SYSTEM_RUNTIME	CONFIG_CORE_COUNT /* one per core */

--- a/src/platform/meteorlake/include/platform/lib/memory.h
+++ b/src/platform/meteorlake/include/platform/lib/memory.h
@@ -44,7 +44,7 @@
 #define SRAM_STREAM_SIZE		0x1000
 
 /* Stack configuration */
-#define SOF_STACK_SIZE			0x1000
+#define SOF_STACK_SIZE			CONFIG_SOF_STACK_SIZE
 
 #define PLATFORM_HEAP_SYSTEM		CONFIG_CORE_COUNT /* one per core */
 #define PLATFORM_HEAP_SYSTEM_RUNTIME	CONFIG_CORE_COUNT /* one per core */


### PR DESCRIPTION
On Intel platforms, SOF_STACK_SIZE is only used to define the IDC worker thread stack size. However, a Kconfig option, CONFIG_SOF_STACK_SIZE, already exists. On some platforms, the IDC worker thread stack size was hard-coded in memory.h, which appears to have been an oversight.

The default value of CONFIG_SOF_STACK_SIZE is 4096, but it is increased to 8192 for the PTL board and in some overlays, such as the MTL DAX overlay. Therefore, this change also increases the IDC worker thread stack size for those configurations.