### PR TITLE
IPC: make some pointers `const` and remove type-casts. No functional changes

### DIFF
--- a/posix/include/rtos/idc.h
+++ b/posix/include/rtos/idc.h
@@ -160,7 +160,7 @@ struct idc_msg {
 	uint32_t extension;	/**< extension value */
 	uint32_t core;		/**< core id */
 	uint32_t size;		/**< payload size in bytes */
-	void *payload;		/**< pointer to payload data */
+	const void *payload;	/**< pointer to payload data */
 };
 
 /** \brief IDC data. */

--- a/src/audio/copier/copier.c
+++ b/src/audio/copier/copier.c
@@ -1229,7 +1229,7 @@ __cold static int copier_get_hw_params(struct comp_dev *dev, struct sof_ipc_stre
 	return dai_common_get_hw_params(dd, dev, params, dir);
 }
 
-__cold static int copier_bind(struct processing_module *mod, struct bind_info *bind_data)
+__cold static int copier_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
 	const struct ipc4_module_bind_unbind *const bu = bind_data->ipc4_data;
 	const uint32_t src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
@@ -1258,7 +1258,7 @@ __cold static int copier_bind(struct processing_module *mod, struct bind_info *b
 	return -ENODEV;
 }
 
-__cold static int copier_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+__cold static int copier_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
 	struct copier_data *cd = module_get_private_data(mod);
 	struct comp_dev *dev = mod->dev;

--- a/src/audio/copier/dai_copier.h
+++ b/src/audio/copier/dai_copier.h
@@ -61,7 +61,7 @@ static inline int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct co
 	return 0;
 }
 
-static inline int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, void *data)
+static inline int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, const void *data)
 {
 	return 0;
 }
@@ -69,7 +69,8 @@ static inline int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, v
 int dai_zephyr_multi_endpoint_copy(struct dai_data **dd, struct comp_dev *dev,
 				   struct comp_buffer *multi_endpoint_buffer,
 				   int num_endpoints);
-int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, struct bind_info *unbind_data);
+int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev,
+		      const struct bind_info *unbind_data);
 #endif
 
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -2045,10 +2045,10 @@ static uint64_t dai_get_processed_data(struct comp_dev *dev, uint32_t stream_no,
 }
 
 #ifdef CONFIG_IPC_MAJOR_4
-__cold
-int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev, struct bind_info *unbind_data)
+__cold int dai_zephyr_unbind(struct dai_data *dd, struct comp_dev *dev,
+			     const struct bind_info *unbind_data)
 {
-	struct ipc4_module_bind_unbind *bu;
+	const struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 
 	assert_can_be_cold();

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -338,10 +338,10 @@ static int kpb_get_attribute(struct comp_dev *dev,
  * \param[in] bind_data - bind/unbind data.
  * \return: none.
  */
-static int kpb_bind(struct comp_dev *dev, struct bind_info *bind_data)
+static int kpb_bind(struct comp_dev *dev, const struct bind_info *bind_data)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
-	struct ipc4_module_bind_unbind *bu;
+	const struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 	int ret = 0;
 
@@ -385,10 +385,10 @@ static int kpb_bind(struct comp_dev *dev, struct bind_info *bind_data)
  * \param[in] data - ipc4 bind/unbind data.
  * \return: none.
  */
-static int kpb_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
+static int kpb_unbind(struct comp_dev *dev, const struct bind_info *unbind_data)
 {
 	struct comp_data *kpb = comp_get_drvdata(dev);
-	struct ipc4_module_bind_unbind *bu;
+	const struct ipc4_module_bind_unbind *bu;
 	int buf_id;
 
 	comp_dbg(dev, "entry");

--- a/src/audio/mixin_mixout/mixin_mixout.c
+++ b/src/audio/mixin_mixout/mixin_mixout.c
@@ -806,9 +806,9 @@ static int mixout_prepare(struct processing_module *mod,
 	return 0;
 }
 
-static int mixout_bind(struct processing_module *mod, struct bind_info *bind_data)
+static int mixout_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
-	struct ipc4_module_bind_unbind *bu;
+	const struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *mixin;
 	struct pending_frames *pending_frames;
 	int src_id;
@@ -853,9 +853,9 @@ static int mixout_bind(struct processing_module *mod, struct bind_info *bind_dat
 	return 0;
 }
 
-static int mixout_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+static int mixout_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
-	struct ipc4_module_bind_unbind *bu;
+	const struct ipc4_module_bind_unbind *bu;
 	struct comp_dev *mixin;
 	struct pending_frames *pending_frames;
 	int src_id;

--- a/src/audio/module_adapter/library/userspace_proxy.c
+++ b/src/audio/module_adapter/library/userspace_proxy.c
@@ -849,7 +849,7 @@ static bool userspace_proxy_is_ready_to_process(struct processing_module *mod,
  * @param bind_data - pointer to bind_info structure.
  * @return 0 for success, error otherwise.
  */
-static int userspace_proxy_bind(struct processing_module *mod, struct bind_info *bind_data)
+static int userspace_proxy_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
 	struct module_params *params = user_work_get_params(mod->user_ctx);
 	int ret;
@@ -877,7 +877,7 @@ static int userspace_proxy_bind(struct processing_module *mod, struct bind_info 
  * @param unbind_data - pointer to bind_info structure.
  * @return 0 for success, error otherwise.
  */
-static int userspace_proxy_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+static int userspace_proxy_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
 	struct module_params *params = user_work_get_params(mod->user_ctx);
 	int ret;

--- a/src/audio/module_adapter/module/generic.c
+++ b/src/audio/module_adapter/module/generic.c
@@ -908,7 +908,7 @@ int module_set_configuration(struct processing_module *mod,
 }
 EXPORT_SYMBOL(module_set_configuration);
 
-int module_bind(struct processing_module *mod, struct bind_info *bind_data)
+int module_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
 	int ret;
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;
@@ -941,7 +941,7 @@ int module_bind(struct processing_module *mod, struct bind_info *bind_data)
 	return ret;
 }
 
-int module_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+int module_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
 	int ret;
 	const struct module_interface *const ops = mod->dev->drv->adapter_ops;

--- a/src/audio/module_adapter/module_adapter_ipc4.c
+++ b/src/audio/module_adapter/module_adapter_ipc4.c
@@ -376,7 +376,7 @@ static bool module_adapter_multi_sink_source_prepare(struct comp_dev *dev)
 }
 
 static int module_update_source_buffer_params(struct processing_module *mod,
-					      struct bind_info *bind_data)
+					      const struct bind_info *bind_data)
 {
 	struct module_config *dst = &mod->priv.cfg;
 	struct sof_ipc_stream_params params;
@@ -407,7 +407,7 @@ static int module_update_source_buffer_params(struct processing_module *mod,
 	return 0;
 }
 
-int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
+int module_adapter_bind(struct comp_dev *dev, const struct bind_info *bind_data)
 {
 	struct processing_module *mod = comp_mod(dev);
 	int ret;
@@ -425,7 +425,7 @@ int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
 	return 0;
 }
 
-int module_adapter_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
+int module_adapter_unbind(struct comp_dev *dev, const struct bind_info *unbind_data)
 {
 	struct processing_module *mod = comp_mod(dev);
 	int ret;

--- a/src/audio/tone/tone-ipc4.c
+++ b/src/audio/tone/tone-ipc4.c
@@ -169,7 +169,7 @@ static int tone_reset(struct processing_module *mod)
 	return 0;
 }
 
-static int tone_bind(struct processing_module *mod, struct bind_info *bind_data)
+static int tone_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 
@@ -183,7 +183,7 @@ static int tone_bind(struct processing_module *mod, struct bind_info *bind_data)
 	return 0;
 }
 
-static int tone_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+static int tone_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
 	struct comp_data *cd = module_get_private_data(mod);
 

--- a/src/debug/tester/tester.c
+++ b/src/debug/tester/tester.c
@@ -186,7 +186,7 @@ static int tester_free(struct processing_module *mod)
 	return ret;
 }
 
-static int tester_bind(struct processing_module *mod, struct bind_info *bind_data)
+static int tester_bind(struct processing_module *mod, const struct bind_info *bind_data)
 {
 	struct tester_module_data *cd = module_get_private_data(mod);
 	int ret = 0;
@@ -197,7 +197,7 @@ static int tester_bind(struct processing_module *mod, struct bind_info *bind_dat
 	return ret;
 }
 
-static int tester_unbind(struct processing_module *mod, struct bind_info *unbind_data)
+static int tester_unbind(struct processing_module *mod, const struct bind_info *unbind_data)
 {
 	struct tester_module_data *cd = module_get_private_data(mod);
 	int ret = 0;

--- a/src/debug/tester/tester.h
+++ b/src/debug/tester/tester.h
@@ -75,12 +75,12 @@ struct tester_test_case_interface {
 	/**
 	 * copy of module bind method, with additional ctx param
 	 */
-	int (*bind)(void *ctx, struct processing_module *mod, struct bind_info *bind_data);
+	int (*bind)(void *ctx, struct processing_module *mod, const struct bind_info *bind_data);
 
 	/**
 	 * copy of module unbind method, with additional ctx param
 	 */
-	int (*unbind)(void *ctx, struct processing_module *mod, struct bind_info *unbind_data);
+	int (*unbind)(void *ctx, struct processing_module *mod, const struct bind_info *unbind_data);
 
 	/**
 	 * copy of module trigger method, with additional ctx param

--- a/src/include/ipc4/handler.h
+++ b/src/include/ipc4/handler.h
@@ -68,6 +68,22 @@ int ipc4_set_pipeline_state(struct ipc4_message_request *ipc4);
  */
 void ipc_compound_msg_done(uint32_t msg_id, int error);
 
+/**
+ * \brief Connect components together on a pipeline.
+ * @param ipc The global IPC context.
+ * @param bu IPC4 bind-unbind data.
+ * @return IPC4_SUCCESS on success, error code otherwise.
+ */
+int ipc4_comp_connect(struct ipc *ipc, const struct ipc4_module_bind_unbind *bu);
+
+/**
+ * \brief Disconnect components in a pipeline.
+ * @param ipc The global IPC context.
+ * @param bu IPC4 bind-unbind data.
+ * @return IPC4_SUCCESS on success, error code otherwise.
+ */
+int ipc4_comp_disconnect(struct ipc *ipc, const struct ipc4_module_bind_unbind *bu);
+
 #if defined(__ZEPHYR__) && defined(CONFIG_SOF_FULL_ZEPHYR_APPLICATION)
 /**
  * \brief Increment the IPC compound message pre-start counter.

--- a/src/include/module/module/interface.h
+++ b/src/include/module/module/interface.h
@@ -268,13 +268,13 @@ struct module_interface {
 	 * (optional) Module specific bind procedure, called when modules are bound with each other.
 	 * Usually can be __cold
 	 */
-	int (*bind)(struct processing_module *mod, struct bind_info *bind_data);
+	int (*bind)(struct processing_module *mod, const struct bind_info *bind_data);
 
 	/**
 	 * (optional) Module specific unbind procedure, called when modules are disconnected from
 	 * one another. Usually can be __cold
 	 */
-	int (*unbind)(struct processing_module *mod, struct bind_info *unbind_data);
+	int (*unbind)(struct processing_module *mod, const struct bind_info *unbind_data);
 
 	/**
 	 * (optional) Module specific trigger procedure, called when modules are triggered. Usually

--- a/src/include/sof/audio/component.h
+++ b/src/include/sof/audio/component.h
@@ -283,7 +283,7 @@ enum bind_type {
 
 struct bind_info {
 	/* pointer to IPC4 bind/unbind data */
-	struct ipc4_module_bind_unbind *ipc4_data;
+	const struct ipc4_module_bind_unbind *ipc4_data;
 
 	/* type of binding
 	 * bind call will be called twice for every component, first when binding a data source,
@@ -516,7 +516,7 @@ struct comp_ops {
 	 *
 	 * Usually can be __cold.
 	 */
-	int (*bind)(struct comp_dev *dev, struct bind_info *bind_data);
+	int (*bind)(struct comp_dev *dev, const struct bind_info *bind_data);
 
 	/**
 	 * Unbind, atomic - used to notify component of unbind event.
@@ -525,7 +525,7 @@ struct comp_ops {
 	 *
 	 * Usually can be __cold.
 	 */
-	int (*unbind)(struct comp_dev *dev, struct bind_info *unbind_data);
+	int (*unbind)(struct comp_dev *dev, const struct bind_info *unbind_data);
 
 	/**
 	 * Gets config in component.

--- a/src/include/sof/audio/component_ext.h
+++ b/src/include/sof/audio/component_ext.h
@@ -438,7 +438,7 @@ static inline struct comp_driver_list *comp_drivers_get(void)
 #endif
 
 #if CONFIG_IPC_MAJOR_4
-static inline int comp_ipc4_bind_remote(struct comp_dev *dev, struct bind_info *bind_data)
+static inline int comp_ipc4_bind_remote(struct comp_dev *dev, const struct bind_info *bind_data)
 {
 	struct idc_msg msg = { IDC_MSG_BIND,
 		IDC_EXTENSION(dev->ipc_config.id), dev->ipc_config.core,
@@ -448,7 +448,7 @@ static inline int comp_ipc4_bind_remote(struct comp_dev *dev, struct bind_info *
 }
 #endif
 
-static inline int comp_bind(struct comp_dev *dev, struct bind_info *bind_data)
+static inline int comp_bind(struct comp_dev *dev, const struct bind_info *bind_data)
 {
 #if CONFIG_IPC_MAJOR_4
 	if (dev->drv->ops.bind)
@@ -467,7 +467,7 @@ static inline int comp_bind(struct comp_dev *dev, struct bind_info *bind_data)
 }
 
 #if CONFIG_IPC_MAJOR_4
-static inline int comp_ipc4_unbind_remote(struct comp_dev *dev, struct bind_info *unbind_data)
+static inline int comp_ipc4_unbind_remote(struct comp_dev *dev, const struct bind_info *unbind_data)
 {
 	struct idc_msg msg = { IDC_MSG_UNBIND,
 		IDC_EXTENSION(dev->ipc_config.id), dev->ipc_config.core,
@@ -477,7 +477,7 @@ static inline int comp_ipc4_unbind_remote(struct comp_dev *dev, struct bind_info
 }
 #endif
 
-static inline int comp_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
+static inline int comp_unbind(struct comp_dev *dev, const struct bind_info *unbind_data)
 {
 #if CONFIG_IPC_MAJOR_4
 	if (dev->drv->ops.unbind)

--- a/src/include/sof/audio/module_adapter/library/userspace_proxy_user.h
+++ b/src/include/sof/audio/module_adapter/library/userspace_proxy_user.h
@@ -72,7 +72,7 @@ struct module_params {
 		struct module_large_cfg_get_params	get_conf;
 		struct module_processing_mode_params	proc_mode;
 		struct module_process_params		proc;
-		struct bind_info			*bind_data;
+		const struct bind_info			*bind_data;
 		int					trigger_data;
 	} ext;
 };

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -321,8 +321,8 @@ int module_set_configuration(struct processing_module *mod,
 			     enum module_cfg_fragment_position pos, size_t data_offset_size,
 			     const uint8_t *fragment, size_t fragment_size, uint8_t *response,
 			     size_t response_size);
-int module_bind(struct processing_module *mod, struct bind_info *bind_data);
-int module_unbind(struct processing_module *mod, struct bind_info *unbind_data);
+int module_bind(struct processing_module *mod, const struct bind_info *bind_data);
+int module_unbind(struct processing_module *mod, const struct bind_info *unbind_data);
 
 struct comp_dev *module_adapter_new(const struct comp_driver *drv,
 				    const struct comp_ipc_config *config, const void *spec);
@@ -369,13 +369,13 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 }
 
 static inline
-int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data)
+int module_adapter_bind(struct comp_dev *dev, const struct bind_info *bind_data)
 {
 	return 0;
 }
 
 static inline
-int module_adapter_unbind(struct comp_dev *dev, struct bind_info *unbind_data)
+int module_adapter_unbind(struct comp_dev *dev, const struct bind_info *unbind_data)
 {
 	return 0;
 }
@@ -404,8 +404,8 @@ int module_get_large_config(struct comp_dev *dev, uint32_t param_id, bool first_
 			    bool last_block, uint32_t *data_offset, char *data);
 int module_adapter_get_attribute(struct comp_dev *dev, uint32_t type, void *value);
 int module_adapter_set_attribute(struct comp_dev *dev, uint32_t type, void *value);
-int module_adapter_bind(struct comp_dev *dev, struct bind_info *bind_data);
-int module_adapter_unbind(struct comp_dev *dev, struct bind_info *unbind_data);
+int module_adapter_bind(struct comp_dev *dev, const struct bind_info *bind_data);
+int module_adapter_unbind(struct comp_dev *dev, const struct bind_info *unbind_data);
 uint64_t module_adapter_get_total_data_processed(struct comp_dev *dev,
 						 uint32_t stream_no, bool input);
 

--- a/src/include/sof/ipc/topology.h
+++ b/src/include/sof/ipc/topology.h
@@ -165,7 +165,7 @@ int ipc_pipeline_complete(struct ipc *ipc, uint32_t comp_id);
 /**
  * \brief Connect components together on a pipeline.
  * @param ipc The global IPC context.
- * @param connect Components to connect together..
+ * @param connect Components to connect together.
  * @return 0 on success or negative error.
  */
 int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *connect);

--- a/src/include/sof/schedule/dp_schedule.h
+++ b/src/include/sof/schedule/dp_schedule.h
@@ -109,7 +109,7 @@ struct sof_sink;
  * that would add multiple functions to the API.
  */
 union scheduler_dp_thread_ipc_param {
-	struct bind_info *bind_data;
+	const struct bind_info *bind_data;
 	struct {
 		unsigned int trigger_cmd;
 		enum ipc4_pipeline_state state;

--- a/src/ipc/ipc4/handler-user.c
+++ b/src/ipc/ipc4/handler-user.c
@@ -812,7 +812,7 @@ __cold static int ipc4_bind_module_instance(struct ipc4_message_request *ipc4)
 	       (uint32_t)bu->primary.r.module_id, (uint32_t)bu->primary.r.instance_id,
 	       (uint32_t)bu->extension.r.dst_module_id, (uint32_t)bu->extension.r.dst_instance_id);
 
-	return ipc_comp_connect(ipc, (ipc_pipe_comp_connect *)bu);
+	return ipc4_comp_connect(ipc, bu);
 }
 
 __cold static int ipc4_unbind_module_instance(struct ipc4_message_request *ipc4)
@@ -826,7 +826,7 @@ __cold static int ipc4_unbind_module_instance(struct ipc4_message_request *ipc4)
 	       (uint32_t)bu->primary.r.module_id, (uint32_t)bu->primary.r.instance_id,
 	       (uint32_t)bu->extension.r.dst_module_id, (uint32_t)bu->extension.r.dst_instance_id);
 
-	return ipc_comp_disconnect(ipc, (ipc_pipe_comp_connect *)bu);
+	return ipc4_comp_disconnect(ipc, bu);
 }
 #endif /* !CONFIG_SOF_USERSPACE_LL */
 
@@ -1707,8 +1707,7 @@ int ipc_user_thread_dispatch(struct ipc_user *ipc_user)
 			if (result < 0)
 				break;
 
-			result = ipc_comp_connect(ipc_user->ipc,
-						  (ipc_pipe_comp_connect *)&bu);
+			result = ipc4_comp_connect(ipc_user->ipc, &bu);
 			break;
 		}
 		case SOF_IPC4_MOD_UNBIND: {
@@ -1718,8 +1717,7 @@ int ipc_user_thread_dispatch(struct ipc_user *ipc_user)
 			if (result < 0)
 				break;
 
-			result = ipc_comp_disconnect(ipc_user->ipc,
-						     (ipc_pipe_comp_connect *)&bu);
+			result = ipc4_comp_disconnect(ipc_user->ipc, &bu);
 			break;
 		}
 		case SOF_IPC4_MOD_INIT_INSTANCE: {

--- a/src/ipc/ipc4/helper.c
+++ b/src/ipc/ipc4/helper.c
@@ -18,6 +18,7 @@
 #include <sof/ipc/topology.h>
 #include <sof/ipc/common.h>
 #include <ipc/dai.h>
+#include <ipc4/handler.h>
 #include <sof/ipc/msg.h>
 #include <sof/lib/mailbox.h>
 #include <sof/lib/memory.h>
@@ -772,9 +773,8 @@ static int ll_wait_finished_on_core(struct comp_dev *dev)
 #endif
 
 /* Only called from ipc4_bind_module_instance(), which is __cold */
-__cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
+__cold int ipc4_comp_connect(struct ipc *ipc, const struct ipc4_module_bind_unbind *bu)
 {
-	struct ipc4_module_bind_unbind *bu;
 	struct bind_info bind_data;
 	struct comp_buffer *buffer;
 	struct comp_dev *source;
@@ -790,7 +790,6 @@ __cold int ipc_comp_connect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 
 	assert_can_be_cold();
 
-	bu = (struct ipc4_module_bind_unbind *)_connect;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
 	sink_id = IPC4_COMP_ID(bu->extension.r.dst_module_id, bu->extension.r.dst_instance_id);
 	source = ipc4_get_comp_dev(src_id);
@@ -1041,9 +1040,8 @@ free:
  * pipeline and create it in modified form.
  */
 /* Only called from ipc4_unbind_module_instance(), which is __cold */
-__cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
+__cold int ipc4_comp_disconnect(struct ipc *ipc, const struct ipc4_module_bind_unbind *bu)
 {
-	struct ipc4_module_bind_unbind *bu;
 	struct comp_buffer *buffer = NULL;
 	struct comp_buffer *buf;
 	struct comp_dev *src, *sink;
@@ -1055,7 +1053,6 @@ __cold int ipc_comp_disconnect(struct ipc *ipc, ipc_pipe_comp_connect *_connect)
 
 	assert_can_be_cold();
 
-	bu = (struct ipc4_module_bind_unbind *)_connect;
 	src_id = IPC4_COMP_ID(bu->primary.r.module_id, bu->primary.r.instance_id);
 	sink_id = IPC4_COMP_ID(bu->extension.r.dst_module_id, bu->extension.r.dst_instance_id);
 	src = ipc4_get_comp_dev(src_id);

--- a/zephyr/include/rtos/idc.h
+++ b/zephyr/include/rtos/idc.h
@@ -160,7 +160,7 @@ struct idc_msg {
 	uint32_t extension;	/**< extension value */
 	uint32_t core;		/**< core id */
 	uint32_t size;		/**< payload size in bytes */
-	void *payload;		/**< pointer to payload data */
+	const void *payload;	/**< pointer to payload data */
 };
 
 /** \brief IDC data. */


### PR DESCRIPTION
remove type-casts and make read-only data guarded by the compiler. AI-aided.