### PR TITLE
ipc: userspace: don't fault when removing an already-sent IPC message

### DIFF
--- a/src/ipc/ipc-common.c
+++ b/src/ipc/ipc-common.c
@@ -356,6 +356,15 @@ void z_vrfy_ipc_msg_list_remove(struct ipc_msg *msg)
 	bool found = false;
 
 	K_OOPS(K_SYSCALL_MEMORY_WRITE(msg, sizeof(*msg)));
+
+	/*
+	 * special case: empty list was passed. we can't trust where
+	 * list->prev points to, so do not pass to
+	 * z_impl_ipc_msg_list_remove(), but handle here
+	 */
+	if (list_is_empty(&msg->list))
+		return;
+
 	list_for_item_safe(mlist, _mlist, &ipc->msg_list)  {
 		if (mlist == &msg->list) {
 			found = true;


### PR DESCRIPTION
z_vrfy_ipc_msg_list_remove() rejected any message that was not currently on ipc->msg_list by failing K_SYSCALL_VERIFY(found), which turns into a kernel oops. But ipc_msg_list_remove() is called from ipc_msg_free() / mod_ipc_msg_free() to drop a message that may or may not still be queued. The common case at stream stop / pipeline delete is freeing a message that has already been sent and dequeued: its list node is self-linked (empty), so it is not "found" and the verifier oopses the LL user thread with:

  <err> os.z_vrfy_ipc_msg_list_remove: syscall z_vrfy_ipc_msg_list_remove
  ... failed check: found
  <err> os.z_fatal_error: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0

Relax the checks to avoid this scenario. If the msg->list is empty, it is safe to call z_impl_ipc_msg_list_remove(). The msg->list pointer itself is already verified with K_SYSCALL_MEMORY_WRITE().