### PR TITLE
west.yml: update to include a p4wq fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 9885b002c1bdfd520355de44daa34edefc86f9e6
+      revision: fbd71c30f7b9083de9826577edb57d360efc01ed
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Update Zephyr to include 24f16b4f886c ("lib: os: p4wq: skip k_thread_cpu_mask_clear() in PIN_ONLY mode").