### PR TITLE
global: remove unused SHARED_DATA

### DIFF
--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -4,7 +4,6 @@
 //
 
 #include <sof/audio/component.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/ut.h>
 #include <sof/tlv.h>
 #include <ipc4/base_fw.h>

--- a/src/audio/base_fw.c
+++ b/src/audio/base_fw.c
@@ -4,7 +4,7 @@
 //
 
 #include <sof/audio/component.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/ut.h>
 #include <sof/tlv.h>
 #include <ipc4/base_fw.h>
@@ -857,7 +857,7 @@ static const struct comp_driver comp_basefw = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_basefw_info = {
+static struct comp_driver_info comp_basefw_info = {
 	.drv = &comp_basefw,
 };
 

--- a/src/audio/chain_dma.c
+++ b/src/audio/chain_dma.c
@@ -795,7 +795,7 @@ static const struct comp_driver comp_chain_dma = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_chain_dma_info = {
+static struct comp_driver_info comp_chain_dma_info = {
 	.drv = &comp_chain_dma,
 };
 

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -13,7 +13,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/sof.h>

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -13,7 +13,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/cache.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/sof.h>
@@ -36,7 +36,7 @@
 
 LOG_MODULE_REGISTER(component, CONFIG_SOF_LOG_LEVEL);
 
-static APP_SYSUSER_BSS SHARED_DATA struct comp_driver_list cd;
+static APP_SYSUSER_BSS struct comp_driver_list cd;
 
 #ifdef CONFIG_SOF_USERSPACE_LL
 struct comp_driver_list *comp_drivers_get(void)

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -19,7 +19,7 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -1128,7 +1128,7 @@ static const struct comp_driver comp_dai = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_dai_info = {
+static struct comp_driver_info comp_dai_info = {
 	.drv = &comp_dai,
 };
 

--- a/src/audio/dai-legacy.c
+++ b/src/audio/dai-legacy.c
@@ -19,7 +19,6 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -19,7 +19,7 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/lib/dma.h>
@@ -2092,7 +2092,7 @@ static const struct comp_driver comp_dai = {
 },
 };
 
-static SHARED_DATA struct comp_driver_info comp_dai_info = {
+static struct comp_driver_info comp_dai_info = {
 	.drv = &comp_dai,
 };
 

--- a/src/audio/dai-zephyr.c
+++ b/src/audio/dai-zephyr.c
@@ -19,7 +19,6 @@
 #include <rtos/cache.h>
 #include <rtos/init.h>
 #include <sof/lib/dai.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/lib/dma.h>

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -15,7 +15,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <rtos/wait.h>
 #include <sof/lib/uuid.h>

--- a/src/audio/google/google_hotword_detect.c
+++ b/src/audio/google/google_hotword_detect.c
@@ -15,7 +15,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <rtos/wait.h>
 #include <sof/lib/uuid.h>
@@ -466,7 +466,7 @@ static const struct comp_driver ghd_driver = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info ghd_driver_info = {
+static struct comp_driver_info ghd_driver_info = {
 	.drv = &ghd_driver,
 };
 

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -17,7 +17,6 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/host-legacy.c
+++ b/src/audio/host-legacy.c
@@ -17,7 +17,7 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/notifier.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -1068,7 +1068,7 @@ static const struct comp_driver comp_host = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_host_info = {
+static struct comp_driver_info comp_host_info = {
 	.drv = &comp_host,
 };
 

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -17,7 +17,6 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>

--- a/src/audio/host-zephyr.c
+++ b/src/audio/host-zephyr.c
@@ -17,7 +17,7 @@
 #include <rtos/init.h>
 #include <sof/lib/dma.h>
 #include <sof/lib/mailbox.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/numbers.h>
@@ -1332,7 +1332,7 @@ static const struct comp_driver comp_host = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_host_info = {
+static struct comp_driver_info comp_host_info = {
 	.drv = &comp_host,
 };
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -26,7 +26,7 @@
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
@@ -2742,7 +2742,7 @@ static const struct comp_driver comp_kpb = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_kpb_info = {
+static struct comp_driver_info comp_kpb_info = {
 	.drv = &comp_kpb,
 };
 

--- a/src/audio/kpb.c
+++ b/src/audio/kpb.c
@@ -26,7 +26,6 @@
 #include <rtos/alloc.h>
 #include <rtos/clk.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/pm_runtime.h>
 #include <sof/lib/uuid.h>
 #include <sof/list.h>

--- a/src/audio/pipeline/pipeline-graph.c
+++ b/src/audio/pipeline/pipeline-graph.c
@@ -50,12 +50,11 @@ struct pipeline_posn {
 #endif
 };
 /* the pipeline position lookup table */
-static APP_SYSUSER_BSS SHARED_DATA struct pipeline_posn pipeline_posn_shared;
+static APP_SYSUSER_BSS struct pipeline_posn pipeline_posn_shared;
 
 #ifdef CONFIG_SOF_USERSPACE_LL
 /* Mutex pointer in user-accessible partition so user-space threads
- * can read the pointer for syscalls. Kept outside the SHARED_DATA
- * struct to avoid kernel object tracking issues.
+ * can read the pointer for syscalls.
  */
 static APP_SYSUSER_BSS struct k_mutex *pipeline_posn_mutex;
 #endif

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -22,7 +22,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/string.h>

--- a/src/audio/selector/selector.c
+++ b/src/audio/selector/selector.c
@@ -22,7 +22,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <rtos/string.h>
@@ -609,7 +609,7 @@ static const struct comp_driver comp_selector = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_selector_info = {
+static struct comp_driver_info comp_selector_info = {
 	.drv = &comp_selector,
 };
 

--- a/src/audio/tone/tone-ipc3.c
+++ b/src/audio/tone/tone-ipc3.c
@@ -16,7 +16,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone-ipc3.c
+++ b/src/audio/tone/tone-ipc3.c
@@ -16,7 +16,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>
@@ -395,7 +395,7 @@ static const struct comp_driver comp_tone = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_tone_info = {
+static struct comp_driver_info comp_tone_info = {
 	.drv = &comp_tone,
 };
 

--- a/src/audio/tone/tone-ipc4.c
+++ b/src/audio/tone/tone-ipc4.c
@@ -17,7 +17,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone-ipc4.c
+++ b/src/audio/tone/tone-ipc4.c
@@ -17,7 +17,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone.c
+++ b/src/audio/tone/tone.c
@@ -17,7 +17,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone.c
+++ b/src/audio/tone/tone.c
@@ -17,7 +17,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone.h
+++ b/src/audio/tone/tone.h
@@ -14,7 +14,6 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/audio/tone/tone.h
+++ b/src/audio/tone/tone.h
@@ -14,7 +14,7 @@
 #include <sof/ipc/msg.h>
 #include <rtos/alloc.h>
 #include <rtos/init.h>
-#include <sof/lib/memory.h> /* for SHARED_DATA */
+#include <sof/lib/memory.h> /* likely unneeded */
 #include <sof/lib/uuid.h>
 #include <sof/list.h>
 #include <sof/math/trig.h>

--- a/src/drivers/interrupt.c
+++ b/src/drivers/interrupt.c
@@ -43,7 +43,7 @@ DECLARE_TR_CTX(irq_tr, SOF_UUID(irq_uuid), LOG_LEVEL_INFO);
 #define interrupt_disable mux_interrupt_disable
 #endif
 
-static SHARED_DATA struct cascade_root cascade_root;
+static struct cascade_root cascade_root;
 
 static int interrupt_register_internal(uint32_t irq, void (*handler)(void *arg),
 				       void *arg, struct irq_desc *desc);

--- a/src/idc/idc.c
+++ b/src/idc/idc.c
@@ -39,7 +39,7 @@
 LOG_MODULE_REGISTER(idc, CONFIG_SOF_LOG_LEVEL);
 
 /** \brief IDC message payload per core. */
-static SHARED_DATA struct idc_payload static_payload[CONFIG_CORE_COUNT];
+static struct idc_payload static_payload[CONFIG_CORE_COUNT];
 
 SOF_DEFINE_REG_UUID(idc);
 

--- a/src/include/sof/audio/module_adapter/module/generic.h
+++ b/src/include/sof/audio/module_adapter/module/generic.h
@@ -78,7 +78,7 @@ static const struct comp_driver comp_##adapter##_module = { \
 	.adapter_ops = &(adapter), \
 }; \
 \
-static SHARED_DATA struct comp_driver_info comp_module_##adapter##_info = { \
+static struct comp_driver_info comp_module_##adapter##_info = { \
 	.drv = &comp_##adapter##_module, \
 }; \
 \

--- a/src/lib/clk.c
+++ b/src/lib/clk.c
@@ -24,7 +24,7 @@ SOF_DEFINE_REG_UUID(clock);
 
 DECLARE_TR_CTX(clock_tr, SOF_UUID(clock_uuid), LOG_LEVEL_INFO);
 
-SHARED_DATA struct k_spinlock clk_lock;
+struct k_spinlock clk_lock;
 
 static inline uint32_t clock_get_nearest_freq_idx(const struct freq_table *tab,
 						  uint32_t size, uint32_t hz)

--- a/src/lib/notifier.c
+++ b/src/lib/notifier.c
@@ -26,7 +26,7 @@ SOF_DEFINE_REG_UUID(notifier);
 
 DECLARE_TR_CTX(nt_tr, SOF_UUID(notifier_uuid), LOG_LEVEL_INFO);
 
-static SHARED_DATA struct notify_data notify_data_shared[CONFIG_CORE_COUNT];
+static struct notify_data notify_data_shared[CONFIG_CORE_COUNT];
 
 struct callback_handle {
 	void *receiver;

--- a/src/platform/amd/acp_6_3/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_6_3/include/platform/lib/memory.h
@@ -162,7 +162,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/acp_6_3/lib/clk.c
+++ b/src/platform/amd/acp_6_3/lib/clk.c
@@ -51,7 +51,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void audio_pll_power_off(void);
 void audio_pll_power_on(void);

--- a/src/platform/amd/acp_6_3/lib/dma.c
+++ b/src/platform/amd/acp_6_3/lib/dma.c
@@ -25,7 +25,7 @@ extern struct dma_ops acp_dai_sp_dma_ops;
 extern struct dma_ops acp_dai_hs_dma_ops;
 extern struct dma_ops acp_dai_sw_audio_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,

--- a/src/platform/amd/acp_6_3/lib/memory.c
+++ b/src/platform/amd/acp_6_3/lib/memory.c
@@ -12,29 +12,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -46,14 +46,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/amd/acp_6_3/platform.c
+++ b/src/platform/amd/acp_6_3/platform.c
@@ -127,7 +127,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
-static SHARED_DATA struct timer timer = {
+static struct timer timer = {
 	.id = TIMER0,
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/amd/acp_7_0/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_7_0/include/platform/lib/memory.h
@@ -173,7 +173,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/acp_7_0/lib/clk.c
+++ b/src/platform/amd/acp_7_0/lib/clk.c
@@ -50,7 +50,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void audio_pll_power_off(void);
 void audio_pll_power_on(void);

--- a/src/platform/amd/acp_7_0/lib/dma.c
+++ b/src/platform/amd/acp_7_0/lib/dma.c
@@ -24,7 +24,7 @@ extern struct dma_ops acp_dai_sp_dma_ops;
 extern struct dma_ops acp_dai_hs_dma_ops;
 extern struct dma_ops acp_dai_sw_audio_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,

--- a/src/platform/amd/acp_7_0/lib/memory.c
+++ b/src/platform/amd/acp_7_0/lib/memory.c
@@ -13,29 +13,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -47,14 +47,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/amd/acp_7_x/include/platform/lib/memory.h
+++ b/src/platform/amd/acp_7_x/include/platform/lib/memory.h
@@ -228,7 +228,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/acp_7_x/lib/clk.c
+++ b/src/platform/amd/acp_7_x/lib/clk.c
@@ -68,7 +68,7 @@ typedef enum _acp_clock_type_ {
 } acp_clock_type_t;
 
 /* Static variables */
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 /* Function prototypes */
 void audio_pll_power_off(void);

--- a/src/platform/amd/rembrandt/include/platform/lib/memory.h
+++ b/src/platform/amd/rembrandt/include/platform/lib/memory.h
@@ -152,8 +152,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/rembrandt/lib/clk.c
+++ b/src/platform/amd/rembrandt/lib/clk.c
@@ -19,7 +19,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 			      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static int acp_reg_read_via_smn(uint32_t reg_offset,
 				uint32_t size)

--- a/src/platform/amd/rembrandt/lib/dma.c
+++ b/src/platform/amd/rembrandt/lib/dma.c
@@ -25,7 +25,7 @@ extern struct dma_ops acp_dai_sp_dma_ops;
 #endif
 extern struct dma_ops acp_dai_hs_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,

--- a/src/platform/amd/renoir/include/platform/lib/memory.h
+++ b/src/platform/amd/renoir/include/platform/lib/memory.h
@@ -147,8 +147,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/renoir/lib/clk.c
+++ b/src/platform/amd/renoir/lib/clk.c
@@ -19,7 +19,7 @@ static struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 			      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static int acp_reg_read_via_smn(uint32_t reg_offset,
 				uint32_t size)

--- a/src/platform/amd/renoir/lib/dma.c
+++ b/src/platform/amd/renoir/lib/dma.c
@@ -24,7 +24,7 @@ extern struct dma_ops acp_dai_bt_dma_ops;
 #endif
 extern struct dma_ops acp_dai_sp_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,

--- a/src/platform/amd/renoir/lib/memory.c
+++ b/src/platform/amd/renoir/lib/memory.c
@@ -12,29 +12,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -46,14 +46,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/amd/renoir/platform.c
+++ b/src/platform/amd/renoir/platform.c
@@ -124,7 +124,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = TIMER0,
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/amd/vangogh/include/platform/lib/memory.h
+++ b/src/platform/amd/vangogh/include/platform/lib/memory.h
@@ -146,8 +146,6 @@
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
 struct sof;
 
-
-#define SHARED_DATA
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/amd/vangogh/lib/clk.c
+++ b/src/platform/amd/vangogh/lib/clk.c
@@ -21,7 +21,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static int acp_reg_read_via_smn(uint32_t reg_offset,
 				uint32_t size)

--- a/src/platform/amd/vangogh/lib/dma.c
+++ b/src/platform/amd/vangogh/lib/dma.c
@@ -23,7 +23,7 @@ extern struct dma_ops acp_dai_bt_dma_ops;
 extern struct dma_ops acp_dai_sp_dma_ops;
 extern struct dma_ops acp_dai_hs_dma_ops;
 
-SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_DMA0,

--- a/src/platform/amd/vangogh/lib/memory.c
+++ b/src/platform/amd/vangogh/lib/memory.c
@@ -13,29 +13,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -47,14 +47,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/amd/vangogh/platform.c
+++ b/src/platform/amd/vangogh/platform.c
@@ -123,7 +123,7 @@ const struct ext_man_windows xsram_window
 	},
 };
 
-static SHARED_DATA struct timer timer = {
+static struct timer timer = {
 	.id = TIMER0,
 	.irq = IRQ_NUM_TIMER0,
 };

--- a/src/platform/imx8/include/platform/lib/memory.h
+++ b/src/platform/imx8/include/platform/lib/memory.h
@@ -179,12 +179,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since IMX doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -195,9 +189,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since IMX doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since IMX doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/imx8/lib/clk.c
+++ b/src/platform/imx8/lib/clk.c
@@ -24,7 +24,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void platform_clock_init(struct sof *sof)
 {

--- a/src/platform/imx8/lib/dai.c
+++ b/src/platform/imx8/lib/dai.c
@@ -15,7 +15,7 @@
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 
-static SHARED_DATA struct dai esai[] = {
+static struct dai esai[] = {
 {
 	.index = 0,
 	.plat_data = {
@@ -39,7 +39,7 @@ static SHARED_DATA struct dai esai[] = {
 },
 };
 
-static SHARED_DATA struct dai sai[] = {
+static struct dai sai[] = {
 {
 	.index = 1,
 	.plat_data = {

--- a/src/platform/imx8/lib/dma.c
+++ b/src/platform/imx8/lib/dma.c
@@ -22,7 +22,7 @@ static const int edma0_ints[EDMA0_CHAN_MAX] = {
 	[EDMA0_SAI_CHAN_TX] = EDMA0_SAI_CHAN_TX_IRQ,
 };
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_EDMA0,

--- a/src/platform/imx8/lib/memory.c
+++ b/src/platform/imx8/lib/memory.c
@@ -12,29 +12,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -46,14 +46,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/imx8m/include/platform/lib/memory.h
+++ b/src/platform/imx8m/include/platform/lib/memory.h
@@ -198,12 +198,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since IMX doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -214,9 +208,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since IMX doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since IMX doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/imx8m/lib/clk.c
+++ b/src/platform/imx8m/lib/clk.c
@@ -19,7 +19,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void platform_clock_init(struct sof *sof)
 {

--- a/src/platform/imx8m/lib/dai.c
+++ b/src/platform/imx8m/lib/dai.c
@@ -15,7 +15,7 @@
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 
-static SHARED_DATA struct dai sai[] = {
+static struct dai sai[] = {
 {
 	.index = 1,
 	.plat_data = {
@@ -144,7 +144,7 @@ static SHARED_DATA struct dai sai[] = {
 
 };
 
-static SHARED_DATA struct dai micfil[] = {
+static struct dai micfil[] = {
 {
 	.index = 2,
 	.plat_data = {

--- a/src/platform/imx8m/lib/dma.c
+++ b/src/platform/imx8m/lib/dma.c
@@ -14,7 +14,7 @@
 extern struct dma_ops dummy_dma_ops;
 extern struct dma_ops sdma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/imx8m/lib/memory.c
+++ b/src/platform/imx8m/lib/memory.c
@@ -12,30 +12,30 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -48,14 +48,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/imx8m_cm7/include/platform/lib/memory.h
+++ b/src/platform/imx8m_cm7/include/platform/lib/memory.h
@@ -12,8 +12,6 @@
 
 #define PLATFORM_DCACHE_ALIGN DCACHE_LINE_SIZE
 
-#define SHARED_DATA
-
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
 #define cache_to_uncache_init(address) address

--- a/src/platform/imx8ulp/include/platform/lib/memory.h
+++ b/src/platform/imx8ulp/include/platform/lib/memory.h
@@ -182,12 +182,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since IMX doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -198,9 +192,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since IMX doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since IMX doesn't support SMP.
  */
 static inline void platform_shared_commit(void *ptr, int bytes) { }
 

--- a/src/platform/imx8ulp/lib/clk.c
+++ b/src/platform/imx8ulp/lib/clk.c
@@ -19,7 +19,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(NUM_CPU_FREQ == ARRAY_SIZE(platform_cpu_freq),
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void platform_clock_init(struct sof *sof)
 {

--- a/src/platform/imx8ulp/lib/dai.c
+++ b/src/platform/imx8ulp/lib/dai.c
@@ -14,7 +14,7 @@
 #include <ipc/dai.h>
 #include <ipc/stream.h>
 
-static SHARED_DATA struct dai sai[] = {
+static struct dai sai[] = {
 {
 	.index = 5,
 	.plat_data = {

--- a/src/platform/imx8ulp/lib/dma.c
+++ b/src/platform/imx8ulp/lib/dma.c
@@ -20,7 +20,7 @@ static const int edma2_ints[IMX8ULP_EDMA2_CHAN_MAX] = {
 	[IMX8ULP_EDMA2_CHAN1] = IMX8ULP_EDMA2_CHAN1_IRQ,
 };
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_EDMA2,

--- a/src/platform/imx8ulp/lib/memory.c
+++ b/src/platform/imx8ulp/lib/memory.c
@@ -13,29 +13,29 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -47,14 +47,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/imx93_a55/include/platform/lib/memory.h
+++ b/src/platform/imx93_a55/include/platform/lib/memory.h
@@ -20,8 +20,6 @@
  * thing so all the below cache/shared data "management"
  * functions aren't necessary.
  */
-#define SHARED_DATA
-
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
 #define cache_to_uncache_init(address) address

--- a/src/platform/imx95/include/platform/lib/memory.h
+++ b/src/platform/imx95/include/platform/lib/memory.h
@@ -12,8 +12,6 @@
 
 #define PLATFORM_DCACHE_ALIGN DCACHE_LINE_SIZE
 
-#define SHARED_DATA
-
 #define uncache_to_cache(address) address
 #define cache_to_uncache(address) address
 #define cache_to_uncache_init(address) address

--- a/src/platform/intel/ace/include/ace/lib/memory.h
+++ b/src/platform/intel/ace/include/ace/lib/memory.h
@@ -19,14 +19,6 @@
 /* data cache line alignment */
 #define PLATFORM_DCACHE_ALIGN		DCACHE_LINE_SIZE
 
-/**
- * \brief Data shared between different cores.
- * Placed into dedicated section, which should be accessed through
- * uncached memory region. SMP platforms without uncache can simply
- * align to cache line size instead.
- */
-#define SHARED_DATA
-
 #include <zephyr/cache.h>
 
 #define uncache_to_cache(address)       sys_cache_cached_ptr_get(address)

--- a/src/platform/intel/cavs/include/cavs/lib/memory.h
+++ b/src/platform/intel/cavs/include/cavs/lib/memory.h
@@ -33,18 +33,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Placed into dedicated section, which should be accessed through
- * uncached memory region. SMP platforms without uncache can simply
- * align to cache line size instead.
- */
-#if !defined(UNIT_TEST) && !defined __ZEPHYR__
-#define SHARED_DATA	__section(".shared_data") __attribute__((aligned(PLATFORM_DCACHE_ALIGN)))
-#else
-#define SHARED_DATA
-#endif
-
 #define SRAM_ALIAS_BASE		0x9E000000
 #define SRAM_ALIAS_MASK		0xFF000000
 #define SRAM_ALIAS_OFFSET	SRAM_UNCACHED_ALIAS

--- a/src/platform/library/include/platform/lib/memory.h
+++ b/src/platform/library/include/platform/lib/memory.h
@@ -35,8 +35,6 @@ uint8_t *get_library_mailbox(void);
 #define PLATFORM_HEAP_SYSTEM_SHARED	1
 #define PLATFORM_HEAP_RUNTIME_SHARED	1
 
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/library/lib/memory.c
+++ b/src/platform/library/lib/memory.c
@@ -27,22 +27,22 @@
 #define HEAP_BUFFER_BASE       0xBE1C0000
 
 /* Heap blocks for system runtime for primary core */
-static SHARED_DATA struct block_hdr sys_rt_0_block64[HEAP_SYS_RT_0_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_0_block512[HEAP_SYS_RT_0_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_0_block1024[HEAP_SYS_RT_0_COUNT1024];
+static struct block_hdr sys_rt_0_block64[HEAP_SYS_RT_0_COUNT64];
+static struct block_hdr sys_rt_0_block512[HEAP_SYS_RT_0_COUNT512];
+static struct block_hdr sys_rt_0_block1024[HEAP_SYS_RT_0_COUNT1024];
 
 /* Heap blocks for system runtime for secondary core */
 #if CONFIG_CORE_COUNT > 1
-static SHARED_DATA struct block_hdr
+static struct block_hdr
 	sys_rt_x_block64[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT64];
-static SHARED_DATA struct block_hdr
+static struct block_hdr
 	sys_rt_x_block512[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT512];
-static SHARED_DATA struct block_hdr
+static struct block_hdr
 	sys_rt_x_block1024[CONFIG_CORE_COUNT - 1][HEAP_SYS_RT_X_COUNT1024];
 #endif
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[CONFIG_CORE_COUNT][3] = {
+static struct block_map sys_rt_heap_map[CONFIG_CORE_COUNT][3] = {
 	{ BLOCK_DEF(64, HEAP_SYS_RT_0_COUNT64,
 		    uncached_block_hdr(sys_rt_0_block64)),
 	  BLOCK_DEF(512, HEAP_SYS_RT_0_COUNT512,
@@ -76,16 +76,16 @@ static SHARED_DATA struct block_map sys_rt_heap_map[CONFIG_CORE_COUNT][3] = {
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block64[HEAP_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_COUNT4096];
+static struct block_hdr mod_block64[HEAP_COUNT64];
+static struct block_hdr mod_block128[HEAP_COUNT128];
+static struct block_hdr mod_block256[HEAP_COUNT256];
+static struct block_hdr mod_block512[HEAP_COUNT512];
+static struct block_hdr mod_block1024[HEAP_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_COUNT64, uncached_block_hdr(mod_block64)),
 	BLOCK_DEF(128, HEAP_COUNT128, uncached_block_hdr(mod_block128)),
 	BLOCK_DEF(256, HEAP_COUNT256, uncached_block_hdr(mod_block256)),
@@ -97,14 +97,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 
 #if CONFIG_CORE_COUNT > 1
 /* Heap blocks for runtime shared */
-static SHARED_DATA struct block_hdr rt_shared_block64[HEAP_RUNTIME_SHARED_COUNT64];
-static SHARED_DATA struct block_hdr rt_shared_block128[HEAP_RUNTIME_SHARED_COUNT128];
-static SHARED_DATA struct block_hdr rt_shared_block256[HEAP_RUNTIME_SHARED_COUNT256];
-static SHARED_DATA struct block_hdr rt_shared_block512[HEAP_RUNTIME_SHARED_COUNT512];
-static SHARED_DATA struct block_hdr rt_shared_block1024[HEAP_RUNTIME_SHARED_COUNT1024];
+static struct block_hdr rt_shared_block64[HEAP_RUNTIME_SHARED_COUNT64];
+static struct block_hdr rt_shared_block128[HEAP_RUNTIME_SHARED_COUNT128];
+static struct block_hdr rt_shared_block256[HEAP_RUNTIME_SHARED_COUNT256];
+static struct block_hdr rt_shared_block512[HEAP_RUNTIME_SHARED_COUNT512];
+static struct block_hdr rt_shared_block1024[HEAP_RUNTIME_SHARED_COUNT1024];
 
 /* Heap memory map for runtime shared */
-static SHARED_DATA struct block_map rt_shared_heap_map[] = {
+static struct block_map rt_shared_heap_map[] = {
 	BLOCK_DEF(64, HEAP_RUNTIME_SHARED_COUNT64, uncached_block_hdr(rt_shared_block64)),
 	BLOCK_DEF(128, HEAP_RUNTIME_SHARED_COUNT128, uncached_block_hdr(rt_shared_block128)),
 	BLOCK_DEF(256, HEAP_RUNTIME_SHARED_COUNT256, uncached_block_hdr(rt_shared_block256)),
@@ -114,21 +114,21 @@ static SHARED_DATA struct block_map rt_shared_heap_map[] = {
 #endif
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT_MAX];
-static SHARED_DATA struct block_hdr lp_buf_block[HEAP_LP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT_MAX];
+static struct block_hdr lp_buf_block[HEAP_LP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT_MAX,
 		  uncached_block_hdr(buf_block)),
 };
 
-static SHARED_DATA struct block_map lp_buf_heap_map[] = {
+static struct block_map lp_buf_heap_map[] = {
 	BLOCK_DEF(HEAP_LP_BUFFER_BLOCK_SIZE, HEAP_LP_BUFFER_COUNT,
 		  uncached_block_hdr(lp_buf_block)),
 };
 
-static SHARED_DATA struct mm memmap;
+static struct mm memmap;
 
 void platform_init_memmap(struct sof *sof)
 {

--- a/src/platform/library/platform.c
+++ b/src/platform/library/platform.c
@@ -13,7 +13,7 @@
 #include <sof/lib/mailbox.h>
 #include <sof/lib/dai.h>
 
-static SHARED_DATA struct timer timer = {};
+static struct timer timer = {};
 
 static uint8_t mailbox[MAILBOX_DSPBOX_SIZE +
 		       MAILBOX_HOSTBOX_SIZE +

--- a/src/platform/mt8186/include/platform/lib/memory.h
+++ b/src/platform/mt8186/include/platform/lib/memory.h
@@ -184,12 +184,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since mt8186 doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -200,9 +194,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since mt8186 doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since mt8186 doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8186/lib/clk.c
+++ b/src/platform/mt8186/lib/clk.c
@@ -32,7 +32,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static void clk_dsppll_enable(uint32_t value)
 {

--- a/src/platform/mt8186/lib/dai.c
+++ b/src/platform/mt8186/lib/dai.c
@@ -23,7 +23,7 @@ static int afe_dai_handshake[MT8186_DAI_NUM] = {
 	AFE_HANDSHAKE(MT8186_AFE_IO_I2S0, MT8186_IRQ_12, MT8186_MEMIF_UL2),
 };
 
-static SHARED_DATA struct dai afe_dai[MT8186_DAI_NUM];
+static struct dai afe_dai[MT8186_DAI_NUM];
 
 const struct dai_type_info dti[] = {
 	{

--- a/src/platform/mt8186/lib/dma.c
+++ b/src/platform/mt8186/lib/dma.c
@@ -19,7 +19,7 @@
 
 extern const struct dma_ops dummy_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/mt8186/lib/memory.c
+++ b/src/platform/mt8186/lib/memory.c
@@ -13,30 +13,30 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -49,14 +49,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/mt8186/platform.c
+++ b/src/platform/mt8186/platform.c
@@ -121,7 +121,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = MTK_DSP_IRQ_OSTIMER32,
 };

--- a/src/platform/mt8188/include/platform/lib/memory.h
+++ b/src/platform/mt8188/include/platform/lib/memory.h
@@ -39,7 +39,7 @@
 #define EXT_MANIFEST_ELF_SIZE		(SRAM_BASE + SRAM_SIZE - EXT_MANIFEST_ELF_BASE)
 
 /*
- * The Memory Layout on MT8186 are organised like this :-
+ * The Memory Layout on MT8188 are organised like this :-
  *
  * +--------------------------------------------------------------------------+
  * | Offset              | Region         |  Size                             |
@@ -184,12 +184,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since mt8186 doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -200,9 +194,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since mt8186 doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since mt8188 doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8188/lib/clk.c
+++ b/src/platform/mt8188/lib/clk.c
@@ -32,7 +32,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static void clk_dsppll_enable(uint32_t value)
 {

--- a/src/platform/mt8188/lib/dai.c
+++ b/src/platform/mt8188/lib/dai.c
@@ -23,7 +23,7 @@ static int afe_dai_handshake[MT8188_DAI_NUM] = {
 	AFE_HANDSHAKE(MT8188_AFE_IO_ETDM2_IN, MT8188_IRQ_22, MT8188_MEMIF_UL5),
 };
 
-static SHARED_DATA struct dai afe_dai[MT8188_DAI_NUM];
+static struct dai afe_dai[MT8188_DAI_NUM];
 
 const struct dai_type_info dti[] = {
 	{

--- a/src/platform/mt8188/lib/dma.c
+++ b/src/platform/mt8188/lib/dma.c
@@ -19,7 +19,7 @@
 
 extern const struct dma_ops dummy_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/mt8188/lib/memory.c
+++ b/src/platform/mt8188/lib/memory.c
@@ -13,30 +13,30 @@
 #include <rtos/sof.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -49,14 +49,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/mt8188/platform.c
+++ b/src/platform/mt8188/platform.c
@@ -121,7 +121,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = MTK_DSP_IRQ_OSTIMER32,
 };

--- a/src/platform/mt8195/include/platform/lib/memory.h
+++ b/src/platform/mt8195/include/platform/lib/memory.h
@@ -175,12 +175,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since mt8195 doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address) address
@@ -191,9 +185,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since mt8195 doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since mt8195 doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8195/lib/clk.c
+++ b/src/platform/mt8195/lib/clk.c
@@ -41,7 +41,7 @@ const uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static inline void clk_setl(uint32_t addr, uint32_t val)
 {

--- a/src/platform/mt8195/lib/dai.c
+++ b/src/platform/mt8195/lib/dai.c
@@ -23,7 +23,7 @@ static int afe_dai_handshake[MT8195_DAI_NUM] = {
 	AFE_HANDSHAKE(MT8195_AFE_IO_ETDM2_IN, MT8195_IRQ_22, MT8195_MEMIF_UL5),
 };
 
-static SHARED_DATA struct dai afe_dai[MT8195_DAI_NUM];
+static struct dai afe_dai[MT8195_DAI_NUM];
 
 const struct dai_type_info dti[] = {
 	{

--- a/src/platform/mt8195/lib/dma.c
+++ b/src/platform/mt8195/lib/dma.c
@@ -18,7 +18,7 @@
 
 extern struct dma_ops dummy_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/mt8195/lib/memory.c
+++ b/src/platform/mt8195/lib/memory.c
@@ -12,30 +12,30 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -48,14 +48,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/mt8195/platform.c
+++ b/src/platform/mt8195/platform.c
@@ -121,7 +121,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = LX_ADSP_TIMTER_IRQ0_B,
 };

--- a/src/platform/mt8196/include/platform/lib/memory.h
+++ b/src/platform/mt8196/include/platform/lib/memory.h
@@ -38,7 +38,7 @@
 #define EXT_MANIFEST_ELF_SIZE		(SRAM_BASE + SRAM_SIZE - EXT_MANIFEST_ELF_BASE)
 
 /*
- * The Memory Layout on MT8189 are organised like this :-
+ * The Memory Layout on MT8196 are organised like this :-
  *
  * +--------------------------------------------------------------------------+
  * | Offset              | Region         |  Size                             |
@@ -183,12 +183,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since mt8186 doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address)	address
@@ -199,9 +193,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since mt8186 doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since mt8196 doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8196/lib/clk.c
+++ b/src/platform/mt8196/lib/clk.c
@@ -30,7 +30,7 @@ const struct freq_table platform_cpu_freq[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 void platform_clock_init(struct sof *sof)
 {

--- a/src/platform/mt8196/lib/dai.c
+++ b/src/platform/mt8196/lib/dai.c
@@ -24,7 +24,7 @@ static int afe_dai_handshake[MT8196_DAI_NUM] = {
 	AFE_HANDSHAKE(MT8196_DAI_AP_DMIC_CH34, MT8196_IRQ_15, MT8196_MEMIF_UL2),
 };
 
-static SHARED_DATA struct dai afe_dai[MT8196_DAI_NUM];
+static struct dai afe_dai[MT8196_DAI_NUM];
 
 const struct dai_type_info dti[] = {
 	{

--- a/src/platform/mt8196/lib/dma.c
+++ b/src/platform/mt8196/lib/dma.c
@@ -18,7 +18,7 @@
 
 extern const struct dma_ops dummy_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/mt8196/lib/memory.c
+++ b/src/platform/mt8196/lib/memory.c
@@ -12,30 +12,30 @@
 #include <rtos/sof.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -48,14 +48,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/mt8196/platform.c
+++ b/src/platform/mt8196/platform.c
@@ -120,7 +120,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = MTK_DSP_IRQ_OSTIMER32_C0,
 };

--- a/src/platform/mt8365/include/platform/lib/memory.h
+++ b/src/platform/mt8365/include/platform/lib/memory.h
@@ -198,12 +198,6 @@
 
 struct sof;
 
-/**
- * \brief Data shared between different cores.
- * Does nothing, since mt8195 doesn't support SMP.
- */
-#define SHARED_DATA
-
 void platform_init_memmap(struct sof *sof);
 
 #define uncache_to_cache(address) address
@@ -214,9 +208,8 @@ void platform_init_memmap(struct sof *sof);
 /**
  * \brief Function for keeping shared data synchronized.
  * It's used after usage of data shared by different cores.
- * Such data is either statically marked with SHARED_DATA
- * or dynamically allocated with SOF_MEM_FLAG_SHARED flag.
- * Does nothing, since mt8195 doesn't support SMP.
+ * Such data is dynamically allocated with SOF_MEM_FLAG_SHARED
+ * flag. Does nothing, since mt8195 doesn't support SMP.
  */
 
 static inline void *platform_rfree_prepare(void *ptr)

--- a/src/platform/mt8365/lib/clk.c
+++ b/src/platform/mt8365/lib/clk.c
@@ -41,7 +41,7 @@ const uint32_t cpu_freq_enc[] = {
 STATIC_ASSERT(ARRAY_SIZE(platform_cpu_freq) == NUM_CPU_FREQ,
 	      invalid_number_of_cpu_frequencies);
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static inline void clk_setl(uint32_t addr, uint32_t val)
 {

--- a/src/platform/mt8365/lib/dai.c
+++ b/src/platform/mt8365/lib/dai.c
@@ -37,7 +37,7 @@ static int afe_dai_handshake[MT8365_DAI_NUM] = {
 	AFE_HANDSHAKE(MT8365_AFE_IO_DMIC, MT8365_AFE_IRQ_4, MT8365_MEMIF_VUL),
 };
 
-static SHARED_DATA struct dai afe_dai[MT8365_DAI_NUM];
+static struct dai afe_dai[MT8365_DAI_NUM];
 
 const struct dai_type_info dti[] = {
 	{

--- a/src/platform/mt8365/lib/dma.c
+++ b/src/platform/mt8365/lib/dma.c
@@ -18,7 +18,7 @@
 
 extern const struct dma_ops dummy_dma_ops;
 
-static SHARED_DATA struct dma dma[PLATFORM_NUM_DMACS] = {
+static struct dma dma[PLATFORM_NUM_DMACS] = {
 {
 	.plat_data = {
 		.id		= DMA_ID_HOST,

--- a/src/platform/mt8365/lib/memory.c
+++ b/src/platform/mt8365/lib/memory.c
@@ -12,30 +12,30 @@
 #include <ipc/topology.h>
 
 /* Heap blocks for system runtime */
-static SHARED_DATA struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
-static SHARED_DATA struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
-static SHARED_DATA struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
+static struct block_hdr sys_rt_block64[HEAP_SYS_RT_COUNT64];
+static struct block_hdr sys_rt_block512[HEAP_SYS_RT_COUNT512];
+static struct block_hdr sys_rt_block1024[HEAP_SYS_RT_COUNT1024];
 
 /* Heap memory for system runtime */
-static SHARED_DATA struct block_map sys_rt_heap_map[] = {
+static struct block_map sys_rt_heap_map[] = {
 	BLOCK_DEF(64, HEAP_SYS_RT_COUNT64, sys_rt_block64),
 	BLOCK_DEF(512, HEAP_SYS_RT_COUNT512, sys_rt_block512),
 	BLOCK_DEF(1024, HEAP_SYS_RT_COUNT1024, sys_rt_block1024),
 };
 
 /* Heap blocks for modules */
-static SHARED_DATA struct block_hdr mod_block16[HEAP_RT_COUNT16];
-static SHARED_DATA struct block_hdr mod_block32[HEAP_RT_COUNT32];
-static SHARED_DATA struct block_hdr mod_block64[HEAP_RT_COUNT64];
-static SHARED_DATA struct block_hdr mod_block128[HEAP_RT_COUNT128];
-static SHARED_DATA struct block_hdr mod_block256[HEAP_RT_COUNT256];
-static SHARED_DATA struct block_hdr mod_block512[HEAP_RT_COUNT512];
-static SHARED_DATA struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
-static SHARED_DATA struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
-static SHARED_DATA struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
+static struct block_hdr mod_block16[HEAP_RT_COUNT16];
+static struct block_hdr mod_block32[HEAP_RT_COUNT32];
+static struct block_hdr mod_block64[HEAP_RT_COUNT64];
+static struct block_hdr mod_block128[HEAP_RT_COUNT128];
+static struct block_hdr mod_block256[HEAP_RT_COUNT256];
+static struct block_hdr mod_block512[HEAP_RT_COUNT512];
+static struct block_hdr mod_block1024[HEAP_RT_COUNT1024];
+static struct block_hdr mod_block2048[HEAP_RT_COUNT2048];
+static struct block_hdr mod_block4096[HEAP_RT_COUNT4096];
 
 /* Heap memory map for modules */
-static SHARED_DATA struct block_map rt_heap_map[] = {
+static struct block_map rt_heap_map[] = {
 	BLOCK_DEF(16, HEAP_RT_COUNT16, mod_block16),
 	BLOCK_DEF(32, HEAP_RT_COUNT32, mod_block32),
 	BLOCK_DEF(64, HEAP_RT_COUNT64, mod_block64),
@@ -48,14 +48,14 @@ static SHARED_DATA struct block_map rt_heap_map[] = {
 };
 
 /* Heap blocks for buffers */
-static SHARED_DATA struct block_hdr buf_block[HEAP_BUFFER_COUNT];
+static struct block_hdr buf_block[HEAP_BUFFER_COUNT];
 
 /* Heap memory map for buffers */
-static SHARED_DATA struct block_map buf_heap_map[] = {
+static struct block_map buf_heap_map[] = {
 	BLOCK_DEF(HEAP_BUFFER_BLOCK_SIZE, HEAP_BUFFER_COUNT, buf_block),
 };
 
-static SHARED_DATA struct mm memmap = {
+static struct mm memmap = {
 	.system[0] = {
 		.heap = HEAP_SYSTEM_BASE,
 		.size = HEAP_SYSTEM_SIZE,

--- a/src/platform/mt8365/platform.c
+++ b/src/platform/mt8365/platform.c
@@ -120,7 +120,7 @@ const struct ext_man_windows xsram_window
 	}
 };
 
-static SHARED_DATA struct timer timer_shared = {
+static struct timer timer_shared = {
 	.id = OSTIMER0,
 	.irq = SYSTICK_TIMER_IRQ,
 };

--- a/src/platform/mtk/include/platform/lib/memory.h
+++ b/src/platform/mtk/include/platform/lib/memory.h
@@ -23,8 +23,6 @@ BUILD_ASSERT(PLATFORM_DCACHE_ALIGN == XCHAL_DCACHE_LINESIZE);
 #define PLATFORM_HEAP_RUNTIME 1
 #define PLATFORM_HEAP_BUFFER 1
 
-#define SHARED_DATA /* no special section attribute needed */
-
 /* Mailbox window addresses for the rimage extended manifest.  The
  * struct is optimized out in generated code, it's just here to be a
  * little clearer than the pages of #defines used traditionally.

--- a/src/platform/posix/include/platform/lib/memory.h
+++ b/src/platform/posix/include/platform/lib/memory.h
@@ -47,6 +47,4 @@ extern uint32_t posix_trace[];
 
 #define host_to_local(addr) (addr)
 
-#define SHARED_DATA /**/
-
 #endif /* PLATFORM_HOST_PLATFORM_MEMORY_H */

--- a/src/platform/qemu_xtensa/include/platform/lib/memory.h
+++ b/src/platform/qemu_xtensa/include/platform/lib/memory.h
@@ -10,6 +10,5 @@
 
 #define PLATFORM_DCACHE_ALIGN sizeof(void *)
 #define HOST_PAGE_SIZE 4096
-#define SHARED_DATA
 
 #endif /* __PLATFORM_LIB_MEMORY_H__ */

--- a/src/samples/audio/detect_test.c
+++ b/src/samples/audio/detect_test.c
@@ -1107,7 +1107,7 @@ static const struct comp_driver comp_keyword = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_keyword_info = {
+static struct comp_driver_info comp_keyword_info = {
 	.drv = &comp_keyword,
 };
 

--- a/src/samples/audio/smart_amp_test_ipc3.c
+++ b/src/samples/audio/smart_amp_test_ipc3.c
@@ -559,7 +559,7 @@ static const struct comp_driver comp_smart_amp = {
 	},
 };
 
-static SHARED_DATA struct comp_driver_info comp_smart_amp_info = {
+static struct comp_driver_info comp_smart_amp_info = {
 	.drv = &comp_smart_amp,
 };
 

--- a/zephyr/lib/clk.c
+++ b/zephyr/lib/clk.c
@@ -13,7 +13,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>
 
-static SHARED_DATA struct clock_info platform_clocks_info[NUM_CLOCKS];
+static struct clock_info platform_clocks_info[NUM_CLOCKS];
 
 static int select_cpu_freq(int clock, int hz)
 {

--- a/zephyr/lib/dma.c
+++ b/zephyr/lib/dma.c
@@ -21,7 +21,7 @@
 #define DW_DMA_BUFFER_PERIOD_COUNT	0x4
 #define HDA_DMA_BUFFER_PERIOD_COUNT	4
 
-APP_SYSUSER_DATA SHARED_DATA struct sof_dma dma[] = {
+APP_SYSUSER_DATA struct sof_dma dma[] = {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(lpgpdma0), okay)
 {	/* Low Power GP DMAC 0 */
 	.plat_data = {


### PR DESCRIPTION
SHARED_DATA is only non-empty on non-Zephyr and non-unit-test builds of cAVS. At most that includes pure build tests or testbench, of which none need it either. Remove it globally.

only free grep and sed tokens have been used.