### PR TITLE
boards: intel_adsp: enable coredump for all Intel targets

### DIFF
--- a/app/boards/intel_adsp/Kconfig.defconfig
+++ b/app/boards/intel_adsp/Kconfig.defconfig
@@ -174,6 +174,24 @@ config LOG_TIMESTAMP_64BIT
 config ZTEST
 	default SOF_BOOT_TEST_SUPPORTED && SOF_BOOT_TEST_ALLOWED
 
+# Zephyr / core dump
+# ----------------------------------------
+# Enable core dump on all Intel ADSP targets, not just the debug (-d) build,
+# so that firmware crashes can always be analysed offline.
+#
+# DEBUG_COREDUMP has no in-tree default, so configdefault is used to force it
+# on without weakening its "depends on ARCH_SUPPORTS_COREDUMP" dependency
+# (SOC_FAMILY_INTEL_ADSP selects ARCH_SUPPORTS_COREDUMP).
+#
+# The coredump backend and memory-dump amount are Kconfig 'choice' symbols
+# with an in-tree default. As noted above, this defconfig is sourced after the
+# Zephyr tree, so choice defaults cannot be overridden from here; the ADSP
+# memory-window backend and minimal dump are therefore selected in each Intel
+# board .conf file instead.
+
+configdefault DEBUG_COREDUMP
+	default y
+
 # Zephyr / debug slot manager
 # ----------------------------------------
 

--- a/app/boards/intel_adsp_ace15_mtpm.conf
+++ b/app/boards/intel_adsp_ace15_mtpm.conf
@@ -49,7 +49,9 @@ CONFIG_LIBRARY_BUILD_LIB=y
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
-CONFIG_DEBUG_COREDUMP=y
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
 CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
 CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/app/boards/intel_adsp_ace20_lnl.conf
+++ b/app/boards/intel_adsp_ace20_lnl.conf
@@ -34,6 +34,11 @@ CONFIG_LIBRARY_MANAGER=y
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
+CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_COUNTER=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_LLEXT=y

--- a/app/boards/intel_adsp_ace30_ptl.conf
+++ b/app/boards/intel_adsp_ace30_ptl.conf
@@ -37,6 +37,11 @@ CONFIG_LIBRARY_DEFAULT_MODULAR=y
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
+CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_COUNTER=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_LLEXT=y

--- a/app/boards/intel_adsp_ace30_wcl.conf
+++ b/app/boards/intel_adsp_ace30_wcl.conf
@@ -37,6 +37,11 @@ CONFIG_LIBRARY_DEFAULT_MODULAR=y
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
+CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y

--- a/app/boards/intel_adsp_ace40_nvl.conf
+++ b/app/boards/intel_adsp_ace40_nvl.conf
@@ -35,6 +35,11 @@ CONFIG_TRACE=n
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
+CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y

--- a/app/boards/intel_adsp_ace40_nvls.conf
+++ b/app/boards/intel_adsp_ace40_nvls.conf
@@ -35,6 +35,11 @@ CONFIG_TRACE=n
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
+CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
+CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192
 CONFIG_LLEXT=y
 CONFIG_LLEXT_STORAGE_WRITABLE=y

--- a/app/boards/intel_adsp_cavs25.conf
+++ b/app/boards/intel_adsp_cavs25.conf
@@ -30,7 +30,9 @@ CONFIG_LIBRARY_MANAGER=n
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
-CONFIG_DEBUG_COREDUMP=y
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
 CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
 CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192

--- a/app/boards/intel_adsp_cavs25_tgph.conf
+++ b/app/boards/intel_adsp_cavs25_tgph.conf
@@ -29,7 +29,9 @@ CONFIG_LIBRARY_MANAGER=n
 CONFIG_SOF_LOG_LEVEL_INF=y
 
 # Zephyr / OS features
-CONFIG_DEBUG_COREDUMP=y
+# note: CONFIG_DEBUG_COREDUMP is enabled for all Intel targets in
+# boards/intel_adsp/Kconfig.defconfig; only the backend and dump-amount
+# choices have to be selected per board.
 CONFIG_DEBUG_COREDUMP_BACKEND_INTEL_ADSP_MEM_WINDOW=y
 CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_MIN=y
 CONFIG_HEAP_MEM_POOL_SIZE=8192


### PR DESCRIPTION
CONFIG_DEBUG_COREDUMP was only enabled on a subset of Intel build targets (ace15_mtpm/mtl and the cavs25 boards), and otherwise only came in through the debug overlay (-d / app/debug_overlay.conf). This left normal builds of lnl, ptl, wcl, nvl and nvls without a core dump, so field crashes on those platforms could not be analysed offline.

Enable it once for every Intel ADSP target in the shared boards/intel_adsp/Kconfig.defconfig. DEBUG_COREDUMP has no in-tree default, so configdefault turns it on without weakening its "depends on ARCH_SUPPORTS_COREDUMP" dependency (SOC_FAMILY_INTEL_ADSP selects ARCH_SUPPORTS_COREDUMP).

The backend and memory-dump amount are Kconfig 'choice' symbols with an in-tree default. Because this SOF defconfig is sourced after the Zephyr tree (unlike upstream board Kconfig.defconfig files, which are sourced first), choice defaults cannot be overridden from it. The ADSP memory-window backend and minimal dump are therefore selected in each Intel board .conf instead; the boards that already enabled coredump keep those two lines and just drop the now-redundant CONFIG_DEBUG_COREDUMP=y.