### PR TITLE
Revert "schedule: zephyr_ll: convert pdata->sem into sys_sem"

### DIFF
--- a/posix/include/rtos/mutex.h
+++ b/posix/include/rtos/mutex.h
@@ -62,25 +62,4 @@ static inline int sys_mutex_unlock(struct sys_mutex *mutex)
 	return 0;
 }
 
-/* provide a no-op implementation for zephyr/sys/sem.h */
-
-struct sys_sem {
-};
-
-static inline int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
-			       unsigned int limit)
-{
-	return 0;
-}
-
-static inline int sys_sem_give(struct sys_sem *sem)
-{
-	return 0;
-}
-
-static inline int sys_sem_take(struct sys_sem *sem, k_timeout_t timeout)
-{
-	return 0;
-}
-
 #endif

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -16,7 +16,6 @@
 #include <rtos/task.h>
 #include <sof/lib/perf_cnt.h>
 #include <zephyr/kernel.h>
-#include <zephyr/sys/sem.h>
 #include <ipc4/base_fw.h>
 #include <sof/debug/telemetry/telemetry.h>
 
@@ -42,7 +41,7 @@ struct zephyr_ll {
 struct zephyr_ll_pdata {
 	bool run;
 	bool freeing;
-	struct sys_sem sem;
+	struct k_sem sem;
 };
 
 #if CONFIG_SOF_USERSPACE_LL
@@ -137,7 +136,7 @@ static void zephyr_ll_task_done(struct zephyr_ll *sch,
 		 * zephyr_ll_task_free() is trying to free this task. Complete
 		 * it and signal the semaphore to let the function proceed
 		 */
-		sys_sem_give(&pdata->sem);
+		k_sem_give(&pdata->sem);
 
 	tr_info(&ll_tr, "task complete %p %pU", task, task->uid);
 	tr_info(&ll_tr, "num_tasks %d total_num_tasks %ld",
@@ -506,7 +505,7 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 
 	if (must_wait)
 		/* Wait for up to 100 periods */
-		sys_sem_take(&pdata->sem, K_USEC(LL_TIMER_PERIOD_US * 100));
+		k_sem_take(&pdata->sem, K_USEC(LL_TIMER_PERIOD_US * 100));
 
 	/* Protect against racing with schedule_task() */
 	zephyr_ll_lock(sch, &flags);
@@ -699,7 +698,7 @@ int zephyr_ll_task_init(struct task *task,
 
 	memset(pdata, 0, sizeof(*pdata));
 
-	sys_sem_init(&pdata->sem, 0, 1);
+	k_sem_init(&pdata->sem, 0, 1);
 
 	task->priv_data = pdata;
 


### PR DESCRIPTION
This reverts commit 48cdc4d5cb31684ca2a34a4116a7a19c67e2ba56. struct sys_sem cannot be on heap and we can have many LL tasks so using a statically allocated pool of them doesn't look like a good idea either. Using k_sem is slower, but so far there don't seem to be good alternatives to that.