### PR TITLE
topology2: kpb: add default KPB_BUFF_TIME_MS to common_definitions

### DIFF
--- a/tools/topology/topology2/include/common/common_definitions.conf
+++ b/tools/topology/topology2/include/common/common_definitions.conf
@@ -75,4 +75,6 @@ Define {
 	SDW_JACK_COMPR_AUDIO_FEATURE_CAPTURE	false # No compress audio features capture for jack
 	SDW_DMIC_AUDIO_FEATURE_CAPTURE		false # No audio features capture for microphone
 	SDW_DMIC_COMPR_AUDIO_FEATURE_CAPTURE	false # No compress audio features capture for microphone
+
+	KPB_BUFF_TIME_MS			"none" # Default for kpb: no blob, later override in Manifest
 }


### PR DESCRIPTION
Commit 6db02a1f(add topology-configurable history buffer) adds
IncludeByKey.KPB_BUFF_TIME_MS to kpb widget class but defined
KPB_BUFF_TIME_MS in dmic-wov-multi-manifest.conf

All topologies including kpb.conf fails to build with err
"No variable defined for KPB_BUFF_TIME_MS"

Add KPB_BUFF_TIME_MS "none" to common_definitions.conf that's
included before kpb.conf in all affected topologies.