### PR TITLE
audio: stft_process: switch assert include to rtos/panic.h

### DIFF
--- a/src/audio/stft_process/stft_process-generic.c
+++ b/src/audio/stft_process/stft_process-generic.c
@@ -4,7 +4,7 @@
 
 #include <sof/audio/format.h>
 #include <sof/common.h>
-#include <assert.h>
+#include <rtos/panic.h>
 #include <stdint.h>
 #include "stft_process.h"
 

--- a/src/audio/stft_process/stft_process-hifi3.c
+++ b/src/audio/stft_process/stft_process-hifi3.c
@@ -13,7 +13,7 @@
 
 #include <sof/audio/format.h>
 #include <sof/common.h>
-#include <assert.h>
+#include <rtos/panic.h>
 #include <stdint.h>
 #include "stft_process.h"
 


### PR DESCRIPTION
The two stft_process source files use lassert.h from libc, which under a newlib-based Zephyr build (e.g. MTL with COMMON_LIBC_MALLOC_ARENA_SIZE set) expands assert() to a __assert_no_args() call whose implementation is not linked into the SOF firmware image. Enabling COMP_STFT_PROCESS on such a build therefore fails at link time with an "undefined reference to __assert_no_args" error.

All other SOF audio modules includes <rtos/panic.h> instead, which maps assert() to Zephyr's __ASSERT_NO_MSG in firmware builds and to sof_panic() in the posix testbench.