### PR TITLE
ipc: eliminate multiple memcpy() calls

### DIFF
--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -37,7 +37,7 @@ struct comp_driver_list {
 #if CONFIG_IPC_MAJOR_3
 struct comp_dev *comp_new(struct sof_ipc_comp *comp);
 #elif CONFIG_IPC_MAJOR_4
-struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init);
+struct comp_dev *comp_new_ipc4(const struct ipc4_module_init_instance *module_init);
 #endif
 
 /** See comp_ops::free */

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -56,8 +56,8 @@ struct comp_driver;
 struct comp_dev *comp_new_ipc4_user(struct ipc4_message_request *ipc4,
 				    const struct comp_driver *drv);
 #endif
-int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma);
-int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma);
+int ipc4_chain_manager_create(const struct ipc4_chain_dma *cdma);
+int ipc4_chain_dma_state(struct comp_dev *dev, const struct ipc4_chain_dma *cdma);
 int ipc4_create_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma);
 int ipc4_trigger_chain_dma(struct ipc *ipc, struct ipc4_chain_dma *cdma, bool *delay);
 int ipc4_process_on_core(uint32_t core, bool blocking);

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -583,15 +583,11 @@ __cold static int ipc4_process_chain_dma(struct ipc4_message_request *ipc4)
 #if CONFIG_COMP_CHAIN_DMA
 	struct ipc_comp_dev *cdma_comp;
 	struct ipc *ipc = ipc_get();
-	struct ipc4_chain_dma cdma;
+	const struct ipc4_chain_dma *cdma = (const struct ipc4_chain_dma *)ipc4;
 	int comp_id;
 	int ret;
 
-	ret = memcpy_s(&cdma, sizeof(cdma), ipc4, sizeof(*ipc4));
-	if (ret < 0)
-		return IPC4_FAILURE;
-
-	comp_id = IPC4_COMP_ID(cdma.primary.r.host_dma_id + IPC4_MAX_MODULE_COUNT, 0);
+	comp_id = IPC4_COMP_ID(cdma->primary.r.host_dma_id + IPC4_MAX_MODULE_COUNT, 0);
 	cdma_comp = ipc_get_comp_by_id(ipc, comp_id);
 
 	if (!cdma_comp) {
@@ -599,10 +595,10 @@ __cold static int ipc4_process_chain_dma(struct ipc4_message_request *ipc4)
 		 * Nothing to do when the chainDMA is not allocated and asked to
 		 * be freed
 		 */
-		if (!cdma.primary.r.allocate && !cdma.primary.r.enable)
+		if (!cdma->primary.r.allocate && !cdma->primary.r.enable)
 			return IPC4_SUCCESS;
 
-		ret = ipc4_chain_manager_create(&cdma);
+		ret = ipc4_chain_manager_create(cdma);
 		if (ret < 0)
 			return IPC4_FAILURE;
 
@@ -611,7 +607,7 @@ __cold static int ipc4_process_chain_dma(struct ipc4_message_request *ipc4)
 			return IPC4_FAILURE;
 		}
 
-		ret = ipc4_chain_dma_state(cdma_comp->cd, &cdma);
+		ret = ipc4_chain_dma_state(cdma_comp->cd, cdma);
 		if (ret < 0) {
 			comp_free(cdma_comp->cd);
 			list_item_del(&cdma_comp->list);
@@ -622,7 +618,7 @@ __cold static int ipc4_process_chain_dma(struct ipc4_message_request *ipc4)
 		return IPC4_SUCCESS;
 	}
 
-	ret = ipc4_chain_dma_state(cdma_comp->cd, &cdma);
+	ret = ipc4_chain_dma_state(cdma_comp->cd, cdma);
 	if (ret < 0)
 		return IPC4_INVALID_CHAIN_STATE_TRANSITION;
 
@@ -760,31 +756,25 @@ int ipc4_user_process_glb_message(struct ipc4_message_request *ipc4,
 
 __cold static int ipc4_init_module_instance(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_module_init_instance module_init;
+	const struct ipc4_module_init_instance *module_init =
+		(const struct ipc4_module_init_instance *)ipc4;
 	struct comp_dev *dev;
 
 	assert_can_be_cold();
 
-	/* we only need the common header here, all we have from the IPC */
-	int ret = memcpy_s(&module_init, sizeof(module_init), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
-	tr_dbg(&ipc_tr,
-		"%x : %x",
-		(uint32_t)module_init.primary.r.module_id,
-		(uint32_t)module_init.primary.r.instance_id);
+	tr_dbg(&ipc_tr, "%x : %x",
+	       (uint32_t)module_init->primary.r.module_id,
+	       (uint32_t)module_init->primary.r.instance_id);
 
 	/* Pass IPC to target core */
-	if (!cpu_is_me(module_init.extension.r.core_id))
-		return ipc4_process_on_core(module_init.extension.r.core_id, false);
+	if (!cpu_is_me(module_init->extension.r.core_id))
+		return ipc4_process_on_core(module_init->extension.r.core_id, false);
 
-	dev = comp_new_ipc4(&module_init);
+	dev = comp_new_ipc4(module_init);
 	if (!dev) {
 		ipc_cmd_err(&ipc_tr, "error: failed to init module %x : %x",
-			    (uint32_t)module_init.primary.r.module_id,
-			    (uint32_t)module_init.primary.r.instance_id);
+			    (uint32_t)module_init->primary.r.module_id,
+			    (uint32_t)module_init->primary.r.instance_id);
 		return IPC4_MOD_NOT_INITIALIZED;
 	}
 
@@ -794,40 +784,30 @@ __cold static int ipc4_init_module_instance(struct ipc4_message_request *ipc4)
 #ifndef CONFIG_SOF_USERSPACE_LL
 __cold static int ipc4_bind_module_instance(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_module_bind_unbind bu;
+	struct ipc4_module_bind_unbind *bu = (struct ipc4_module_bind_unbind *)ipc4;
 	struct ipc *ipc = ipc_get();
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&bu, sizeof(bu), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	tr_dbg(&ipc_tr, "%x : %x with %x : %x",
-	       (uint32_t)bu.primary.r.module_id, (uint32_t)bu.primary.r.instance_id,
-	       (uint32_t)bu.extension.r.dst_module_id, (uint32_t)bu.extension.r.dst_instance_id);
+	       (uint32_t)bu->primary.r.module_id, (uint32_t)bu->primary.r.instance_id,
+	       (uint32_t)bu->extension.r.dst_module_id, (uint32_t)bu->extension.r.dst_instance_id);
 
-	return ipc_comp_connect(ipc, (ipc_pipe_comp_connect *)&bu);
+	return ipc_comp_connect(ipc, (ipc_pipe_comp_connect *)bu);
 }
 
 __cold static int ipc4_unbind_module_instance(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_module_bind_unbind bu;
+	struct ipc4_module_bind_unbind *bu = (struct ipc4_module_bind_unbind *)ipc4;
 	struct ipc *ipc = ipc_get();
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&bu, sizeof(bu), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	tr_dbg(&ipc_tr, "%x : %x with %x : %x",
-	       (uint32_t)bu.primary.r.module_id, (uint32_t)bu.primary.r.instance_id,
-	       (uint32_t)bu.extension.r.dst_module_id, (uint32_t)bu.extension.r.dst_instance_id);
+	       (uint32_t)bu->primary.r.module_id, (uint32_t)bu->primary.r.instance_id,
+	       (uint32_t)bu->extension.r.dst_module_id, (uint32_t)bu->extension.r.dst_instance_id);
 
-	return ipc_comp_disconnect(ipc, (ipc_pipe_comp_connect *)&bu);
+	return ipc_comp_disconnect(ipc, (ipc_pipe_comp_connect *)bu);
 }
 #endif /* !CONFIG_SOF_USERSPACE_LL */
 
@@ -1048,30 +1028,27 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 					void **reply_tx_data)
 {
 	struct ipc4_module_large_config_reply reply;
-	struct ipc4_module_large_config config;
+	const struct ipc4_module_large_config *config =
+		(const struct ipc4_module_large_config *)ipc4;
 	char *data = ipc_get()->comp_data;
 	const struct comp_driver *drv;
 	struct comp_dev *dev = NULL;
 	uint32_t data_offset;
+	int ret;
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	tr_dbg(&ipc_tr, "%x : %x",
-	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+	       (uint32_t)config->primary.r.module_id, (uint32_t)config->primary.r.instance_id);
 
 	/* get component dev for non-basefw since there is no
 	 * component dev for basefw
 	 */
-	if (config.primary.r.module_id) {
+	if (config->primary.r.module_id) {
 		uint32_t comp_id;
 
-		comp_id = IPC4_COMP_ID(config.primary.r.module_id,
-				       config.primary.r.instance_id);
+		comp_id = IPC4_COMP_ID(config->primary.r.module_id,
+				       config->primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
 			return IPC4_MOD_INVALID_ID;
@@ -1082,7 +1059,7 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 		 * non-userspace path retains ipc4_process_on_core()
 		 */
 	} else {
-		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+		drv = ipc4_get_comp_drv(config->primary.r.module_id);
 	}
 
 	if (!drv)
@@ -1091,16 +1068,16 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 	if (!drv->ops.get_large_config)
 		return IPC4_INVALID_REQUEST;
 
-	data_offset = config.extension.r.data_off_size;
+	data_offset = config->extension.r.data_off_size;
 
 	/* check for vendor param first */
-	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+	if (config->extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
 		/* For now only vendor_config case uses payload from hostbox */
 		dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
-					 config.extension.r.data_off_size);
+					 config->extension.r.data_off_size);
 		ret = ipc4_get_vendor_config_module_instance(dev, drv,
-							     config.extension.r.init_block,
-							     config.extension.r.final_block,
+							     config->extension.r.init_block,
+							     config->extension.r.final_block,
 							     &data_offset,
 							     data,
 							     (const char *)MAILBOX_HOSTBOX_BASE);
@@ -1108,12 +1085,12 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 #if CONFIG_LIBRARY
 		data += sizeof(reply);
 #endif
-		ipc4_prepare_for_kcontrol_get(dev, config.extension.r.large_param_id,
+		ipc4_prepare_for_kcontrol_get(dev, config->extension.r.large_param_id,
 					      data, data_offset);
 
-		ret = drv->ops.get_large_config(dev, config.extension.r.large_param_id,
-						config.extension.r.init_block,
-						config.extension.r.final_block,
+		ret = drv->ops.get_large_config(dev, config->extension.r.large_param_id,
+						config->extension.r.init_block,
+						config->extension.r.final_block,
 						&data_offset, data);
 	}
 
@@ -1122,11 +1099,11 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 		ret = IPC4_MOD_INVALID_ID;
 
 	/* Copy host config and overwrite */
-	reply.extension.dat = config.extension.dat;
+	reply.extension.dat = config->extension.dat;
 	reply.extension.r.data_off_size = data_offset;
 
 	/* The last block, no more data */
-	if (!config.extension.r.final_block && data_offset < SOF_IPC_MSG_MAX_SIZE)
+	if (!config->extension.r.final_block && data_offset < SOF_IPC_MSG_MAX_SIZE)
 		reply.extension.r.final_block = 1;
 
 	/* Indicate last block if error occurs */
@@ -1147,30 +1124,27 @@ __cold int ipc4_process_large_config_get(struct ipc4_message_request *ipc4,
 __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_request *ipc4)
 {
 	struct ipc4_module_large_config_reply reply;
-	struct ipc4_module_large_config config;
+	const struct ipc4_module_large_config *config =
+		(const struct ipc4_module_large_config *)ipc4;
 	char *data = ipc_get()->comp_data;
 	const struct comp_driver *drv;
 	struct comp_dev *dev = NULL;
 	uint32_t data_offset;
+	int ret;
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	tr_dbg(&ipc_tr, "%x : %x",
-	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+	       (uint32_t)config->primary.r.module_id, (uint32_t)config->primary.r.instance_id);
 
 	/* get component dev for non-basefw since there is no
 	 * component dev for basefw
 	 */
-	if (config.primary.r.module_id) {
+	if (config->primary.r.module_id) {
 		uint32_t comp_id;
 
-		comp_id = IPC4_COMP_ID(config.primary.r.module_id,
-				       config.primary.r.instance_id);
+		comp_id = IPC4_COMP_ID(config->primary.r.module_id,
+				       config->primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
 			return IPC4_INVALID_RESOURCE_ID;
@@ -1182,10 +1156,10 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 			return ipc4_process_on_core(dev->ipc_config.core, false);
 	} else {
 		/* BaseFW module has only 0th instance */
-		if (config.primary.r.instance_id)
+		if (config->primary.r.instance_id)
 			return IPC4_INVALID_RESOURCE_ID;
 
-		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+		drv = ipc4_get_comp_drv(config->primary.r.module_id);
 	}
 
 	if (!drv)
@@ -1194,10 +1168,10 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 	if (!drv->ops.get_large_config)
 		return IPC4_INVALID_REQUEST;
 
-	data_offset =  config.extension.r.data_off_size;
+	data_offset = config->extension.r.data_off_size;
 
 	/* check for vendor param first */
-	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+	if (config->extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
 		/* data_off_size is a 20-bit host-controlled field, so it can
 		 * claim far more than the hostbox can physically hold.
 		 */
@@ -1208,23 +1182,22 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 		}
 		/* For now only vendor_config case uses payload from hostbox */
 		dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
-					 config.extension.r.data_off_size);
+					 config->extension.r.data_off_size);
 		ret = ipc4_get_vendor_config_module_instance(dev, drv,
-							     config.extension.r.init_block,
-							     config.extension.r.final_block,
-							     &data_offset,
-							     data,
+							     config->extension.r.init_block,
+							     config->extension.r.final_block,
+							     &data_offset, data,
 							     (const char *)MAILBOX_HOSTBOX_BASE);
 	} else {
 #if CONFIG_LIBRARY
 		data += sizeof(reply);
 #endif
-		ipc4_prepare_for_kcontrol_get(dev, config.extension.r.large_param_id,
+		ipc4_prepare_for_kcontrol_get(dev, config->extension.r.large_param_id,
 					      data, data_offset);
 
-		ret = drv->ops.get_large_config(dev, config.extension.r.large_param_id,
-						config.extension.r.init_block,
-						config.extension.r.final_block,
+		ret = drv->ops.get_large_config(dev, config->extension.r.large_param_id,
+						config->extension.r.init_block,
+						config->extension.r.final_block,
 						&data_offset, data);
 	}
 
@@ -1233,11 +1206,11 @@ __cold static int ipc4_get_large_config_module_instance(struct ipc4_message_requ
 		ret = IPC4_INVALID_RESOURCE_ID;
 
 	/* Copy host config and overwrite */
-	reply.extension.dat = config.extension.dat;
+	reply.extension.dat = config->extension.dat;
 	reply.extension.r.data_off_size = data_offset;
 
 	/* The last block, no more data */
-	if (!config.extension.r.final_block && data_offset < SOF_IPC_MSG_MAX_SIZE)
+	if (!config->extension.r.final_block && data_offset < SOF_IPC_MSG_MAX_SIZE)
 		reply.extension.r.final_block = 1;
 
 	/* Indicate last block if error occurs */
@@ -1338,26 +1311,23 @@ __cold static int ipc4_set_vendor_config_module_instance(struct comp_dev *dev,
 
 __cold int ipc4_process_large_config_set(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_module_large_config config;
+	const struct ipc4_module_large_config *config =
+		(const struct ipc4_module_large_config *)ipc4;
 	struct comp_dev *dev = NULL;
 	const struct comp_driver *drv;
+	int ret;
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
-				 config.extension.r.data_off_size);
+				 config->extension.r.data_off_size);
 	tr_dbg(&ipc_tr, "%x : %x",
-	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+	       (uint32_t)config->primary.r.module_id, (uint32_t)config->primary.r.instance_id);
 
-	if (config.primary.r.module_id) {
+	if (config->primary.r.module_id) {
 		uint32_t comp_id;
 
-		comp_id = IPC4_COMP_ID(config.primary.r.module_id, config.primary.r.instance_id);
+		comp_id = IPC4_COMP_ID(config->primary.r.module_id, config->primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
 			return IPC4_MOD_INVALID_ID;
@@ -1368,7 +1338,7 @@ __cold int ipc4_process_large_config_set(struct ipc4_message_request *ipc4)
 		 * non-userspace path retains ipc4_process_on_core()
 		 */
 	} else {
-		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+		drv = ipc4_get_comp_drv(config->primary.r.module_id);
 	}
 
 	if (!drv)
@@ -1378,28 +1348,28 @@ __cold int ipc4_process_large_config_set(struct ipc4_message_request *ipc4)
 		return IPC4_INVALID_REQUEST;
 
 	/* check for vendor param first */
-	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+	if (config->extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
 		ret = ipc4_set_vendor_config_module_instance(dev, drv,
-							     (uint32_t)config.primary.r.module_id,
-							     (uint32_t)config.primary.r.instance_id,
-							     config.extension.r.init_block,
-							     config.extension.r.final_block,
-							     config.extension.r.data_off_size,
+							     (uint32_t)config->primary.r.module_id,
+							     (uint32_t)config->primary.r.instance_id,
+							     config->extension.r.init_block,
+							     config->extension.r.final_block,
+							     config->extension.r.data_off_size,
 							     (const char *)MAILBOX_HOSTBOX_BASE);
 	} else {
 #if CONFIG_LIBRARY
 		struct ipc *ipc = ipc_get();
-		const char *data = (const char *)ipc->comp_data + sizeof(config);
+		const char *data = (const char *)ipc->comp_data + sizeof(*config);
 #else
 		const char *data = (const char *)MAILBOX_HOSTBOX_BASE;
 #endif
-		ret = drv->ops.set_large_config(dev, config.extension.r.large_param_id,
-			config.extension.r.init_block, config.extension.r.final_block,
-			config.extension.r.data_off_size, data);
+		ret = drv->ops.set_large_config(dev, config->extension.r.large_param_id,
+			config->extension.r.init_block, config->extension.r.final_block,
+			config->extension.r.data_off_size, data);
 		if (ret < 0) {
 			ipc_cmd_err(&ipc_tr, "failed to set large_config_module_instance %x : %x",
-				    (uint32_t)config.primary.r.module_id,
-				    (uint32_t)config.primary.r.instance_id);
+				    (uint32_t)config->primary.r.module_id,
+				    (uint32_t)config->primary.r.instance_id);
 			ret = IPC4_INVALID_RESOURCE_ID;
 		}
 	}
@@ -1409,26 +1379,23 @@ __cold int ipc4_process_large_config_set(struct ipc4_message_request *ipc4)
 
 __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_request *ipc4)
 {
-	struct ipc4_module_large_config config;
+	const struct ipc4_module_large_config *config =
+		(const struct ipc4_module_large_config *)ipc4;
 	struct comp_dev *dev = NULL;
 	const struct comp_driver *drv;
+	int ret;
 
 	assert_can_be_cold();
 
-	int ret = memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-
-	if (ret < 0)
-		return IPC4_FAILURE;
-
 	dcache_invalidate_region((__sparse_force void __sparse_cache *)MAILBOX_HOSTBOX_BASE,
-				 config.extension.r.data_off_size);
+				 config->extension.r.data_off_size);
 	tr_dbg(&ipc_tr, "%x : %x",
-	       (uint32_t)config.primary.r.module_id, (uint32_t)config.primary.r.instance_id);
+	       (uint32_t)config->primary.r.module_id, (uint32_t)config->primary.r.instance_id);
 
-	if (config.primary.r.module_id) {
+	if (config->primary.r.module_id) {
 		uint32_t comp_id;
 
-		comp_id = IPC4_COMP_ID(config.primary.r.module_id, config.primary.r.instance_id);
+		comp_id = IPC4_COMP_ID(config->primary.r.module_id, config->primary.r.instance_id);
 		dev = ipc4_get_comp_dev(comp_id);
 		if (!dev)
 			return IPC4_INVALID_RESOURCE_ID;
@@ -1440,10 +1407,10 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 			return ipc4_process_on_core(dev->ipc_config.core, false);
 	} else {
 		/* BaseFW module has only 0th instance */
-		if (config.primary.r.instance_id)
+		if (config->primary.r.instance_id)
 			return IPC4_INVALID_RESOURCE_ID;
 
-		drv = ipc4_get_comp_drv(config.primary.r.module_id);
+		drv = ipc4_get_comp_drv(config->primary.r.module_id);
 	}
 
 	if (!drv)
@@ -1453,28 +1420,28 @@ __cold static int ipc4_set_large_config_module_instance(struct ipc4_message_requ
 		return IPC4_INVALID_REQUEST;
 
 	/* check for vendor param first */
-	if (config.extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
+	if (config->extension.r.large_param_id == VENDOR_CONFIG_PARAM) {
 		ret = ipc4_set_vendor_config_module_instance(dev, drv,
-							     (uint32_t)config.primary.r.module_id,
-							     (uint32_t)config.primary.r.instance_id,
-							     config.extension.r.init_block,
-							     config.extension.r.final_block,
-							     config.extension.r.data_off_size,
+							     (uint32_t)config->primary.r.module_id,
+							     (uint32_t)config->primary.r.instance_id,
+							     config->extension.r.init_block,
+							     config->extension.r.final_block,
+							     config->extension.r.data_off_size,
 							     (const char *)MAILBOX_HOSTBOX_BASE);
 	} else {
 #if CONFIG_LIBRARY
 		struct ipc *ipc = ipc_get();
-		const char *data = (const char *)ipc->comp_data + sizeof(config);
+		const char *data = (const char *)ipc->comp_data + sizeof(*config);
 #else
 		const char *data = (const char *)MAILBOX_HOSTBOX_BASE;
 #endif
-		ret = drv->ops.set_large_config(dev, config.extension.r.large_param_id,
-			config.extension.r.init_block, config.extension.r.final_block,
-			config.extension.r.data_off_size, data);
+		ret = drv->ops.set_large_config(dev, config->extension.r.large_param_id,
+			config->extension.r.init_block, config->extension.r.final_block,
+			config->extension.r.data_off_size, data);
 		if (ret < 0) {
 			ipc_cmd_err(&ipc_tr, "failed to set large_config_module_instance %x : %x",
-				    (uint32_t)config.primary.r.module_id,
-				    (uint32_t)config.primary.r.instance_id);
+				    (uint32_t)config->primary.r.module_id,
+				    (uint32_t)config->primary.r.instance_id);
 			ret = IPC4_INVALID_RESOURCE_ID;
 		}
 	}
@@ -1609,10 +1576,10 @@ __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 	case SOF_IPC4_MOD_LARGE_CONFIG_GET:
 #ifdef CONFIG_SOF_USERSPACE_LL
 	{
-		struct ipc4_module_large_config config;
+		const struct ipc4_module_large_config *config =
+			(const struct ipc4_module_large_config *)ipc4;
 
-		memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-		if (config.primary.r.module_id) {
+		if (config->primary.r.module_id) {
 			/* Module case: forward to user thread */
 			ret = ipc_user_forward_cmd(ipc4->primary.dat,
 						   ipc4->extension.dat);
@@ -1639,10 +1606,10 @@ __cold int ipc4_user_process_module_message(struct ipc4_message_request *ipc4,
 	case SOF_IPC4_MOD_LARGE_CONFIG_SET:
 #ifdef CONFIG_SOF_USERSPACE_LL
 	{
-		struct ipc4_module_large_config config;
+		const struct ipc4_module_large_config *config =
+			(const struct ipc4_module_large_config *)ipc4;
 
-		memcpy_s(&config, sizeof(config), ipc4, sizeof(*ipc4));
-		if (config.primary.r.module_id) {
+		if (config->primary.r.module_id) {
 			ret = ipc_user_forward_cmd(ipc4->primary.dat,
 						   ipc4->extension.dat);
 		} else {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -110,7 +110,7 @@ __cold static inline char *ipc4_get_comp_new_data(void)
 #endif
 
 /* Only called from ipc4_init_module_instance(), which is __cold */
-__cold struct comp_dev *comp_new_ipc4(struct ipc4_module_init_instance *module_init)
+__cold struct comp_dev *comp_new_ipc4(const struct ipc4_module_init_instance *module_init)
 {
 	struct comp_ipc_config ipc_config;
 	const struct comp_driver *drv;
@@ -1148,7 +1148,7 @@ __cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 
 #if CONFIG_COMP_CHAIN_DMA
 /* Only called from ipc4_process_chain_dma(), which is __cold */
-__cold int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma)
+__cold int ipc4_chain_manager_create(const struct ipc4_chain_dma *cdma)
 {
 	const struct sof_uuid uuid = SOF_REG_UUID(chain_dma);
 	const struct comp_driver *drv;
@@ -1175,7 +1175,7 @@ __cold int ipc4_chain_manager_create(struct ipc4_chain_dma *cdma)
 }
 
 /* Only called from ipc4_process_chain_dma(), which is __cold */
-__cold int ipc4_chain_dma_state(struct comp_dev *dev, struct ipc4_chain_dma *cdma)
+__cold int ipc4_chain_dma_state(struct comp_dev *dev, const struct ipc4_chain_dma *cdma)
 {
 	const bool allocate = cdma->primary.r.allocate;
 	const bool enable = cdma->primary.r.enable;


### PR DESCRIPTION
Eliminate multiple instances of IPC4 data copying, use simple type- casts instead. This removes stack objects and replaces run-time copying with compile-time pointer substitution.