### PR TITLE
[Userspace LL] ipc: ipc4: use the SOF sof_dma_get_status() in dai_common_position()

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -425,7 +425,7 @@ int dai_common_position(struct dai_data *dd, struct comp_dev *dev,
 	platform_dai_wallclock(dev, &dd->wallclock);
 	posn->wallclock = dd->wallclock;
 
-	ret = dma_get_status(dd->dma->z_dev, dd->chan_index, &status);
+	ret = sof_dma_get_status(dd->dma, dd->chan_index, &status);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
Use the sof_dma_get_status() wrapper to get DMA status in dai_common_position(). This allows the code to be used from user-space context.