### PR TITLE
topology2: rename sof-ptl-rt713-l3-rt1320-l1-2ch.tplg

### DIFF
--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -168,11 +168,11 @@ SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-
 SDW_JACK_OUT_STREAM=Playback-SimpleJack,SDW_JACK_IN_STREAM=Capture-SimpleJack"
 
 # LG Gram Pro 2026 (16Z90U-KU7BK) with RT713 on link 3 and single stereo RT1320 on link 1
-"cavs-sdw\;sof-ptl-rt713-l3-rt1320-l1\;PLATFORM=ptl,SDW_DMIC=0,NUM_SDW_AMP_LINKS=1,\
+"cavs-sdw\;sof-ptl-rt713-l3-rt1320-l1-2ch\;PLATFORM=ptl,SDW_DMIC=0,NUM_SDW_AMP_LINKS=1,\
 NUM_DMICS=2,PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=SDW1-Playback,\
 SDW_JACK_OUT_STREAM=SDW3-Playback,SDW_JACK_IN_STREAM=SDW3-Capture,\
-PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt713-l3-rt1320-l1.bin"
+PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-rt713-l3-rt1320-l1-2ch.bin"
 
 "cavs-sdw\;sof-ptl-cs42l43-l2-cs35l56x6-l13\;NUM_SDW_AMP_LINKS=3,SDW_DMIC=1,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_STREAM=Playback-SmartAmp,SDW_DMIC_STREAM=Capture-SmartMic,\


### PR DESCRIPTION
The existing sof-ptl-rt713-l3-rt1320-l1.tplg includes 2ch PCH DMIC. And the '-2ch' suffix will be added in the Linux driver. Rename sof-ptl-rt713-l3-rt1320-l1 to sof-ptl-rt713-l3-rt1320-l1-2ch. It is fine because the sof-ptl-rt713-l3-rt1320-l1.tplg was not released to sof-bin yet.