### PR TITLE
audio: mux: fix a blob size check

### DIFF
--- a/src/audio/mux/mux_ipc4.c
+++ b/src/audio/mux/mux_ipc4.c
@@ -148,7 +148,7 @@ int mux_params(struct processing_module *mod)
 	int ret;
 
 	cfg = comp_get_data_blob(cd->model_handler, &blob_size, NULL);
-	if (!cfg || blob_size > MUX_BLOB_MAX_SIZE) {
+	if (!cfg || blob_size != sizeof(*cfg)) {
 		comp_err(mod->dev, "illegal blob size %zu", blob_size);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Before dereferencing the data blob make sure that it matches the expected size, not just isn't exceeding the maximum size.

found by fuzzer https://github.com/thesofproject/sof/actions/runs/32463369471/job/96714735796?pr=11108