### PR TITLE
audio: pcm_converter: change pcm conversion functions interface

### DIFF
--- a/posix/include/sof/lib/dma.h
+++ b/posix/include/sof/lib/dma.h
@@ -265,10 +265,11 @@ struct dma_info {
 	size_t num_dmas;
 };
 
-struct audio_stream;
-typedef int (*dma_process_func)(const struct audio_stream __sparse_cache *source,
-				uint32_t ioffset, struct audio_stream __sparse_cache *sink,
-				uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
+struct cir_buf_source;
+struct cir_buf_sink;
+typedef int (*dma_process_func)(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t source_samples, uint32_t chmap);
 
 /**
  * \brief API to initialize a platform DMA controllers.

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -269,7 +269,7 @@ int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
 	return samples;
 }
 
-void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
+void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, void *dst,
 		  void *dst_addr, void *dst_end, size_t byte_size)
 {
 	size_t bytes = byte_size;
@@ -281,7 +281,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
 	ae_int16x4 in_sample1, in_sample2;
 	ae_valignx2 inu;
 	ae_valignx2 outu = AE_ZALIGN128();
-	ae_int16x8 *in = (ae_int16x8 *)src;
+	const ae_int16x8 *in = cir_buf_wrap(src, src_addr, src_end);
 	ae_int16x8 *out = (ae_int16x8 *)dst;
 
 	while (bytes) {
@@ -360,7 +360,7 @@ int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
 	return samples;
 }
 
-void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
+void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, void *dst,
 		  void *dst_addr, void *dst_end, size_t byte_size)
 {
 	size_t bytes = byte_size;
@@ -373,7 +373,7 @@ void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
 	ae_int16x4 in_sample = AE_ZERO16();
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_int16x4 *in = (ae_int16x4 *)src;
+	ae_int16x4 *in = cir_buf_wrap(src, src_addr, src_end);
 	ae_int16x4 *out = (ae_int16x4 *)dst;
 
 	while (bytes) {
@@ -433,14 +433,14 @@ int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
 	return samples;
 }
 
-void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
+void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, void *dst,
 		  void *dst_addr, void *dst_end, size_t byte_size)
 {
 	size_t bytes = byte_size;
 	size_t bytes_src;
 	size_t bytes_dst;
 	size_t bytes_copied;
-	uint8_t *in = (uint8_t *)src;
+	const uint8_t *in = src;
 	uint8_t *out = (uint8_t *)dst;
 
 	while (bytes) {

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -531,6 +531,16 @@ static int do_conversion_copy(struct comp_dev *dev,
 			      struct comp_buffer *sink,
 			      struct comp_copy_limits *processed_data)
 {
+	struct cir_buf_source src_cir = {
+		.buf_start = audio_stream_get_addr(&src->stream),
+		.buf_end = audio_stream_get_end_addr(&src->stream),
+		.ptr = audio_stream_get_rptr(&src->stream),
+	};
+	struct cir_buf_sink snk_cir = {
+		.buf_start = audio_stream_get_addr(&sink->stream),
+		.buf_end = audio_stream_get_end_addr(&sink->stream),
+		.ptr = audio_stream_get_wptr(&sink->stream),
+	};
 	int i;
 
 	/* buffer params might be not yet configured by component on another pipeline */
@@ -550,7 +560,8 @@ static int do_conversion_copy(struct comp_dev *dev,
 		return -EINVAL;
 	buffer_stream_invalidate(src, processed_data->source_bytes);
 
-	cd->converter[i](&src->stream, 0, &sink->stream, 0,
+	cd->converter[i](&src_cir, audio_stream_get_channels(&src->stream),
+			 &snk_cir, audio_stream_get_channels(&sink->stream),
 			 processed_data->frames * audio_stream_get_channels(&src->stream),
 			 DUMMY_CHMAP);
 
@@ -619,8 +630,22 @@ static int copier_module_copy(struct processing_module *mod,
 		sink_dev = comp_buffer_get_sink_component(sink_c);
 		processed_data.sink_bytes = 0;
 		if (sink_dev->state == COMP_STATE_ACTIVE) {
+			/* Bridge the legacy audio_stream buffers into cir_buf descriptors for
+			 * the new pcm_converter interface (read/write pointers = offset 0).
+			 */
+			struct cir_buf_source src_cir = {
+				.buf_start = audio_stream_get_addr(input_buffers[0].data),
+				.buf_end = audio_stream_get_end_addr(input_buffers[0].data),
+				.ptr = audio_stream_get_rptr(input_buffers[0].data),
+			};
+			struct cir_buf_sink snk_cir = {
+				.buf_start = audio_stream_get_addr(output_buffers[i].data),
+				.buf_end = audio_stream_get_end_addr(output_buffers[i].data),
+				.ptr = audio_stream_get_wptr(output_buffers[i].data),
+			};
 			uint32_t source_samples;
 			int sink_queue_id;
+			pcm_converter_func converter;
 
 			/*
 			 * Buffer ID is constructed as IPC4_COMP_ID(src_queue, dst_queue).
@@ -630,14 +655,15 @@ static int copier_module_copy(struct processing_module *mod,
 			sink_queue_id = IPC4_SRC_QUEUE_ID(buf_get_id(sink_c));
 			if (sink_queue_id >= IPC4_COPIER_MODULE_OUTPUT_PINS_COUNT)
 				return -EINVAL;
+			converter = cd->converter[sink_queue_id];
 
 			comp_get_copy_limits(src_c, sink_c, &processed_data);
 
 			source_samples = processed_data.frames *
 					audio_stream_get_channels(input_buffers[0].data);
-			cd->converter[sink_queue_id](input_buffers[0].data, 0,
-						     output_buffers[i].data, 0,
-						     source_samples, DUMMY_CHMAP);
+			converter(&src_cir, audio_stream_get_channels(input_buffers[0].data),
+				  &snk_cir, audio_stream_get_channels(output_buffers[i].data),
+				  source_samples, DUMMY_CHMAP);
 
 			output_buffers[i].size = processed_data.sink_bytes;
 			cd->output_total_data_processed += processed_data.sink_bytes;

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -15,35 +15,23 @@
 #include <sof/audio/pcm_converter.h>
 #include <rtos/panic.h>
 
-int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
-			  struct audio_stream *sink, uint32_t ooffset,
-			  uint32_t samples, pcm_converter_lin_func converter)
+int pcm_convert_as_linear(const struct cir_buf_source *source, size_t s_size_in,
+			  struct cir_buf_sink *sink, size_t s_size_out,
+			  size_t samples, pcm_converter_lin_func converter)
 {
-	const int s_size_in = audio_stream_sample_bytes(source);
-	const int s_size_out = audio_stream_sample_bytes(sink);
 	const int log2_s_size_in = ffs(s_size_in) - 1;
 	const int log2_s_size_out = ffs(s_size_out) - 1;
-	char *r_ptr = audio_stream_get_frag(source, audio_stream_get_rptr(source), ioffset,
-					    s_size_in);
-	char *w_ptr = audio_stream_get_frag(sink, audio_stream_get_wptr(sink), ooffset,
-					    s_size_out);
-	int i = 0;
-	int chunk;
-	int N1, N2;
+	const char *r_ptr = source->ptr;
+	char *w_ptr = sink->ptr;
+	size_t i = 0;
+	size_t chunk;
+	size_t N1, N2;
 
-	/* assert enough avail/free samples in source and sink buffer */
-	if (audio_stream_get_avail_samples(source) < samples + ioffset)
-		return -EINVAL;
-	if (audio_stream_get_free_samples(sink) < samples + ooffset)
-		return -EINVAL;
 
 	while (i < samples) {
-		/* calculate chunk size */
-		/* "">> log2_s_size" is equal "/ s_size" here */
-		N1 = audio_stream_bytes_without_wrap(source, r_ptr) >>
-			log2_s_size_in;
-		N2 = audio_stream_bytes_without_wrap(sink, w_ptr) >>
-			log2_s_size_out;
+		/* calculate chunk size; shifting by log2_s_size is dividing by s_size */
+		N1 = ((const char *)source->buf_end - r_ptr) >> log2_s_size_in;
+		N2 = ((char *)sink->buf_end - w_ptr) >> log2_s_size_out;
 		chunk = MIN(N1, N2);
 		chunk = MIN(chunk, samples - i);
 
@@ -51,16 +39,52 @@ int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
 		converter(r_ptr, w_ptr, chunk);
 
 		/* move pointers */
-		r_ptr = audio_stream_wrap(source, r_ptr + chunk * s_size_in);
-		w_ptr = audio_stream_wrap(sink, w_ptr + chunk * s_size_out);
+		r_ptr = cir_buf_wrap(r_ptr + chunk * s_size_in,
+				     source->buf_start, source->buf_end);
+		w_ptr = cir_buf_wrap(w_ptr + chunk * s_size_out,
+				     sink->buf_start, sink->buf_end);
 		i += chunk;
 	}
 
 	return samples;
 }
 
-int just_copy(const struct audio_stream *source, uint32_t ioffset,
-	      struct audio_stream *sink, uint32_t ooffset, uint32_t samples, uint32_t chmap)
+/* Copy "bytes" of raw data from a source to a sink circular buffer. */
+static void just_copy_bytes(const struct cir_buf_source *source, struct cir_buf_sink *sink,
+			    size_t bytes)
 {
-	return audio_stream_copy(source, ioffset, sink, ooffset, samples);
+	cir_buf_copy(source->ptr, source->buf_start, source->buf_end,
+		     sink->ptr, sink->buf_start, sink->buf_end, bytes);
+}
+
+int just_copy_1b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap)
+{
+	just_copy_bytes(source, sink, samples);
+	return samples;
+}
+
+int just_copy_2b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap)
+{
+	just_copy_bytes(source, sink, samples * sizeof(int16_t));
+	return samples;
+}
+
+int just_copy_3b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap)
+{
+	just_copy_bytes(source, sink, samples * 3);
+	return samples;
+}
+
+int just_copy_4b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap)
+{
+	just_copy_bytes(source, sink, samples * sizeof(int32_t));
+	return samples;
 }

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -36,24 +36,22 @@
 #define BYTES_TO_S32_SAMPLES	2
 
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
-static int pcm_convert_u8_to_s32(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_u8_to_s32(const struct cir_buf_source *source,
+				 uint32_t src_channels, struct cir_buf_sink *sink,
+				 uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const uint8_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = (INT8_MIN + *src) << 24;
@@ -65,24 +63,22 @@ static int pcm_convert_u8_to_s32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_u8(const struct audio_stream *source,
-				 uint32_t ioffset, struct audio_stream *sink,
-				 uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_u8(const struct cir_buf_source *source,
+				 uint32_t src_channels, struct cir_buf_sink *sink,
+				 uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const int32_t *src = source->ptr;
+	uint8_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int8(Q_SHIFT_RND(*src, 24, 0)) - INT8_MIN;
@@ -96,24 +92,22 @@ static int pcm_convert_s32_to_u8(const struct audio_stream *source,
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
 #if CONFIG_PCM_CONVERTER_FORMAT_A_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE
-static int pcm_convert_alaw_to_s32(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_alaw_to_s32(const struct cir_buf_source *source,
+				   uint32_t src_channels, struct cir_buf_sink *sink,
+				   uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	const uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const uint8_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, (void *)src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sofm_a_law_decode(*src) << 16;
@@ -125,24 +119,22 @@ static int pcm_convert_alaw_to_s32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_alaw(const struct audio_stream *source,
-				   uint32_t ioffset, struct audio_stream *sink,
-				   uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_alaw(const struct cir_buf_source *source,
+				   uint32_t src_channels, struct cir_buf_sink *sink,
+				   uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	const int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const int32_t *src = source->ptr;
+	uint8_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, (void *)src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sofm_a_law_encode(*src >> 16);
@@ -156,24 +148,22 @@ static int pcm_convert_s32_to_alaw(const struct audio_stream *source,
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_A_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
 #if CONFIG_PCM_CONVERTER_FORMAT_MU_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE
-static int pcm_convert_mulaw_to_s32(const struct audio_stream *source,
-				    uint32_t ioffset, struct audio_stream *sink,
-				    uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_mulaw_to_s32(const struct cir_buf_source *source,
+				    uint32_t src_channels, struct cir_buf_sink *sink,
+				    uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	const uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const uint8_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, (void *)src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sofm_mu_law_decode(*src) << 16;
@@ -185,24 +175,22 @@ static int pcm_convert_mulaw_to_s32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_mulaw(const struct audio_stream *source,
-				    uint32_t ioffset, struct audio_stream *sink,
-				    uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_mulaw(const struct cir_buf_source *source,
+				    uint32_t src_channels, struct cir_buf_sink *sink,
+				    uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	const int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = audio_stream_get_wptr(sink);
-	uint32_t processed;
-	uint32_t nmax, i, n;
+	const int32_t *src = source->ptr;
+	uint8_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, (void *)src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_U8_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_U8_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sofm_mu_law_encode(*src >> 16);
@@ -217,24 +205,22 @@ static int pcm_convert_s32_to_mulaw(const struct audio_stream *source,
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 
-static int pcm_convert_s16_to_s24(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_s24(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int16_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src << 8;
@@ -246,24 +232,22 @@ static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s24_to_s16(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_s16(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int16_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src), 23, 15));
@@ -279,24 +263,22 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s16_to_s32(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_s32(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int16_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src << 16;
@@ -308,24 +290,22 @@ static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_s16(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s16(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int16_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
@@ -341,24 +321,22 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 
-static int pcm_convert_s24_to_s32(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_s32(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src << 8;
@@ -370,24 +348,22 @@ static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s24(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23));
@@ -399,24 +375,22 @@ static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
-				     uint32_t ioffset, struct audio_stream *sink,
-				     uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s24_be(const struct cir_buf_source *source,
+				     uint32_t src_channels, struct cir_buf_sink *sink,
+				     uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_samples_without_wrap_s32(source, src);
+		nmax = cir_buf_samples_without_wrap_s32(src, source->buf_end);
 		n = MIN(n, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, dst);
+		nmax = cir_buf_samples_without_wrap_s32(dst, sink->buf_end);
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int24(Q_SHIFT_RND(*src, 31, 23)) << 8;
@@ -539,7 +513,7 @@ static int32_t _pcm_convert_i_to_f(int32_t src, int32_t pow)
 
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 static void pcm_convert_s16_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int16_t *src = psrc;
 	int32_t *dst = pdst; /* float */
@@ -552,7 +526,7 @@ static void pcm_convert_s16_to_f_lin(const void *psrc, void *pdst,
 }
 
 static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int32_t *src = psrc; /* float */
 	int16_t *dst = pdst;
@@ -564,26 +538,26 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int16(_pcm_convert_f_to_i(src[i], 15));
 }
 
-static int pcm_convert_s16_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int16_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s16_to_f_lin);
 }
 
-static int pcm_convert_f_to_s16(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s16(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int16_t), samples,
 				     pcm_convert_f_to_s16_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 static void pcm_convert_s24_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int32_t *src = psrc;
 	int32_t *dst = pdst; /* float */
@@ -596,7 +570,7 @@ static void pcm_convert_s24_to_f_lin(const void *psrc, void *pdst,
 }
 
 static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int32_t *src = psrc; /* float */
 	int32_t *dst = pdst;
@@ -608,26 +582,26 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
 		dst[i] = sat_int24(_pcm_convert_f_to_i(src[i], 23));
 }
 
-static int pcm_convert_s24_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s24_to_f_lin);
 }
 
-static int pcm_convert_f_to_s24(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s24(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_f_to_s24_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 static void pcm_convert_s32_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int32_t *src = psrc;
 	int32_t *dst = pdst; /* float */
@@ -640,7 +614,7 @@ static void pcm_convert_s32_to_f_lin(const void *psrc, void *pdst,
 }
 
 static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+				     size_t samples)
 {
 	const int32_t *src = psrc; /* float */
 	int32_t *dst = pdst;
@@ -652,60 +626,60 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
 		dst[i] = _pcm_convert_f_to_i(src[i], 31);
 }
 
-static int pcm_convert_s32_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s32_to_f_lin);
 }
 
-static int pcm_convert_f_to_s32(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s32(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_f_to_s32_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_U8
-	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, just_copy },
+	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_U8, just_copy_1b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 */
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 	{ SOF_IPC_FRAME_U8, SOF_IPC_FRAME_S32_LE, pcm_convert_u8_to_s32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_U8, pcm_convert_s32_to_u8 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_A_LAW
-	{ SOF_IPC_FRAME_A_LAW, SOF_IPC_FRAME_A_LAW, just_copy },
+	{ SOF_IPC_FRAME_A_LAW, SOF_IPC_FRAME_A_LAW, just_copy_1b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_A_LAW */
 #if CONFIG_PCM_CONVERTER_FORMAT_A_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 	{ SOF_IPC_FRAME_A_LAW, SOF_IPC_FRAME_S32_LE, pcm_convert_alaw_to_s32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_A_LAW, pcm_convert_s32_to_alaw },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_A_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_MU_LAW
-	{ SOF_IPC_FRAME_MU_LAW, SOF_IPC_FRAME_MU_LAW, just_copy },
+	{ SOF_IPC_FRAME_MU_LAW, SOF_IPC_FRAME_MU_LAW, just_copy_1b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_MU_LAW */
 #if CONFIG_PCM_CONVERTER_FORMAT_MU_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE
 	{ SOF_IPC_FRAME_MU_LAW, SOF_IPC_FRAME_S32_LE, pcm_convert_mulaw_to_s32 },
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_MU_LAW, pcm_convert_s32_to_mulaw },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_A_LAW && CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy_2b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
-	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy },
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy_3b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -717,10 +691,10 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be },
-	{ SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE, just_copy },
+	{ SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },
@@ -739,24 +713,22 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c16_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int16_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src;
@@ -768,24 +740,22 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s16_c16(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int16_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S16_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S16_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src & 0xffff;
@@ -798,24 +768,22 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s32_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src << 16;
@@ -827,24 +795,22 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_c32_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int16(Q_SHIFT_RND(*src, 31, 15));
@@ -857,24 +823,22 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 }
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s24_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = *src << 8;
@@ -886,24 +850,22 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c32_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i++) {
 			*dst = sat_int16(Q_SHIFT_RND(sign_extend_s24(*src & 0xffffff), 23, 15));
@@ -917,24 +879,22 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c24_to_s24_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const uint8_t *src = source->ptr;
+	int32_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset * 3;
-	dst += ooffset;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) / 3;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) / 3;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i += 1) {
 			*dst = (*(src + 2) << 24) | (*(src + 1) << 16) | (*(src + 0) << 8);
@@ -947,24 +907,22 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
-					  uint32_t ioffset, struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c32_to_s24_c24(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i, n;
+	const int32_t *src = source->ptr;
+	uint8_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i, n;
 
-	src += ioffset;
-	dst += ooffset * 3;
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) / 3;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) / 3;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i += 1) {
 			*dst = *src & 0xFF;
@@ -981,25 +939,23 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 }
 
 /* 2x24bit samples are packed into 3x16bit samples for hda link dma */
-static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct audio_stream *source,
-						   uint32_t ioffset, struct audio_stream *sink,
-						   uint32_t ooffset, uint32_t samples,
+static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct cir_buf_source *source,
+						   uint32_t src_channels, struct cir_buf_sink *sink,
+						   uint32_t sink_channels, size_t samples,
 						   uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	uint16_t *dst = audio_stream_get_wptr(sink);
-	int processed;
-	int nmax, i = 0, n = 0;
+	const int32_t *src = source->ptr;
+	uint16_t *dst = sink->ptr;
+	size_t processed;
+	size_t nmax, i = 0, n = 0;
 
-	src += ioffset;
-	assert(ooffset == 0);
 	for (processed = 0; processed < samples; processed += n) {
-		src = audio_stream_wrap(source, src);
-		dst = audio_stream_wrap(sink, dst);
+		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
-		nmax = audio_stream_bytes_without_wrap(source, src) >> BYTES_TO_S32_SAMPLES;
+		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
 		n = MIN(n, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, dst) / 3;
+		nmax = cir_buf_bytes_without_wrap(dst, sink->buf_end) / 3;
 		n = MIN(n, nmax);
 		for (i = 0; i < n; i += 2) {
 			*dst = (*src >> 8) & 0xFFFF;
@@ -1045,11 +1001,11 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_U8,
-		just_copy },
+		just_copy_2b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_U8 && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		just_copy},
+		just_copy_4b},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		pcm_convert_s24_to_s32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
@@ -1071,7 +1027,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		just_copy },
+		just_copy_4b },
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S24LE
@@ -1080,14 +1036,14 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, just_copy},
+		SOF_IPC_FRAME_S24_4LE_MSB, just_copy_4b},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S32_LE, just_copy},
+		SOF_IPC_FRAME_S32_LE, just_copy_4b},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S16LE

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -36,24 +36,21 @@
  * \param[in,out] sink Destination buffer.
  * \param[in] samples Number of samples to process.
  */
-static int pcm_convert_s16_to_s24(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_s24(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
 	ae_int16x4 sample = AE_ZERO16();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
-
-	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int16x4 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s16(source, in);
+		nmax = cir_buf_samples_without_wrap_s16(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x03;
@@ -73,15 +70,15 @@ static int pcm_convert_s16_to_s24(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 16 bit samples */
-			AE_L16_IP(sample, (ae_int16 *)in, sizeof(ae_int16));
+			AE_L16_IP(sample, (const ae_int16 *)in, sizeof(ae_int16));
 
 			/* shift right and store one 32 bit sample */
 			AE_S32_L_IP(AE_SRAI32(AE_CVT32X2F16_32(sample), 8), (ae_int32 *)out,
 				    sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink,  out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -110,26 +107,23 @@ static ae_int32x2 pcm_shift_s24_to_s16(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s16(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_s16(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-	ae_int32 *src = audio_stream_get_rptr(source);
-	ae_int16 *dst = audio_stream_get_wptr(sink);
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int16x4 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int16x4 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, out);
+		nmax = cir_buf_samples_without_wrap_s16(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x03;
@@ -153,7 +147,7 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 32 bit sample */
-			AE_L32_IP(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample_1, (const ae_int32 *)in, sizeof(ae_int32));
 
 			/* shift and round */
 			sample_1 = pcm_shift_s24_to_s16(sample_1);
@@ -164,8 +158,8 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
 				    sizeof(ae_int16));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
 }
@@ -181,24 +175,21 @@ static int pcm_convert_s24_to_s16(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_s32(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_s32(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-
-	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int16x4 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s16(source, in);
+		nmax = cir_buf_samples_without_wrap_s16(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x03;
@@ -218,14 +209,14 @@ static int pcm_convert_s16_to_s32(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 16 bit samples */
-			AE_L16_IP(sample, (ae_int16 *)in, sizeof(ae_int16));
+			AE_L16_IP(sample, (const ae_int16 *)in, sizeof(ae_int16));
 
 			/* store one 32 bit sample */
 			AE_S32_L_IP(AE_CVT32X2F16_32(sample), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
 }
@@ -237,26 +228,23 @@ static int pcm_convert_s16_to_s32(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s16(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s16(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int16x4 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int16x4 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, out);
+		nmax = cir_buf_samples_without_wrap_s16(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x3;
@@ -277,7 +265,7 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 32 bit samples */
-			AE_L32_IP(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample_1, (const ae_int32 *)in, sizeof(ae_int32));
 			/* shift and round */
 			sample = AE_ROUND16X4F32SSYM(sample_1, sample_1);
 			/* store one 16 bit sample */
@@ -285,8 +273,8 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
 				    sizeof(ae_int16));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -303,24 +291,21 @@ static int pcm_convert_s32_to_s16(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_s32(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_s32(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -334,13 +319,13 @@ static int pcm_convert_s24_to_s32(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			AE_S32_L_IP(AE_SLAI32(sample, 8), (ae_int32 *)out,
 				    sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -368,24 +353,21 @@ static ae_int32x2 pcm_shift_s32_to_s24(ae_int32x2 sample)
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_s24(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s24(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -400,37 +382,34 @@ static int pcm_convert_s32_to_s24(const struct audio_stream *source,
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
 			/* load one 32 bit sample */
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			/* shift right and store one 32 bit sample */
 			sample = pcm_shift_s32_to_s24(sample);
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
 }
 
-static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
-				     uint32_t ioffset, struct audio_stream *sink,
-				     uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_s24_be(const struct cir_buf_source *source,
+				     uint32_t src_channels, struct cir_buf_sink *sink,
+				     uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -447,15 +426,15 @@ static int pcm_convert_s32_to_s24_be(const struct audio_stream *source,
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
 			/* load one 32 bit sample */
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			/* shift with saturation and rounding and store one 32 bit sample */
 			sample = AE_SRAA32RS(sample, 8);
 			sample = AE_SLAI32S(sample, 8);
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -481,14 +460,13 @@ static inline int _round_s(xtfloat x)
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s16_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_s16_to_f_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const ae_int16 *in = psrc;
 	xtfloat *out = pdst;
 	ae_int16x4 sample = AE_ZERO16();
 	xtfloat fl;
-	int i = 0;
+	size_t i = 0;
 
 	while (i < samples) {
 		/* load one 16 bit sample */
@@ -511,14 +489,13 @@ static void pcm_convert_s16_to_f_lin(const void *psrc, void *pdst,
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const xtfloat *in = psrc;
 	ae_int16x4 *out = pdst;
 	xtfloat x;
 	int y;
-	int i = 0;
+	size_t i = 0;
 
 	while (i < samples) {
 		/* load one 32 bit sample */
@@ -541,11 +518,11 @@ static void pcm_convert_f_to_s16_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s16_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int16_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s16_to_f_lin);
 }
 
@@ -556,11 +533,11 @@ static int pcm_convert_s16_to_f(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s16(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s16(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int16_t), samples,
 				     pcm_convert_f_to_s16_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
@@ -573,15 +550,14 @@ static int pcm_convert_f_to_s16(const struct audio_stream *source,
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s24_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_s24_to_f_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const ae_int32 *in = psrc;
 	xtfloat *out = pdst;
 	ae_int32x2 sample = AE_ZERO32();
 	xtfloat fl;
 	const xtfloat ratio = (xtfloat)(1.f / (1 << (23 - 15)));
-	int i = 0;
+	size_t i = 0;
 
 	while (i < samples) {
 		/* load one 24 bit sample */
@@ -607,14 +583,13 @@ static void pcm_convert_s24_to_f_lin(const void *psrc, void *pdst,
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const xtfloat *in = psrc;
 	ae_int32 *out = pdst;
 	xtfloat x;
 	ae_int32x2 y1;
-	int i = 0;
+	size_t i = 0;
 	const xtfloat ratio = (xtfloat)(1 << (23 - 15));
 
 	while (i < samples) {
@@ -642,11 +617,11 @@ static void pcm_convert_f_to_s24_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s24_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s24_to_f_lin);
 }
 
@@ -657,11 +632,11 @@ static int pcm_convert_s24_to_f(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s24(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s24(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_f_to_s24_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_24LE */
@@ -674,15 +649,14 @@ static int pcm_convert_f_to_s24(const struct audio_stream *source,
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_s32_to_f_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_s32_to_f_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const ae_int32 *in = psrc;
 	xtfloat *out = pdst;
 	ae_int32x2 sample = AE_ZERO32();
 	xtfloat fl;
 	const xtfloat ratio = (xtfloat)(1.f / (1ul << (31 - 15)));
-	int i = 0;
+	size_t i = 0;
 
 	while (i < samples) {
 		/* load one 32 bit sample */
@@ -706,14 +680,13 @@ static void pcm_convert_s32_to_f_lin(const void *psrc, void *pdst,
  * \param[out] pdst destination linear buffer.
  * \param[in] samples Number of samples to process.
  */
-static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
-				     uint32_t samples)
+static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst, size_t samples)
 {
 	const xtfloat *in = psrc;
 	ae_int32 *out = pdst;
 	xtfloat x;
 	ae_int32x2 y1;
-	int i = 0;
+	size_t i = 0;
 	const xtfloat ratio = (xtfloat)(1ul << (31 - 15));
 
 	while (i < samples) {
@@ -739,11 +712,11 @@ static void pcm_convert_f_to_s32_lin(const void *psrc, void *pdst,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_s32_to_f(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_to_f(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_s32_to_f_lin);
 }
 
@@ -754,11 +727,11 @@ static int pcm_convert_s32_to_f(const struct audio_stream *source,
  * \param[in] samples Number of samples to process.
  * \return error code or number of processed samples.
  */
-static int pcm_convert_f_to_s32(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_f_to_s32(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	return pcm_convert_as_linear(source, ioffset, sink, ooffset, samples,
+	return pcm_convert_as_linear(source, sizeof(int32_t), sink, sizeof(int32_t), samples,
 				     pcm_convert_f_to_s32_lin);
 }
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_32LE */
@@ -766,20 +739,20 @@ static int pcm_convert_f_to_s32(const struct audio_stream *source,
 
 const struct pcm_func_map pcm_func_map[] = {
 #if CONFIG_PCM_CONVERTER_FORMAT_S16LE
-	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy },
+	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S16_LE, just_copy_2b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE
-	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy },
+	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S24_4LE, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_3LE
-	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy },
+	{ SOF_IPC_FRAME_S24_3LE, SOF_IPC_FRAME_S24_3LE, just_copy_3b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24_3LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S24_4LE, pcm_convert_s16_to_s24 },
 	{ SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S16_LE, pcm_convert_s24_to_s16 },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S24LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE
-	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy },
+	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE */
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, pcm_convert_s16_to_s32 },
@@ -791,7 +764,7 @@ const struct pcm_func_map pcm_func_map[] = {
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE */
 #if XCHAL_HAVE_FP
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT
-	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy },
+	{ SOF_IPC_FRAME_FLOAT, SOF_IPC_FRAME_FLOAT, just_copy_4b },
 #endif /* CONFIG_PCM_CONVERTER_FORMAT_FLOAT */
 #if CONFIG_PCM_CONVERTER_FORMAT_FLOAT && CONFIG_PCM_CONVERTER_FORMAT_S16LE
 	{ SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_FLOAT, pcm_convert_s16_to_f },
@@ -810,25 +783,22 @@ const struct pcm_func_map pcm_func_map[] = {
 const size_t pcm_func_count = ARRAY_SIZE(pcm_func_map);
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C16_AND_S16_C32
-static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c16_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int16_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign inu = AE_ZALIGN64();
 	ae_valign outu = AE_ZALIGN64();
-
-	ae_int16x4 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int16x4 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s16(source, in);
+		nmax = cir_buf_samples_without_wrap_s16(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x03;
@@ -848,39 +818,36 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 16 bit samples */
-			AE_L16_IP(sample, (ae_int16 *)in, sizeof(ae_int16));
+			AE_L16_IP(sample, (const ae_int16 *)in, sizeof(ae_int16));
 
 			/* store one 32 bit sample */
 			AE_S32_L_IP(AE_SEXT32X2D16_32(sample), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
 }
 
-static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s16_c16(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int16_t *dst = audio_stream_get_wptr(sink);
 	ae_int16x4 sample = AE_ZERO16();
 	ae_int32x2 sample_1 = AE_ZERO32();
 	ae_int32x2 sample_2 = AE_ZERO32();
-	uint32_t nmax, i, n, m, left, left_samples;
+	size_t nmax, i, n, m, left, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int16x4 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int16x4 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s16(sink, out);
+		nmax = cir_buf_samples_without_wrap_s16(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 2;
 		left = n & 0x3;
@@ -903,15 +870,15 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 		 */
 		for (i = 0; i < left ; i++) {
 			/* load one 32 bit samples */
-			AE_L32_IP(sample_1, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample_1, (const ae_int32 *)in, sizeof(ae_int32));
 			/* shift and round */
 			sample = AE_CVT16X4(sample_1, sample_1);
 			/* store one 16 bit sample */
 			AE_S16_0_IP(AE_MOVAD16_0(sample), (ae_int16 *)out, sizeof(ae_int16));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -919,25 +886,22 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct audio_stream *source,
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S32_C32
-static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s32_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -951,36 +915,33 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			AE_S32_L_IP(AE_SLAI32(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
 }
 
-static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s32_c32_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -994,12 +955,12 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			AE_S32_L_IP(AE_SRAA32RS(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -1007,25 +968,22 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct audio_stream *source,
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S24_C32
-static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s16_c32_to_s24_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -1039,12 +997,12 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			AE_S32_L_IP(AE_SLAI32(sample, 8), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -1062,25 +1020,22 @@ static ae_int32x2 pcm_shift_s24_c32_to_s16(ae_int32x2 sample)
 	return sample;
 }
 
-static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c32_to_s16_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int32x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -1095,13 +1050,13 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			sample = pcm_shift_s24_c32_to_s16(sample);
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -1109,26 +1064,23 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct audio_stream *source,
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_C24_AND_S24_C32
-static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c24_to_s24_c32(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	uint8_t *src = audio_stream_get_rptr(source);
-	int32_t *dst = audio_stream_get_wptr(sink);
 	ae_int24x2 sample24 =  AE_ZERO24();
 	ae_int32x2 sample = AE_ZERO32();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int24x2 *in = audio_stream_wrap(source, src + ioffset * 3);
-	ae_int32x2 *out = audio_stream_wrap(sink, dst + ooffset);
+	const ae_int24x2 *in = source->ptr;
+	ae_int32x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_bytes_without_wrap(source, in) / 3;
+		nmax = cir_buf_bytes_without_wrap(in, source->buf_end) / 3;
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_samples_without_wrap_s32(sink, out);
+		nmax = cir_buf_samples_without_wrap_s32(out, sink->buf_end);
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -1149,33 +1101,30 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct audio_stream *source,
 				    sizeof(ae_int32));
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
 }
 
-static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
-					  uint32_t ioffset,
-					  struct audio_stream *sink,
-					  uint32_t ooffset, uint32_t samples, uint32_t chmap)
+static int pcm_convert_s24_c32_to_s24_c24(const struct cir_buf_source *source,
+					  uint32_t src_channels,
+					  struct cir_buf_sink *sink,
+					  uint32_t sink_channels, size_t samples, uint32_t chmap)
 {
-	int32_t *src = audio_stream_get_rptr(source);
-	uint8_t *dst = audio_stream_get_wptr(sink);
 	ae_int32x2 sample = AE_ZERO32();
 	ae_int24x2 sample24 =  AE_ZERO24();
-	uint32_t nmax, i, n, m, left_samples;
+	size_t nmax, i, n, m, left_samples;
 	ae_valign outu = AE_ZALIGN64();
 	ae_valign inu = AE_ZALIGN64();
-
-	ae_int32x2 *in = audio_stream_wrap(source, src + ioffset);
-	ae_int24x2 *out = audio_stream_wrap(sink, dst + ooffset * 3);
+	const ae_int32x2 *in = source->ptr;
+	ae_int24x2 *out = sink->ptr;
 
 	for (left_samples = samples; left_samples; left_samples -= n) {
-		nmax = audio_stream_samples_without_wrap_s32(source, in);
+		nmax = cir_buf_samples_without_wrap_s32(in, source->buf_end);
 		n = MIN(left_samples, nmax);
-		nmax = audio_stream_bytes_without_wrap(sink, out) / 3;
+		nmax = cir_buf_bytes_without_wrap(out, sink->buf_end) / 3;
 		n = MIN(n, nmax);
 		m = n >> 1;
 		inu = AE_LA64_PP(in);
@@ -1189,13 +1138,13 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct audio_stream *source,
 
 		/* process the left 1 sample to avoid memory access overrun */
 		if (n & 0x01) {
-			AE_L32_IP(sample, (ae_int32 *)in, sizeof(ae_int32));
+			AE_L32_IP(sample, (const ae_int32 *)in, sizeof(ae_int32));
 			sample24 = AE_MOVINT24X2_FROMF32X2(sample);
 			AE_SA24_IP(sample24, outu, out);
 		}
 
-		in = audio_stream_wrap(source, in);
-		out = audio_stream_wrap(sink, out);
+		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
 	return samples;
@@ -1227,7 +1176,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24LE
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
-		just_copy},
+		just_copy_4b},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		pcm_convert_s24_to_s32},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE,
@@ -1249,7 +1198,7 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 #endif
 #if CONFIG_PCM_CONVERTER_FORMAT_S16_C32_AND_S16_C32
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S16_LE,
-		just_copy },
+		just_copy_4b },
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S24LE
@@ -1258,14 +1207,14 @@ const struct pcm_func_vc_map pcm_func_vc_map[] = {
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE, pcm_convert_s32_to_s24},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S24_4LE_MSB, just_copy},
+		SOF_IPC_FRAME_S24_4LE_MSB, just_copy_4b},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S32LE && CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S32_LE,
 		SOF_IPC_FRAME_S24_4LE_MSB, pcm_convert_s32_to_s24_be},
 	{ SOF_IPC_FRAME_S32_LE, SOF_IPC_FRAME_S24_4LE_MSB, SOF_IPC_FRAME_S32_LE,
-		SOF_IPC_FRAME_S32_LE, just_copy},
+		SOF_IPC_FRAME_S32_LE, just_copy_4b},
 #endif
 
 #if CONFIG_PCM_CONVERTER_FORMAT_S24_4LE_MSB && CONFIG_PCM_CONVERTER_FORMAT_S16LE

--- a/src/audio/pcm_converter/pcm_remap.c
+++ b/src/audio/pcm_converter/pcm_remap.c
@@ -6,17 +6,17 @@
 #include <sof/audio/pcm_converter.h>
 #include <sof/audio/audio_stream.h>
 
-static void mute_channel_c16(struct audio_stream *stream, int channel, int frames)
+static void mute_channel_c16(struct cir_buf_sink *sink, uint32_t num_channels, uint32_t channel,
+			     size_t frames)
 {
-	int num_channels = audio_stream_get_channels(stream);
-	int16_t *ptr = (int16_t *)audio_stream_get_wptr(stream) + channel;
+	int16_t *ptr = (int16_t *)sink->ptr + channel;
 
 	while (frames) {
-		int samples_wo_wrap, n, i;
+		size_t samples_wo_wrap, n, i;
 
-		ptr = audio_stream_wrap(stream, ptr);
+		ptr = cir_buf_wrap(ptr, sink->buf_start, sink->buf_end);
 
-		samples_wo_wrap = audio_stream_samples_without_wrap_s16(stream, ptr);
+		samples_wo_wrap = cir_buf_samples_without_wrap_s16(ptr, sink->buf_end);
 		n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_channels);
 		n = MIN(n, frames);
 
@@ -29,17 +29,17 @@ static void mute_channel_c16(struct audio_stream *stream, int channel, int frame
 	}
 }
 
-static void mute_channel_c32(struct audio_stream *stream, int channel, int frames)
+static void mute_channel_c32(struct cir_buf_sink *sink, uint32_t num_channels, uint32_t channel,
+			     size_t frames)
 {
-	int num_channels = audio_stream_get_channels(stream);
-	int32_t *ptr = (int32_t *)audio_stream_get_wptr(stream) + channel;
+	int32_t *ptr = (int32_t *)sink->ptr + channel;
 
 	while (frames) {
-		int samples_wo_wrap, n, i;
+		size_t samples_wo_wrap, n, i;
 
-		ptr = audio_stream_wrap(stream, ptr);
+		ptr = cir_buf_wrap(ptr, sink->buf_start, sink->buf_end);
 
-		samples_wo_wrap = audio_stream_samples_without_wrap_s32(stream, ptr);
+		samples_wo_wrap = cir_buf_samples_without_wrap_s32(ptr, sink->buf_end);
 		n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_channels);
 		n = MIN(n, frames);
 
@@ -52,18 +52,17 @@ static void mute_channel_c32(struct audio_stream *stream, int channel, int frame
 	}
 }
 
-static int remap_c16(const struct audio_stream *source, uint32_t dummy1,
-		     struct audio_stream *sink, uint32_t dummy2,
-		     uint32_t source_samples, uint32_t chmap)
+static int remap_c16(const struct cir_buf_source *source, uint32_t src_channels,
+		     struct cir_buf_sink *sink, uint32_t sink_channels,
+		     size_t source_samples, uint32_t chmap)
 {
-	int src_channel, sink_channel;
-	int num_src_channels = audio_stream_get_channels(source);
-	int num_sink_channels = audio_stream_get_channels(sink);
-	int frames = source_samples / num_src_channels;
+	uint32_t src_channel, sink_channel;
+	size_t frames = source_samples / src_channels;
 
-	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
-		int16_t *src, *dst;
-		int frames_left;
+	for (sink_channel = 0; sink_channel < sink_channels; sink_channel++) {
+		const int16_t *src;
+		int16_t *dst;
+		size_t frames_left;
 
 		src_channel = chmap & 0xf;
 		chmap >>= 4;
@@ -71,36 +70,34 @@ static int remap_c16(const struct audio_stream *source, uint32_t dummy1,
 		/* 0xf means "mute"; also mute any out-of-range source channel so
 		 * a crafted chmap nibble cannot index past the source frame.
 		 */
-		if (src_channel == 0xf || src_channel >= num_src_channels) {
-			mute_channel_c16(sink, sink_channel, frames);
+		if (src_channel == 0xf || src_channel >= src_channels) {
+			mute_channel_c16(sink, sink_channels, sink_channel, frames);
 			continue;
 		}
 
-		src = (int16_t *)audio_stream_get_rptr(source) + src_channel;
-		dst = (int16_t *)audio_stream_get_wptr(sink) + sink_channel;
+		src = (const int16_t *)source->ptr + src_channel;
+		dst = (int16_t *)sink->ptr + sink_channel;
 
 		frames_left = frames;
 
 		while (frames_left) {
-			int src_samples_wo_wrap, dst_samples_wo_wrap;
-			int src_loops, dst_loops, n, i;
+			size_t samples_wo_wrap, n, i;
 
-			src = audio_stream_wrap(source, src);
-			dst = audio_stream_wrap(sink, dst);
+			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
-			src_samples_wo_wrap = audio_stream_samples_without_wrap_s16(source, src);
-			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s16(src, source->buf_end);
+			n = SOF_DIV_ROUND_UP(samples_wo_wrap, src_channels);
 
-			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s16(sink, dst);
-			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s16(dst, sink->buf_end);
+			n = MIN(n, SOF_DIV_ROUND_UP(samples_wo_wrap, sink_channels));
 
-			n = MIN(src_loops, dst_loops);
 			n = MIN(n, frames_left);
 
 			for (i = 0; i < n; i++) {
 				*dst = *src;
-				src += num_src_channels;
-				dst += num_sink_channels;
+				src += src_channels;
+				dst += sink_channels;
 			}
 
 			frames_left -= n;
@@ -110,19 +107,20 @@ static int remap_c16(const struct audio_stream *source, uint32_t dummy1,
 	return source_samples;
 }
 
-static inline int remap_c32_left_shift(const struct audio_stream *source,
-				       struct audio_stream *sink,
-				       uint32_t source_samples, uint32_t chmap,
+static inline int remap_c32_left_shift(const struct cir_buf_source *source,
+				       uint32_t num_src_channels,
+				       struct cir_buf_sink *sink,
+				       uint32_t num_sink_channels,
+				       size_t source_samples, uint32_t chmap,
 				       int shift)
 {
-	int src_channel, sink_channel;
-	int num_src_channels = audio_stream_get_channels(source);
-	int num_sink_channels = audio_stream_get_channels(sink);
-	int frames = source_samples / num_src_channels;
+	uint32_t src_channel, sink_channel;
+	size_t frames = source_samples / num_src_channels;
 
 	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
-		int32_t *src, *dst;
-		int frames_left;
+		const int32_t *src;
+		int32_t *dst;
+		size_t frames_left;
 
 		src_channel = chmap & 0xf;
 		chmap >>= 4;
@@ -131,29 +129,27 @@ static inline int remap_c32_left_shift(const struct audio_stream *source,
 		 * a crafted chmap nibble cannot index past the source frame.
 		 */
 		if (src_channel == 0xf || src_channel >= num_src_channels) {
-			mute_channel_c32(sink, sink_channel, frames);
+			mute_channel_c32(sink, num_sink_channels, sink_channel, frames);
 			continue;
 		}
 
-		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
-		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+		src = (const int32_t *)source->ptr + src_channel;
+		dst = (int32_t *)sink->ptr + sink_channel;
 
 		frames_left = frames;
 
 		while (frames_left) {
-			int src_samples_wo_wrap, dst_samples_wo_wrap;
-			int src_loops, dst_loops, n, i;
+			size_t samples_wo_wrap, n, i;
 
-			src = audio_stream_wrap(source, src);
-			dst = audio_stream_wrap(sink, dst);
+			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
-			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
-			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);
+			n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_src_channels);
 
-			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
-			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(dst, sink->buf_end);
+			n = MIN(n, SOF_DIV_ROUND_UP(samples_wo_wrap, num_sink_channels));
 
-			n = MIN(src_loops, dst_loops);
 			n = MIN(n, frames_left);
 
 			for (i = 0; i < n; i++) {
@@ -169,19 +165,20 @@ static inline int remap_c32_left_shift(const struct audio_stream *source,
 	return source_samples;
 }
 
-static inline int remap_c32_right_shift(const struct audio_stream *source,
-					struct audio_stream *sink,
-					uint32_t source_samples, uint32_t chmap,
+static inline int remap_c32_right_shift(const struct cir_buf_source *source,
+					uint32_t num_src_channels,
+					struct cir_buf_sink *sink,
+					uint32_t num_sink_channels,
+					size_t source_samples, uint32_t chmap,
 					int shift)
 {
-	int src_channel, sink_channel;
-	int num_src_channels = audio_stream_get_channels(source);
-	int num_sink_channels = audio_stream_get_channels(sink);
-	int frames = source_samples / num_src_channels;
+	uint32_t src_channel, sink_channel;
+	size_t frames = source_samples / num_src_channels;
 
 	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
-		int32_t *src, *dst;
-		int frames_left;
+		const int32_t *src;
+		int32_t *dst;
+		size_t frames_left;
 
 		src_channel = chmap & 0xf;
 		chmap >>= 4;
@@ -190,29 +187,27 @@ static inline int remap_c32_right_shift(const struct audio_stream *source,
 		 * a crafted chmap nibble cannot index past the source frame.
 		 */
 		if (src_channel == 0xf || src_channel >= num_src_channels) {
-			mute_channel_c32(sink, sink_channel, frames);
+			mute_channel_c32(sink, num_sink_channels, sink_channel, frames);
 			continue;
 		}
 
-		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
-		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+		src = (const int32_t *)source->ptr + src_channel;
+		dst = (int32_t *)sink->ptr + sink_channel;
 
 		frames_left = frames;
 
 		while (frames_left) {
-			int src_samples_wo_wrap, dst_samples_wo_wrap;
-			int src_loops, dst_loops, n, i;
+			size_t samples_wo_wrap, n, i;
 
-			src = audio_stream_wrap(source, src);
-			dst = audio_stream_wrap(sink, dst);
+			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
-			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
-			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);
+			n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_src_channels);
 
-			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
-			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(dst, sink->buf_end);
+			n = MIN(n, SOF_DIV_ROUND_UP(samples_wo_wrap, num_sink_channels));
 
-			n = MIN(src_loops, dst_loops);
 			n = MIN(n, frames_left);
 
 			for (i = 0; i < n; i++) {
@@ -228,20 +223,20 @@ static inline int remap_c32_right_shift(const struct audio_stream *source,
 	return source_samples;
 }
 
-static inline int remap_c16_to_c32(const struct audio_stream *source,
-				   struct audio_stream *sink,
-				   uint32_t source_samples, uint32_t chmap,
+static inline int remap_c16_to_c32(const struct cir_buf_source *source,
+				   uint32_t num_src_channels,
+				   struct cir_buf_sink *sink,
+				   uint32_t num_sink_channels,
+				   size_t source_samples, uint32_t chmap,
 				   int shift)
 {
-	int src_channel, sink_channel;
-	int num_src_channels = audio_stream_get_channels(source);
-	int num_sink_channels = audio_stream_get_channels(sink);
-	int frames = source_samples / num_src_channels;
+	uint32_t src_channel, sink_channel;
+	size_t frames = source_samples / num_src_channels;
 
 	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
-		int16_t *src;
+		const int16_t *src;
 		int32_t *dst;
-		int frames_left;
+		size_t frames_left;
 
 		src_channel = chmap & 0xf;
 		chmap >>= 4;
@@ -250,29 +245,27 @@ static inline int remap_c16_to_c32(const struct audio_stream *source,
 		 * a crafted chmap nibble cannot index past the source frame.
 		 */
 		if (src_channel == 0xf || src_channel >= num_src_channels) {
-			mute_channel_c32(sink, sink_channel, frames);
+			mute_channel_c32(sink, num_sink_channels, sink_channel, frames);
 			continue;
 		}
 
-		src = (int16_t *)audio_stream_get_rptr(source) + src_channel;
-		dst = (int32_t *)audio_stream_get_wptr(sink) + sink_channel;
+		src = (const int16_t *)source->ptr + src_channel;
+		dst = (int32_t *)sink->ptr + sink_channel;
 
 		frames_left = frames;
 
 		while (frames_left) {
-			int src_samples_wo_wrap, dst_samples_wo_wrap;
-			int src_loops, dst_loops, n, i;
+			size_t samples_wo_wrap, n, i;
 
-			src = audio_stream_wrap(source, src);
-			dst = audio_stream_wrap(sink, dst);
+			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
-			src_samples_wo_wrap = audio_stream_samples_without_wrap_s16(source, src);
-			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s16(src, source->buf_end);
+			n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_src_channels);
 
-			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s32(sink, dst);
-			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(dst, sink->buf_end);
+			n = MIN(n, SOF_DIV_ROUND_UP(samples_wo_wrap, num_sink_channels));
 
-			n = MIN(src_loops, dst_loops);
 			n = MIN(n, frames_left);
 
 			for (i = 0; i < n; i++) {
@@ -288,20 +281,20 @@ static inline int remap_c16_to_c32(const struct audio_stream *source,
 	return source_samples;
 }
 
-static inline int remap_c32_to_c16(const struct audio_stream *source,
-				   struct audio_stream *sink,
-				   uint32_t source_samples, uint32_t chmap,
+static inline int remap_c32_to_c16(const struct cir_buf_source *source,
+				   uint32_t num_src_channels,
+				   struct cir_buf_sink *sink,
+				   uint32_t num_sink_channels,
+				   size_t source_samples, uint32_t chmap,
 				   int shift)
 {
-	int src_channel, sink_channel;
-	int num_src_channels = audio_stream_get_channels(source);
-	int num_sink_channels = audio_stream_get_channels(sink);
-	int frames = source_samples / num_src_channels;
+	uint32_t src_channel, sink_channel;
+	size_t frames = source_samples / num_src_channels;
 
 	for (sink_channel = 0; sink_channel < num_sink_channels; sink_channel++) {
-		int32_t *src;
+		const int32_t *src;
 		int16_t *dst;
-		int frames_left;
+		size_t frames_left;
 
 		src_channel = chmap & 0xf;
 		chmap >>= 4;
@@ -310,29 +303,27 @@ static inline int remap_c32_to_c16(const struct audio_stream *source,
 		 * a crafted chmap nibble cannot index past the source frame.
 		 */
 		if (src_channel == 0xf || src_channel >= num_src_channels) {
-			mute_channel_c16(sink, sink_channel, frames);
+			mute_channel_c16(sink, num_sink_channels, sink_channel, frames);
 			continue;
 		}
 
-		src = (int32_t *)audio_stream_get_rptr(source) + src_channel;
-		dst = (int16_t *)audio_stream_get_wptr(sink) + sink_channel;
+		src = (const int32_t *)source->ptr + src_channel;
+		dst = (int16_t *)sink->ptr + sink_channel;
 
 		frames_left = frames;
 
 		while (frames_left) {
-			int src_samples_wo_wrap, dst_samples_wo_wrap;
-			int src_loops, dst_loops, n, i;
+			size_t samples_wo_wrap, n, i;
 
-			src = audio_stream_wrap(source, src);
-			dst = audio_stream_wrap(sink, dst);
+			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
-			src_samples_wo_wrap = audio_stream_samples_without_wrap_s32(source, src);
-			src_loops = SOF_DIV_ROUND_UP(src_samples_wo_wrap, num_src_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);
+			n = SOF_DIV_ROUND_UP(samples_wo_wrap, num_src_channels);
 
-			dst_samples_wo_wrap = audio_stream_samples_without_wrap_s16(sink, dst);
-			dst_loops = SOF_DIV_ROUND_UP(dst_samples_wo_wrap, num_sink_channels);
+			samples_wo_wrap = cir_buf_samples_without_wrap_s16(dst, sink->buf_end);
+			n = MIN(n, SOF_DIV_ROUND_UP(samples_wo_wrap, num_sink_channels));
 
-			n = MIN(src_loops, dst_loops);
 			n = MIN(n, frames_left);
 
 			for (i = 0; i < n; i++) {
@@ -348,81 +339,96 @@ static inline int remap_c32_to_c16(const struct audio_stream *source,
 	return source_samples;
 }
 
-static int remap_c32(const struct audio_stream *source, uint32_t dummy1,
-		     struct audio_stream *sink, uint32_t dummy2,
-		     uint32_t source_samples, uint32_t chmap)
+static int remap_c32(const struct cir_buf_source *source, uint32_t src_channels,
+		     struct cir_buf_sink *sink, uint32_t sink_channels,
+		     size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_left_shift(source, sink, source_samples, chmap, 0);
+	return remap_c32_left_shift(source, src_channels, sink, sink_channels,
+				    source_samples, chmap, 0);
 }
 
-static int remap_c32_to_c16_right_shift_16(const struct audio_stream *source, uint32_t dummy1,
-					   struct audio_stream *sink, uint32_t dummy2,
-					   uint32_t source_samples, uint32_t chmap)
+static int remap_c32_to_c16_right_shift_16(const struct cir_buf_source *source,
+					   uint32_t src_channels, struct cir_buf_sink *sink,
+					   uint32_t sink_channels,
+					   size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_to_c16(source, sink, source_samples, chmap, 16);
+	return remap_c32_to_c16(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 16);
 }
 
-static int remap_c16_to_c32_left_shift_16(const struct audio_stream *source, uint32_t dummy1,
-					  struct audio_stream *sink, uint32_t dummy2,
-					  uint32_t source_samples, uint32_t chmap)
+static int remap_c16_to_c32_left_shift_16(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels,
+					  size_t source_samples, uint32_t chmap)
 {
-	return remap_c16_to_c32(source, sink, source_samples, chmap, 16);
+	return remap_c16_to_c32(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 16);
 }
 
-static int remap_c32_to_c16_right_shift_8(const struct audio_stream *source, uint32_t dummy1,
-					  struct audio_stream *sink, uint32_t dummy2,
-					  uint32_t source_samples, uint32_t chmap)
+static int remap_c32_to_c16_right_shift_8(const struct cir_buf_source *source,
+					  uint32_t src_channels, struct cir_buf_sink *sink,
+					  uint32_t sink_channels,
+					  size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_to_c16(source, sink, source_samples, chmap, 8);
+	return remap_c32_to_c16(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 8);
 }
 
-static int remap_c16_to_c32_left_shift_8(const struct audio_stream *source, uint32_t dummy1,
-					 struct audio_stream *sink, uint32_t dummy2,
-					 uint32_t source_samples, uint32_t chmap)
+static int remap_c16_to_c32_left_shift_8(const struct cir_buf_source *source,
+					 uint32_t src_channels, struct cir_buf_sink *sink,
+					 uint32_t sink_channels,
+					 size_t source_samples, uint32_t chmap)
 {
-	return remap_c16_to_c32(source, sink, source_samples, chmap, 8);
+	return remap_c16_to_c32(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 8);
 }
 
-static int remap_c32_right_shift_8(const struct audio_stream *source, uint32_t dummy1,
-				   struct audio_stream *sink, uint32_t dummy2,
-				   uint32_t source_samples, uint32_t chmap)
+static int remap_c32_right_shift_8(const struct cir_buf_source *source, uint32_t src_channels,
+				   struct cir_buf_sink *sink, uint32_t sink_channels,
+				   size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_right_shift(source, sink, source_samples, chmap, 8);
+	return remap_c32_right_shift(source, src_channels, sink, sink_channels,
+				     source_samples, chmap, 8);
 }
 
-static int remap_c32_left_shift_8(const struct audio_stream *source, uint32_t dummy1,
-				  struct audio_stream *sink, uint32_t dummy2,
-				  uint32_t source_samples, uint32_t chmap)
+static int remap_c32_left_shift_8(const struct cir_buf_source *source, uint32_t src_channels,
+				  struct cir_buf_sink *sink, uint32_t sink_channels,
+				  size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_left_shift(source, sink, source_samples, chmap, 8);
+	return remap_c32_left_shift(source, src_channels, sink, sink_channels,
+				    source_samples, chmap, 8);
 }
 
-static int remap_c32_right_shift_16(const struct audio_stream *source, uint32_t dummy1,
-				    struct audio_stream *sink, uint32_t dummy2,
-				    uint32_t source_samples, uint32_t chmap)
+static int remap_c32_right_shift_16(const struct cir_buf_source *source, uint32_t src_channels,
+				    struct cir_buf_sink *sink, uint32_t sink_channels,
+				    size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_right_shift(source, sink, source_samples, chmap, 16);
+	return remap_c32_right_shift(source, src_channels, sink, sink_channels,
+				     source_samples, chmap, 16);
 }
 
-static int remap_c32_left_shift_16(const struct audio_stream *source, uint32_t dummy1,
-				   struct audio_stream *sink, uint32_t dummy2,
-				   uint32_t source_samples, uint32_t chmap)
+static int remap_c32_left_shift_16(const struct cir_buf_source *source, uint32_t src_channels,
+				   struct cir_buf_sink *sink, uint32_t sink_channels,
+				   size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_left_shift(source, sink, source_samples, chmap, 16);
+	return remap_c32_left_shift(source, src_channels, sink, sink_channels,
+				    source_samples, chmap, 16);
 }
 
-static int remap_c32_to_c16_no_shift(const struct audio_stream *source, uint32_t dummy1,
-				     struct audio_stream *sink, uint32_t dummy2,
-				     uint32_t source_samples, uint32_t chmap)
+static int remap_c32_to_c16_no_shift(const struct cir_buf_source *source, uint32_t src_channels,
+				     struct cir_buf_sink *sink, uint32_t sink_channels,
+				     size_t source_samples, uint32_t chmap)
 {
-	return remap_c32_to_c16(source, sink, source_samples, chmap, 0);
+	return remap_c32_to_c16(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 0);
 }
 
-static int remap_c16_to_c32_no_shift(const struct audio_stream *source, uint32_t dummy1,
-				     struct audio_stream *sink, uint32_t dummy2,
-				     uint32_t source_samples, uint32_t chmap)
+static int remap_c16_to_c32_no_shift(const struct cir_buf_source *source, uint32_t src_channels,
+				     struct cir_buf_sink *sink, uint32_t sink_channels,
+				     size_t source_samples, uint32_t chmap)
 {
-	return remap_c16_to_c32(source, sink, source_samples, chmap, 0);
+	return remap_c16_to_c32(source, src_channels, sink, sink_channels,
+				source_samples, chmap, 0);
 }
 
 /* Unfortunately, all these nice "if"s were commented out to suppress

--- a/src/include/sof/audio/audio_stream.h
+++ b/src/include/sof/audio/audio_stream.h
@@ -902,7 +902,7 @@ audio_stream_samples_without_wrap_s32(const struct audio_stream *source, const v
  * @return Number of bytes to buffer wrap. For number of samples calculate
  *	   need to add size of sample to returned bytes count.
  */
-static inline int cir_buf_bytes_without_wrap(void *ptr, void *buf_end)
+static inline int cir_buf_bytes_without_wrap(const void *ptr, const void *buf_end)
 {
 	assert((intptr_t)buf_end >= (intptr_t)ptr);
 	return (intptr_t)buf_end - (intptr_t)ptr;
@@ -946,7 +946,7 @@ int audio_stream_copy(const struct audio_stream *source, uint32_t ioffset,
  * @param dst_end End address of sink circular buffer.
  * @param byte_size Number of bytes to copy.
  */
-void cir_buf_copy(void *src, void *src_addr, void *src_end, void *dst,
+void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, void *dst,
 		  void *dst_addr, void *dst_end, size_t byte_size);
 
 /**

--- a/src/include/sof/audio/pcm_converter.h
+++ b/src/include/sof/audio/pcm_converter.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 
 struct audio_stream;
+struct cir_buf_source;
+struct cir_buf_sink;
 
 #if __XCC__
 #include <xtensa/config/core-isa.h>
@@ -38,17 +40,17 @@ struct audio_stream;
 
 /**
  * \brief PCM conversion function interface for data in circular buffer
- * \param source buffer with samples to process, read pointer is not modified
- * \param ioffset offset to first sample in source stream
- * \param sink output buffer, write pointer is not modified
- * \param ooffset offset to first sample in sink stream
+ * \param source circular-buffer source descriptor, read pointer is not modified
+ * \param src_channels number of channels in the source stream
+ * \param sink circular-buffer sink descriptor, write pointer is not modified
+ * \param sink_channels number of channels in the sink stream
  * \param source_samples number of samples to convert, for remapping -- number of source samples
  * \param chmap channel map for remapping, ignored by non-remapping conversion func
  * \return error code or number of processed samples (source samples in case of remapping).
  */
-typedef int (*pcm_converter_func)(const struct audio_stream *source,
-				  uint32_t ioffset, struct audio_stream *sink,
-				  uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
+typedef int (*pcm_converter_func)(const struct cir_buf_source *source,
+				  uint32_t src_channels, struct cir_buf_sink *sink,
+				  uint32_t sink_channels, size_t source_samples, uint32_t chmap);
 
 /* A channel map that does not perform any remapping. */
 #define DUMMY_CHMAP 0x76543210
@@ -60,7 +62,7 @@ typedef int (*pcm_converter_func)(const struct audio_stream *source,
  * \param samples number of samples to convert
  */
 typedef void (*pcm_converter_lin_func)(const void *psrc, void *pdst,
-				       uint32_t samples);
+				       size_t samples);
 
 /** \brief PCM conversion functions map. */
 struct pcm_func_map {
@@ -184,20 +186,30 @@ pcm_get_conversion_vc_function(enum sof_ipc_frame in_bits,
 /**
  * \brief Convert data from circular buffer using converter working on linear
  *	  memory space
- * \param source buffer with samples to process, read pointer is not modified
- * \param ioffset offset to first sample in source stream
- * \param sink output buffer, write pointer is not modified
- * \param ooffset offset to first sample in sink stream
+ * \param source circular-buffer source descriptor, read pointer is not modified
+ * \param s_size_in source sample size in bytes
+ * \param sink circular-buffer sink descriptor, write pointer is not modified
+ * \param s_size_out sink sample size in bytes
  * \param samples number of samples to convert
  * \param converter core conversion function working on linear memory regions
  * \return error code or number of processed samples
  */
-int pcm_convert_as_linear(const struct audio_stream *source, uint32_t ioffset,
-			  struct audio_stream *sink, uint32_t ooffset,
-			  uint32_t samples, pcm_converter_lin_func converter);
+int pcm_convert_as_linear(const struct cir_buf_source *source, size_t s_size_in,
+			  struct cir_buf_sink *sink, size_t s_size_out,
+			  size_t samples, pcm_converter_lin_func converter);
 
-/* Copy stream without conversion. chmap parameter is ignored. */
-int just_copy(const struct audio_stream *source, uint32_t ioffset,
-	      struct audio_stream *sink, uint32_t ooffset, uint32_t samples, uint32_t chmap);
+/* Copy stream without conversion, typed by sample size in bytes. chmap is ignored. */
+int just_copy_1b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap);
+int just_copy_2b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap);
+int just_copy_3b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap);
+int just_copy_4b(const struct cir_buf_source *source, uint32_t src_channels,
+		 struct cir_buf_sink *sink, uint32_t sink_channels,
+		 size_t samples, uint32_t chmap);
 
 #endif /* __SOF_AUDIO_PCM_CONVERTER_H__ */

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -380,8 +380,19 @@ int dma_buffer_copy_from(struct comp_buffer *source,
 	/* source buffer contains data copied by DMA */
 	audio_stream_invalidate(istream, source_bytes);
 
-	/* process data */
-	ret = process(istream, 0, &sink->stream, 0, source_samples, chmap);
+	/* process data; the converter consumes cir_buf descriptors */
+	struct cir_buf_source cir_src = {
+		.buf_start = audio_stream_get_addr(istream),
+		.buf_end = audio_stream_get_end_addr(istream),
+		.ptr = audio_stream_get_rptr(istream),
+	};
+	struct cir_buf_sink cir_snk = {
+		.buf_start = audio_stream_get_addr(&sink->stream),
+		.buf_end = audio_stream_get_end_addr(&sink->stream),
+		.ptr = audio_stream_get_wptr(&sink->stream),
+	};
+
+	ret = process(&cir_src, source_channels, &cir_snk, sink_channels, source_samples, chmap);
 
 	buffer_stream_writeback(sink, sink_bytes);
 
@@ -443,8 +454,19 @@ int dma_buffer_copy_to(struct comp_buffer *source,
 
 	buffer_stream_invalidate(source, source_bytes);
 
-	/* process data */
-	ret = process(&source->stream, 0, ostream, 0, source_samples, chmap);
+	/* process data; the converter consumes cir_buf descriptors */
+	struct cir_buf_source cir_src = {
+		.buf_start = audio_stream_get_addr(&source->stream),
+		.buf_end = audio_stream_get_end_addr(&source->stream),
+		.ptr = audio_stream_get_rptr(&source->stream),
+	};
+	struct cir_buf_sink cir_snk = {
+		.buf_start = audio_stream_get_addr(ostream),
+		.buf_end = audio_stream_get_end_addr(ostream),
+		.ptr = audio_stream_get_wptr(ostream),
+	};
+
+	ret = process(&cir_src, source_channels, &cir_snk, sink_channels, source_samples, chmap);
 
 	/* sink buffer contains data meant to copied to DMA */
 	audio_stream_writeback(ostream, sink_bytes);
@@ -505,8 +527,19 @@ int stream_copy_from_no_consume(struct comp_dev *dev, struct comp_buffer *source
 		source_samples = frames * source_channels;
 	}
 
-	/* process data */
-	ret = process(istream, 0, &sink->stream, 0, source_samples, chmap);
+	/* process data; the converter consumes cir_buf descriptors */
+	struct cir_buf_source cir_src = {
+		.buf_start = audio_stream_get_addr(istream),
+		.buf_end = audio_stream_get_end_addr(istream),
+		.ptr = audio_stream_get_rptr(istream),
+	};
+	struct cir_buf_sink cir_snk = {
+		.buf_start = audio_stream_get_addr(&sink->stream),
+		.buf_end = audio_stream_get_end_addr(&sink->stream),
+		.ptr = audio_stream_get_wptr(&sink->stream),
+	};
+
+	ret = process(&cir_src, source_channels, &cir_snk, sink_channels, source_samples, chmap);
 
 #if CONFIG_INTEL_ADSP_MIC_PRIVACY
 	struct processing_module *mod = comp_mod(dev);

--- a/test/cmocka/src/audio/pcm_converter/pcm_float.c
+++ b/test/cmocka/src/audio/pcm_converter/pcm_float.c
@@ -99,7 +99,20 @@ static struct comp_buffer *_test_pcm_convert(enum sof_ipc_frame frm_in, enum sof
 	/* run conversion */
 	fun = pcm_get_conversion_function(frm_in, frm_out);
 	assert_non_null(fun);
-	fun(&source->stream, 0, &sink->stream, 0, samples, DUMMY_CHMAP);
+
+	struct cir_buf_source cir_src = {
+		.buf_start = source->stream.addr,
+		.buf_end = source->stream.end_addr,
+		.ptr = source->stream.r_ptr,
+	};
+	struct cir_buf_sink cir_snk = {
+		.buf_start = sink->stream.addr,
+		.buf_end = sink->stream.end_addr,
+		.ptr = sink->stream.w_ptr,
+	};
+
+	fun(&cir_src, audio_stream_get_channels(&source->stream),
+	    &cir_snk, audio_stream_get_channels(&sink->stream), samples, DUMMY_CHMAP);
 
 	/* assert last value in sink is untouched */
 	assert_int_equal(((uint8_t *)sink->stream.w_ptr)[outbytes - 1], fillval);

--- a/zephyr/include/sof/lib/dma.h
+++ b/zephyr/include/sof/lib/dma.h
@@ -259,10 +259,11 @@ struct dma_copy {
 #endif
 };
 
-struct audio_stream;
-typedef int (*dma_process_func)(const struct audio_stream *source,
-				uint32_t ioffset, struct audio_stream *sink,
-				uint32_t ooffset, uint32_t source_samples, uint32_t chmap);
+struct cir_buf_source;
+struct cir_buf_sink;
+typedef int (*dma_process_func)(const struct cir_buf_source *source,
+				uint32_t src_channels, struct cir_buf_sink *sink,
+				uint32_t sink_channels, size_t source_samples, uint32_t chmap);
 
 /**
  * \brief API to initialize a platform DMA controllers.


### PR DESCRIPTION
Rework the pcm conversion and dma copy paths to operate on circular buffer source and sink descriptors instead of the legacy audio stream buffers to prepare the sof for the full transition to pipeline 2.0.