### PR TITLE
audio: introduce and use source_cir_buf_wrap for const source reads

### DIFF
--- a/src/audio/asrc/asrc.c
+++ b/src/audio/asrc/asrc.c
@@ -70,7 +70,7 @@ static void src_copy_s32(struct processing_module *mod,
 
 		/* Update and check both source and destination for wrap */
 		n -= n_copy;
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 	}
 
 	/* Run ASRC */
@@ -144,7 +144,7 @@ static void src_copy_s16(struct processing_module *mod,
 		n -= n_copy;
 		src += n_copy;
 		buf += n_copy;
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 	}
 
 	/* Run ASRC */

--- a/src/audio/component.c
+++ b/src/audio/component.c
@@ -280,7 +280,7 @@ void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, vo
 	ae_int16x4 in_sample1, in_sample2;
 	ae_valignx2 inu;
 	ae_valignx2 outu = AE_ZALIGN128();
-	const ae_int16x8 *in = cir_buf_wrap(src, src_addr, src_end);
+	const ae_int16x8 *in = source_cir_buf_wrap(src, src_addr, src_end);
 	ae_int16x8 *out = (ae_int16x8 *)dst;
 
 	while (bytes) {
@@ -307,7 +307,7 @@ void cir_buf_copy(const void *src, const void *src_addr, const void *src_end, vo
 		}
 
 		bytes -= bytes_copied;
-		in = cir_buf_wrap(in, src_addr, src_end);
+		in = source_cir_buf_wrap(in, src_addr, src_end);
 		out = cir_buf_wrap(out, dst_addr, dst_end);
 	}
 }

--- a/src/audio/dcblock/dcblock_generic.c
+++ b/src/audio/dcblock/dcblock_generic.c
@@ -74,7 +74,7 @@ static int dcblock_s16_default(struct comp_data *cd,
 			if (++ch == nch)
 				ch = 0;
 		}
-		x = cir_buf_wrap((void *)x, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y, sink->buf_start, sink->buf_end);
 		remaining_samples -= samples_without_wrap;
 	}
@@ -121,7 +121,7 @@ static int dcblock_s24_default(struct comp_data *cd,
 			if (++ch == nch)
 				ch = 0;
 		}
-		x = cir_buf_wrap((void *)x, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y, sink->buf_start, sink->buf_end);
 		remaining_samples -= samples_without_wrap;
 	}
@@ -166,7 +166,7 @@ static int dcblock_s32_default(struct comp_data *cd,
 			if (++ch == nch)
 				ch = 0;
 		}
-		x = cir_buf_wrap((void *)x, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y, sink->buf_start, sink->buf_end);
 		remaining_samples -= samples_without_wrap;
 	}

--- a/src/audio/dcblock/dcblock_hifi3.c
+++ b/src/audio/dcblock/dcblock_hifi3.c
@@ -31,7 +31,7 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Set source as circular buffer 0 for the strided per-channel reads */
-static inline void dcblock_set_circular(void *src_begin, void *src_end)
+static inline void dcblock_set_circular(const void *src_begin, const void *src_end)
 {
 	AE_SETCBEGIN0(src_begin);
 	AE_SETCEND0(src_end);
@@ -43,13 +43,14 @@ static int dcblock_s16_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int16 *src = (ae_int16 *)source->ptr;
+	const ae_int16 *src = source->ptr;
 	ae_int16 *dst = (ae_int16 *)sink->ptr;
-	ae_int16 *x_start = (ae_int16 *)source->buf_start;
+	const ae_int16 *x_start = source->buf_start;
 	ae_int16 *y_start = (ae_int16 *)sink->buf_start;
-	ae_int16 *x_end = (ae_int16 *)source->buf_end;
+	const ae_int16 *x_end = source->buf_end;
 	ae_int16 *y_end = (ae_int16 *)sink->buf_end;
-	ae_int16 *in, *out;
+	const ae_int16 *in;
+	ae_int16 *out;
 	ae_int32x2 R, state_x, state_y, sample;
 	ae_int16x4 in_sample, out_sample;
 	int x_size = x_end - x_start;
@@ -106,13 +107,14 @@ static int dcblock_s24_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int32 *src = (ae_int32 *)source->ptr;
+	const ae_int32 *src = source->ptr;
 	ae_int32 *dst = (ae_int32 *)sink->ptr;
-	ae_int32 *x_start = (ae_int32 *)source->buf_start;
+	const ae_int32 *x_start = source->buf_start;
 	ae_int32 *y_start = (ae_int32 *)sink->buf_start;
-	ae_int32 *x_end = (ae_int32 *)source->buf_end;
+	const ae_int32 *x_end = source->buf_end;
 	ae_int32 *y_end = (ae_int32 *)sink->buf_end;
-	ae_int32 *in, *out;
+	const ae_int32 *in;
+	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample, out_sample;
 	int x_size = x_end - x_start;
@@ -165,13 +167,14 @@ static int dcblock_s32_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int32 *src = (ae_int32 *)source->ptr;
+	const ae_int32 *src = source->ptr;
 	ae_int32 *dst = (ae_int32 *)sink->ptr;
-	ae_int32 *x_start = (ae_int32 *)source->buf_start;
+	const ae_int32 *x_start = source->buf_start;
 	ae_int32 *y_start = (ae_int32 *)sink->buf_start;
-	ae_int32 *x_end = (ae_int32 *)source->buf_end;
+	const ae_int32 *x_end = source->buf_end;
 	ae_int32 *y_end = (ae_int32 *)sink->buf_end;
-	ae_int32 *in, *out;
+	const ae_int32 *in;
+	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample;
 	int x_size = x_end - x_start;

--- a/src/audio/dcblock/dcblock_hifi4.c
+++ b/src/audio/dcblock/dcblock_hifi4.c
@@ -31,7 +31,7 @@ static inline ae_int32x2  dcblock_cal(ae_int32x2 R, ae_int32x2 state_x, ae_int32
 }
 
 /* Set source as circular buffer 0 and sink as circular buffer 1 */
-static inline void dcblock_set_circular(void *src_begin, void *src_end,
+static inline void dcblock_set_circular(const void *src_begin, const void *src_end,
 					void *sink_begin, void *sink_end)
 {
 	AE_SETCBEGIN0(src_begin);
@@ -46,13 +46,14 @@ static int dcblock_s16_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int16 *src = (ae_int16 *)source->ptr;
+	const ae_int16 *src = source->ptr;
 	ae_int16 *dst = (ae_int16 *)sink->ptr;
-	ae_int16 *x_start = (ae_int16 *)source->buf_start;
+	const ae_int16 *x_start = source->buf_start;
 	ae_int16 *y_start = (ae_int16 *)sink->buf_start;
-	ae_int16 *x_end = (ae_int16 *)source->buf_end;
+	const ae_int16 *x_end = source->buf_end;
 	ae_int16 *y_end = (ae_int16 *)sink->buf_end;
-	ae_int16 *in, *out;
+	const ae_int16 *in;
+	ae_int16 *out;
 	ae_int32x2 R, state_x, state_y, sample;
 	ae_int16x4 in_sample, out_sample;
 	int nch = cd->channels;
@@ -91,13 +92,14 @@ static int dcblock_s24_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int32 *src = (ae_int32 *)source->ptr;
+	const ae_int32 *src = source->ptr;
 	ae_int32 *dst = (ae_int32 *)sink->ptr;
-	ae_int32 *x_start = (ae_int32 *)source->buf_start;
+	const ae_int32 *x_start = source->buf_start;
 	ae_int32 *y_start = (ae_int32 *)sink->buf_start;
-	ae_int32 *x_end = (ae_int32 *)source->buf_end;
+	const ae_int32 *x_end = source->buf_end;
 	ae_int32 *y_end = (ae_int32 *)sink->buf_end;
-	ae_int32 *in, *out;
+	const ae_int32 *in;
+	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample, out_sample;
 	int nch = cd->channels;
@@ -136,13 +138,14 @@ static int dcblock_s32_default(struct comp_data *cd,
 			       struct cir_buf_sink *sink,
 			       uint32_t frames)
 {
-	ae_int32 *src = (ae_int32 *)source->ptr;
+	const ae_int32 *src = source->ptr;
 	ae_int32 *dst = (ae_int32 *)sink->ptr;
-	ae_int32 *x_start = (ae_int32 *)source->buf_start;
+	const ae_int32 *x_start = source->buf_start;
 	ae_int32 *y_start = (ae_int32 *)sink->buf_start;
-	ae_int32 *x_end = (ae_int32 *)source->buf_end;
+	const ae_int32 *x_end = source->buf_end;
 	ae_int32 *y_end = (ae_int32 *)sink->buf_end;
-	ae_int32 *in, *out;
+	const ae_int32 *in;
+	ae_int32 *out;
 	ae_int32x2 R, state_x, state_y;
 	ae_int32x2 in_sample;
 	int nch = cd->channels;

--- a/src/audio/pcm_converter/pcm_converter.c
+++ b/src/audio/pcm_converter/pcm_converter.c
@@ -39,8 +39,8 @@ int pcm_convert_as_linear(const struct cir_buf_source *source, size_t s_size_in,
 		converter(r_ptr, w_ptr, chunk);
 
 		/* move pointers */
-		r_ptr = cir_buf_wrap(r_ptr + chunk * s_size_in,
-				     source->buf_start, source->buf_end);
+		r_ptr = source_cir_buf_wrap(r_ptr + chunk * s_size_in,
+					    source->buf_start, source->buf_end);
 		w_ptr = cir_buf_wrap(w_ptr + chunk * s_size_out,
 				     sink->buf_start, sink->buf_end);
 		i += chunk;

--- a/src/audio/pcm_converter/pcm_converter_generic.c
+++ b/src/audio/pcm_converter/pcm_converter_generic.c
@@ -46,7 +46,7 @@ static int pcm_convert_u8_to_s32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
@@ -73,7 +73,7 @@ static int pcm_convert_s32_to_u8(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -102,7 +102,7 @@ static int pcm_convert_alaw_to_s32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
@@ -129,7 +129,7 @@ static int pcm_convert_s32_to_alaw(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -158,7 +158,7 @@ static int pcm_convert_mulaw_to_s32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_U8_SAMPLES;
@@ -185,7 +185,7 @@ static int pcm_convert_s32_to_mulaw(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -215,7 +215,7 @@ static int pcm_convert_s16_to_s24(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
@@ -242,7 +242,7 @@ static int pcm_convert_s24_to_s16(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -273,7 +273,7 @@ static int pcm_convert_s16_to_s32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
@@ -300,7 +300,7 @@ static int pcm_convert_s32_to_s16(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -331,7 +331,7 @@ static int pcm_convert_s24_to_s32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -358,7 +358,7 @@ static int pcm_convert_s32_to_s24(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -385,7 +385,7 @@ static int pcm_convert_s32_to_s24_be(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_samples_without_wrap_s32(src, source->buf_end);
@@ -723,7 +723,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S16_SAMPLES;
@@ -750,7 +750,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -778,7 +778,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -805,7 +805,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -833,7 +833,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -860,7 +860,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -889,7 +889,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) / 3;
@@ -917,7 +917,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct cir_buf_source *source,
 	size_t nmax, i, n;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;
@@ -950,7 +950,7 @@ static int pcm_convert_s24_c32_to_s24_c24_link_gtw(const struct cir_buf_source *
 	size_t nmax, i = 0, n = 0;
 
 	for (processed = 0; processed < samples; processed += n) {
-		src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+		src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 		dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 		n = samples - processed;
 		nmax = cir_buf_bytes_without_wrap(src, source->buf_end) >> BYTES_TO_S32_SAMPLES;

--- a/src/audio/pcm_converter/pcm_converter_hifi3.c
+++ b/src/audio/pcm_converter/pcm_converter_hifi3.c
@@ -77,7 +77,7 @@ static int pcm_convert_s16_to_s24(const struct cir_buf_source *source,
 				    sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -158,7 +158,7 @@ static int pcm_convert_s24_to_s16(const struct cir_buf_source *source,
 				    sizeof(ae_int16));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
@@ -215,7 +215,7 @@ static int pcm_convert_s16_to_s32(const struct cir_buf_source *source,
 			AE_S32_L_IP(AE_CVT32X2F16_32(sample), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
@@ -273,7 +273,7 @@ static int pcm_convert_s32_to_s16(const struct cir_buf_source *source,
 				    sizeof(ae_int16));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -324,7 +324,7 @@ static int pcm_convert_s24_to_s32(const struct cir_buf_source *source,
 				    sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -388,7 +388,7 @@ static int pcm_convert_s32_to_s24(const struct cir_buf_source *source,
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -433,7 +433,7 @@ static int pcm_convert_s32_to_s24_be(const struct cir_buf_source *source,
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -824,7 +824,7 @@ static int pcm_convert_s16_c16_to_s16_c32(const struct cir_buf_source *source,
 			AE_S32_L_IP(AE_SEXT32X2D16_32(sample), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	return samples;
@@ -877,7 +877,7 @@ static int pcm_convert_s16_c32_to_s16_c16(const struct cir_buf_source *source,
 			AE_S16_0_IP(AE_MOVAD16_0(sample), (ae_int16 *)out, sizeof(ae_int16));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -919,7 +919,7 @@ static int pcm_convert_s16_c32_to_s32_c32(const struct cir_buf_source *source,
 			AE_S32_L_IP(AE_SLAI32(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -959,7 +959,7 @@ static int pcm_convert_s32_c32_to_s16_c32(const struct cir_buf_source *source,
 			AE_S32_L_IP(AE_SRAA32RS(sample, 16), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -1001,7 +1001,7 @@ static int pcm_convert_s16_c32_to_s24_c32(const struct cir_buf_source *source,
 			AE_S32_L_IP(AE_SLAI32(sample, 8), (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -1055,7 +1055,7 @@ static int pcm_convert_s24_c32_to_s16_c32(const struct cir_buf_source *source,
 			AE_S32_L_IP(sample, (ae_int32 *)out, sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -1101,7 +1101,7 @@ static int pcm_convert_s24_c24_to_s24_c32(const struct cir_buf_source *source,
 				    sizeof(ae_int32));
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -1143,7 +1143,7 @@ static int pcm_convert_s24_c32_to_s24_c24(const struct cir_buf_source *source,
 			AE_SA24_IP(sample24, outu, out);
 		}
 
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 

--- a/src/audio/pcm_converter/pcm_remap.c
+++ b/src/audio/pcm_converter/pcm_remap.c
@@ -83,7 +83,7 @@ static int remap_c16(const struct cir_buf_source *source, uint32_t src_channels,
 		while (frames_left) {
 			size_t samples_wo_wrap, n, i;
 
-			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
 			samples_wo_wrap = cir_buf_samples_without_wrap_s16(src, source->buf_end);
@@ -141,7 +141,7 @@ static inline int remap_c32_left_shift(const struct cir_buf_source *source,
 		while (frames_left) {
 			size_t samples_wo_wrap, n, i;
 
-			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
 			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);
@@ -199,7 +199,7 @@ static inline int remap_c32_right_shift(const struct cir_buf_source *source,
 		while (frames_left) {
 			size_t samples_wo_wrap, n, i;
 
-			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
 			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);
@@ -257,7 +257,7 @@ static inline int remap_c16_to_c32(const struct cir_buf_source *source,
 		while (frames_left) {
 			size_t samples_wo_wrap, n, i;
 
-			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
 			samples_wo_wrap = cir_buf_samples_without_wrap_s16(src, source->buf_end);
@@ -315,7 +315,7 @@ static inline int remap_c32_to_c16(const struct cir_buf_source *source,
 		while (frames_left) {
 			size_t samples_wo_wrap, n, i;
 
-			src = cir_buf_wrap(src, source->buf_start, source->buf_end);
+			src = source_cir_buf_wrap(src, source->buf_start, source->buf_end);
 			dst = cir_buf_wrap(dst, sink->buf_start, sink->buf_end);
 
 			samples_wo_wrap = cir_buf_samples_without_wrap_s32(src, source->buf_end);

--- a/src/audio/volume/volume.c
+++ b/src/audio/volume/volume.c
@@ -69,7 +69,7 @@ static uint32_t vol_zc_get_s16(struct cir_buf_source *source, const int channels
 	int remaining_samples = frames * channels;
 
 	/* Go to last channel */
-	x = cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
+	x = source_cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
 	while (remaining_samples) {
 		bytes = cir_buf_bytes_without_wrap_rewind(x, source->buf_start);
 		nmax = VOL_BYTES_TO_S16_SAMPLES(bytes) + 1;
@@ -118,7 +118,7 @@ static uint32_t vol_zc_get_s24(struct cir_buf_source *source, const int channels
 	int remaining_samples = frames * channels;
 
 	/* Go to last channel */
-	x = cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
+	x = source_cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
 	while (remaining_samples) {
 		bytes = cir_buf_bytes_without_wrap_rewind(x, source->buf_start);
 		nmax = VOL_BYTES_TO_S32_SAMPLES(bytes) + 1;
@@ -167,7 +167,7 @@ static uint32_t vol_zc_get_s32(struct cir_buf_source *source, const int channels
 	int remaining_samples = frames * channels;
 
 	/* Go to last channel */
-	x = cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
+	x = source_cir_buf_wrap(x + remaining_samples - 1, source->buf_start, source->buf_end);
 	while (remaining_samples) {
 		bytes = cir_buf_bytes_without_wrap_rewind(x, source->buf_start);
 		nmax = VOL_BYTES_TO_S32_SAMPLES(bytes) + 1;
@@ -635,7 +635,7 @@ static int volume_process(struct processing_module *mod,
 		cd->scale_vol(mod, &source_buf, &sink_buf, frames, cd->attenuation);
 
 		/* advance the views by the processed frames */
-		source_buf.ptr = cir_buf_wrap((const char *)source_buf.ptr +
+		source_buf.ptr = source_cir_buf_wrap((const char *)source_buf.ptr +
 					      frames * source_frame_bytes,
 					      source_buf.buf_start, source_buf.buf_end);
 		sink_buf.ptr = cir_buf_wrap((char *)sink_buf.ptr + frames * sink_frame_bytes,

--- a/src/audio/volume/volume_generic.c
+++ b/src/audio/volume/volume_generic.c
@@ -83,7 +83,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct cir_buf_source 
 			}
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -120,7 +120,7 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 		n = MIN(n, nmax);
 		memcpy_s(y, n * sizeof(int32_t), x, n * sizeof(int32_t));
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -169,7 +169,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct cir_buf_source 
 			}
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -206,7 +206,7 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 		n = MIN(n, nmax);
 		memcpy_s(y, n * sizeof(int32_t), x, n * sizeof(int32_t));
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -252,7 +252,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 			}
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -289,7 +289,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		n = MIN(n, nmax);
 		memcpy_s(y, n * sizeof(int16_t), x, n * sizeof(int16_t));
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }

--- a/src/audio/volume/volume_generic_with_peakvol.c
+++ b/src/audio/volume/volume_generic_with_peakvol.c
@@ -84,7 +84,7 @@ static void vol_s24_to_s24(struct processing_module *mod, struct cir_buf_source 
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -132,7 +132,7 @@ static void vol_passthrough_s24_to_s24(struct processing_module *mod,
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -186,7 +186,7 @@ static void vol_s32_to_s32(struct processing_module *mod, struct cir_buf_source 
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -237,7 +237,7 @@ static void vol_passthrough_s32_to_s32(struct processing_module *mod,
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -288,7 +288,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }
@@ -336,7 +336,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 			cd->peak_regs.peak_meter[j] = MAX(tmp, cd->peak_regs.peak_meter[j]);
 		}
 		remaining_samples -= n;
-		x = cir_buf_wrap(x + n, source->buf_start, source->buf_end);
+		x = source_cir_buf_wrap(x + n, source->buf_start, source->buf_end);
 		y = cir_buf_wrap(y + n, sink->buf_start, sink->buf_end);
 	}
 }

--- a/src/audio/volume/volume_hifi3.c
+++ b/src/audio/volume/volume_hifi3.c
@@ -123,7 +123,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -166,7 +166,7 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -246,7 +246,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -288,7 +288,7 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -384,7 +384,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -425,7 +425,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }

--- a/src/audio/volume/volume_hifi4.c
+++ b/src/audio/volume/volume_hifi4.c
@@ -123,7 +123,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -165,7 +165,7 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -248,7 +248,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -290,7 +290,7 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -413,7 +413,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 		}
 
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -465,7 +465,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		}
 
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }

--- a/src/audio/volume/volume_hifi4_with_peakvol.c
+++ b/src/audio/volume/volume_hifi4_with_peakvol.c
@@ -121,7 +121,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++)
@@ -180,7 +180,7 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++)
@@ -276,7 +276,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++)
@@ -332,7 +332,7 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA64POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++)
@@ -477,7 +477,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 		}
 
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {
@@ -556,7 +556,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		}
 
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 

--- a/src/audio/volume/volume_hifi5.c
+++ b/src/audio/volume/volume_hifi5.c
@@ -129,7 +129,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -171,7 +171,7 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -259,7 +259,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -301,7 +301,7 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -401,7 +401,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }
@@ -442,7 +442,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 }

--- a/src/audio/volume/volume_hifi5_with_peakvol.c
+++ b/src/audio/volume/volume_hifi5_with_peakvol.c
@@ -135,7 +135,7 @@ static void vol_s24_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 
@@ -197,7 +197,7 @@ static void vol_passthrough_s24_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {
@@ -300,7 +300,7 @@ static void vol_s32_to_s24_s32(struct processing_module *mod, struct cir_buf_sou
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {
@@ -361,7 +361,7 @@ static void vol_passthrough_s32_to_s24_s32(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {
@@ -480,7 +480,7 @@ static void vol_s16_to_s16(struct processing_module *mod, struct cir_buf_source 
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {
@@ -546,7 +546,7 @@ static void vol_passthrough_s16_to_s16(struct processing_module *mod,
 		}
 		AE_SA128POS_FP(outu, out);
 		samples -= n;
-		in = cir_buf_wrap(in, source->buf_start, source->buf_end);
+		in = source_cir_buf_wrap(in, source->buf_start, source->buf_end);
 		out = cir_buf_wrap(out, sink->buf_start, sink->buf_end);
 	}
 	for (i = 0; i < channels_count; i++) {

--- a/src/include/module/audio/audio_stream.h
+++ b/src/include/module/audio/audio_stream.h
@@ -185,6 +185,26 @@ static inline void *cir_buf_wrap(const void *ptr, const void *buf_addr, const vo
 }
 
 /**
+ * Verifies a read pointer and performs rollover when reached the end of the circular buffer.
+ * @param ptr Pointer
+ * @param buf_addr Start address of the circular buffer.
+ * @param buf_end End address of the circular buffer.
+ * @return Pointer, adjusted if necessary.
+ */
+
+static inline const void *source_cir_buf_wrap(const void *ptr, const void *buf_addr,
+					      const void *buf_end)
+{
+	if (ptr >= buf_end)
+		ptr = (const char *)buf_addr +
+			((const char *)ptr - (const char *)buf_end);
+
+	assert((intptr_t)ptr <= (intptr_t)buf_end);
+
+	return ptr;
+}
+
+/**
  * @brief Calculates number of bytes to buffer wrap when reading a circular
  *	  buffer backwards from current pointer towards the buffer start.
  * @param ptr Read or write pointer of circular buffer.


### PR DESCRIPTION
Adds a const-correct forward-wrap helper for read-only circular buffers and uses it on the source (read) side across the audio components, so source read pointers can wrap without casting away const. Also constifies the dcblock HiFi read paths that previously stripped const via casts.