### PR TITLE
Trace - make clear that trace context is unused with Zephyr

### DIFF
--- a/src/audio/aria/aria.c
+++ b/src/audio/aria/aria.c
@@ -327,6 +327,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(aria_comp_tr, SOF_UUID(aria_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(aria_interface, aria_uuid, aria_comp_tr);
 SOF_MODULE_INIT(aria, sys_comp_module_aria_interface_init);

--- a/src/audio/asrc/asrc_ipc3.c
+++ b/src/audio/asrc/asrc_ipc3.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(asrc);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc_uuid), LOG_LEVEL_INFO);
 LOG_MODULE_DECLARE(asrc, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/audio/asrc/asrc_ipc4.c
+++ b/src/audio/asrc/asrc_ipc4.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(asrc4);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(asrc_tr, SOF_UUID(asrc4_uuid), LOG_LEVEL_INFO);
 
 int asrc_dai_configure_timestamp(struct comp_data *cd)

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -40,6 +40,7 @@
 LOG_MODULE_REGISTER(basefw, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(basefw);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(basefw_comp_tr, SOF_UUID(basefw_uuid), LOG_LEVEL_INFO);
 
 static struct ipc4_system_time_info global_system_time_info;
@@ -849,7 +850,9 @@ __cold static int basefw_set_large_config(struct comp_dev *dev, uint32_t param_i
 
 static const struct comp_driver comp_basefw = {
 	.uid	= SOF_RT_UUID(basefw_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &basefw_comp_tr,
+#endif
 	.ops	= {
 		.get_large_config = basefw_get_large_config,
 		.set_large_config = basefw_set_large_config,

--- a/src/audio/buffers/comp_buffer.c
+++ b/src/audio/buffers/comp_buffer.c
@@ -29,6 +29,7 @@
 LOG_MODULE_REGISTER(buffer, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(buffer);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(buffer_tr, SOF_UUID(buffer_uuid), LOG_LEVEL_INFO);
 
 static size_t comp_buffer_get_data_available(struct sof_source *source)

--- a/src/audio/buffers/ring_buffer.c
+++ b/src/audio/buffers/ring_buffer.c
@@ -18,6 +18,7 @@
 LOG_MODULE_REGISTER(ring_buffer, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(ring_buffer);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ring_buffer_tr, SOF_UUID(ring_buffer_uuid), LOG_LEVEL_INFO);
 
 static inline struct ring_buffer *ring_buffer_from_sink(struct sof_sink *sink)

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -43,6 +43,7 @@ static const uint32_t max_chain_number = DT_NUM_HDA_HOST_OUT + DT_NUM_HDA_HOST_I
 LOG_MODULE_REGISTER(chain_dma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(chain_dma);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(chain_dma_tr, SOF_UUID(chain_dma_uuid), LOG_LEVEL_INFO);
 
 /* chain dma component private data */
@@ -787,7 +788,9 @@ __cold static void chain_task_free(struct comp_dev *dev)
 
 static const struct comp_driver comp_chain_dma = {
 	.uid = SOF_RT_UUID(chain_dma_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &chain_dma_tr,
+#endif
 	.ops = {
 		.create = chain_task_create,
 		.trigger = chain_task_trigger,

--- a/src/audio/channel_map.c
+++ b/src/audio/channel_map.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(channel_map, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(chmap);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(chmap_tr, SOF_UUID(chmap_uuid), LOG_LEVEL_INFO);
 
 struct sof_ipc_channel_map *chmap_get(struct sof_ipc_stream_map *smap,

--- a/src/audio/codec/dts/dts.c
+++ b/src/audio/codec/dts/dts.c
@@ -491,6 +491,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dts_tr, SOF_UUID(dts_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(dts_interface, dts_uuid, dts_tr);
 SOF_MODULE_INIT(dts, sys_comp_module_dts_interface_init);

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -47,6 +47,7 @@ struct comp_driver_list *comp_drivers_get(void)
 
 SOF_DEFINE_REG_UUID(component);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(comp_tr, SOF_UUID(component_uuid), LOG_LEVEL_INFO);
 
 int comp_register(struct comp_driver_info *drv)

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -88,11 +88,11 @@ int comp_set_adapter_ops(const struct comp_driver *drv, const struct module_inte
 			 */
 			if (!info->adapter_ops) {
 				tr_err(&comp_tr, "NULL adapter ops ptr for %pU!",
-				       info->drv->tctx->uuid_p);
+				       SOF_DRV_UID_NAME(info->drv));
 				return -EINVAL;
 			}
 
-			tr_dbg(&comp_tr, "update uuid %pU", info->drv->tctx->uuid_p);
+			tr_dbg(&comp_tr, "update uuid %pU", SOF_DRV_UID_NAME(info->drv));
 			*info->adapter_ops = ops;
 			return 0;
 		}

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1298,6 +1298,7 @@ static APP_SYSUSER_DATA const struct module_interface copier_interface = {
 	.endpoint_ops = &copier_endpoint_ops,
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(copier_comp_tr, SOF_UUID(copier_uuid), LOG_LEVEL_INFO);
 
 DECLARE_MODULE_ADAPTER(copier_interface, copier_uuid, copier_comp_tr);

--- a/src/audio/crossover/crossover.c
+++ b/src/audio/crossover/crossover.c
@@ -689,6 +689,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(crossover_tr, SOF_UUID(crossover_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(crossover_interface, crossover_uuid, crossover_tr);
 SOF_MODULE_INIT(crossover, sys_comp_module_crossover_interface_init);

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -2066,12 +2066,15 @@ __cold int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev,
 }
 #endif /* CONFIG_IPC_MAJOR_4 */
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dai_comp_tr, SOF_UUID(dai_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_dai = {
 	.type	= SOF_COMP_DAI,
 	.uid	= SOF_RT_UUID(dai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &dai_comp_tr,
+#endif
 	.ops	= {
 		.create				= dai_new,
 		.free				= dai_free,

--- a/src/audio/dcblock/dcblock.c
+++ b/src/audio/dcblock/dcblock.c
@@ -311,6 +311,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dcblock_tr, SOF_UUID(dcblock_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(dcblock_interface, dcblock_uuid, dcblock_tr);
 SOF_MODULE_INIT(dcblock, sys_comp_module_dcblock_interface_init);

--- a/src/audio/drc/drc_log.c
+++ b/src/audio/drc/drc_log.c
@@ -9,6 +9,7 @@
 
 SOF_DEFINE_REG_UUID(drc);
 LOG_MODULE_REGISTER(drc, CONFIG_SOF_LOG_LEVEL);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(drc_tr, SOF_UUID(drc_uuid), LOG_LEVEL_INFO);
 EXPORT_SYMBOL(log_const_drc);
 #ifdef CONFIG_LOG_RUNTIME_FILTERING

--- a/src/audio/eq_fir/eq_fir.c
+++ b/src/audio/eq_fir/eq_fir.c
@@ -533,6 +533,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(eq_fir_tr, SOF_UUID(eq_fir_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(eq_fir_interface, eq_fir_uuid, eq_fir_tr);
 SOF_MODULE_INIT(eq_fir, sys_comp_module_eq_fir_interface_init);

--- a/src/audio/eq_iir/eq_iir.c
+++ b/src/audio/eq_iir/eq_iir.c
@@ -254,6 +254,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(eq_iir_tr, SOF_UUID(eq_iir_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(eq_iir_interface, eq_iir_uuid, eq_iir_tr);
 SOF_MODULE_INIT(eq_iir, sys_comp_module_eq_iir_interface_init);

--- a/src/audio/google/google_ctc_audio_processing.c
+++ b/src/audio/google/google_ctc_audio_processing.c
@@ -472,6 +472,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(google_ctc_audio_processing_tr, SOF_UUID(google_ctc_audio_processing_uuid),
 	       LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(google_ctc_audio_processing_interface,

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -445,12 +445,15 @@ static int ghd_prepare(struct comp_dev *dev)
 	return comp_set_state(dev, COMP_TRIGGER_PREPARE);
 }
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ghd_tr, SOF_UUID(ghd_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver ghd_driver = {
 	.type	= SOF_COMP_KEYWORD_DETECT,
 	.uid	= SOF_RT_UUID(ghd_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &ghd_tr,
+#endif
 	.ops	= {
 		.create		= ghd_create,
 		.free		= ghd_free,

--- a/src/audio/google/google_rtc_audio_processing.c
+++ b/src/audio/google/google_rtc_audio_processing.c
@@ -860,6 +860,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(google_rtc_audio_processing_tr, SOF_UUID(google_rtc_audio_processing_uuid),
 			   LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(google_rtc_audio_processing_interface,

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -1310,12 +1310,15 @@ static uint64_t host_get_processed_data(struct comp_dev *dev, uint32_t stream_no
 	return ret;
 }
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(host_tr, SOF_UUID(host_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_host = {
 	.type	= SOF_COMP_HOST,
 	.uid	= SOF_RT_UUID(host_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &host_tr,
+#endif
 	.ops	= {
 		.create				= host_new,
 		.free				= host_free,

--- a/src/audio/igo_nr/igo_nr.c
+++ b/src/audio/igo_nr/igo_nr.c
@@ -932,6 +932,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(igo_nr_tr, SOF_UUID(igo_nr_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(igo_nr_interface, igo_nr_uuid, igo_nr_tr);
 SOF_MODULE_INIT(igo_nr, sys_comp_module_igo_nr_interface_init);

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -2716,12 +2716,15 @@ static int kpb_set_large_config(struct comp_dev *dev, uint32_t param_id,
 	}
 }
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(kpb_tr, SOF_UUID(KPB_UUID), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_kpb = {
 	.type = SOF_COMP_KPB,
 	.uid = SOF_RT_UUID(KPB_UUID),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &kpb_tr,
+#endif
 	.ops = {
 		.create		= kpb_new,
 		.free		= kpb_free,

--- a/src/audio/level_multiplier/level_multiplier.c
+++ b/src/audio/level_multiplier/level_multiplier.c
@@ -200,6 +200,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(level_multiplier_tr, SOF_UUID(level_multiplier_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(level_multiplier_interface, level_multiplier_uuid, level_multiplier_tr);
 SOF_MODULE_INIT(level_multiplier, sys_comp_module_level_multiplier_interface_init);

--- a/src/audio/mfcc/mfcc.c
+++ b/src/audio/mfcc/mfcc.c
@@ -333,6 +333,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mfcc_tr, SOF_UUID(mfcc_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(mfcc_interface, mfcc_uuid, mfcc_tr);
 SOF_MODULE_INIT(mfcc, sys_comp_module_mfcc_interface_init);

--- a/src/audio/mixer/mixer.c
+++ b/src/audio/mixer/mixer.c
@@ -256,6 +256,7 @@ static const struct module_interface mixer_interface = {
 	.free = mixer_free,
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mixer_tr, SOF_UUID(mixer_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(mixer_interface, mixer_uuid, mixer_tr);
 SOF_MODULE_INIT(mixer, sys_comp_module_mixer_interface_init);

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -1063,10 +1063,12 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mixin_tr, SOF_UUID(mixin_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(mixin_interface, mixin_uuid, mixin_tr);
 SOF_MODULE_INIT(mixin, sys_comp_module_mixin_interface_init);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mixout_tr, SOF_UUID(mixout_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(mixout_interface, mixout_uuid, mixout_tr);
 SOF_MODULE_INIT(mixout, sys_comp_module_mixout_interface_init);

--- a/src/audio/module_adapter/library/userspace_proxy.c
+++ b/src/audio/module_adapter/library/userspace_proxy.c
@@ -46,6 +46,7 @@ LOG_MODULE_REGISTER(userspace_proxy, CONFIG_SOF_LOG_LEVEL);
 /* 6f6b6f4b-6f73-7466-20e1e62b9779f003 */
 SOF_DEFINE_REG_UUID(userspace_proxy);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(userspace_proxy_tr, SOF_UUID(userspace_proxy_uuid), LOG_LEVEL_INFO);
 
 static const struct module_interface userspace_proxy_interface;

--- a/src/audio/module_adapter/module/cadence_ipc3.c
+++ b/src/audio/module_adapter/module/cadence_ipc3.c
@@ -18,6 +18,7 @@
 
 SOF_DEFINE_REG_UUID(cadence_codec);
 LOG_MODULE_DECLARE(cadence_codec, CONFIG_SOF_LOG_LEVEL);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(cadence_codec_tr, SOF_UUID(cadence_codec_uuid), LOG_LEVEL_INFO);
 
 int cadence_codec_resolve_api(struct processing_module *mod)

--- a/src/audio/module_adapter/module/cadence_ipc4.c
+++ b/src/audio/module_adapter/module/cadence_ipc4.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(cadence_codec);
 LOG_MODULE_DECLARE(cadence_codec, CONFIG_SOF_LOG_LEVEL);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(cadence_codec_tr, SOF_UUID(cadence_codec_uuid), LOG_LEVEL_INFO);
 
 int cadence_codec_resolve_api(struct processing_module *mod)

--- a/src/audio/module_adapter/module/dolby/dax.c
+++ b/src/audio/module_adapter/module/dolby/dax.c
@@ -1000,6 +1000,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dolby_dax_audio_processing_tr, SOF_UUID(dolby_dax_audio_processing_uuid),
 	       LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(dolby_dax_audio_processing_interface, dolby_dax_audio_processing_uuid,

--- a/src/audio/module_adapter/module/passthrough.c
+++ b/src/audio/module_adapter/module/passthrough.c
@@ -150,6 +150,7 @@ static const struct module_interface passthrough_interface = {
 	.free = passthrough_codec_free
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(passthrough_tr, SOF_UUID(passthrough_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(passthrough_interface, passthrough_uuid, passthrough_tr);
 SOF_MODULE_INIT(passthrough, sys_comp_module_passthrough_interface_init);

--- a/src/audio/module_adapter/module/waves/waves.c
+++ b/src/audio/module_adapter/module/waves/waves.c
@@ -962,6 +962,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(waves_tr, SOF_UUID(waves_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(waves_interface, waves_uuid, waves_tr);
 SOF_MODULE_INIT(waves, sys_comp_module_waves_interface_init);

--- a/src/audio/multiband_drc/multiband_drc.c
+++ b/src/audio/multiband_drc/multiband_drc.c
@@ -460,6 +460,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(multiband_drc_tr, SOF_UUID(multiband_drc_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(multiband_drc_interface, multiband_drc_uuid, multiband_drc_tr);
 SOF_MODULE_INIT(multiband_drc, sys_comp_module_multiband_drc_interface_init);

--- a/src/audio/mux/mux_ipc3.c
+++ b/src/audio/mux/mux_ipc3.c
@@ -25,10 +25,12 @@ LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(mux);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux_uuid), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(demux);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);
 
 static int mux_set_values(struct processing_module *mod)

--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -26,10 +26,12 @@ LOG_MODULE_DECLARE(muxdemux, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(mux4);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(mux_tr, SOF_UUID(mux4_uuid), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(demux);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(demux_tr, SOF_UUID(demux_uuid), LOG_LEVEL_INFO);
 
 static int build_config(struct processing_module *mod, struct mux_data *cfg)

--- a/src/audio/nxp/eap.c
+++ b/src/audio/nxp/eap.c
@@ -31,6 +31,7 @@
 
 LOG_MODULE_REGISTER(nxp_eap, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(nxp_eap);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(nxp_eap_tr, SOF_UUID(nxp_eap_uuid), LOG_LEVEL_INFO);
 
 #define NXP_EAP_DEFAULT_MAX_BLOCK_SIZE 480

--- a/src/audio/phase_vocoder/phase_vocoder.c
+++ b/src/audio/phase_vocoder/phase_vocoder.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(phase_vocoder, CONFIG_SOF_LOG_LEVEL);
 /* Creates the component trace. Traces show in trace console the component
  * info, warning, and error messages.
  */
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(phase_vocoder_tr, SOF_UUID(phase_vocoder_uuid), LOG_LEVEL_INFO);
 
 #if STFT_DEBUG

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -36,6 +36,7 @@ LOG_MODULE_REGISTER(pipe, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(pipe);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(pipe_tr, SOF_UUID(pipe_uuid), LOG_LEVEL_INFO);
 
 /* number of pipeline stream metadata objects we export in mailbox */
@@ -201,7 +202,7 @@ struct pipeline *pipeline_new(struct k_heap *heap, uint32_t pipeline_id, uint32_
 	p->status = COMP_STATE_INIT;
 	p->trigger.cmd = COMP_TRIGGER_NO_ACTION;
 
-#ifndef CONFIG_SOF_USERSPACE_LL
+#if !CONFIG_SOF_USERSPACE_LL && !CONFIG_ZEPHYR_LOG
 	/*
 	 * pipe_tr lives in the .trace_ctx section, which is not mapped into
 	 * the sysuser partition, so it cannot be read from a user-mode thread.

--- a/src/audio/rtnr/rtnr.c
+++ b/src/audio/rtnr/rtnr.c
@@ -62,6 +62,7 @@ LOG_MODULE_REGISTER(rtnr, CONFIG_SOF_LOG_LEVEL);
 /* UUID 5c7ca334-e15d-11eb-ba80-0242ac130004 */
 SOF_DEFINE_REG_UUID(rtnr);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(rtnr_tr, SOF_UUID(rtnr_uuid), LOG_LEVEL_INFO);
 
 /* Generic processing */

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -589,13 +589,16 @@ static int selector_reset(struct comp_dev *dev)
 	return ret;
 }
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(selector_tr, SOF_UUID(selector_uuid), LOG_LEVEL_INFO);
 
 /** \brief Selector component definition. */
 static const struct comp_driver comp_selector = {
 	.type	= SOF_COMP_SELECTOR,
 	.uid	= SOF_RT_UUID(selector_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &selector_tr,
+#endif
 	.ops	= {
 		.create		= selector_new,
 		.free		= selector_free,
@@ -1175,6 +1178,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(selector_tr, SOF_UUID(selector4_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(selector_interface, selector4_uuid, selector_tr);
 SOF_MODULE_INIT(selector, sys_comp_module_selector_interface_init);

--- a/src/audio/smart_amp/smart_amp.c
+++ b/src/audio/smart_amp/smart_amp.c
@@ -827,6 +827,7 @@ static struct module_interface smart_amp_interface = {
 	.trigger = smart_amp_trigger,
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(smart_amp_comp_tr, SOF_UUID(UUID_SYM), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(smart_amp_interface, UUID_SYM, smart_amp_comp_tr);
 SOF_MODULE_INIT(smart_amp, sys_comp_module_smart_amp_interface_init);

--- a/src/audio/sound_dose/sound_dose.c
+++ b/src/audio/sound_dose/sound_dose.c
@@ -361,6 +361,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sound_dose_tr, SOF_UUID(sound_dose_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(sound_dose_interface, sound_dose_uuid, sound_dose_tr);
 SOF_MODULE_INIT(sound_dose, sys_comp_module_sound_dose_interface_init);

--- a/src/audio/src/src_ipc3.c
+++ b/src/audio/src/src_ipc3.c
@@ -42,6 +42,7 @@
 
 SOF_DEFINE_REG_UUID(src);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(src_tr, SOF_UUID(src_uuid), LOG_LEVEL_INFO);
 
 LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/src/src_ipc4.c
+++ b/src/audio/src/src_ipc4.c
@@ -44,6 +44,7 @@
 
 SOF_DEFINE_REG_UUID(src4);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(src_tr, SOF_UUID(src4_uuid), LOG_LEVEL_INFO);
 
 LOG_MODULE_DECLARE(src, CONFIG_SOF_LOG_LEVEL);

--- a/src/audio/src/src_lite.c
+++ b/src/audio/src/src_lite.c
@@ -67,6 +67,7 @@ const struct module_interface src_lite_interface = {
 
 SOF_DEFINE_REG_UUID(src_lite);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(src_lite_tr, SOF_UUID(src_lite_uuid), LOG_LEVEL_INFO);
 
 #if !CONFIG_COMP_SRC_MODULE

--- a/src/audio/stft_process/stft_process.c
+++ b/src/audio/stft_process/stft_process.c
@@ -247,6 +247,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(stft_process_tr, SOF_UUID(stft_process_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(stft_process_interface, stft_process_uuid, stft_process_tr);
 SOF_MODULE_INIT(stft_process, sys_comp_module_stft_process_interface_init);

--- a/src/audio/tdfb/tdfb.c
+++ b/src/audio/tdfb/tdfb.c
@@ -941,6 +941,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(tdfb_tr, SOF_UUID(tdfb_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(tdfb_interface, tdfb_uuid, tdfb_tr);
 SOF_MODULE_INIT(tdfb, sys_comp_module_tdfb_interface_init);

--- a/src/audio/template/template.c
+++ b/src/audio/template/template.c
@@ -201,6 +201,7 @@ SOF_LLEXT_BUILDINFO;
 #else
 
 /* Only used for the module adapter trace context, soon to be deprecated */
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(template_tr, SOF_UUID(template_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(template_interface, template_uuid, template_tr);
 SOF_MODULE_INIT(template, sys_comp_module_template_interface_init);

--- a/src/audio/tensorflow/tflm-classify.c
+++ b/src/audio/tensorflow/tflm-classify.c
@@ -238,6 +238,7 @@ static const struct module_interface tflmcly_interface = {
 	.free = tflm_free
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(tflm_tr, SOF_UUID(tflmcly_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(tflmcly_interface, tflmcly_uuid, tflm_tr);
 SOF_MODULE_INIT(tflmcly, sys_comp_module_tflmcly_interface_init);

--- a/src/audio/tone/tone-ipc3.c
+++ b/src/audio/tone/tone-ipc3.c
@@ -374,12 +374,15 @@ static int tone_reset(struct comp_dev *dev)
 	return 0;
 }
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(tone_tr, SOF_UUID(tone_uuid), LOG_LEVEL_INFO);
 
 static const struct comp_driver comp_tone = {
 	.type = SOF_COMP_TONE,
 	.uid = SOF_RT_UUID(tone_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &tone_tr,
+#endif
 	.ops = {
 		.create = tone_new,
 		.free = tone_free,

--- a/src/audio/tone/tone-ipc4.c
+++ b/src/audio/tone/tone-ipc4.c
@@ -221,6 +221,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(tone_tr, SOF_UUID(tone_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(tone_interface, tone_uuid, tone_tr);
 SOF_MODULE_INIT(tone, sys_comp_module_tone_interface_init);

--- a/src/audio/up_down_mixer/up_down_mixer.c
+++ b/src/audio/up_down_mixer/up_down_mixer.c
@@ -452,6 +452,7 @@ static const struct module_interface up_down_mixer_interface = {
 	.free = up_down_mixer_free
 };
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(up_down_mixer_comp_tr, SOF_UUID(up_down_mixer_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(up_down_mixer_interface, up_down_mixer_uuid, up_down_mixer_comp_tr);
 SOF_MODULE_INIT(up_down_mixer, sys_comp_module_up_down_mixer_interface_init);

--- a/src/audio/volume/volume_uuid.h
+++ b/src/audio/volume/volume_uuid.h
@@ -20,9 +20,11 @@ SOF_DEFINE_REG_UUID(volume4);
 
 SOF_DEFINE_REG_UUID(gain);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(gain_tr, SOF_UUID(gain_uuid), LOG_LEVEL_INFO);
 #endif
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(volume_tr, SOF_UUID(volume_uuid), LOG_LEVEL_INFO);
 
 #endif /* __SOF_AUDIO_VOLUME_UUID_H__ */

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -248,6 +248,7 @@ SOF_LLEXT_BUILDINFO;
 
 #else
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(tester_tr, SOF_UUID(tester_uuid), LOG_LEVEL_INFO);
 DECLARE_MODULE_ADAPTER(tester_interface, tester_uuid, tester_tr);
 SOF_MODULE_INIT(tester, sys_comp_module_tester_interface_init);

--- a/src/drivers/amd/common/acp_bt_dai.c
+++ b/src/drivers/amd/common/acp_bt_dai.c
@@ -21,6 +21,7 @@
 
 SOF_DEFINE_REG_UUID(btdai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(btdai_tr, SOF_UUID(btdai_uuid), LOG_LEVEL_INFO);
 
 static inline int btdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -79,7 +80,9 @@ static int btdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_btdai_driver = {
 	.type	  = SOF_DAI_AMD_BT,
 	.uid	  = SOF_UUID(btdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	  = &btdai_tr,
+#endif
 	.dma_dev  = SOF_DMA_DEV_BT,
 	.dma_caps = SOF_DMA_CAP_BT,
 	.ops = {

--- a/src/drivers/amd/common/acp_dma.c
+++ b/src/drivers/amd/common/acp_dma.c
@@ -25,6 +25,7 @@
 #include <sof/probe/probe.h>
 
 SOF_DEFINE_REG_UUID(acpdma);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acpdma_tr, SOF_UUID(acpdma_uuid), LOG_LEVEL_INFO);
 #define PROBE_UPDATE_POS_MASK	0x80000000
 #define PROBE_BUFFER_WATERMARK	(16 * 1024)

--- a/src/drivers/amd/common/acp_dmic_dai.c
+++ b/src/drivers/amd/common/acp_dmic_dai.c
@@ -24,6 +24,7 @@ extern struct acp_dmic_silence acp_initsilence;
 
 SOF_DEFINE_REG_UUID(acp_dmic_dai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_dmic_dai_tr, SOF_UUID(acp_dmic_dai_uuid), LOG_LEVEL_INFO);
 
 static inline int acp_dmic_dai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -157,7 +158,9 @@ static int acp_dmic_dai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_dmic_dai_driver = {
 	.type = SOF_DAI_AMD_DMIC,
 	.uid = SOF_UUID(acp_dmic_dai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &acp_dmic_dai_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_DMIC,
 	.dma_caps = SOF_DMA_CAP_DMIC,
 	.ops = {

--- a/src/drivers/amd/common/acp_dmic_dma.c
+++ b/src/drivers/amd/common/acp_dmic_dma.c
@@ -37,6 +37,7 @@ extern uint32_t dmic_rngbuff_size;
 struct acp_dmic_silence acp_initsilence;
 
 SOF_DEFINE_REG_UUID(acp_dmic_dma_common);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_dmic_dma_tr, SOF_UUID(acp_dmic_dma_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */

--- a/src/drivers/amd/common/acp_sp_dma.c
+++ b/src/drivers/amd/common/acp_sp_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_sp_common);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_sp_tr, SOF_UUID(acp_sp_common_uuid), LOG_LEVEL_INFO);
 
 /* allocate next free DMA channel */

--- a/src/drivers/amd/rembrandt/acp_bt_dma.c
+++ b/src/drivers/amd/rembrandt/acp_bt_dma.c
@@ -34,6 +34,7 @@
 
 SOF_DEFINE_REG_UUID(acp_bt_dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 
 /* DMA number of buffer periods */

--- a/src/drivers/amd/rembrandt/acp_dmic_dma.c
+++ b/src/drivers/amd/rembrandt/acp_dmic_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_dmic_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_dmic_dma);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_dmic_dma_rmb_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/rembrandt/acp_hs_dai.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dai.c
@@ -20,6 +20,7 @@
 #include <platform/chip_offset_byte.h>
 
 SOF_DEFINE_REG_UUID(hsdai);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 
 #if defined(__ZEPHYR__)
@@ -193,7 +194,9 @@ static int hsdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_hsdai_driver = {
 	.type = SOF_DAI_AMD_HS,
 	.uid = SOF_UUID(hsdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &hsdai_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_SP,
 	.dma_caps = SOF_DMA_CAP_SP,
 	.ops = {

--- a/src/drivers/amd/rembrandt/acp_hs_dma.c
+++ b/src/drivers/amd/rembrandt/acp_hs_dma.c
@@ -33,6 +33,7 @@
 #include <platform/chip_registers.h>
 
 SOF_DEFINE_REG_UUID(acp_hs);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 
 #define HS_FIFO_SIZE		512

--- a/src/drivers/amd/rembrandt/acp_sp_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dai.c
@@ -20,6 +20,7 @@
 #include <platform/chip_offset_byte.h>
 
 SOF_DEFINE_REG_UUID(spdai);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -79,7 +80,9 @@ static int spdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_spdai_driver = {
 	.type = SOF_DAI_AMD_SP,
 	.uid = SOF_UUID(spdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &spdai_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_SP,
 	.dma_caps = SOF_DMA_CAP_SP,
 	.ops = {

--- a/src/drivers/amd/rembrandt/acp_sp_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sp_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_sp);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_sp_rmb_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 #define SP_TX_FIFO_ADDR		(SP_FIFO_SIZE * 2)

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dai.c
@@ -12,6 +12,7 @@
 
 SOF_DEFINE_REG_UUID(swaudiodai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(swaudiodai_tr, SOF_UUID(swaudiodai_uuid), LOG_LEVEL_INFO);
 
 static inline int swaudiodai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -98,7 +99,9 @@ static int swaudiodai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_swaudiodai_driver = {
 	.type = SOF_DAI_AMD_SDW,
 	.uid = SOF_UUID(swaudiodai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &swaudiodai_tr,
+#endif
 	.dma_dev = DMA_DEV_SW,
 	.dma_caps = DMA_CAP_SW,
 	.ops = {

--- a/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
+++ b/src/drivers/amd/rembrandt/acp_sw_audio_dma.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(acp_sw_audio);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_sw_audio_tr, SOF_UUID(acp_sw_audio_uuid), LOG_LEVEL_INFO);
 
 #if defined(CONFIG_ACP_6_3)

--- a/src/drivers/amd/rembrandt/interrupt.c
+++ b/src/drivers/amd/rembrandt/interrupt.c
@@ -25,6 +25,7 @@
 
 SOF_DEFINE_REG_UUID(irq_acp);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 
 #define IRQ_INT_MASK(irq)	(1 << (irq))

--- a/src/drivers/amd/renoir/acp_bt_dma.c
+++ b/src/drivers/amd/renoir/acp_bt_dma.c
@@ -35,6 +35,7 @@
 
 SOF_DEFINE_REG_UUID(acp_bt_dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 
 /* DMA number of buffer periods */

--- a/src/drivers/amd/renoir/acp_dmic_dma.c
+++ b/src/drivers/amd/renoir/acp_dmic_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_dmic_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_dmic_dma);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_dmic_dma_rn_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/renoir/acp_sp_dai.c
+++ b/src/drivers/amd/renoir/acp_sp_dai.c
@@ -20,6 +20,7 @@
 #include <platform/chip_offset_byte.h>
 
 SOF_DEFINE_REG_UUID(spdai);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -145,7 +146,9 @@ static int spdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_spdai_driver = {
 	.type = SOF_DAI_AMD_SP,
 	.uid = SOF_UUID(spdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &spdai_tr,
+#endif
 	.dma_dev = DMA_DEV_SP,
 	.dma_caps = DMA_CAP_SP,
 	.ops = {

--- a/src/drivers/amd/renoir/acp_sp_dma.c
+++ b/src/drivers/amd/renoir/acp_sp_dma.c
@@ -35,6 +35,7 @@
 #include <platform/acp_sp_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_sp);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_sp_rn_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 static uint64_t prev_tx_pos;

--- a/src/drivers/amd/renoir/interrupt.c
+++ b/src/drivers/amd/renoir/interrupt.c
@@ -28,6 +28,7 @@
 
 SOF_DEFINE_REG_UUID(irq_acp);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 
 #define IRQ_INT_MASK(irq)	(1 << (irq))

--- a/src/drivers/amd/vangogh/acp_bt_dma.c
+++ b/src/drivers/amd/vangogh/acp_bt_dma.c
@@ -34,6 +34,7 @@
 
 SOF_DEFINE_REG_UUID(acp_bt_dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_bt_dma_tr, SOF_UUID(acp_bt_dma_uuid), LOG_LEVEL_INFO);
 
 /* DMA number of buffer periods */

--- a/src/drivers/amd/vangogh/acp_dmic_dma.c
+++ b/src/drivers/amd/vangogh/acp_dmic_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_dmic_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_dmic_dma);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_dmic_dma_vgh_tr, SOF_UUID(acp_dmic_dma_uuid), LOG_LEVEL_INFO);
 
 uint32_t dmic_rngbuff_size;

--- a/src/drivers/amd/vangogh/acp_hs_dai.c
+++ b/src/drivers/amd/vangogh/acp_hs_dai.c
@@ -19,6 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 SOF_DEFINE_REG_UUID(hsdai);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(hsdai_tr, SOF_UUID(hsdai_uuid), LOG_LEVEL_INFO);
 
 static inline int hsdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -82,7 +83,9 @@ static int hsdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_hsdai_driver = {
 	.type = SOF_DAI_AMD_HS,
 	.uid = SOF_UUID(hsdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &hsdai_tr,
+#endif
 	.dma_dev = DMA_DEV_HS,
 	.dma_caps = DMA_CAP_HS,
 	.ops = {

--- a/src/drivers/amd/vangogh/acp_hs_dma.c
+++ b/src/drivers/amd/vangogh/acp_hs_dma.c
@@ -33,6 +33,7 @@
 #include <platform/chip_registers.h>
 
 SOF_DEFINE_REG_UUID(acp_hs);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_hs_tr, SOF_UUID(acp_hs_uuid), LOG_LEVEL_INFO);
 
 #define HS_FIFO_SIZE		512

--- a/src/drivers/amd/vangogh/acp_sp_dai.c
+++ b/src/drivers/amd/vangogh/acp_sp_dai.c
@@ -19,6 +19,7 @@
 #include <platform/chip_offset_byte.h>
 
 SOF_DEFINE_REG_UUID(spdai);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(spdai_tr, SOF_UUID(spdai_uuid), LOG_LEVEL_INFO);
 
 static inline int spdai_set_config(struct dai *dai, struct ipc_config_dai *common_config,
@@ -79,7 +80,9 @@ static int spdai_get_hw_params(struct dai *dai,
 const struct dai_driver acp_spdai_driver = {
 	.type = SOF_DAI_AMD_SP,
 	.uid = SOF_UUID(spdai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &spdai_tr,
+#endif
 	.dma_dev = DMA_DEV_SP,
 	.dma_caps = DMA_CAP_SP,
 	.ops = {

--- a/src/drivers/amd/vangogh/acp_sp_dma.c
+++ b/src/drivers/amd/vangogh/acp_sp_dma.c
@@ -34,6 +34,7 @@
 #include <platform/acp_sp_dma.h>
 
 SOF_DEFINE_REG_UUID(acp_sp);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_sp_vgh_tr, SOF_UUID(acp_sp_uuid), LOG_LEVEL_INFO);
 
 /* Vangogh hw specific addr map */

--- a/src/drivers/amd/vangogh/interrupt.c
+++ b/src/drivers/amd/vangogh/interrupt.c
@@ -27,6 +27,7 @@
 
 SOF_DEFINE_REG_UUID(irq_acp);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_irq_tr, SOF_UUID(irq_acp_uuid), LOG_LEVEL_INFO);
 
 #define IRQ_INT_MASK(irq)	(1 << (irq))

--- a/src/drivers/dw/dma.c
+++ b/src/drivers/dw/dma.c
@@ -48,6 +48,7 @@ LOG_MODULE_REGISTER(dw_dma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dw_dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dwdma_tr, SOF_UUID(dw_dma_uuid), LOG_LEVEL_INFO);
 
 /* pointer data for DW DMA buffer */

--- a/src/drivers/generic/dummy-dma.c
+++ b/src/drivers/generic/dummy-dma.c
@@ -50,6 +50,7 @@ LOG_MODULE_REGISTER(dummy_dma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dummy_dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ddma_tr, SOF_UUID(dummy_dma_uuid), LOG_LEVEL_INFO);
 
 struct dma_chan_pdata {

--- a/src/drivers/imx/edma.c
+++ b/src/drivers/imx/edma.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(edma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(edma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(edma_tr, SOF_UUID(edma_uuid), LOG_LEVEL_INFO);
 
 static void chan_addr_convert(struct dma_chan_data *channel, uint32_t *sbase, uint32_t *dbase)

--- a/src/drivers/imx/esai.c
+++ b/src/drivers/imx/esai.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(esai, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(esai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(esai_tr, SOF_UUID(esai_uuid), LOG_LEVEL_INFO);
 
 struct esai_pdata {
@@ -429,7 +430,9 @@ static int esai_get_hw_params(struct dai *dai,
 const struct dai_driver esai_driver = {
 	.type = SOF_DAI_IMX_ESAI,
 	.uid = SOF_UUID(esai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &esai_tr,
+#endif
 	.dma_dev = DMA_DEV_ESAI,
 	.ops = {
 		.trigger		= esai_trigger,

--- a/src/drivers/imx/interrupt-generic.c
+++ b/src/drivers/imx/interrupt-generic.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(generic_irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(interrupt);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(noirq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /* this is needed because i.MX8 implementation assumes all boards have an irqsteer.

--- a/src/drivers/imx/interrupt-irqsteer.c
+++ b/src/drivers/imx/interrupt-irqsteer.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(irq_imx, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(interrupt);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(irq_i_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/drivers/imx/micfil.c
+++ b/src/drivers/imx/micfil.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(micfil_dai, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(micfil);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(micfil_tr, SOF_UUID(micfil_uuid), LOG_LEVEL_INFO);
 
 #define MICFIL_OSR_DEFAULT		16
@@ -318,7 +319,9 @@ static int micfil_remove(struct dai *dai)
 const struct dai_driver micfil_driver = {
 	.type = SOF_DAI_IMX_MICFIL,
 	.uid = SOF_UUID(micfil_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &micfil_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_MICFIL,
 	.ops = {
 		.trigger		= micfil_trigger,

--- a/src/drivers/imx/sai.c
+++ b/src/drivers/imx/sai.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(sai, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(sai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sai_tr, SOF_UUID(sai_uuid), LOG_LEVEL_INFO);
 
 #define REG_TX_DIR 0
@@ -559,7 +560,9 @@ static int sai_get_hw_params(struct dai *dai,
 const struct dai_driver sai_driver = {
 	.type = SOF_DAI_IMX_SAI,
 	.uid = SOF_UUID(sai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &sai_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_SAI,
 	.ops = {
 		.trigger		= sai_trigger,

--- a/src/drivers/imx/sdma.c
+++ b/src/drivers/imx/sdma.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(sdma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(sdma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sdma_tr, SOF_UUID(sdma_uuid), LOG_LEVEL_INFO);
 
 #define SDMA_BUFFER_PERIOD_COUNT 2

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -26,6 +26,7 @@ LOG_MODULE_REGISTER(irq, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(irq);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(irq_tr, SOF_UUID(irq_uuid), LOG_LEVEL_INFO);
 
 /* For i.MX, when building SOF with Zephyr, we use wrapper.c,

--- a/src/drivers/mediatek/afe/afe-dai.c
+++ b/src/drivers/mediatek/afe/afe-dai.c
@@ -26,6 +26,7 @@
 
 SOF_DEFINE_REG_UUID(afe_dai);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(afe_dai_tr, SOF_UUID(afe_dai_uuid), LOG_LEVEL_INFO);
 LOG_MODULE_DECLARE(mtk_afe, CONFIG_SOF_LOG_LEVEL);
 
@@ -100,7 +101,9 @@ static int afe_dai_drv_get_fifo(struct dai *dai, int direction, int stream_id)
 const struct dai_driver afe_dai_driver = {
 	.type = SOF_DAI_MEDIATEK_AFE,
 	.uid = SOF_UUID(afe_dai_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &afe_dai_tr,
+#endif
 	.dma_dev = SOF_DMA_DEV_AFE_MEMIF,
 	.ops = {
 		.trigger		= afe_dai_drv_trigger,

--- a/src/drivers/mediatek/afe/afe-drv.c
+++ b/src/drivers/mediatek/afe/afe-drv.c
@@ -28,6 +28,7 @@ static struct mtk_base_afe mtk_afe;
 
 SOF_DEFINE_REG_UUID(afedrv);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(afedrv_tr, SOF_UUID(afedrv_uuid), LOG_LEVEL_INFO);
 LOG_MODULE_DECLARE(mtk_afe, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/drivers/mediatek/afe/afe-memif.c
+++ b/src/drivers/mediatek/afe/afe-memif.c
@@ -28,6 +28,7 @@
 
 SOF_DEFINE_REG_UUID(memif);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(memif_tr, SOF_UUID(memif_uuid), LOG_LEVEL_INFO);
 LOG_MODULE_REGISTER(mtk_afe, CONFIG_SOF_LOG_LEVEL);
 

--- a/src/drivers/mediatek/afe/mt8186/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8186/afe-sgen.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(sgen_mt8186);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8186_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/drivers/mediatek/afe/mt8188/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8188/afe-sgen.c
@@ -17,6 +17,7 @@
 
 SOF_DEFINE_REG_UUID(sgen_mt8188);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8188_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/drivers/mediatek/afe/mt8195/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8195/afe-sgen.c
@@ -17,6 +17,7 @@
 
 SOF_DEFINE_REG_UUID(sgen_mt8195);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8195_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/drivers/mediatek/afe/mt8365/afe-sgen.c
+++ b/src/drivers/mediatek/afe/mt8365/afe-sgen.c
@@ -17,6 +17,7 @@
 
 SOF_DEFINE_REG_UUID(sgen_mt8365);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sgen_tr, SOF_UUID(sgen_mt8365_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/drivers/mediatek/mt818x/interrupt.c
+++ b/src/drivers/mediatek/mt818x/interrupt.c
@@ -25,6 +25,7 @@
 
 SOF_DEFINE_REG_UUID(irq_mt818x);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt818x_uuid), LOG_LEVEL_INFO);
 
 static void mtk_irq_init(void)

--- a/src/drivers/mediatek/mt8195/interrupt.c
+++ b/src/drivers/mediatek/mt8195/interrupt.c
@@ -22,6 +22,7 @@
 
 SOF_DEFINE_REG_UUID(interrupt);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(int_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 /* os timer reg value * 77ns 13M os timer

--- a/src/drivers/mediatek/mt8196/intc.c
+++ b/src/drivers/mediatek/mt8196/intc.c
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 SOF_DEFINE_REG_UUID(intc_mt8196);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(intc_tr, SOF_UUID(intc_mt8196_uuid), LOG_LEVEL_INFO);
 
 static struct intc_desc_t intc_desc;

--- a/src/drivers/mediatek/mt8196/interrupt.c
+++ b/src/drivers/mediatek/mt8196/interrupt.c
@@ -24,6 +24,7 @@
 
 SOF_DEFINE_REG_UUID(irq_mt8196);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(int_tr, SOF_UUID(irq_mt8196_uuid), LOG_LEVEL_INFO);
 
 static void mtk_irq_init(void)

--- a/src/drivers/mediatek/mt8365/interrupt.c
+++ b/src/drivers/mediatek/mt8365/interrupt.c
@@ -24,6 +24,7 @@
 
 SOF_DEFINE_REG_UUID(interrupt);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(int_tr, SOF_UUID(interrupt_uuid), LOG_LEVEL_INFO);
 
 static void mtk_irq_init(void)

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -43,6 +43,7 @@ static struct idc_payload static_payload[CONFIG_CORE_COUNT];
 
 SOF_DEFINE_REG_UUID(idc);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(idc_tr, SOF_UUID(idc_uuid), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(idc_task);

--- a/src/idc/zephyr_idc.c
+++ b/src/idc/zephyr_idc.c
@@ -39,6 +39,7 @@ LOG_MODULE_REGISTER(zephyr_idc, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(zephyr_idc);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(zephyr_idc_tr, SOF_UUID(zephyr_idc_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/include/sof/audio/buffer.h
+++ b/src/include/sof/audio/buffer.h
@@ -41,9 +41,6 @@ struct buffer_cb_transact;
 /* buffer tracing */
 extern struct tr_ctx buffer_tr;
 
-/** \brief Retrieves trace context from the buffer */
-#define trace_buf_get_tr_ctx(buf_ptr) (&(buf_ptr)->tctx)
-
 /** \brief Retrieves subid (comp id) from the buffer */
 #define buf_get_id(buf_ptr) ((buf_ptr)->stream.runtime_stream_params.id)
 
@@ -68,6 +65,9 @@ extern struct tr_ctx buffer_tr;
 					   buf_get_id(buf_ptr), ##__VA_ARGS__)
 
 #else
+/** \brief Retrieves trace context from the buffer */
+#define trace_buf_get_tr_ctx(buf_ptr) (&(buf_ptr)->tctx)
+
 /** \brief Trace error message from buffer */
 #define buf_err(buf_ptr, __e, ...)						\
 	trace_dev_err(trace_buf_get_tr_ctx, buffer_pipeline_id,			\
@@ -136,7 +136,10 @@ struct comp_buffer {
 	/* configuration */
 	uint32_t flags;
 	uint32_t core;
+
+#if !CONFIG_ZEPHYR_LOG
 	struct tr_ctx tctx;			/* trace settings */
+#endif
 
 	/* connected components */
 	struct comp_dev *source;	/* source component */

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -129,17 +129,11 @@ enum {
  *  @{
  */
 
-/** \brief Retrieves trace context from the component driver */
-#define trace_comp_drv_get_tr_ctx(drv_p) ((drv_p)->tctx)
-
 /** \brief Retrieves id (-1 = undefined) from the component driver */
 #define trace_comp_drv_get_id(drv_p) (-1)
 
 /** \brief Retrieves subid (-1 = undefined) from the component driver */
 #define trace_comp_drv_get_subid(drv_p) (-1)
-
-/** \brief Retrieves trace context from the component device */
-#define trace_comp_get_tr_ctx(comp_p) (&(comp_p)->tctx)
 
 /** \brief Retrieves id (pipe id) from the component device */
 #define trace_comp_get_id(comp_p) ((comp_p)->ipc_config.pipeline_id)
@@ -178,6 +172,12 @@ enum {
 					   trace_comp_get_subid(comp_p), ##__VA_ARGS__)
 
 #else
+/** \brief Retrieves trace context from the component driver */
+#define trace_comp_drv_get_tr_ctx(drv_p) ((drv_p)->tctx)
+
+/** \brief Retrieves trace context from the component device */
+#define trace_comp_get_tr_ctx(comp_p) (&(comp_p)->tctx)
+
 /* class (driver) level (no device object) tracing */
 
 /** \brief Trace error message from component driver (no comp instance) */
@@ -580,6 +580,12 @@ struct comp_ops {
 	uint64_t (*get_total_data_processed)(struct comp_dev *dev, uint32_t stream_no, bool input);
 };
 
+#if CONFIG_ZEPHYR_LOG
+#define SOF_DRV_UID_NAME(drv) (drv)->uid
+#else
+#define SOF_DRV_UID_NAME(drv) (drv)->tctx->uuid_p
+#endif
+
 /**
  * Audio component base driver "class"
  * - used by all other component types.
@@ -587,7 +593,9 @@ struct comp_ops {
 struct comp_driver {
 	uint32_t type;					/**< SOF_COMP_ for driver */
 	const struct sof_uuid *uid;			/**< Address to UUID value */
+#if !CONFIG_ZEPHYR_LOG
 	struct tr_ctx *tctx;				/**< Pointer to trace context */
+#endif
 	struct comp_ops ops;				/**< component operations */
 	const struct module_interface *adapter_ops;	/**< module specific operations.
 							  * Intended to replace the ops field.
@@ -666,7 +674,9 @@ struct comp_dev {
 				  *  across cores
 				  */
 	struct comp_ipc_config ipc_config;	/**< Component IPC configuration */
+#if !CONFIG_ZEPHYR_LOG
 	struct tr_ctx tctx;	/**< trace settings */
+#endif
 
 	/* common runtime configuration for downstream/upstream */
 	uint32_t direction;	/**< enum sof_ipc_stream_direction */
@@ -866,7 +876,7 @@ static inline void comp_init(const struct comp_driver *drv,
 	dev->state = COMP_STATE_INIT;
 	list_init(&dev->bsink_list);
 	list_init(&dev->bsource_list);
-#ifndef __ZEPHYR__
+#if !CONFIG_ZEPHYR_LOG
 	memcpy_s(&dev->tctx, sizeof(dev->tctx),
 		 trace_comp_drv_get_tr_ctx(dev->drv), sizeof(struct tr_ctx));
 #endif

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -38,6 +38,13 @@
 #define IPC_MOD_CMD(v) .cmd = v,
 #endif
 
+/* Zephyr's tr_*() macros ignore the trace context, no need to store it */
+#if CONFIG_ZEPHYR_LOG
+#define SET_MODULE_ADAPTER_TCTX(tr)
+#else
+#define SET_MODULE_ADAPTER_TCTX(tr) .tctx = &(tr),
+#endif
+
 /*
  * \brief Macro to declare a module adapter component.
  * \param adapter - name of the module.
@@ -52,7 +59,7 @@
 static const struct comp_driver comp_##adapter##_module = { \
 	.type = SOF_COMP_MODULE_ADAPTER, \
 	.uid = SOF_RT_UUID(uuid), \
-	.tctx = &(tr), \
+	SET_MODULE_ADAPTER_TCTX(tr) \
 	.ops = { \
 		.create = module_adapter_new, \
 		.prepare = module_adapter_prepare, \

--- a/src/ipc/dma-copy.c
+++ b/src/ipc/dma-copy.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(dma_copy, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dma_copy);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dmacpy_tr, SOF_UUID(dma_copy_uuid), LOG_LEVEL_INFO);
 
 static struct dma_sg_elem *sg_get_elem_at(struct dma_sg_config *host_sg,

--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -52,6 +52,7 @@ LOG_MODULE_REGISTER(ipc, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(ipc);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ipc_tr, SOF_UUID(ipc_uuid), LOG_LEVEL_INFO);
 
 #ifdef CONFIG_SOF_USERSPACE_LL

--- a/src/ipc/ipc-helper.c
+++ b/src/ipc/ipc-helper.c
@@ -88,7 +88,8 @@ __cold struct comp_buffer *buffer_new(struct mod_alloc_ctx *alloc,
 		buffer->stream.runtime_stream_params.pipeline_id = desc->comp.pipeline_id;
 		buffer->core = desc->comp.core;
 
-#if !defined(CONFIG_SOF_USERSPACE_LL)
+/* Zephyr's tr_*() macros ignore the trace context, no need to copy it */
+#if !CONFIG_ZEPHYR_LOG
 		memcpy_s(&buffer->tctx, sizeof(struct tr_ctx),
 			 &buffer_tr, sizeof(struct tr_ctx));
 #endif

--- a/src/ipc/ipc3/helper.c
+++ b/src/ipc/ipc3/helper.c
@@ -151,7 +151,7 @@ static const struct comp_driver *get_drv(struct sof_ipc_comp *comp)
 out:
 	if (drv)
 		tr_dbg(&comp_tr, "get_drv(), found driver type %d, uuid %pU",
-		       drv->type, drv->tctx->uuid_p);
+		       drv->type, SOF_DRV_UID_NAME(drv));
 
 	return drv;
 }
@@ -361,7 +361,7 @@ struct comp_dev *comp_new(struct sof_ipc_comp *comp)
 	}
 
 	tr_info(&comp_tr, "comp new %pU type %d id %d.%d",
-		drv->tctx->uuid_p, comp->type, comp->pipeline_id, comp->id);
+		SOF_DRV_UID_NAME(drv), comp->type, comp->pipeline_id, comp->id);
 
 	/* build the component */
 	if (comp_specific_builder(comp, &spec) < 0) {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -1321,7 +1321,7 @@ __cold static const struct comp_driver *ipc4_search_for_drv(const void *uuid)
 		info = container_of(clist, struct comp_driver_info, list);
 		if (!memcmp(info->drv->uid, uuid, UUID_SIZE)) {
 			tr_dbg(&comp_tr, "found type %d, uuid %pU",
-			       info->drv->type, info->drv->tctx->uuid_p);
+			       info->drv->type, SOF_DRV_UID_NAME(info->drv));
 			drv = info->drv;
 			break;
 		}

--- a/src/ipc/notification_pool.c
+++ b/src/ipc/notification_pool.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(notification_pool, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(notification_pool);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(notif_tr, SOF_UUID(notification_pool_uuid), LOG_LEVEL_INFO);
 
 struct ipc_notif_pool_item {

--- a/src/lib/agent.c
+++ b/src/lib/agent.c
@@ -39,6 +39,7 @@ LOG_MODULE_REGISTER(sa, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(sa);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sa_tr, SOF_UUID(sa_uuid), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(agent_work);

--- a/src/lib/ams.c
+++ b/src/lib/ams.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(ams, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(ams);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ams_tr, SOF_UUID(ams_uuid), LOG_LEVEL_INFO);
 
 static struct ams_context ctx[CONFIG_CORE_COUNT];

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(clock, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(clock);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clock_tr, SOF_UUID(clock_uuid), LOG_LEVEL_INFO);
 
 struct k_spinlock clk_lock;

--- a/src/lib/dai.c
+++ b/src/lib/dai.c
@@ -27,6 +27,7 @@ LOG_MODULE_REGISTER(dai, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dai_lib);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dai_tr, SOF_UUID(dai_lib_uuid), LOG_LEVEL_INFO);
 
 struct dai_group_list {

--- a/src/lib/dma.c
+++ b/src/lib/dma.c
@@ -31,6 +31,7 @@ LOG_MODULE_REGISTER(dma, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dma);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dma_tr, SOF_UUID(dma_uuid), LOG_LEVEL_INFO);
 
 #if CONFIG_ZEPHYR_NATIVE_DRIVERS

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -24,6 +24,7 @@ LOG_MODULE_REGISTER(notifier, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(notifier);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(nt_tr, SOF_UUID(notifier_uuid), LOG_LEVEL_INFO);
 
 static struct notify_data notify_data_shared[CONFIG_CORE_COUNT];

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -567,7 +567,9 @@ static int lib_manager_start_agent(const struct comp_driver *drv,
 	agent_params.module_id = IPC4_MOD_ID(config->id);
 	agent_params.instance_id = IPC4_INST_ID(config->id);
 	agent_params.core_id = config->core;
+#if !CONFIG_ZEPHYR_LOG
 	agent_params.log_handle = (uint32_t)drv->tctx;
+#endif
 	agent_params.mod_cfg = &mod_cfg;
 
 #if CONFIG_SOF_USERSPACE_PROXY

--- a/src/library_manager/lib_manager.c
+++ b/src/library_manager/lib_manager.c
@@ -55,6 +55,7 @@ LOG_MODULE_REGISTER(lib_manager, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(lib_manager);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(lib_manager_tr, SOF_UUID(lib_manager_uuid), LOG_LEVEL_INFO);
 
 struct lib_manager_dma_ext {
@@ -817,7 +818,9 @@ static void lib_manager_prepare_module_adapter(struct comp_driver *drv, const st
 	drv->type = SOF_COMP_MODULE_ADAPTER;
 	drv->uid_cp = *uuid;
 	drv->uid = &drv->uid_cp;
+#if !CONFIG_ZEPHYR_LOG
 	drv->tctx = &lib_manager_tr;
+#endif
 	drv->ops.create = lib_manager_module_create;
 	drv->ops.prepare = module_adapter_prepare;
 	drv->ops.params = module_adapter_params;

--- a/src/math/fft/fft_common.c
+++ b/src/math/fft/fft_common.c
@@ -17,6 +17,7 @@
 
 LOG_MODULE_REGISTER(math_fft, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(math_fft);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(math_fft_tr, SOF_UUID(math_fft_uuid), LOG_LEVEL_INFO);
 
 struct fft_plan *fft_plan_common_new(struct processing_module *mod, void *inb,

--- a/src/math/fft/fft_multi.c
+++ b/src/math/fft/fft_multi.c
@@ -17,6 +17,7 @@
 
 LOG_MODULE_REGISTER(math_fft_multi, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(math_fft_multi);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(math_fft_multi_tr, SOF_UUID(math_fft_multi_uuid), LOG_LEVEL_INFO);
 
 struct fft_multi_plan *mod_fft_multi_plan_new(struct processing_module *mod, void *inb,

--- a/src/math/power.c
+++ b/src/math/power.c
@@ -18,6 +18,7 @@
 
 SOF_DEFINE_REG_UUID(math_power);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(math_power_tr, SOF_UUID(math_power_uuid), LOG_LEVEL_INFO);
 /* define constant */
 #define POWER_MAX_LIMIT 0x8000

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -42,6 +42,7 @@
 
 SOF_DEFINE_REG_UUID(acp_clk);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/amd/acp_7_0/lib/clk.c
+++ b/src/platform/amd/acp_7_0/lib/clk.c
@@ -41,6 +41,7 @@
 
 LOG_MODULE_REGISTER(acp_clk, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(acp_clk);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 
 const struct freq_table platform_cpu_freq[] = {

--- a/src/platform/amd/acp_7_x/lib/clk.c
+++ b/src/platform/amd/acp_7_x/lib/clk.c
@@ -40,6 +40,7 @@
 
 SOF_DEFINE_REG_UUID(acp_clk);
 LOG_MODULE_REGISTER(acp_clk, CONFIG_SOF_LOG_LEVEL);
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(acp_clk_tr, SOF_UUID(acp_clk_uuid), LOG_LEVEL_INFO);
 
 /* Frequency tables */

--- a/src/platform/intel/ace/lib/watchdog.c
+++ b/src/platform/intel/ace/lib/watchdog.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(wdt, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(wdt);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(wdt_tr, SOF_UUID(wdt_uuid), LOG_LEVEL_INFO);
 
 static const struct device *const watchdog = DEVICE_DT_GET(DT_NODELABEL(adsp_watchdog));

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -20,6 +20,7 @@
 
 SOF_DEFINE_REG_UUID(clkdrv_mt8186);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8186_uuid), LOG_LEVEL_INFO);
 
 /* default voltage is 0.8V */

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -20,6 +20,7 @@
 
 SOF_DEFINE_REG_UUID(clkdrv_mt8188);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8188_uuid), LOG_LEVEL_INFO);
 
 /* default voltage is 0.75V */

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -16,6 +16,7 @@
 
 SOF_DEFINE_REG_UUID(clkdrv_mt8195);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8195_uuid), LOG_LEVEL_INFO);
 
 static int dsppll_enable; /* default no adsp clock*/

--- a/src/platform/mt8196/lib/clk.c
+++ b/src/platform/mt8196/lib/clk.c
@@ -19,6 +19,7 @@
 
 SOF_DEFINE_REG_UUID(clkdrv_mt8196);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8196_uuid), LOG_LEVEL_INFO);
 
 /* default voltage is 0.75V */

--- a/src/platform/mt8365/lib/clk.c
+++ b/src/platform/mt8365/lib/clk.c
@@ -17,6 +17,7 @@
 
 SOF_DEFINE_REG_UUID(clkdrv_mt8365);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(clkdrv_tr, SOF_UUID(clkdrv_mt8365_uuid), LOG_LEVEL_INFO);
 
 static int dsppll_enable;  /* default no adsp clock*/

--- a/src/probe/probe.c
+++ b/src/probe/probe.c
@@ -40,6 +40,7 @@ SOF_DEFINE_REG_UUID(probe);
 #error "No or invalid IPC MAJOR version selected."
 #endif /* CONFIG_IPC_MAJOR_4 */
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(pr_tr, SOF_UUID(PROBE_UUID), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(probe_task);

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -70,6 +70,7 @@ LOG_MODULE_REGISTER(kd_test, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(keyword);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(keyword_tr, SOF_UUID(keyword_uuid), LOG_LEVEL_INFO);
 
 struct comp_data {
@@ -1088,7 +1089,9 @@ void test_keyword_set_drain_req(struct comp_dev *dev, uint32_t drain_req)
 static const struct comp_driver comp_keyword = {
 	.type	= SOF_COMP_KEYWORD_DETECT,
 	.uid	= SOF_RT_UUID(keyword_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx	= &keyword_tr,
+#endif
 	.ops	= {
 		.create			= test_keyword_new,
 		.free			= test_keyword_free,

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(smart_amp_test);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);
 
@@ -546,7 +547,9 @@ static int smart_amp_prepare(struct comp_dev *dev)
 static const struct comp_driver comp_smart_amp = {
 	.type = SOF_COMP_SMART_AMP,
 	.uid = SOF_RT_UUID(smart_amp_test_uuid),
+#if !CONFIG_ZEPHYR_LOG
 	.tctx = &smart_amp_test_comp_tr,
+#endif
 	.ops = {
 		.create			= smart_amp_new,
 		.free			= smart_amp_free,

--- a/src/samples/audio/smart_amp_test_ipc4.c
+++ b/src/samples/audio/smart_amp_test_ipc4.c
@@ -21,6 +21,7 @@ LOG_MODULE_REGISTER(smart_amp_test, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(smart_amp_test);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(smart_amp_test_comp_tr, SOF_UUID(smart_amp_test_uuid),
 	       LOG_LEVEL_INFO);
 

--- a/src/schedule/ll_schedule_xtos.c
+++ b/src/schedule/ll_schedule_xtos.c
@@ -38,6 +38,7 @@ LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(ll_sched);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ll_tr, SOF_UUID(ll_sched_uuid), LOG_LEVEL_INFO);
 
 /*

--- a/src/schedule/schedule.c
+++ b/src/schedule/schedule.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(schedule, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(schedule);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(sch_tr, SOF_UUID(schedule_uuid), LOG_LEVEL_INFO);
 
 static inline bool scheduler_is_user(int type)

--- a/src/schedule/zephyr_dp_schedule.c
+++ b/src/schedule/zephyr_dp_schedule.c
@@ -33,6 +33,7 @@
 LOG_MODULE_REGISTER(dp_schedule, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(dp_sched);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dp_tr, SOF_UUID(dp_sched_uuid), LOG_LEVEL_INFO);
 
 #define DP_LOCK_INIT(i, _)	Z_SEM_INITIALIZER(dp_lock[i], 1, 1)

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(ll_schedule, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(zll_sched);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(ll_tr, SOF_UUID(zll_sched_uuid), LOG_LEVEL_INFO);
 
 /* per-scheduler data */

--- a/src/schedule/zephyr_twb_schedule.c
+++ b/src/schedule/zephyr_twb_schedule.c
@@ -24,6 +24,7 @@
 LOG_MODULE_REGISTER(twb_schedule, CONFIG_SOF_LOG_LEVEL);
 SOF_DEFINE_REG_UUID(twb_sched);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(twb_tr, SOF_UUID(twb_sched_uuid), LOG_LEVEL_INFO);
 
 struct scheduler_twb_data {

--- a/src/trace/dma-trace.c
+++ b/src/trace/dma-trace.c
@@ -41,6 +41,7 @@ LOG_MODULE_REGISTER(dma_trace, CONFIG_SOF_LOG_LEVEL);
 
 SOF_DEFINE_REG_UUID(dma_trace);
 
+/* unused with Zephyr, generates no output */
 DECLARE_TR_CTX(dt_tr, SOF_UUID(dma_trace_uuid), LOG_LEVEL_INFO);
 
 SOF_DEFINE_REG_UUID(dma_trace_task);


### PR DESCRIPTION
We have a lot of code that uses trace context like `tr_dbg()` / `tr_err()` calls. Changing all those locations would be a very big change. This PR takes a middle ground: it adds comments to trace context declarations where they are harmless and makes harmless those, that end up generating needless code under Zephyr. Yes, made with AI.