### PR TITLE
ipc: ipc4: dai: do not set the direction bit for UAOL

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -66,7 +66,7 @@ void dai_set_link_hda_config(uint16_t *link_config,
 	case SOF_DAI_INTEL_UAOL:
 		link_cfg.full = 0;
 		link_cfg.part.hchan = gtw_fmt->channels_count - 1;
-		link_cfg.part.dir = common_config->direction;
+		/* UAOLxPCMSyCM has no direction bit, the stream selects it */
 		link_cfg.part.stream = common_config->host_dma_config[0]->stream_id;
 		break;
 	default:


### PR DESCRIPTION
The link_config computed here is handed to the UAOL driver as the stream channel map and written to UAOLxPCMSyCM. On ACE 2.x and later that register only defines the lchan, hchan and strm fields, its two upper bits are reserved, and union hdalink_cfg keeps the direction in the topmost of them.

Setting the direction therefore wrote a reserved bit for every capture stream, after which the link transferred no data at all and reported no error. Playback was unaffected because its direction is zero.

The link does not need to be told the direction: transmit and receive streams have separate indices, so the stream already implies it.

Fixes: ddd5c6442915 ("dai: uaol: add support for Intel UAOL")