### PR TITLE
ipc4: honor pipeline pause requests

### DIFF
--- a/src/audio/module_adapter/module_adapter.c
+++ b/src/audio/module_adapter/module_adapter.c
@@ -1361,6 +1361,7 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 	if (dev->ipc_config.type == SOF_COMP_HOST || dev->ipc_config.type == SOF_COMP_DAI)
 		return interface->endpoint_ops->trigger(dev, cmd);
 
+#if CONFIG_IPC_MAJOR_3
 	/*
 	 * If the module doesn't support pause, keep it active along with the rest of the
 	 * downstream modules
@@ -1369,6 +1370,7 @@ int module_adapter_trigger(struct comp_dev *dev, int cmd)
 		dev->state = COMP_STATE_ACTIVE;
 		return PPL_STATUS_PATH_STOP;
 	}
+#endif
 
 	if (interface->trigger) {
 #if CONFIG_SOF_USERSPACE_APPLICATION

--- a/src/audio/mux/mux.c
+++ b/src/audio/mux/mux.c
@@ -112,7 +112,9 @@ static int mux_demux_common_init(struct processing_module *mod, enum sof_comp_ty
 	}
 
 	mod->verify_params_flags = BUFF_PARAMS_CHANNELS;
+#if CONFIG_IPC_MAJOR_3
 	mod->no_pause = true;
+#endif
 	cd->comp_type = type;
 	return 0;
 

--- a/src/include/module/module/base.h
+++ b/src/include/module/module/base.h
@@ -168,8 +168,10 @@ struct processing_module {
 	 */
 	bool dp_startup_delay;
 
+#if CONFIG_IPC_MAJOR_3
 	/* flag to indicate module does not pause */
 	bool no_pause;
+#endif
 
 	/*
 	 * flag to indicate that the sink buffer writeback should be skipped. It will be handled


### PR DESCRIPTION
The no_pause flag should not be used with IPC4. An IPC4 module must not silently ignore a pipeline pause request without sending an error response.

This fixes a crash during pipeline deletion when a pipeline containing a MUX ignored a prior PAUSE request and remained active during teardown.