### PR TITLE
github: workflows: updating checkout and upload actions

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get -y install
             clang llvm ninja-build device-tree-compiler python3-pyelftools
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: ./workspace/sof
           filter: 'tree:0'

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -27,7 +27,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           filter: 'tree:0'
 

--- a/.github/workflows/ipc_fuzzer.yml
+++ b/.github/workflows/ipc_fuzzer.yml
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get -y install
             clang llvm ninja-build device-tree-compiler python3-pyelftools
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: ./workspace/sof
           filter: 'tree:0'
@@ -103,7 +103,7 @@ jobs:
             -j"$(nproc)" -d "$RUNNER_TEMP/ipc${{ matrix.IPC }}.dict"
 
       - name: Upload stdout
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
           name: ${{ matrix.IPC }} logs

--- a/.github/workflows/llext.yml
+++ b/.github/workflows/llext.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
           fetch-depth: 0  # fix git describe

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-26.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           filter: 'tree:0'
 

--- a/.github/workflows/repro-build.yml
+++ b/.github/workflows/repro-build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-26.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with: {fetch-depth: 0, submodules: recursive, filter: 'tree:0'}
 
       - name: docker pull

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -43,7 +43,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with: {submodules: recursive, fetch-depth: 0, filter: 'tree:0'}
 
       - run: cmake -B build-rimage/ -S tools/rimage/ -DCMAKE_C_FLAGS="${_CFLGS}"
@@ -57,7 +57,7 @@ jobs:
   cppcheck:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with: {submodules: recursive, fetch-depth: 0, filter: 'tree:0'}
 
       - name: apt install cppcheck

--- a/.github/workflows/sof-docs.yml
+++ b/.github/workflows/sof-docs.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-26.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           filter: 'tree:0'
 

--- a/.github/workflows/sparse-zephyr.yml
+++ b/.github/workflows/sparse-zephyr.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: git clone sparse analyzer
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: thesofproject/sparse
           fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
           make -j4  # HAVE_LLVM=no
 
       - name: git clone sof
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
           fetch-depth: 0  # fix git describe

--- a/.github/workflows/testbench.yml
+++ b/.github/workflows/testbench.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout SOF repository (PR source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -21,7 +21,7 @@ jobs:
   top-level_default_CMake_target_ALL:
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           filter: 'tree:0'
           path: sof
@@ -92,7 +92,7 @@ jobs:
     # https://github.com/openvinotoolkit/openvino/issues/37509
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with: {filter: 'tree:0'}
 
       - name: apt install

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
   cmocka_utests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with: {fetch-depth: 2, filter: 'tree:0'}
 
       - name: build and run all defconfigs

--- a/.github/workflows/zephyr-shell.yml
+++ b/.github/workflows/zephyr-shell.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
           fetch-depth: 0  # fix git describe

--- a/.github/workflows/zephyr-unit-tests.yml
+++ b/.github/workflows/zephyr-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install gcc-multilib g++-multilib
 
       - name: Checkout SOF repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: ./workspace/sof
           fetch-depth: 2

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -37,7 +37,7 @@ jobs:
     container:
       image: thesofproject/zephyr-lite:v0.29.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
           filter: 'tree:0'
@@ -88,7 +88,7 @@ jobs:
       image: thesofproject/zephyr-lite:v0.29.3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           path: sof
           filter: 'tree:0'
@@ -157,7 +157,7 @@ jobs:
             IPC_platforms: wcl imx95
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         # Download a full clone to fix `git describe`, sof_version.h and
         # build reproducibility. sof.git is still small.
         # This is especially useful for daily builds (but not just).
@@ -236,7 +236,7 @@ jobs:
             ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: linux-build ${{ matrix.build_opts }} ${{ matrix.IPC_platforms }}
@@ -278,7 +278,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           filter: 'tree:0'
@@ -289,14 +289,14 @@ jobs:
       # or delete cache manually in Github Actions tab
       - name: Cache unzip
         id: cache-unzip
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: unzip-5.51-1-bin.zip
           key: ${{ runner.os }}-cache-unzip-5-51-1
 
       - name: Cache wget
         id: cache-wget
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: wget-1.11.4-1-bin.zip
           key: ${{ runner.os }}-cache-wget-1-11-4-1
@@ -305,7 +305,7 @@ jobs:
       # sof/zephyr/docker-run.sh
       - name: Cache Zephyr SDK 1.0.1
         id: cache-zephyr-sdk
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: zephyr-sdk-1.0.1_windows-x86_64_gnu.7z
           key: ${{ runner.os }}-cache-zephyr-sdk-1-0-1
@@ -445,7 +445,7 @@ jobs:
           ${{ matrix.build_opts }} ${{ matrix.platforms }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: windows-build ${{ matrix.build_opts }} ${{ matrix.platforms }}
@@ -465,7 +465,7 @@ jobs:
     needs: [build-linux, build-windows]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         # we need only one script but it's simpler to get the (last
         # revision of the) whole repo and it takes seconds.
         with:


### PR DESCRIPTION
These actions use Node.js 20. This version is now deprecated and GitHub is emitting warnings in action workflow logs.

Updated to use version SHA instead of tags. Tags can be changed and the current trend is to pin to a specific version.