### PR TITLE
module: generic: remove unnecessary EXPORT_SYMBOL

### DIFF
--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -770,7 +770,6 @@ void z_impl_mod_free_all(struct processing_module *mod)
 	/* Make sure resource lists and accounting are reset */
 	mod_resource_init(mod);
 }
-EXPORT_SYMBOL(z_impl_mod_free_all);
 
 int module_free(struct processing_module *mod)
 {


### PR DESCRIPTION
Remove export for mod_free_all(). It is not needed and unnecessary exports have a cost when modules are loaded.

Fixes: a0939f4bc2e6 ("module: generic: use a single static lock for module resources")