### PR TITLE
topology2: sdw-jack-generic: Make BE DAI and copiers honor SDW_JACK_C…

### DIFF
--- a/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
+++ b/tools/topology/topology2/platform/intel/sdw-jack-generic.conf
@@ -38,7 +38,8 @@ Object.Dai.ALH [
 		name		$SDW_JACK_IN_STREAM
 		default_hw_conf_id	0
 		rate			$JACK_RATE
-		channels		2
+		channels		$SDW_JACK_CAPTURE_CH
+
 
 		Object.Base.hw_config.1 {
 			id	0
@@ -344,8 +345,15 @@ Object.Pipeline.host-gateway-capture [
 			Object.Base.input_audio_format [
 				{
 					in_rate			$JACK_RATE
+					in_channels		$SDW_JACK_CAPTURE_CH
 					in_bit_depth 32
 					in_valid_bit_depth 32
+					IncludeByKey.SDW_JACK_CAPTURE_CH {
+						"1" {
+							in_ch_map		$CHANNEL_MAP_MONO
+							in_ch_cfg		$CHANNEL_CONFIG_MONO
+						}
+					}
 				}
 			]
 			IncludeByKey.PCM_FORMAT_ALL {
@@ -354,30 +362,65 @@ Object.Pipeline.host-gateway-capture [
 					Object.Base.output_audio_format [
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		16
 							out_valid_bit_depth	16
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		32
 							out_valid_bit_depth	24
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		32
 							out_valid_bit_depth	32
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		32
 							out_valid_bit_depth	32
 							out_sample_type		$SAMPLE_TYPE_FLOAT
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		8
 							out_valid_bit_depth	8
 							out_sample_type		$SAMPLE_TYPE_UNSIGNED_INTEGER
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 					]
 				}
@@ -386,18 +429,39 @@ Object.Pipeline.host-gateway-capture [
 					Object.Base.output_audio_format [
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		16
 							out_valid_bit_depth	16
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		32
 							out_valid_bit_depth	24
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 						{
 							out_rate		$JACK_RATE
+							out_channels		$SDW_JACK_CAPTURE_CH
 							out_bit_depth		32
 							out_valid_bit_depth	32
+							IncludeByKey.SDW_JACK_CAPTURE_CH {
+								"1" {
+									out_ch_map		$CHANNEL_MAP_MONO
+									out_ch_cfg		$CHANNEL_CONFIG_MONO
+								}
+							}
 						}
 					]
 				}
@@ -444,17 +508,31 @@ Object.Widget {
 			Object.Base.input_audio_format [
 				{
 					in_rate			$JACK_RATE
+					in_channels		$SDW_JACK_CAPTURE_CH
 					in_bit_depth		32
 					in_valid_bit_depth	$SDW_LINK_VALID_BITS
 					in_sample_type		$SAMPLE_TYPE_MSB_INTEGER
 					in_fmt_cfg		"$[($in_channels | ($in_valid_bit_depth * 256))]"
+					IncludeByKey.SDW_JACK_CAPTURE_CH {
+						"1" {
+							in_ch_map		$CHANNEL_MAP_MONO
+							in_ch_cfg		$CHANNEL_CONFIG_MONO
+						}
+					}
 				}
 			]
 			Object.Base.output_audio_format [
 				{
 					out_rate		$JACK_RATE
+					out_channels		$SDW_JACK_CAPTURE_CH
 					out_bit_depth		32
 					out_valid_bit_depth	32
+					IncludeByKey.SDW_JACK_CAPTURE_CH {
+						"1" {
+							out_ch_map		$CHANNEL_MAP_MONO
+							out_ch_cfg		$CHANNEL_CONFIG_MONO
+						}
+					}
 				}
 			]
 		}
@@ -478,6 +556,7 @@ Object.Widget {
 							Object.Base.input_audio_format [
 								{
 									in_rate			$JACK_RATE
+									in_channels		$SDW_JACK_CAPTURE_CH
 									in_bit_depth		32
 									in_valid_bit_depth	32
 								}
@@ -485,6 +564,7 @@ Object.Widget {
 							Object.Base.output_audio_format [
 								{
 									out_rate		$JACK_RATE
+									out_channels		$SDW_JACK_CAPTURE_CH
 									out_bit_depth		32
 									out_valid_bit_depth	32
 								}
@@ -505,6 +585,7 @@ Object.Widget {
 							Object.Base.input_audio_format [
 								{
 									in_rate			$JACK_RATE
+									in_channels		$SDW_JACK_CAPTURE_CH
 									in_bit_depth		32
 									in_valid_bit_depth	32
 								}
@@ -512,6 +593,7 @@ Object.Widget {
 							Object.Base.output_audio_format [
 								{
 									out_rate		$JACK_RATE
+									out_channels		$SDW_JACK_CAPTURE_CH
 									out_bit_depth		32
 									out_valid_bit_depth	32
 								}


### PR DESCRIPTION
CS42L42 capture DP only has 1 channel.

Jack capture was not working on CS42L42 even with SDW_JACK_CAPTURE_CH=1. This was because the simple-jack tplg did not apply SDW_JACK_CAPTURE_CH to the BE DAI or copiers. The result was that SOF/ASoC would attempt to open a 2-channel stream, which would then fail to prepare because DP0.ch1 does not exist.

