### PR TITLE
vregion: Cross core user-space DP fix

### DIFF
--- a/zephyr/lib/vregion.c
+++ b/zephyr/lib/vregion.c
@@ -257,6 +257,11 @@ static void interim_heap_init(struct vregion *vr)
 	k_heap_init(&vr->interim.heap, interim_base, interim_size);
 	vr->type = VREGION_MEM_TYPE_INTERIM;
 
+	/* Flush the heap metadata written by k_heap_init to main memory
+	 * so other cores can access the interim heap without stale cache.
+	 */
+	sys_cache_data_flush_range(interim_base, interim_size);
+
 	/* Update lifetime heap with the interim heap usage. */
 	vr->lifetime.ptr = (void *)(interim_base + interim_size);
 	vr->lifetime.used = (uint8_t *)vr->lifetime.ptr - (uint8_t *)vr->lifetime.base;

--- a/zephyr/lib/vregion.c
+++ b/zephyr/lib/vregion.c
@@ -127,8 +127,11 @@ struct vregion *vregion_create(size_t memsize)
 	 */
 	total_size = ALIGN_UP(memsize, CONFIG_MM_DRV_PAGE_SIZE);
 
-	/* allocate vregion metadata separately to keep it inaccessible to the user */
-	vr = rmalloc(0, sizeof(*vr));
+	/* allocate vregion metadata separately to keep it inaccessible to the user.
+	 * Use coherent memory so interim heap state written on one core is
+	 * visible to other cores during cross-core buffer allocation.
+	 */
+	vr = rmalloc(SOF_MEM_FLAG_COHERENT, sizeof(*vr));
 	if (!vr)
 		return NULL;
 


### PR DESCRIPTION
I noticed some time ago that placing DP module to another core than the rest of the pipeline did not work on PTL any more. With other platforms it still worked and when turning CONFIG_USERSPACE=n PTL worked again too.

After some debugging I found out that there were some cache coherency issues in vregions that caused this. With these two fixes the sof-ptl-nocodec-dp-core-test.tplg topology works on PTL again too. I think we should add this or something similar to our CI. Maybe just edit nocodec topology a bit.
