### PR TITLE
IADK: fix module configuration sizing and error handling

### DIFF
--- a/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
+++ b/src/audio/module_adapter/iadk/module_initial_settings_concrete.cpp
@@ -54,11 +54,11 @@ ModuleInitialSettingsConcrete::ModuleInitialSettingsConcrete(DwordArray const &c
 		const size_t computed_msg_size =
 			sizeof(CompoundCfg) -
 			/* CompoundCfg already contains one InputPinFormat and
-			 * one InputPinFormat
+			 * one OutputPinFormat
 			 */
 			(sizeof(InputPinFormat) + sizeof(OutputPinFormat)) +
 			unvalidated_compound_cfg->cfg_ext.nb_input_pins*sizeof(InputPinFormat) +
-			unvalidated_compound_cfg->cfg_ext.nb_output_pins*sizeof(InputPinFormat);
+			unvalidated_compound_cfg->cfg_ext.nb_output_pins*sizeof(OutputPinFormat);
 
 		/* check size consistency */
 		if (ipc_msg_size != computed_msg_size) {

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -87,6 +87,7 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 			 void *obfuscated_parent_ppl,
 			 void **obfuscated_modinst_p)
 {
+	ErrorCode::Type error;
 	IoPinsInfo pins_info;
 	const dsp_fw::DwordArray& cfg_ipc_msg =
 			*reinterpret_cast<const dsp_fw::DwordArray*>(obfuscated_mod_cfg);
@@ -112,7 +113,11 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 	settings.DeduceBaseModuleCfgExt(prerequisites.input_pins_count,
 					prerequisites.output_pins_count);
 
-	module_factory.Create(*this, module_placeholder, ModuleInitialSettings(settings), pins_info);
+	error = module_factory.Create(*this, module_placeholder, ModuleInitialSettings(settings),
+				      pins_info);
+	if (error != ErrorCode::NO_ERROR)
+		return -EINVAL;
+
 	IadkModuleAdapter& module_adapter = *reinterpret_cast<IadkModuleAdapter*>(module_handle_);
 	*obfuscated_modinst_p = &module_adapter;
 	reinterpret_cast<intel_adsp::ProcessingModuleInterface*>(module_placeholder)->Init();

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -91,6 +91,8 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 	const dsp_fw::DwordArray& cfg_ipc_msg =
 			*reinterpret_cast<const dsp_fw::DwordArray*>(obfuscated_mod_cfg);
 	ModuleInitialSettingsConcrete settings(cfg_ipc_msg);
+	if (!settings.IsParsable())
+		return -EINVAL;
 
 	ProcessingModulePrerequisites prerequisites;
 	module_factory.GetPrerequisites(prerequisites);

--- a/src/audio/module_adapter/iadk/system_agent.cpp
+++ b/src/audio/module_adapter/iadk/system_agent.cpp
@@ -107,7 +107,7 @@ int SystemAgent::CheckIn(ProcessingModuleFactoryInterface& module_factory,
 		(prerequisites.input_pins_count > INPUT_PIN_COUNT) ||
 		(prerequisites.output_pins_count < 1) ||
 		(prerequisites.output_pins_count > OUTPUT_PIN_COUNT))
-		return -1;
+		return -EINVAL;
 
 	/* Deduce BaseModuleCfgExt if it was not part of the INIT_INSTANCE IPC message */
 	settings.DeduceBaseModuleCfgExt(prerequisites.input_pins_count,


### PR DESCRIPTION
- Correct the IADK compound configuration size calculation to use `OutputPinFormat` for output pins.
- Reject unparsable module configuration messages during `SystemAgent::CheckIn`.
- Propagate module factory creation failures instead of continuing with an invalid module instance.