### PR TITLE
ci: add concurrency groups to all pr triggered workflows

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -11,6 +11,12 @@ on: [pull_request, workflow_dispatch, workflow_call]
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
 
   stub-build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,9 @@ on:
 permissions:
   contents: read
 
-# Specifies group name that stops previous workflows if the name matches
+# Group workflows together to cancel outdated runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,6 +17,12 @@ on: [pull_request, workflow_call, workflow_dispatch]
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -25,6 +25,12 @@ on:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
 
   simple-IPC-fuzz_sh:

--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -14,6 +14,12 @@ defaults:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,6 +34,12 @@ on:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
 
   doxygen:

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -17,6 +17,12 @@ on: [pull_request, workflow_dispatch, workflow_call]
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ubuntu-24.04

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -25,6 +25,12 @@ on:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
 
   # Basic build test

--- a/.github/workflows/sof-docs.yml
+++ b/.github/workflows/sof-docs.yml
@@ -20,6 +20,12 @@ on:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
 
   # This is unfortunately a mix of sof-docs/.github/ + pull-request.yml#doxygen

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -14,6 +14,12 @@ defaults:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   # As of sparse commit ce1a6720f69e / Sept 2022, the exit status of
   # sparse.c is an unusable mess and always zero in practice. Moreover

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -31,6 +31,12 @@ on:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -10,6 +10,12 @@ on: [pull_request, workflow_dispatch, workflow_call]
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   # This is not the same as building every ./build-tools.sh option.
   top-level_default_CMake_target_ALL:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,12 @@ on: [pull_request, workflow_dispatch, workflow_call]
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   cmocka_utests:
     runs-on: ubuntu-latest

--- a/.github/workflows/zephyr-shell.yml
+++ b/.github/workflows/zephyr-shell.yml
@@ -23,6 +23,12 @@ defaults:
 permissions:
   contents: read
 
+# Group workflows together to cancel outdated runs, do not cancel manual runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/zephyr-unit-tests.yml
+++ b/.github/workflows/zephyr-unit-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: "Unit tests"
+name: "Zephyr Unit tests"
 # yamllint disable-line rule:truthy
 on:
   pull_request:
@@ -9,9 +9,9 @@ on:
 permissions:
   contents: read
 
-# Specifies group name that stops previous workflows if the name matches
+# Group workflows together to cancel outdated runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -17,11 +17,12 @@ on:
         required: false
         default: 'mnfst'
 
-# Specifies group name that stops previous wokrflows if the name matches
+# Group workflows together to cancel outdated runs, do not cancel manual runs
 concurrency:
-  # eg. "Zephyr-pull_request-my_fork_branch_to_merge"
-  # eg. "Zephyr-push-refs/heads/my_branch_merging"
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  # eg. 'Zephyr-workflow_dispatch-62137'
+  # eg. 'Zephyr-pull_request-refs/pull/{pr_number}/merge'
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,9 +11,10 @@ on:
 
 permissions: {}
 
-# Specifies group name that stops previous workflows if the name matches
+# Group workflows together to cancel outdated runs, do not cancel manual runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  group: "${{ github.workflow }}-${{ github.event_name }}-\
+          ${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
#### This PR is a proposition to improve CI with cancelling many concurrent runs eg.
- Member pushes many commits one-by-one in one minute which spines as many full CI runs as commits pushed

#### However the manual and pushed runes will be ignored and not cancelled if run on top of each other

Add concurrency groups to all pr triggered workflows.

```${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}```

In case of PR trigger the above translates to: 
- ```'Zephyr-pull_request-refs/pull/{pr_number}/merge'```

In any other case it translates to:
- ```'Zephyr-workflow_dispatch-62137'```
- ```'Zephyr-push-62138'```

This allows to group and cancel only PR runs that can clog the CI and skips the dispatched or pushed workflows.