### PR TITLE
schedule: add a function for finding userspace scherulers

### DIFF
--- a/src/include/sof/schedule/schedule.h
+++ b/src/include/sof/schedule/schedule.h
@@ -186,14 +186,8 @@ struct schedulers **arch_user_schedulers_get(void);
 
 struct schedulers **arch_user_schedulers_get_for_core(int core);
 
-/**
- * Retrieves scheduler's data.
- * @param type SOF_SCHEDULE_ type.
- * @return Pointer to scheduler's data.
- */
-static inline void *scheduler_get_data(uint16_t type)
+static inline void *scheduler_list_get_data(struct schedulers *schedulers, uint16_t type)
 {
-	struct schedulers *schedulers = *arch_schedulers_get();
 	struct schedule_data *sch;
 	struct list_item *slist;
 
@@ -207,6 +201,26 @@ static inline void *scheduler_get_data(uint16_t type)
 	}
 
 	return NULL;
+}
+
+/**
+ * Retrieves scheduler's data.
+ * @param type SOF_SCHEDULE_ type.
+ * @return Pointer to scheduler's data.
+ */
+static inline void *scheduler_get_data(uint16_t type)
+{
+	return scheduler_list_get_data(*arch_schedulers_get(), type);
+}
+
+/**
+ * Retrieves userspace scheduler's data.
+ * @param type SOF_SCHEDULE_ type.
+ * @return Pointer to scheduler's data.
+ */
+static inline void *scheduler_get_user_data(uint16_t type)
+{
+	return scheduler_list_get_data(*arch_user_schedulers_get(), type);
 }
 
 /** See scheduler_ops::schedule_task_running */

--- a/src/schedule/zephyr_ll.c
+++ b/src/schedule/zephyr_ll.c
@@ -889,9 +889,13 @@ void scheduler_get_task_info_ll(struct scheduler_props *scheduler_props,
 				uint32_t *data_off_size)
 {
 	uint32_t flags;
+#if CONFIG_SOF_USERSPACE_LL
+	struct zephyr_ll *ll_sch = scheduler_get_user_data(SOF_SCHEDULE_LL_TIMER);
+#else
+	struct zephyr_ll *ll_sch = scheduler_get_data(SOF_SCHEDULE_LL_TIMER);
+#endif
 
 	scheduler_props->processing_domain = COMP_PROCESSING_DOMAIN_LL;
-	struct zephyr_ll *ll_sch = scheduler_get_data(SOF_SCHEDULE_LL_TIMER);
 
 	zephyr_ll_lock(ll_sch, &flags);
 	scheduler_get_task_info(scheduler_props, data_off_size, &ll_sch->tasks);
@@ -901,7 +905,11 @@ void scheduler_get_task_info_ll(struct scheduler_props *scheduler_props,
 /* Return a pointer to the LL scheduler timer domain */
 struct ll_schedule_domain *zephyr_ll_domain(void)
 {
+#if CONFIG_SOF_USERSPACE_LL
+	struct zephyr_ll *ll_sch = scheduler_get_user_data(SOF_SCHEDULE_LL_TIMER);
+#else
 	struct zephyr_ll *ll_sch = scheduler_get_data(SOF_SCHEDULE_LL_TIMER);
+#endif
 
 	return ll_sch ? ll_sch->ll_domain : NULL;
 }


### PR DESCRIPTION
scheduler_get_data() only finds scheduler data for kernel mode schedulers. Add a similar function for userspace schedulers.
part of #10945 