### PR TITLE
audio: module_adapter_ipc4: add range check to module_set_large_config()

### DIFF
--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -254,6 +254,11 @@ int module_set_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 		return -EINVAL;
 	}
 
+	if (fragment_size > MAILBOX_HOSTBOX_SIZE) {
+		comp_err(dev, "invalid large_config fragment size %u", fragment_size);
+		return -EINVAL;
+	}
+
 	if (interface->set_configuration)
 		return interface->set_configuration(mod, param_id, pos, data_offset_size,
 						    (const uint8_t *)data, fragment_size,


### PR DESCRIPTION
module_set_large_config() reads a SET_LARGE_CONFIG payload out of the fixed-size HOSTBOX mailbox. For a single-fragment config (init_block && final_block) the number of bytes copied, fragment_size, is set verbatim to the host-controlled data_off_size (a 20-bit field, up to ~1 MB), without bounding it to the mailbox. The .set_configuration handler (e.g. comp_data_blob_set() -> memcpy_s()) then copies that many bytes from the ~4 KB mailbox; memcpy_s() only validates the destination size, so the source over-read is not caught and reads past MAILBOX_HOSTBOX_BASE.

A fuzzer-crafted request (data_off_size = 64778 from a 4096-byte mailbox) triggers a global-buffer-overflow read reported by AddressSanitizer.

Reject a single fragment larger than MAILBOX_HOSTBOX_SIZE, mirroring the range check already present on the GET path (commit f72dbb2b7) and the mailbox bound used at module init.