### PR TITLE
app: overlays: ptl: increased LL user-space heap

### DIFF
--- a/app/overlays/ptl/ll_userspace_overlay.conf
+++ b/app/overlays/ptl/ll_userspace_overlay.conf
@@ -37,3 +37,9 @@ CONFIG_CROSS_CORE_STREAM=n
 CONFIG_INTEL_ADSP_MIC_PRIVACY=n
 CONFIG_XRUN_NOTIFICATIONS_ENABLE=n
 CONFIG_ZEPHYR_DP_SCHEDULER=n
+
+# Extend the shared LL user-space heap to 512KiB. This
+# is current maximum for PTL builds with virtual heap
+# enabled and uses the vmh allocation intended for KBP.
+# TODO: needs some better solution to allocate
+CONFIG_SOF_ZEPHYR_SYS_USER_HEAP_SIZE=0x80000


### PR DESCRIPTION
Bump the LL heap size of 0x8000 (512 KiB). This is current maximum with CONFIG_VIRTUAL_HEAP (enabled by default for PTL).

This is a shortterm solution to allow more test to be run with current build configuration. This is using the virtual heap pool intended for keyphrase buffer. Now this memory is instead used to run user-space pipelines.