### PR TITLE
schedule: zephyr_ll: protect against a race in task free

### DIFF
--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -551,6 +551,7 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 	uint32_t flags;
 	struct zephyr_ll_pdata *pdata = task->priv_data;
 	bool must_wait, on_list = true;
+	int wait_ret = 0;
 
 	zephyr_ll_assert_core(sch);
 
@@ -598,10 +599,17 @@ static int zephyr_ll_task_free(void *data, struct task *task)
 
 	if (must_wait)
 		/* Wait for up to 100 periods */
-		k_sem_take(pdata->sem_p, K_USEC(LL_TIMER_PERIOD_US * 100));
+		wait_ret = k_sem_take(pdata->sem_p, K_USEC(LL_TIMER_PERIOD_US * 100));
 
 	/* Protect against racing with schedule_task() */
 	zephyr_ll_lock(sch, &flags);
+
+	if (wait_ret && task->state != SOF_TASK_STATE_FREE) {
+		tr_warn(&ll_tr, "task %p still active on free (state %d, semret %d)",
+			task, task->state, wait_ret);
+		zephyr_ll_task_done(sch, task);
+	}
+
 #if CONFIG_DYNAMIC_OBJECTS
 	zephyr_ll_task_sem_free(task);
 #endif


### PR DESCRIPTION
Add a check to ensure task state is what is expected after k_sem_take() returns in zephyr_ll_task_free().

This is needed to avoid a rare error hit when running stress tests with chain DMA in user-space LL builds. Issue is hard to reproduce, but similar error signature can be created by passing K_NO_WAIT to k_sem_take() and running a test with chain-dma pipeline.

Add defensive code that handles this scenario and prints out a warning when unexpected return occurs. Tested with a custom build with K_NO_WAIT passed to k_sem_take().