### PR TITLE
[Userspace LL] schedule: dp: call directly instead of a notifier

### DIFF
--- a/src/include/sof/lib/notifier.h
+++ b/src/include/sof/lib/notifier.h
@@ -28,7 +28,6 @@ enum notify_id {
 	NOTIFIER_ID_KPB_CLIENT_EVT,		/* struct kpb_event_data * */
 	NOTIFIER_ID_DMA_DOMAIN_CHANGE,		/* struct dma_chan_data * */
 	NOTIFIER_ID_DMA_COPY,			/* struct dma_cb_data* */
-	NOTIFIER_ID_LL_POST_RUN,		/* NULL */
 	NOTIFIER_ID_DMA_IRQ,			/* struct dma_chan_data * */
 	NOTIFIER_ID_DAI_TRIGGER,		/* struct dai_group * */
 	NOTIFIER_ID_MIC_PRIVACY_STATE_CHANGE,	/* struct mic_privacy_settings * */

--- a/src/include/sof/schedule/dp_schedule.h
+++ b/src/include/sof/schedule/dp_schedule.h
@@ -78,6 +78,7 @@ int scheduler_dp_task_init(struct task **task,
 			   uint16_t core,
 			   size_t stack_size,
 			   uint32_t options);
+void scheduler_dp_ll_tick(void);
 
 /**
  * \brief Extract information about scheduler's tasks

--- a/src/schedule/README.md
+++ b/src/schedule/README.md
@@ -50,7 +50,7 @@ graph TD
     DMADomain --> |Wakeup| LL
     LL -->|Runs tasks| Threads
 
-    LL -->|NOTIFIER_ID_LL_POST_RUN| DP
+    LL -->|LL Tick Source| DP
     DP -->|Recalculate Deadlines| DPThread
     DPThread -->|Update Thread Deadlines| Threads
 
@@ -69,7 +69,7 @@ The LL scheduler (`zephyr_ll.c`) is designed for extreme low-latency processing.
 -   **Domain Threads**: The LL scheduler runs within a dedicated high-priority Zephyr thread (`ll_thread0`, etc.) pinned to each core (`zephyr_domain.c`).
 -   **Triggers**: It is woken up by a hardware timer (e.g., a 1ms tick) or directly by hardware DMA interrupts (`zephyr_dma_domain.c`).
 -   **Execution**: Once woken up, it locks the domain, iterates through all scheduled tasks in priority order, moves them to a temporary list, and calls their `.run()` functions.
--   **Post-Run**: After all tasks execute, it triggers a `NOTIFIER_ID_LL_POST_RUN` event. This event cascades to wake up other dependent schedulers like DP and TWB. Event not run on LL userspace configuration.
+-   **Post-Run**: After all tasks execute, it triggers the DP scheduler for task deadline recalculation.
 
 ### Task State Diagram
 

--- a/src/schedule/ll_schedule_xtos.c
+++ b/src/schedule/ll_schedule_xtos.c
@@ -20,6 +20,7 @@
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/platform.h>
+#include <sof/schedule/dp_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
@@ -317,8 +318,9 @@ static void schedule_ll_tasks_run(void *data)
 	if (schedule_ll_is_pending(sch))
 		schedule_ll_tasks_execute(sch);
 
-	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
-		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
+#ifdef CONFIG_ZEPHYR_DP_SCHEDULER
+	scheduler_dp_ll_tick();
+#endif
 
 	perf_cnt_stamp(&sch->pcd, perf_ll_sched_trace, 0 /* ignored */);
 	perf_cnt_average(&sch->pcd, perf_avg_ll_sched_trace, 0 /* ignored */);

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -22,7 +22,6 @@
 #include <zephyr/sys/sem.h>
 #include <zephyr/sys/mutex.h>
 #include <sof/lib/memory.h>
-#include <sof/lib/notifier.h>
 #include <ipc4/base_fw.h>
 
 #include "zephyr_dp_schedule.h"
@@ -223,19 +222,19 @@ static enum task_state scheduler_dp_ll_tick_dummy(void *data)
  * needed 1.2ms for processing - but the example would be too complicated)
  */
 
-void scheduler_dp_ll_tick(void *receiver_data, enum notify_id event_type, void *caller_data)
+void scheduler_dp_ll_tick(void)
 {
-	(void)receiver_data;
-	(void)event_type;
-	(void)caller_data;
 	unsigned int lock_key;
 	struct scheduler_dp_data *dp_sch = scheduler_get_data(SOF_SCHEDULE_DP);
+
+	if (!dp_sch)
+		return;
 
 	/* remember current timestamp as "NOW" */
 	dp_sch->last_ll_tick_timestamp = k_cycle_get_32();
 
 	lock_key = scheduler_dp_lock(cpu_get_id());
-	scheduler_dp_recalculate(dp_sch, event_type == NOTIFIER_ID_LL_POST_RUN);
+	scheduler_dp_recalculate(dp_sch);
 	scheduler_dp_unlock(lock_key);
 }
 
@@ -347,10 +346,9 @@ static struct scheduler_ops schedule_dp_ops = {
 	.schedule_task_free	= scheduler_dp_task_free,
 };
 
+/* Runs on each core */
 __cold int scheduler_dp_init(void)
 {
-	int ret;
-
 	assert_can_be_cold();
 
 	struct scheduler_dp_data *dp_sch = rzalloc(SOF_MEM_FLAG_KERNEL,
@@ -364,18 +362,11 @@ __cold int scheduler_dp_init(void)
 	scheduler_init(SOF_SCHEDULE_DP, &schedule_dp_ops, dp_sch);
 
 	/* init src of DP tick */
-	ret = schedule_task_init_ll(&dp_sch->ll_tick_src,
-				    SOF_UUID(dp_sched_uuid),
-				    SOF_SCHEDULE_LL_TIMER,
-				    0, scheduler_dp_ll_tick_dummy, dp_sch,
-				    cpu_get_id(), 0);
-
-	if (ret)
-		return ret;
-
-	notifier_register(NULL, NULL, NOTIFIER_ID_LL_POST_RUN, scheduler_dp_ll_tick, 0);
-
-	return 0;
+	return schedule_task_init_ll(&dp_sch->ll_tick_src,
+				     SOF_UUID(dp_sched_uuid),
+				     SOF_SCHEDULE_LL_TIMER,
+				     0, scheduler_dp_ll_tick_dummy, dp_sch,
+				     cpu_get_id(), 0);
 }
 
 void scheduler_get_task_info_dp(struct scheduler_props *scheduler_props, uint32_t *data_off_size)

--- a/src/schedule/zephyr_dp_schedule.h
+++ b/src/schedule/zephyr_dp_schedule.h
@@ -52,7 +52,7 @@ struct task_dp_pdata {
 #endif
 };
 
-void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_run);
+void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch);
 void dp_thread_fn(void *p1, void *p2, void *p3);
 unsigned int scheduler_dp_lock(uint16_t core);
 void scheduler_dp_unlock(unsigned int key);

--- a/src/schedule/zephyr_dp_schedule_application.c
+++ b/src/schedule/zephyr_dp_schedule_application.c
@@ -197,7 +197,7 @@ int scheduler_dp_thread_ipc(struct processing_module *pmod, unsigned int cmd,
 /* Go through all DP tasks and recalculate their readiness and deadlines
  * NOT REENTRANT, called with scheduler_dp_lock() held
  */
-void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_run)
+void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch)
 {
 	struct list_item *tlist;
 	struct task *curr_task;
@@ -210,7 +210,7 @@ void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_
 		bool trigger_task = false;
 
 		/* decrease number of LL ticks/cycles left till the module reaches its deadline */
-		if (mod->dp_startup_delay && is_ll_post_run && pdata->ll_cycles_to_start) {
+		if (mod->dp_startup_delay && pdata->ll_cycles_to_start) {
 			pdata->ll_cycles_to_start--;
 			if (!pdata->ll_cycles_to_start)
 				/* delayed start complete, clear startup delay flag.

--- a/src/schedule/zephyr_dp_schedule_thread.c
+++ b/src/schedule/zephyr_dp_schedule_thread.c
@@ -30,7 +30,7 @@ extern struct tr_ctx dp_tr;
 /* Go through all DP tasks and recalculate their readiness and deadlines
  * NOT REENTRANT, should be called with scheduler_dp_lock()
  */
-void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_run)
+static void scheduler_dp_recalculate_thread(struct scheduler_dp_data *dp_sch, bool is_ll_post_run)
 {
 	struct list_item *tlist;
 	struct task *curr_task;
@@ -106,6 +106,11 @@ void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch, bool is_ll_post_
 	}
 }
 
+void scheduler_dp_recalculate(struct scheduler_dp_data *dp_sch)
+{
+	scheduler_dp_recalculate_thread(dp_sch, true);
+}
+
 /* Thread function called in component context, on target core */
 void dp_thread_fn(void *p1, void *p2, void *p3)
 {
@@ -177,7 +182,7 @@ void dp_thread_fn(void *p1, void *p2, void *p3)
 			 * currently its limited to current core only
 			 */
 			if (dp_sch)
-				scheduler_dp_recalculate(dp_sch, false);
+				scheduler_dp_recalculate_thread(dp_sch, false);
 
 			scheduler_dp_unlock(lock_key);
 		}

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -10,7 +10,7 @@
 #include <sof/audio/component.h>
 #include <rtos/interrupt.h>
 #include <sof/lib/memory.h>
-#include <sof/lib/notifier.h>
+#include <sof/schedule/dp_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
 #include <sof/schedule/schedule.h>
 #include <rtos/task.h>
@@ -322,10 +322,8 @@ static void zephyr_ll_run(void *data)
 
 	zephyr_ll_unlock(sch, &flags);
 
-#ifndef CONFIG_SOF_USERSPACE_LL
-	/* TODO: to be replaced with direct function calls */
-	notifier_event(sch, NOTIFIER_ID_LL_POST_RUN,
-		       NOTIFIER_TARGET_CORE_LOCAL, NULL, 0);
+#ifdef CONFIG_ZEPHYR_DP_SCHEDULER
+	scheduler_dp_ll_tick();
 #endif
 }
 


### PR DESCRIPTION
scheduler_dp_ll_tick() is currently registered as a notifier callback, but it's always triggered deterministically, always with the same-core-only flag, which leads to it being called immediately. So the notifier only adds a layer of indirection and reduces clarity. Replace it with a direct function call.