### PR TITLE
audio: fix NULL buffer-peer dereferences on IPC3 half-connected pipelines

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -506,8 +506,10 @@ struct comp_dev *pipeline_get_dai_comp(uint32_t pipeline_id, int dir)
 		buffer = buffer_from_list(blist->next, dir);
 		comp = buffer_get_comp(buffer, dir);
 
-		/* buffer_comp is in another pipeline and it is not complete */
-		if (!comp->pipeline)
+		/* A half-connected buffer has no peer component on this side, or
+		 * buffer_comp is in another pipeline and it is not complete.
+		 */
+		if (!comp || !comp->pipeline)
 			return NULL;
 
 		crt = ipc_get_ppl_comp(ipc, comp->pipeline->pipeline_id, dir);

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -411,7 +411,7 @@ static int selector_cmd(struct comp_dev *dev, int cmd, void *data,
 static int selector_trigger(struct comp_dev *dev, int cmd)
 {
 	struct comp_buffer *sourceb;
-	enum sof_comp_type type;
+	struct comp_dev *source_comp;
 	int ret;
 
 	comp_dbg(dev, "entry");
@@ -423,6 +423,8 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 	}
 
 	ret = comp_set_state(dev, cmd);
+	if (ret < 0)
+		return ret;
 	if (ret == COMP_STATUS_STATE_ALREADY_SET)
 		ret = 0;
 
@@ -430,9 +432,14 @@ static int selector_trigger(struct comp_dev *dev, int cmd)
 	 * kpb_init_draining() and kpb_draining_task() are interrupted by
 	 * new pipeline_task()
 	 */
-	type = dev_comp_type(comp_buffer_get_source_component(sourceb));
+	/* The source buffer may be present without an attached producer
+	 * component (e.g. a partially connected pipeline), so guard against a
+	 * NULL source component before dereferencing it.
+	 */
+	source_comp = comp_buffer_get_source_component(sourceb);
 
-	return type == SOF_COMP_KPB ? PPL_STATUS_PATH_TERMINATE : ret;
+	return source_comp && dev_comp_type(source_comp) == SOF_COMP_KPB ?
+		PPL_STATUS_PATH_TERMINATE : ret;
 }
 
 /**


### PR DESCRIPTION
Two independent NULL-pointer dereferences found by the IPC3 fuzzer when a pipeline contains a half-connected buffer (one end attached to a component, the other end left NULL). The IPC3 graph is built incrementally (each COMP_CONNECT attaches a single buffer end) so a dangling edge can exist and later be walked.

- **selector_trigger()** passed a buffer's producer component straight to `dev_comp_type()`. Missing producer caused a SEGV at the type accessor. Also now honours the `comp_set_state()` return value instead of falling through on error.
- **pipeline_get_dai_comp()** (STREAM_POSITION path) dereferenced `comp->pipeline` without checking the buffer peer, faulting on `NULL + 8`.

Guard the buffer peer before dereferencing it in both walks. Only a genuinely NULL peer is rejected; fully-connected and cross-pipeline peers are unaffected, so valid topologies keep working. Mirrors existing guards already in the tree (`kpb.c`, `pipeline_get_dai_comp_latency()`, `pipeline_trigger_xrun()`).