### PR TITLE
west.yml: update zephyr to sep 01 

### DIFF
--- a/app/boards/intel_adsp_ace15_mtpm.overlay
+++ b/app/boards/intel_adsp_ace15_mtpm.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace20_lnl.overlay
+++ b/app/boards/intel_adsp_ace20_lnl.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};
+
+&cpu3 {
+	zephyr,deferred-start;
+};
+
+&cpu4 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace30_ptl.overlay
+++ b/app/boards/intel_adsp_ace30_ptl.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};
+
+&cpu3 {
+	zephyr,deferred-start;
+};
+
+&cpu4 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace30_ptl_sim.overlay
+++ b/app/boards/intel_adsp_ace30_ptl_sim.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};
+
+&cpu3 {
+	zephyr,deferred-start;
+};
+
+&cpu4 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace30_wcl.overlay
+++ b/app/boards/intel_adsp_ace30_wcl.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace30_wcl_sim.overlay
+++ b/app/boards/intel_adsp_ace30_wcl_sim.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace40_nvl.overlay
+++ b/app/boards/intel_adsp_ace40_nvl.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};
+
+&cpu3 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_ace40_nvls.overlay
+++ b/app/boards/intel_adsp_ace40_nvls.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_cavs25.overlay
+++ b/app/boards/intel_adsp_cavs25.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};
+
+&cpu2 {
+	zephyr,deferred-start;
+};
+
+&cpu3 {
+	zephyr,deferred-start;
+};

--- a/app/boards/intel_adsp_cavs25_tgph.overlay
+++ b/app/boards/intel_adsp_cavs25_tgph.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Secondary DSP cores are started on demand, not at kernel boot.
+ * Replaces the former CONFIG_SMP_BOOT_DELAY=y default.
+ */
+
+&cpu1 {
+	zephyr,deferred-start;
+};

--- a/west.yml
+++ b/west.yml
@@ -43,7 +43,7 @@ manifest:
 
     - name: zephyr
       repo-path: zephyr
-      revision: 133c2eb7d3cb4625f74cbeb3e8d99a705b21543d
+      revision: 256e764458c653104eed6fe7a0b211060fc187be
       remote: zephyrproject
 
       # Import some projects listed in zephyr/west.yml@revision


### PR DESCRIPTION
Zephyr update plus addition of DTS overlay for Intel multicore targets (to match these definitions getting dropped in Zephyr upstream).