### PR TITLE
ci: use the newest Zephyr SDK version 1.0.1

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -303,12 +303,12 @@ jobs:
 
       # Keep this SDK version identical to the one in
       # sof/zephyr/docker-run.sh
-      - name: Cache Zephyr SDK 1.0.0
+      - name: Cache Zephyr SDK 1.0.1
         id: cache-zephyr-sdk
         uses: actions/cache@v4
         with:
-          path: zephyr-sdk-1.0.0_windows-x86_64_gnu.7z
-          key: ${{ runner.os }}-cache-zephyr-sdk-1-0-0
+          path: zephyr-sdk-1.0.1_windows-x86_64_gnu.7z
+          key: ${{ runner.os }}-cache-zephyr-sdk-1-0-1
 
       # Wget is needed by Zephyr SDK setup.cmd installation script
       - name: Download wget
@@ -316,11 +316,11 @@ jobs:
         run: |
           curl -L -O http://downloads.sourceforge.net/gnuwin32/wget-1.11.4-1-bin.zip
 
-      - name: Download Zephyr SDK 1.0.0
+      - name: Download Zephyr SDK 1.0.1
         if: ${{ steps.cache-zephyr-sdk.outputs.cache-hit != 'true' }}
         run: |  # yamllint disable-line rule:line-length
           curl -L -O `
-          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.0/zephyr-sdk-1.0.0_windows-x86_64_gnu.7z
+          https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v1.0.1/zephyr-sdk-1.0.1_windows-x86_64_gnu.7z
 
       # Unzips every .zip package to directory matching its name without extension
       - name: Unzip downloaded packages
@@ -343,7 +343,7 @@ jobs:
       # setup.cmd may not be called in from msys shell as it does not parse
       # forward slash script input arguments correctly.
       - name: Install Zephyr SDK
-        run: zephyr-sdk-1.0.0_windows-x86_64_gnu/zephyr-sdk-1.0.0/setup.cmd /t all /h /c
+        run: zephyr-sdk-1.0.1_windows-x86_64_gnu/zephyr-sdk-1.0.1/setup.cmd /t all /h /c
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Switch to Zephyr SDK 1.0.1 to keep in sync with zephyr/docker-run.sh