### PR TITLE
scripts: uuid-registry: only write header when content changes

### DIFF
--- a/scripts/gen-uuid-reg.py
+++ b/scripts/gen-uuid-reg.py
@@ -55,11 +55,24 @@ def main():
             emit_uuid_rec(uu, sym)
             print(f"Added UUID {uu} with symbol {sym}")
 
+    new_content = header + "".join(l + "\n" for l in out_recs) \
+        + "#endif /* _UUID_REGISTRY_H */\n"
+
+    # Write only when the content actually changed.  This header is
+    # force-included (-imacros) into nearly every SOF translation unit,
+    # so rewriting it unconditionally would bump its mtime on every
+    # build and make Ninja recompile the whole tree even when the UUID
+    # registry is unchanged.  Same idea as sof_check_version_h() in
+    # scripts/cmake/version.cmake for sof_versions.h.
+    try:
+        with open(sys.argv[2]) as f:
+            if f.read() == new_content:
+                return
+    except FileNotFoundError:
+        pass
+
     with open(sys.argv[2], "w") as f:
-        f.write(header)
-        for l in out_recs:
-            f.write(l + "\n")
-        f.write("#endif /* _UUID_REGISTRY_H */\n")
+        f.write(new_content)
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
Every invocation of gen-uuid-reg.py rewrites uuid-registry.h with open(..., "w"), updating the file's mtime even when the generated content was byte-for-byte identical. The uuid-registry.cmake custom command that runs this script executes on every build (it is wired into zephyr_interface via the uuid_reg_h target), and the header is force-included with -imacros into nearly every SOF translation unit. As a result, incremental builds in practise rebuild all objects even if no code is changed.

Fix incremental builds by only updating uuid-registery if the content changes.