### PR TITLE
[Userspace LL] audio: pipeline: enable position reporting for user-space pipelines

### DIFF
--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -15,6 +15,7 @@
 #include <rtos/interrupt.h>
 #include <rtos/symbol.h>
 #include <rtos/alloc.h>
+#include <rtos/userspace_helper.h>
 #include <sof/lib/mm_heap.h>
 #include <sof/lib/uuid.h>
 #include <sof/compiler_attributes.h>
@@ -44,10 +45,20 @@ DECLARE_TR_CTX(pipe_tr, SOF_UUID(pipe_uuid), LOG_LEVEL_INFO);
 /* lookup table to determine busy/free pipeline metadata objects */
 struct pipeline_posn {
 	bool posn_offset[PPL_POSN_OFFSETS];	/**< available offsets */
+#ifndef CONFIG_SOF_USERSPACE_LL
 	struct k_spinlock lock;			/**< lock mechanism */
+#endif
 };
 /* the pipeline position lookup table */
-static SHARED_DATA struct pipeline_posn pipeline_posn_shared;
+static APP_SYSUSER_BSS SHARED_DATA struct pipeline_posn pipeline_posn_shared;
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+/* Mutex pointer in user-accessible partition so user-space threads
+ * can read the pointer for syscalls. Kept outside the SHARED_DATA
+ * struct to avoid kernel object tracking issues.
+ */
+static APP_SYSUSER_BSS struct k_mutex *pipeline_posn_mutex;
+#endif
 
 /**
  * \brief Retrieves pipeline position structure.
@@ -55,8 +66,47 @@ static SHARED_DATA struct pipeline_posn pipeline_posn_shared;
  */
 static inline struct pipeline_posn *pipeline_posn_get(void)
 {
+#ifdef CONFIG_SOF_USERSPACE_LL
+	return &pipeline_posn_shared;
+#else
 	return sof_get()->pipeline_posn;
+#endif
 }
+
+/*
+ * Position table locking. User-space LL cannot use a spinlock (disabling
+ * interrupts is privileged), so it uses a mutex; the config split is kept
+ * here so the callers below stay identical for both configurations.
+ */
+#ifdef CONFIG_SOF_USERSPACE_LL
+typedef int pipeline_posn_key_t;
+
+static inline pipeline_posn_key_t pipeline_posn_lock(struct pipeline_posn *posn)
+{
+	(void)posn;
+	k_mutex_lock(pipeline_posn_mutex, K_FOREVER);
+	return 0;
+}
+
+static inline void pipeline_posn_unlock(struct pipeline_posn *posn, pipeline_posn_key_t key)
+{
+	(void)posn;
+	(void)key;
+	k_mutex_unlock(pipeline_posn_mutex);
+}
+#else
+typedef k_spinlock_key_t pipeline_posn_key_t;
+
+static inline pipeline_posn_key_t pipeline_posn_lock(struct pipeline_posn *posn)
+{
+	return k_spin_lock(&posn->lock);
+}
+
+static inline void pipeline_posn_unlock(struct pipeline_posn *posn, pipeline_posn_key_t key)
+{
+	k_spin_unlock(&posn->lock, key);
+}
+#endif
 
 /**
  * \brief Retrieves first free pipeline position offset.
@@ -68,9 +118,7 @@ static inline int pipeline_posn_offset_get(uint32_t *posn_offset)
 	struct pipeline_posn *pipeline_posn = pipeline_posn_get();
 	int ret = -EINVAL;
 	uint32_t i;
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&pipeline_posn->lock);
+	pipeline_posn_key_t key = pipeline_posn_lock(pipeline_posn);
 
 	for (i = 0; i < PPL_POSN_OFFSETS; ++i) {
 		if (!pipeline_posn->posn_offset[i]) {
@@ -81,8 +129,7 @@ static inline int pipeline_posn_offset_get(uint32_t *posn_offset)
 		}
 	}
 
-
-	k_spin_unlock(&pipeline_posn->lock, key);
+	pipeline_posn_unlock(pipeline_posn, key);
 
 	return ret;
 }
@@ -95,20 +142,34 @@ static inline void pipeline_posn_offset_put(uint32_t posn_offset)
 {
 	struct pipeline_posn *pipeline_posn = pipeline_posn_get();
 	int i = posn_offset / sizeof(struct sof_ipc_stream_posn);
-	k_spinlock_key_t key;
-
-	key = k_spin_lock(&pipeline_posn->lock);
+	pipeline_posn_key_t key = pipeline_posn_lock(pipeline_posn);
 
 	pipeline_posn->posn_offset[i] = false;
 
-	k_spin_unlock(&pipeline_posn->lock, key);
+	pipeline_posn_unlock(pipeline_posn, key);
 }
 
 void pipeline_posn_init(struct sof *sof)
 {
 	sof->pipeline_posn = &pipeline_posn_shared;
+#ifdef CONFIG_SOF_USERSPACE_LL
+	pipeline_posn_mutex = k_object_alloc(K_OBJ_MUTEX);
+	if (!pipeline_posn_mutex) {
+		pipe_cl_err("pipeline posn mutex alloc failed");
+		k_panic();
+	}
+	k_mutex_init(pipeline_posn_mutex);
+#else
 	k_spinlock_init(&sof->pipeline_posn->lock);
+#endif
 }
+
+#ifdef CONFIG_SOF_USERSPACE_LL
+void pipeline_posn_grant_access(struct k_thread *thread)
+{
+	k_thread_access_grant(thread, pipeline_posn_mutex);
+}
+#endif
 
 /* create new pipeline - returns pipeline id or negative error */
 struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_t priority,
@@ -140,12 +201,21 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 	p->pipeline_id = pipeline_id;
 	p->status = COMP_STATE_INIT;
 	p->trigger.cmd = COMP_TRIGGER_NO_ACTION;
+
+#ifndef CONFIG_SOF_USERSPACE_LL
+	/*
+	 * pipe_tr lives in the .trace_ctx section, which is not mapped into
+	 * the sysuser partition, so it cannot be read from a user-mode thread.
+	 * The copy is also unnecessary in that configuration: with Zephyr
+	 * logging the pipe_*() macros use the global pipe_tr, not p->tctx.
+	 */
 	ret = memcpy_s(&p->tctx, sizeof(struct tr_ctx), &pipe_tr,
 		       sizeof(struct tr_ctx));
 	if (ret < 0) {
 		pipe_err(p, "failed to copy trace settings");
 		goto free;
 	}
+#endif
 
 	ret = pipeline_posn_offset_get(&p->posn_offset);
 	if (ret < 0) {

--- a/src/include/sof/audio/pipeline-trace.h
+++ b/src/include/sof/audio/pipeline-trace.h
@@ -59,6 +59,10 @@ extern struct tr_ctx pipe_tr;
 
 #else
 
+#if defined(__ZEPHYR__) && defined(CONFIG_SOF_USERSPACE_LL)
+#error "Invalid build config: User-space cannot access trace context."
+#endif
+
 #define pipe_err(pipe_p, __e, ...)					\
 	trace_dev_err(trace_pipe_get_tr_ctx, trace_pipe_get_id,		\
 		      trace_pipe_get_subid, pipe_p, __e, ##__VA_ARGS__)

--- a/src/include/sof/audio/pipeline.h
+++ b/src/include/sof/audio/pipeline.h
@@ -206,6 +206,14 @@ int pipeline_complete(struct pipeline *p, struct comp_dev *source,
  */
 void pipeline_posn_init(struct sof *sof);
 
+#ifdef CONFIG_SOF_USERSPACE_LL
+/**
+ * \brief Grants user-space thread access to pipeline position mutex.
+ * \param[in] thread Thread to grant access to.
+ */
+void pipeline_posn_grant_access(struct k_thread *thread);
+#endif
+
 /**
  * \brief Resets the pipeline and free runtime resources.
  * \param[in] p pipeline.

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -32,6 +32,7 @@
 #include <sof/schedule/dp_schedule.h>
 #include <sof/schedule/ll_schedule.h>
 #include <sof/schedule/ll_schedule_domain.h>
+#include <sof/audio/pipeline.h>
 #include <ipc/trace.h>
 #if CONFIG_IPC_MAJOR_4
 #include <ipc4/fw_reg.h>
@@ -231,6 +232,11 @@ __cold static int primary_core_init(int argc, char *argv[], struct sof *sof)
 #if CONFIG_SOF_USERSPACE_LL
 	zephyr_ll_user_resources_init();
 #endif
+
+	/* init pipeline position offsets - must be before platform_init()
+	 * which calls ipc_init() -> ipc_user_init() that needs the posn mutex.
+	 */
+	pipeline_posn_init(sof);
 
 	/* init the platform */
 	if (platform_init(sof) < 0)

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -457,6 +457,7 @@ __cold static int ipc_user_init_thread(struct ipc_user *ipc_user)
 	user_grant_dma_access_all(ipc_user->thread);
 	k_mem_domain_add_thread(zephyr_ll_mem_domain(), ipc_user->thread);
 	user_ll_grant_access(ipc_user->thread, PLATFORM_PRIMARY_CORE_ID);
+	pipeline_posn_grant_access(ipc_user->thread);
 
 	return 0;
 

--- a/zephyr/wrapper.c
+++ b/zephyr/wrapper.c
@@ -177,9 +177,6 @@ int task_main_start(struct sof *sof)
 	/* init default audio components */
 	sys_comp_init(sof);
 
-	/* init pipeline position offsets */
-	pipeline_posn_init(sof);
-
 	return 0;
 }
 


### PR DESCRIPTION
Place the pipeline position lookup table in the sysuser memory partition and replace k_spinlock with a dynamically allocated k_mutex when CONFIG_SOF_USERSPACE_LL is enabled. Spinlocks disable interrupts which is a privileged operation unavailable from user-mode threads.

The mutex pointer is stored in a separate APP_SYSUSER_BSS variable outside the SHARED_DATA struct so Zephyr's kernel object tracking can recognize it for syscall verification.

Move pipeline_posn_init() from task_main_start() to primary_core_init() before platform_init(), so the mutex is allocated before ipc_user_init() grants thread access to it.

In pipeline_posn_get(), bypass the sof_get() kernel singleton and access the shared structure directly when running in user-space. Grant the ipc_user_init thread access to the pipeline position mutex via new pipeline_posn_grant_access() helper.