### PR TITLE
topology2: uaol-generic: Tag DAI-copier formats as MSB_INTEGER

### DIFF
--- a/tools/topology/topology2/include/formats/uaol_input_audio_formats_msb.conf
+++ b/tools/topology/topology2/include/formats/uaol_input_audio_formats_msb.conf
@@ -1,0 +1,543 @@
+				# Every format the offloaded USB endpoint can carry: S16_LE, S24_LE and
+				# S32_LE, 1 to 8 channels and every standard rate from 8 to 192 kHz.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				#
+				# Same table as uaol_input_audio_formats.conf, but tagged
+				# SAMPLE_TYPE_MSB_INTEGER for the DAI copier's wire-facing side,
+				# matching the convention every other link type (HDA, SoundWire,
+				# SSP, DMIC) uses so the copier right-shifts 24-bit samples back
+				# out of the link's left-justified container.
+				#
+				# 32 valid bits stay LSB: the alignment is a no-op when every bit
+				# is valid, and the driver only honours the tag at 8 and 32 bits,
+				# so an MSB tag there would never match an S32_LE PCM.
+				num_input_audio_formats 315
+				CombineArrays.Object.Base.input_audio_format [
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 1 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						in_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 2 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						in_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 3 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 4 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 5 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 6 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 16 ]
+						in_valid_bit_depth [ 16 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 24 ]
+						in_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						in_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						in_bit_depth [ 32 ]
+						in_valid_bit_depth [ 32 ]
+						in_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						in_channels [ 8 ]
+						in_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						in_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/include/formats/uaol_output_audio_formats_msb.conf
+++ b/tools/topology/topology2/include/formats/uaol_output_audio_formats_msb.conf
@@ -1,0 +1,539 @@
+				# Every format the offloaded USB endpoint can carry: S16_LE, S24_LE and
+				# S32_LE, 1 to 8 channels and every standard rate from 8 to 192 kHz.
+				#
+				# 7 channels is left out, it has no channel config and no channel map in
+				# common_definitions.conf.
+				#
+				# Same table as uaol_output_audio_formats.conf, but tagged
+				# SAMPLE_TYPE_MSB_INTEGER for the DAI copier's wire-facing side,
+				# matching the convention every other link type (HDA, SoundWire,
+				# SSP, DMIC) uses so the copier left-justifies 24-bit samples
+				# before handing them to the link.
+				num_output_audio_formats 315
+				CombineArrays.Object.Base.output_audio_format [
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 1 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_MONO ]
+						out_ch_map [ $CHANNEL_MAP_MONO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 2 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_STEREO ]
+						out_ch_map [ $CHANNEL_MAP_STEREO ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 3 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_2_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_2_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 4 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_3_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_3_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 5 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_0 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_0 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 6 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_5_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_5_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 16 ]
+						out_valid_bit_depth [ 16 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 24 ]
+						out_sample_type [ $SAMPLE_TYPE_MSB_INTEGER ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+					{
+						out_rate [
+							8000
+							11025
+							12000
+							16000
+							22050
+							24000
+							32000
+							44100
+							48000
+							64000
+							88200
+							96000
+							128000
+							176400
+							192000
+						]
+						out_bit_depth [ 32 ]
+						out_valid_bit_depth [ 32 ]
+						out_sample_type [ $SAMPLE_TYPE_LSB_INTEGER ]
+						out_channels [ 8 ]
+						out_ch_cfg [ $CHANNEL_CONFIG_7_POINT_1 ]
+						out_ch_map [ $CHANNEL_MAP_7_POINT_1 ]
+					}
+				]

--- a/tools/topology/topology2/platform/intel/uaol-generic.conf
+++ b/tools/topology/topology2/platform/intel/uaol-generic.conf
@@ -89,7 +89,7 @@ Object.Pipeline {
 				dai_type "UAOL"
 				copier_type "UAOL"
 				<include/formats/uaol_input_audio_formats_s32.conf>
-				<include/formats/uaol_output_audio_formats.conf>
+				<include/formats/uaol_output_audio_formats_msb.conf>
 			}
 			Object.Widget.gain.1 {
 				Object.Control.mixer.1 {
@@ -125,7 +125,7 @@ Object.Pipeline {
 				type dai_out
 				copier_type "UAOL"
 				num_output_pins 1
-				<include/formats/uaol_input_audio_formats.conf>
+				<include/formats/uaol_input_audio_formats_msb.conf>
 				<include/formats/uaol_output_audio_formats_s32.conf>
 			}
 


### PR DESCRIPTION
The UAOL DAI copier's wire-facing audio formats never set out_sample_type/in_sample_type, so they defaulted to SAMPLE_TYPE_LSB_INTEGER. Every other link type (HDA, SoundWire, SSP, DMIC) tags its DAI copier side SAMPLE_TYPE_MSB_INTEGER instead, which is what makes the copier left-justify 24-bit samples before handing them to the link. Without it, 24-bit UAOL audio played back right shifted by a byte: quiet and missing the top bits of resolution.

Add uaol_output_audio_formats_msb.conf and
uaol_input_audio_formats_msb.conf, copies of the existing tables with SAMPLE_TYPE_MSB_INTEGER added, and point only the two DAI-copier widgets (playback output, capture input) at them. The host-copier widgets keep the original tables, since their host-facing side has to stay in the standard LSB-aligned ALSA convention.