### PR TITLE
ci: zephyr: fix Linux/Windows artifact comparison

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -511,7 +511,8 @@ jobs:
 
           set -x
           for windir in windows-build*; do
-            lindir=linux-"${windir#windows-}"
+            # Remove "windows-build" prefix and prepend "linux-build"
+            lindir="linux-build${windir#windows-build}"
             diff -qr "$lindir" "$windir" || : $((diffs++))
           done
           exit $diffs


### PR DESCRIPTION
Preserve the complete artifact suffix when deriving Linux artifact names from Windows artifact names.

Fixes #11148