### PR TITLE
tools: include types.h to build probes tool on musl

### DIFF
--- a/tools/probes/probes_demux.c
+++ b/tools/probes/probes_demux.c
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <ipc/probe_dma_frame.h>


### PR DESCRIPTION
- tools: include `sys/types.h` explicitly to build on musl 