### PR TITLE
zephyr: vregion: stop logging spurious "read access denied" on free p…

### DIFF
--- a/zephyr/lib/vregion.c
+++ b/zephyr/lib/vregion.c
@@ -554,8 +554,15 @@ bool vregion_verify(struct vregion *vr)
 	if (!vr)
 		return false;
 
-	/* vregion instances must not be accessible to the userspace. */
-	K_OOPS(!K_SYSCALL_MEMORY_READ(vr, sizeof(*vr)));
+	/*
+	 * vregion instances must not be accessible to the userspace.
+	 *
+	 * Don't use K_SYSCALL_MEMORY_READ() here: it logs an "access denied"
+	 * error whenever the region is inaccessible, which is exactly the
+	 * expected (good) case for a kernel-only vregion. Omit false
+	 * error messages by using arch_buffer_validate() directly.
+	 */
+	K_OOPS(arch_buffer_validate((void *)vr, sizeof(*vr), 0) == 0);
 
 	size_t vr_size = 0;
 	uintptr_t vr_start;


### PR DESCRIPTION
…aths

vregion_verify() asserts that the vregion metadata object is NOT accessible to the userspace context. It did this with

	K_OOPS(!K_SYSCALL_MEMORY_READ(vr, sizeof(*vr)));

but K_SYSCALL_MEMORY_READ() emits an "os.vregion_verify: ... Memory region <addr> (size 88) read access denied" error via LOG_ERR precisely when the region is inaccessible - i.e. in the expected, correct case for a kernel-only vregion.

Probe the mapping directly with arch_buffer_validate(), which performs the same check without logging, and oops only if the userspace context can actually read the metadata. No functional change to the security check; only the false-positive error logging is removed.