### PR TITLE
topology2: add an HDA topology with DP SRC on core 2

### DIFF
--- a/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
+++ b/tools/topology/topology2/cavs-src-mixin-mixout-hda.conf
@@ -7,6 +7,8 @@ Define {
 	DEEP_BUFFER_PIPELINE_SRC	'mixin.15.1'
 	DEEP_BUFFER_PIPELINE_SINK	'mixout.2.1'
 	DEEP_BUFFER_PCM_NAME		'Deepbuffer HDA Analog'
+	SRC_CORE			0
+	SRC_DOMAIN			"default"
 }
 
 # include deep buffer config if buffer size is in 1 - 1000 ms.
@@ -31,6 +33,7 @@ Object.Pipeline {
 	mixout-gain-dai-copier-playback [
 		{
 			index 2
+			core_id $SRC_CORE
 
 			Object.Widget.dai-copier.1 {
 				node_type $HDA_LINK_OUTPUT_CLASS
@@ -43,12 +46,16 @@ Object.Pipeline {
 					name '2 Main Playback Volume'
 				}
 			}
+			Object.Widget.pipeline.1 {
+				core $SRC_CORE
+			}
 		}
 	]
 
 	host-copier-gain-src-mixin-playback [
 		{
 			index 1
+			core_id $SRC_CORE
 
 			Object.Widget.host-copier.1 {
 				stream_name $ANALOG_PLAYBACK_PCM
@@ -56,12 +63,16 @@ Object.Pipeline {
 			}
 
 			Object.Widget.src.1 {
+				scheduler_domain "$SRC_DOMAIN"
 			}
 
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
 					name '1 2nd Playback Volume'
 				}
+			}
+			Object.Widget.pipeline.1 {
+				core $SRC_CORE
 			}
 		}
 	]

--- a/tools/topology/topology2/development/tplg-targets.cmake
+++ b/tools/topology/topology2/development/tplg-targets.cmake
@@ -270,6 +270,10 @@ GOOGLE_RTC_AEC_SUPPORT=1,DEEP_BUF_SPK=true,GOOGLE_AEC_DP_CORE_ID=2"
 # CAVS HDA topology with gain and SRC before mixin for HDA and passthrough pipelines for HDMI
 "sof-hda-generic\;sof-hda-src-generic\;HDA_CONFIG=src"
 
+# Like above but with SRC in DP mode on core 2
+"sof-hda-generic\;sof-hda-src-generic-dp\;HDA_CONFIG=src,DEEP_BUFFER_CORE=2,SRC_CORE=2,\
+SRC_DOMAIN=DP"
+
 # BT offload for tgl
 "cavs-nocodec-bt\;sof-nocodec-bt-tgl\;PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-nocodec-bt-tgl.bin,\
 PLATFORM=tgl"

--- a/tools/topology/topology2/platform/intel/deep-buffer.conf
+++ b/tools/topology/topology2/platform/intel/deep-buffer.conf
@@ -1,7 +1,11 @@
+Define {
+	DEEP_BUFFER_CORE	0
+}
 
 Object.Pipeline.deepbuffer-playback [
 	{
 		index $DEEP_BUFFER_PIPELINE_ID
+		core_id $DEEP_BUFFER_CORE
 
 		Object.Widget.host-copier.1 {
 			stream_name $DEEP_BUFFER_PCM_NAME
@@ -103,6 +107,9 @@ Object.Pipeline.deepbuffer-playback [
 					out_valid_bit_depth	32
 				}
 			]
+		}
+		Object.Widget.pipeline.1 {
+			core	$DEEP_BUFFER_CORE
 		}
 	}
 ]


### PR DESCRIPTION
Add a topology, similar to the existing HDA SRC one, but with SRC in DP scheduling domain and with it and connected pipelines running on core 2.