### PR TITLE
topology2: add d0i3_compatible properties to host-copier widget

### DIFF
--- a/tools/topology/topology2/include/components/host-copier.conf
+++ b/tools/topology/topology2/include/components/host-copier.conf
@@ -83,6 +83,18 @@ Class.Widget."host-copier" {
 		token_ref	"copier.word"
 	}
 
+	#
+	# D0I3 compatibility flags for streams. When set, the DSP can
+	# remain in D0i3 during S0ix while this stream is active.
+	#
+	DefineAttribute."playback_compatible_d0i3" {
+		token_ref	"stream.bool"
+	}
+
+	DefineAttribute."capture_compatible_d0i3" {
+		token_ref	"stream.bool"
+	}
+
 	attributes {
 		#
 		# The host copier widget name would be constructed using the copier pcm_id and


### PR DESCRIPTION
Add playback_compatible_d0i3 and capture_compatible_d0i3 attributes to the host-copier widget class so they can be set on host-copier widgets to enable Wake on Voice and similar functionalities for the associated PCMs.

This PR completes https://github.com/thesofproject/linux/pull/5878