### PR TITLE
ci: bump ubuntu to 26.04, zephyr lite version to v0.29.3, zephyr-sdk to 1.0.1

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stale:
     name: Find stale issues
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.repository == 'thesofproject/sof'
     permissions:
       issues: write

--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: thesofproject/zephyr-lite:v0.29.3
 

--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
 
   doxygen:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   main:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -29,7 +29,7 @@ jobs:
 
   # Basic build test
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       # FIXME: add  -Wpointer-arith
       _CFLGS: -Werror -Wall -Wmissing-prototypes
@@ -49,7 +49,7 @@ jobs:
 
   # cppcheck
   cppcheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
         with: {submodules: recursive, fetch-depth: 0, filter: 'tree:0'}

--- a/.github/workflows/sof-docs.yml
+++ b/.github/workflows/sof-docs.yml
@@ -29,7 +29,7 @@ jobs:
   # example in
   # https://github.com/thesofproject/sof/pull/5731#issuecomment-1175630147
   sof-docs:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -29,7 +29,7 @@ jobs:
     # this in sync with it.
     runs-on: ubuntu-24.04
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -27,7 +27,7 @@ jobs:
 
     # We're sharing the sparse binary with the zephyr-build container so keep
     # this in sync with it.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: thesofproject/zephyr-lite:v0.29.3
 

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout SOF repository (PR source)

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   # This is not the same as building every ./build-tools.sh option.
   top-level_default_CMake_target_ALL:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,6 +81,9 @@ jobs:
 
 
   SOF-alsa-plugin:
+    # TODO: Update ubuntu to 26.04 when openvino situation is resolved
+    # It's not in the base ubuntu 26.04 OS and installation fails
+    # https://github.com/openvinotoolkit/openvino/issues/37509
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zephyr-shell.yml
+++ b/.github/workflows/zephyr-shell.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     container:
       image: thesofproject/zephyr-lite:v0.29.3
 

--- a/.github/workflows/zephyr-shell.yml
+++ b/.github/workflows/zephyr-shell.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/zephyr-unit-tests.yml
+++ b/.github/workflows/zephyr-unit-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   zephyr-utests:
     name: Zephyr Unit Tests (ZTest)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,7 +84,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
 
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: thesofproject/zephyr-lite:v0.29.0
+      image: thesofproject/zephyr-lite:v0.29.3
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -79,7 +79,7 @@ jobs:
   # sof/scripts/xtensa-build-zephyr.py configuration script. Then this
   # job will be disappear, folded back in the regular build-* jobs below.
   LP64-WIP:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: bash
@@ -110,7 +110,7 @@ jobs:
             -DEXTRA_AFLAGS=-Werror
 
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: bash

--- a/scripts/docker_build/zephyr_lite/Dockerfile
+++ b/scripts/docker_build/zephyr_lite/Dockerfile
@@ -2,16 +2,16 @@
 # Copyright(c) 2025 Intel Corporation. All rights reserved.
 
 # Use zephyr-build as base image
-FROM ghcr.io/zephyrproject-rtos/zephyr-build:v0.29.0 as base
+FROM ghcr.io/zephyrproject-rtos/zephyr-build:v0.29.3 as base
 
 # Remove additional toolchains.
 # As this is not ideal solution there is a plan to build docker image without zephyr-build as the base
 # and install only needed toolchains in the future.
 USER root
 
-RUN rm -rvf /opt/toolchains/zephyr-sdk-1.0.0/hosttools/sysroots && \
+RUN rm -rvf /opt/toolchains/zephyr-sdk-1.0.1/hosttools/sysroots && \
     rm -rvf /opt/fvps && \
-    cd /opt/toolchains/zephyr-sdk-1.0.0/gnu && \
+    cd /opt/toolchains/zephyr-sdk-1.0.1/gnu && \
       rm -rvf arc* \
           micro* \
           mips* \
@@ -23,8 +23,8 @@ RUN rm -rvf /opt/toolchains/zephyr-sdk-1.0.0/hosttools/sysroots && \
           xtensa-sample* \
           xtensa-dc233c*
 
-# Use ubuntu24.04 as base for zephyr-lite
-FROM ubuntu:24.04 as zephyr-lite
+# Use ubuntu26.04 as base for zephyr-lite
+FROM ubuntu:26.04 as zephyr-lite
 
 # Copy only required files from base image to zephyr-lite
 # /opt for toolchains and sdk
@@ -52,8 +52,8 @@ RUN /opt/python/venv/bin/pip install 'cmake>=3.21' jsonschema
 
 # Set zephyr env variables
 ENV PATH="/opt/python/venv/bin/:$PATH"
-ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-1.0.0
-ENV ZSDK_VERSION=1.0.0
+ENV ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/zephyr-sdk-1.0.1
+ENV ZSDK_VERSION=1.0.1
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 
 CMD ["/bin/bash", "-l"]

--- a/zephyr/docker-run.sh
+++ b/zephyr/docker-run.sh
@@ -54,8 +54,8 @@ main()
 
 run_command()
 {
-    # zephyr-lite:v0.29.0 has /opt/toolchains/zephyr-sdk-1.0.0
-    # zephyr-lite:v0.29.0 is based on zephyr-build:v0.29.0
+    # zephyr-lite:v0.29.3 has /opt/toolchains/zephyr-sdk-1.0.1
+    # zephyr-lite:v0.29.3 is based on zephyr-build:v0.29.3
     # https://hub.docker.com/r/zephyrprojectrtos/zephyr-build/tags
     # https://hub.docker.com/r/thesofproject/zephyr-lite/tags
     #
@@ -65,7 +65,7 @@ run_command()
            --workdir /zep_workspace \
            $SOF_DOCKER_RUN \
            --env REAL_CC --env http_proxy --env https_proxy \
-           thesofproject/zephyr-lite:v0.29.0 \
+           thesofproject/zephyr-lite:v0.29.3 \
            ./sof/scripts/sudo-cwd.sh "$@"
 }
 


### PR DESCRIPTION
### Dockerfile
#### [zephyr-lite: bump ubuntu to 26.04 and sdk to zephyr-sdk-1.0.1](https://github.com/thesofproject/sof/pull/11099/changes/f79f9e4eee64733cfc5e3671733b09e4043a4985)
Upgrade:
- ubuntu to 26.04
- zephyr-base to v0.29.3
- zephyr-sdk to zephyr-sdk-1.0.1

### CI
#### [ci: bump zephyr-lite version to v0.29.3 across workflows](https://github.com/thesofproject/sof/pull/11099/changes/f74919e4b0d5fd3825c8afb8c28f5ffb9c8a36f0)
Bump zephyr-lite version to v0.29.3 across workflows
#### [ci: bump ubuntu runners to 26.04](https://github.com/thesofproject/sof/pull/11099/changes/83e50cdd1c8f80f3a6fe4c407fa8103e41e79278)
Bump ubuntu runners to 26.04 except:
- tools.yml SOF-alsa-plugin.
  There is a problem with cmake:

  ```shell
    CMake Warning at modules/ov_noise_suppression/CMakeLists.txt:4 (find_package):
    By not providing "FindOpenVINO.cmake" in CMAKE_MODULE_PATH this project has
    asked CMake to find a package configuration file provided by "OpenVINO",
    but CMake did not find one.

    Could not find a package configuration file provided by "OpenVINO" with any
    of the following names:

      OpenVINO.cps
      openvino.cps
      OpenVINOConfig.cmake
      openvino-config.cmake
  ```

  Installation of the Openvino fails so there is a need to leave ubuntu 24.04 on this one until resolved.
  https://github.com/openvinotoolkit/openvino/issues/37509

- ipc_fuzzer.yml / build_all.yml
  > /usr/bin/x86_64-linux-gnu-ld.bfd: cannot find -lstdc++: No such file or directory

In this stage ubuntu26.04 supports only limited amount of worflows