### PR TITLE
topology2: Add USB Audio Offload Link (UAOL) support

### DIFF
--- a/src/ipc/ipc4/dai.c
+++ b/src/ipc/ipc4/dai.c
@@ -66,7 +66,7 @@ void dai_set_link_hda_config(uint16_t *link_config,
 	case SOF_DAI_INTEL_UAOL:
 		link_cfg.full = 0;
 		link_cfg.part.hchan = gtw_fmt->channels_count - 1;
-		link_cfg.part.dir = common_config->direction;
+		/* UAOLxPCMSyCM has no direction bit, the stream selects it */
 		link_cfg.part.stream = common_config->host_dma_config[0]->stream_id;
 		break;
 	default:

--- a/tools/topology/topology2/README.md
+++ b/tools/topology/topology2/README.md
@@ -242,6 +242,8 @@ default ID ranges for the same endpoint types.
 | Jack Echo Ref | 11 | `SDW_JACK_ECHO_REF_PCM_ID` |
 | Speaker Echo Ref | 12 | `SDW_SPK_ECHO_REF_PCM_ID` |
 | Bluetooth | 2 or 20 | `BT_PCM_ID` |
+| USB Audio Offload (UAOL) | 21 | `UAOL_PCM_ID` |
+| Deepbuffer UAOL | 22 | `DEEP_BUFFER_PCM_ID` |
 | Deep Buffer (Jack) | 31 | `DEEP_BUFFER_PCM_ID` |
 | Deep Buffer (Speaker) | 35 | `DEEP_BUFFER_PCM_ID_2` |
 | DMIC Deep Buffer | 46 | `DMIC0_DEEP_BUFFER_PCM_ID` |
@@ -301,6 +303,9 @@ is at N1 (50/51, 60/61, 70/71, 80/81).
 | HDMI 4 Host / DAI | 80 / 81 | `HDMI4_HOST_PIPELINE_ID` / `HDMI4_DAI_PIPELINE_ID` |
 | Compress Jack / Speaker | 90 / 92 | `COMPR_PIPELINE_ID` / `COMPR_2_PIPELINE_ID` |
 | PCH DMIC0 Host / DAI | 100 / 101 | `DMIC0_HOST_PIPELINE_ID` / `DMIC0_DAI_PIPELINE_ID` |
+| UAOL Playback Host / DAI | 210 / 211 | `UAOL_PB_HOST_PIPELINE_ID` / `UAOL_PB_DAI_PIPELINE_ID` |
+| UAOL Capture Host / DAI | 212 / 213 | `UAOL_CP_HOST_PIPELINE_ID` / `UAOL_CP_DAI_PIPELINE_ID` |
+| UAOL Deepbuffer | 214 | `DEEP_BUFFER_PIPELINE_ID` |
 
 **Intel HDA Pipeline IDs:**
 

--- a/tools/topology/topology2/cavs-uaol.conf
+++ b/tools/topology/topology2/cavs-uaol.conf
@@ -1,0 +1,86 @@
+# Basic USB Audio Offload Link (UAOL) topology.
+#
+# This is a function topology, loaded next to the other function topologies of
+# the sof_sdw card, so its PCM and pipeline IDs must not collide with theirs.
+#
+# The UAOL function itself lives in platform/intel/uaol-generic.conf.
+
+<searchdir:include>
+<searchdir:include/common>
+<searchdir:include/components>
+<searchdir:include/dais>
+<searchdir:include/pipelines>
+<searchdir:include/pipelines/cavs>
+<searchdir:platform>
+<searchdir:platform/intel>
+
+<vendor-token.conf>
+<manifest.conf>
+<tokens.conf>
+<virtual.conf>
+<host-copier-gain-mixin-playback.conf>
+<mixout-gain-dai-copier-playback.conf>
+<deepbuffer-playback.conf>
+<host-gateway-capture.conf>
+<dai-copier-eqiir-module-copier-capture.conf>
+<input_audio_format.conf>
+<output_audio_format.conf>
+<data.conf>
+<pcm.conf>
+<pcm_caps.conf>
+<fe_dai.conf>
+<uaol.conf>
+<hw_config_simple.conf>
+<manifest.conf>
+<route.conf>
+<common_definitions.conf>
+<deep-buffer-default.conf>
+<dai-copier.conf>
+<module-copier.conf>
+<pipeline.conf>
+<dai.conf>
+<host.conf>
+
+Define {
+	UAOL_PLAYBACK_PCM	'UAOL Playback'
+	UAOL_CAPTURE_PCM	'UAOL Capture'
+	# The two directions are separate DAI links so that the format fixup of
+	# a link is decided by the DAI copier of that direction alone. The names
+	# are abbreviated because alsatplg drops widget tuples above 36 characters
+	# and the dai-copier name is 'dai-copier.UAOL.<name>.<direction>'
+	UAOL_PB_DAI_NAME	'UAOL0-Play'
+	UAOL_CP_DAI_NAME	'UAOL0-Cap'
+	# The BE IDs are the dai link IDs that are matched with the machine
+	# driver, which creates the playback link first
+	UAOL_PB_BE_ID		9
+	UAOL_CP_BE_ID		10
+	# UAOL_DAI_INDEX is the UAOL link the DSP uses, only link 0 is addressable
+	UAOL_DAI_INDEX		0
+	UAOL_PCM_NAME		'UAOL'
+	UAOL_PCM_ID		21
+	UAOL_PB_HOST_PIPELINE_ID	210
+	UAOL_PB_DAI_PIPELINE_ID		211
+	UAOL_CP_HOST_PIPELINE_ID	212
+	UAOL_CP_DAI_PIPELINE_ID		213
+	# Both paths pass through whatever the offloaded USB device asks for, so
+	# the PCM advertises everything a USB device may support. 7 channels is
+	# left out of the widget formats, it has no channel config and no channel
+	# map, so it is the one count in the range which cannot be run.
+	UAOL_CHANNELS_MIN	1
+	UAOL_CHANNELS_MAX	8
+	# UAOL supports up to 192 kHz
+	UAOL_RATE_MIN		8000
+	UAOL_RATE_MAX		192000
+	UAOL_RATES		'8000,11025,12000,16000,22050,24000,32000,44100,48000,64000,88200,96000,128000,176400,192000'
+
+	# The deep buffer PCM feeds the same mixer as the normal playback PCM. It
+	# takes the source and the sink as plain widget names, so it repeats the
+	# pipeline IDs defined above.
+	DEEP_BUFFER_PCM_NAME	'Deepbuffer UAOL'
+	DEEP_BUFFER_PCM_ID	22
+	DEEP_BUFFER_PIPELINE_ID	214
+	DEEP_BUFFER_PIPELINE_SRC	'mixin.214.1'
+	DEEP_BUFFER_PIPELINE_SINK	'mixout.211.1'
+}
+
+<platform/intel/uaol-generic.conf>

--- a/tools/topology/topology2/include/components/dai-copier.conf
+++ b/tools/topology/topology2/include/components/dai-copier.conf
@@ -44,6 +44,7 @@ Class.Widget."dai-copier" {
 				"HDA"
 				"SSP"
 				"DMIC"
+				"UAOL"
 				"SAI"
 			]
 		}
@@ -57,6 +58,7 @@ Class.Widget."dai-copier" {
                                 "SSP"
                                 "DMIC"
                                 "HDA"
+                                "UAOL"
                                 "SAI"
                         ]
                 }
@@ -103,6 +105,8 @@ Class.Widget."dai-copier" {
 				$DMIC_LINK_INPUT_CLASS # DMIC link input (DSP <-)
 				$I2S_LINK_OUTPUT_CLASS # I2S link output (DSP ->)
 				$I2S_LINK_INPUT_CLASS # I2S link input (DSP <-)
+				$ALH_UAOL_STREAM_LINK_OUTPUT_CLASS # UAOL link output (DSP ->)
+				$ALH_UAOL_STREAM_LINK_INPUT_CLASS # UAOL link input (DSP <-)
 				$IPC_OUTPUT_CLASS # IPC output (DSP ->)
 				$IPC_INPUT_CLASS # IPC input (DSP <-)
 				$I2S_MULTILINK_OUTPUT_CLASS # I2S Multi gtw output (DSP ->)

--- a/tools/topology/topology2/include/components/dai.conf
+++ b/tools/topology/topology2/include/components/dai.conf
@@ -28,6 +28,7 @@ Class.Widget."dai" {
 				"DMIC"
 				"HDA"
 				"ALH"
+				"UAOL"
 				"SAI"
 				"ESAI"
 			]

--- a/tools/topology/topology2/include/dais/uaol.conf
+++ b/tools/topology/topology2/include/dais/uaol.conf
@@ -1,0 +1,95 @@
+#
+# UAOL DAI
+#
+# All attributes defined herein are namespaced by alsatplg to
+# "Object.Dai.UAOL.attribute_name"
+#
+# UAOL (USB Audio Offload Link) is an ACE2+ alt link. It belongs to the ALH
+# class family in the firmware gateway enumeration, but it is described by its
+# own DAI class because the ALH class carries SoundWire specific attributes.
+#
+# Usage: this component can be used by declaring as follows:
+#
+# For Playback
+#Object.Dai.UAOL."N" {
+#		direction	"playback"
+#		name		"UAOL0"
+#		id		0
+#		Object.Base.hw_config."0" {}
+# }
+# For Capture
+#Object.Dai.UAOL."N" {
+#		direction	"capture"
+#		name		"UAOL0"
+#		id		0
+#		Object.Base.hw_config."1" {}
+# }
+#
+# Where N is the dai index of the UAOL DAI in the firmware
+
+Class.Dai."UAOL" {
+	#
+	# instance ID of UAOL DAI object
+	#
+	DefineAttribute."instance" {}
+
+	#
+	# UAOL link index in the firmware
+	#
+	DefineAttribute."dai_index" {
+		token_ref	"dai.word"
+	}
+
+	DefineAttribute."direction" {
+		type "string"
+		constraints {
+			!valid_values [
+				"playback"
+				"capture"
+				"duplex"
+			]
+		}
+	}
+
+	# type of DAI
+	DefineAttribute.dai_type {
+		type	"string"
+		token_ref	"dai.string"
+	}
+
+	# Backend DAI Link ID matching with the machine driver
+	DefineAttribute.id {}
+
+	DefineAttribute."default_hw_config_id" {}
+
+	DefineAttribute.name {
+		type	"string"
+	}
+
+	DefineAttribute.rate {}
+
+	DefineAttribute.ch {}
+
+	attributes {
+		!constructor [
+			"name"
+		]
+		!mandatory [
+			"id"
+			"dai_index"
+		]
+		!immutable [
+			"type"
+		]
+		#
+		# UAOL DAI objects instantiated within the same alsaconf node must
+		# have unique instance attribute
+		#
+		unique	"instance"
+	}
+
+	dai_type		"UAOL"
+	default_hw_config_id	0
+	rate	48000
+	ch	2
+}

--- a/tools/topology/topology2/include/formats/uaol_input_audio_formats.conf
+++ b/tools/topology/topology2/include/formats/uaol_input_audio_formats.conf
@@ -1,0 +1,344 @@
+				# Every format the offloaded USB endpoint can carry: S16_LE, S24_LE and
+				# S32_LE, 1 to 8 channels and every standard rate from 8 to 192 kHz.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				num_input_audio_formats 315
+				CombineArrays.Object.Base.input_audio_format [
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 32 ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/include/formats/uaol_input_audio_formats_s32.conf
+++ b/tools/topology/topology2/include/formats/uaol_input_audio_formats_s32.conf
@@ -1,0 +1,176 @@
+				# The formats of a module which only processes 32 bit samples, for every
+				# channel count and rate the offloaded USB endpoint can carry.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				num_input_audio_formats 105
+				CombineArrays.Object.Base.input_audio_format [
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/include/formats/uaol_output_audio_formats.conf
+++ b/tools/topology/topology2/include/formats/uaol_output_audio_formats.conf
@@ -1,0 +1,344 @@
+				# Every format the offloaded USB endpoint can carry: S16_LE, S24_LE and
+				# S32_LE, 1 to 8 channels and every standard rate from 8 to 192 kHz.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				num_output_audio_formats 315
+				CombineArrays.Object.Base.output_audio_format [
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 32 ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/include/formats/uaol_output_audio_formats_s32.conf
+++ b/tools/topology/topology2/include/formats/uaol_output_audio_formats_s32.conf
@@ -1,0 +1,176 @@
+				# The formats of a module which only processes 32 bit samples, for every
+				# channel count and rate the offloaded USB endpoint can carry.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				num_output_audio_formats 105
+				CombineArrays.Object.Base.output_audio_format [
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/platform/intel/uaol-generic.conf
+++ b/tools/topology/topology2/platform/intel/uaol-generic.conf
@@ -1,0 +1,204 @@
+# USB Audio Offload Link (UAOL) function.
+#
+# The offloaded USB endpoint is driven by the UAOL gateway in the firmware:
+#
+#   PCM ---------------> gain ---> mixin ---+
+#                                           |
+#   Deepbuffer PCM ----> gain ---> mixin ---+--> mixout --> gain --> UAOL0-Play
+#
+#   PCM <------------ module-copier <--- eqiir <---------------- UAOL0-Cap
+#
+# The capture path carries no mixer, as the number of channels follows the USB
+# device and a mixer only handles a fixed channel count.
+#
+# What the endpoint can be run at is decided by the USB device, which is only
+# known once one is plugged in, so every widget of both paths carries the whole
+# set of formats a USB device may ask for: S16_LE, S24_LE and S32_LE, 1 to 8
+# channels and the standard rates from 8 to 192 kHz, which is as far as UAOL
+# goes. The kernel narrows the PCM down to what the connected device actually
+# supports.
+#
+# The deep buffer PCM is left at 48 kHz stereo, as it comes from the shared
+# platform/intel/deep-buffer.conf. It can only join the mixer while the normal
+# playback PCM runs at that format, or is not running at all.
+
+# Deep buffer playback, included when the DMA buffer is 1 - 1000 ms
+IncludeByKey.DEEPBUFFER_FW_DMA_MS {
+	"([1-9]|[1-9][0-9]|[1-9][0-9][0-9]|1000)" "platform/intel/deep-buffer.conf"
+}
+
+Object.Dai.UAOL [
+	{
+		name $UAOL_PB_DAI_NAME
+		dai_index $UAOL_DAI_INDEX
+		id $UAOL_PB_BE_ID
+		default_hw_conf_id 0
+		Object.Base.hw_config.1 {
+			name	"UAOL0-Play"
+		}
+		direction playback
+	}
+	{
+		name $UAOL_CP_DAI_NAME
+		dai_index $UAOL_DAI_INDEX
+		id $UAOL_CP_BE_ID
+		default_hw_conf_id 0
+		Object.Base.hw_config.1 {
+			name	"UAOL0-Cap"
+		}
+		direction capture
+	}
+]
+
+Object.Pipeline {
+	host-copier-gain-mixin-playback [
+		{
+			index $UAOL_PB_HOST_PIPELINE_ID
+
+			Object.Widget.host-copier.1 {
+				stream_name $UAOL_PLAYBACK_PCM
+				pcm_id $UAOL_PCM_ID
+				<include/formats/uaol_input_audio_formats.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+			Object.Widget.gain.1 {
+				Object.Control.mixer.1 {
+					name 'Pre Mixer $UAOL_PCM_NAME Playback Volume'
+				}
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+			Object.Widget.mixin.1 {
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+		}
+	]
+
+	mixout-gain-dai-copier-playback [
+		{
+			index $UAOL_PB_DAI_PIPELINE_ID
+
+			Object.Widget.mixout.1 {
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+			Object.Widget.dai-copier.1 {
+				node_type $ALH_UAOL_STREAM_LINK_OUTPUT_CLASS
+				stream_name $UAOL_PB_DAI_NAME
+				dai_type "UAOL"
+				copier_type "UAOL"
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats.conf>
+			}
+			Object.Widget.gain.1 {
+				Object.Control.mixer.1 {
+					name 'Post Mixer $UAOL_PCM_NAME Playback Volume'
+				}
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+		}
+	]
+
+	host-gateway-capture [
+		{
+			index $UAOL_CP_HOST_PIPELINE_ID
+
+			Object.Widget.host-copier.1 {
+				stream_name $UAOL_CAPTURE_PCM
+				pcm_id $UAOL_PCM_ID
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats.conf>
+			}
+		}
+	]
+
+	dai-copier-eqiir-module-copier-capture [
+		{
+			index $UAOL_CP_DAI_PIPELINE_ID
+
+			Object.Widget.dai-copier.1 {
+				node_type $ALH_UAOL_STREAM_LINK_INPUT_CLASS
+				stream_name $UAOL_CP_DAI_NAME
+				dai_type "UAOL"
+				type dai_out
+				copier_type "UAOL"
+				num_output_pins 1
+				<include/formats/uaol_input_audio_formats.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+
+			# The coefficients are designed for 48 kHz, so the corner
+			# frequency scales with the rate the device is run at
+			Object.Widget.eqiir.1 {
+				Object.Control.bytes.1 {
+					name '$UAOL_PCM_NAME Capture IIR Eq'
+					<include/components/eqiir/highpass_40hz_0db_48khz.conf>
+				}
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+
+			Object.Widget.module-copier.2 {
+				<include/formats/uaol_input_audio_formats_s32.conf>
+				<include/formats/uaol_output_audio_formats_s32.conf>
+			}
+		}
+	]
+}
+
+Object.PCM.pcm [
+	{
+		name	$UAOL_PCM_NAME
+		id $UAOL_PCM_ID
+		direction	"duplex"
+		Object.Base.fe_dai.1 {
+			name	$UAOL_PCM_NAME
+		}
+		Object.PCM.pcm_caps.1 {
+			direction	"playback"
+			name $UAOL_PLAYBACK_PCM
+			formats 'S16_LE,S24_LE,S32_LE'
+			channels_min $UAOL_CHANNELS_MIN
+			channels_max $UAOL_CHANNELS_MAX
+			rates $UAOL_RATES
+			rate_min $UAOL_RATE_MIN
+			rate_max $UAOL_RATE_MAX
+		}
+		Object.PCM.pcm_caps.2 {
+			direction	"capture"
+			name $UAOL_CAPTURE_PCM
+			formats 'S16_LE,S24_LE,S32_LE'
+			channels_min $UAOL_CHANNELS_MIN
+			channels_max $UAOL_CHANNELS_MAX
+			rates $UAOL_RATES
+			rate_min $UAOL_RATE_MIN
+			rate_max $UAOL_RATE_MAX
+		}
+	}
+]
+
+# top-level pipeline connections
+Object.Base.route [
+	{
+		source "host-copier.$UAOL_PCM_ID.playback"
+		sink "gain.$UAOL_PB_HOST_PIPELINE_ID.1"
+	}
+	{
+		source "mixin.$UAOL_PB_HOST_PIPELINE_ID.1"
+		sink "mixout.$UAOL_PB_DAI_PIPELINE_ID.1"
+	}
+	{
+		source "gain.$UAOL_PB_DAI_PIPELINE_ID.1"
+		sink "dai-copier.UAOL.$UAOL_PB_DAI_NAME.playback"
+	}
+	{
+		source "dai-copier.UAOL.$UAOL_CP_DAI_NAME.capture"
+		sink "eqiir.$UAOL_CP_DAI_PIPELINE_ID.1"
+	}
+	{
+		source "module-copier.$UAOL_CP_DAI_PIPELINE_ID.2"
+		sink "host-copier.$UAOL_PCM_ID.capture"
+	}
+]

--- a/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
+++ b/tools/topology/topology2/production/tplg-targets-sdca-generic.cmake
@@ -37,6 +37,19 @@ SDW_DMIC_STREAM=Capture-SmartMic"
 "cavs-sdw\;sof-hdmi-pcm5-id6\;SDW_JACK=false,HDMI1_ID=6,HDMI2_ID=7,HDMI3_ID=8"
 "cavs-sdw\;sof-hdmi-pcm5-id7\;SDW_JACK=false,HDMI1_ID=7,HDMI2_ID=8,HDMI3_ID=9"
 
+# USB Audio Offload Link function topology. The UAOL backend is the last one
+# sof_sdw creates, so its dai link ID depends on the composition of the board:
+# it follows the SoundWire links, the PCH DMIC pair, the three HDMI links and
+# the BT link. Each direction is a separate link, so two consecutive IDs are
+# taken. The range below covers a jack and amplifier board without DMIC and BT
+# (6) up to a jack, amplifier with feedback, PCH DMIC and BT board (10).
+# Add a variant here for every further ID that is needed.
+"cavs-uaol\;sof-uaol-id6\;UAOL_PB_BE_ID=6,UAOL_CP_BE_ID=7"
+"cavs-uaol\;sof-uaol-id7\;UAOL_PB_BE_ID=7,UAOL_CP_BE_ID=8"
+"cavs-uaol\;sof-uaol-id8\;UAOL_PB_BE_ID=8,UAOL_CP_BE_ID=9"
+"cavs-uaol\;sof-uaol-id9\;UAOL_PB_BE_ID=9,UAOL_CP_BE_ID=10"
+"cavs-uaol\;sof-uaol-id10\;UAOL_PB_BE_ID=10,UAOL_CP_BE_ID=11"
+
 # Feature topologies which should work with the function topologies above
 "cavs-sdw\;sof-sdca-amp-ref\;SDW_JACK=false,NUM_HDMIS=0,JACK_RATE=48000,\
 SDW_AMP_FEEDBACK=false,SDW_SPK_ECHO_REF=true,SDW_SPK_ECHO_REF_PCM_ID=12"


### PR DESCRIPTION

Add the topology for the USB Audio Offload Link, the ACE2+ alt link which lets
the DSP drive an offloaded USB isochronous endpoint directly.

UAOL belongs to the ALH class family in the firmware, but the ALH DAI class
carries SoundWire specific attributes, so it gets a DAI class of its own.

The `cavs-uaol` function topology is loaded next to the other function
topologies of the sof_sdw card:

```
  PCM 21 ------------> gain --> mixin --+
                                        |
  PCM 22 (deepbuf) --> gain --> mixin --+--> mixout --> gain --> UAOL0-Play

  PCM 21 <-------- module-copier <-- eqiir <----------------- UAOL0-Cap
```

The capture path carries no mixer because the captured channel count follows
the USB device, while a mixer only handles a fixed channel count.

The two directions are separate DAI links so the format fixup of a link is
decided by the DAI copier of that direction alone. The UAOL backend is the
last one the machine driver creates, so its link ID depends on the board;
`sof-uaol-id6` to `sof-uaol-id10` cover the range SoundWire boards produce.

Depends on the kernel side UAOL series, which is not upstream yet.

Tested on a PTL device, resolves to `sof-uaol-id9`) with a
Sennheiser 1395:0024 and a Huawei 12d1:3a07 headset: playback, deep buffer,
both mixed, and capture with the EQ IIR running in the DSP.

Known limitation: the PCM advertises the topology's capabilities rather than
those of the connected device, so an unsupported format or channel count is
only rejected at hw_params time. Constraining it needs kernel side work.
