### PR TITLE
ipc4: use fixed-width types in ipc4_audio_fromat

### DIFF
--- a/src/include/module/ipc4/base-config.h
+++ b/src/include/module/ipc4/base-config.h
@@ -115,14 +115,14 @@ enum ipc4_stream_type {
 };
 
 struct ipc4_audio_format {
-	enum ipc4_sampling_frequency sampling_frequency;
-	enum ipc4_bit_depth depth;
+	uint32_t sampling_frequency;	/* enum ipc4_sampling_frequency */
+	uint32_t depth;			/* enum ipc4_bit_depth */
 	uint32_t ch_map;
-	enum ipc4_channel_config ch_cfg;
+	uint32_t ch_cfg;		/* enum ipc4_channel_config */
 	uint32_t interleaving_style;
 	uint32_t channels_count : 8;
 	uint32_t valid_bit_depth : 8;
-	enum ipc4_sample_type s_type : 8;
+	uint32_t s_type : 8;		/* enum ipc4_sample_type */
 	uint32_t reserved : 8;
 } __attribute__((packed, aligned(4)));
 


### PR DESCRIPTION
struct ipc4_audio_format used bare enum members. On ARM EABI targets (e.g i.MX95 Cortex-M7) the toolchain defaults to -fshort-enums, which shrinks the enum-typed members. This makes host-supplied channels_count/valid_bit_depth be on the wrong offset.

Fix this by using fixed uint32_t type instead of enums. Note that the same struct on the Linux kernel side uses uint32_t so this patch also aligns ipc4_audio_format structs on FW side / Host side.

This patch is the first one in a series preparing IPC4 support for IMX platforms.