### PR TITLE
template module: fix llext build and enable for nvl as well

### DIFF
--- a/src/audio/template/llext/CMakeLists.txt
+++ b/src/audio/template/llext/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-sof_llext_build("template_comp"
+sof_llext_build("template"
 	SOURCES	../template.c
 		../template-generic.c
 		../template-ipc4.c

--- a/src/audio/template/llext/llext.toml.h
+++ b/src/audio/template/llext/llext.toml.h
@@ -1,6 +1,6 @@
 #include <tools/rimage/config/platform.toml>
 #define LOAD_TYPE "2"
-#include "../template_comp.toml"
+#include "../template.toml"
 
 [module]
 count = __COUNTER__

--- a/tools/rimage/config/nvl.toml.h
+++ b/tools/rimage/config/nvl.toml.h
@@ -142,6 +142,10 @@ index = __COUNTER__
 #include <audio/mfcc/mfcc.toml>
 #endif
 
+#if defined(CONFIG_COMP_TEMPLATE) || defined(LLEXT_FORCE_ALL_MODULAR)
+#include <audio/template/template.toml>
+#endif
+
 #if defined(CONFIG_COMP_SOUND_DOSE) || defined(LLEXT_FORCE_ALL_MODULAR)
 #include <audio/sound_dose/sound_dose.toml>
 #endif


### PR DESCRIPTION
The rename from template_comp left the llext build of the module failing.
Enable it for NVL as well.