### PR TITLE
topology2: Add support for SYMLINKs for topologies and convert the WCL DMIC functions to symlink to the PTL ones.

### DIFF
--- a/tools/topology/topology2/CMakeLists.txt
+++ b/tools/topology/topology2/CMakeLists.txt
@@ -8,9 +8,9 @@ add_custom_target(topologies2 ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/target/sof-ipc4-tplg
     COMMAND ${CMAKE_COMMAND} -E create_symlink sof-ipc4-tplg ${CMAKE_CURRENT_BINARY_DIR}/target/sof-ace-tplg
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/target/development
-    # copy the topology files only to target
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different production/*.tplg ${CMAKE_CURRENT_BINARY_DIR}/target/sof-ipc4-tplg/
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different development/*.tplg ${CMAKE_CURRENT_BINARY_DIR}/target/development/
+    # copy the topology files only to target, preserving symbolic links
+    COMMAND sh -c "cp -a production/*.tplg \"${CMAKE_CURRENT_BINARY_DIR}/target/sof-ipc4-tplg/\""
+    COMMAND sh -c "cp -a development/*.tplg \"${CMAKE_CURRENT_BINARY_DIR}/target/development/\""
 )
 
 # Check alsatplg version and build topology2 if alsatplg version is

--- a/tools/topology/topology2/production/CMakeLists.txt
+++ b/tools/topology/topology2/production/CMakeLists.txt
@@ -32,3 +32,23 @@ foreach(tplg ${TPLGS})
 	add_custom_target(topology2_prod_${output} DEPENDS ${output}.tplg)
 	add_dependencies(topology2_prod topology2_prod_${output})
 endforeach()
+
+foreach(link ${SYMLINKS})
+	list(LENGTH link length)
+	if(NOT length EQUAL 2)
+		message(FATAL_ERROR "SYMLINKS entry '${link}' must have exactly 2 elements (link_name;link_target), got ${length}")
+	endif()
+
+	list(GET link 0 link_name)
+	list(GET link 1 link_target)
+
+	add_custom_command(
+		OUTPUT ${link_name}.tplg
+		COMMAND ${CMAKE_COMMAND} -E create_symlink "${link_target}.tplg" "${link_name}.tplg"
+		DEPENDS ${link_target}.tplg
+		VERBATIM
+	)
+
+	add_custom_target(topology2_prod_${link_name} DEPENDS ${link_name}.tplg)
+	add_dependencies(topology2_prod topology2_prod_${link_name})
+endforeach()

--- a/tools/topology/topology2/production/tplg-targets-ace3.cmake
+++ b/tools/topology/topology2/production/tplg-targets-ace3.cmake
@@ -303,47 +303,6 @@ PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=5,DMIC1_ID=6,PREPROCESS_PLUGINS
 NHLT_BIN=nhlt-sof-ptl-dmic-4ch-id5.bin,DMIC0_ENHANCED_CAPTURE=true,\
 EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
 
-# for WCL
-"cavs-sdw\;sof-wcl-dmic-2ch-id2\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=2,\
-PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=2,DMIC1_ID=3,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-2ch-id2.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-2ch-id3\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=2,\
-PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=3,DMIC1_ID=4,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-2ch-id3.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-2ch-id4\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=2,\
-PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=4,DMIC1_ID=5,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-2ch-id4.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-2ch-id5\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=2,\
-PDM1_MIC_A_ENABLE=0,PDM1_MIC_B_ENABLE=0,DMIC0_ID=5,DMIC1_ID=6,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-2ch-id5.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line2_generic_pm10deg,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-4ch-id2\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=4,\
-PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=2,DMIC1_ID=3,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-4ch-id2.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-4ch-id3\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=4,\
-PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=3,DMIC1_ID=4,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-4ch-id3.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-4ch-id4\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=4,\
-PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=4,DMIC1_ID=5,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-4ch-id4.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
-"cavs-sdw\;sof-wcl-dmic-4ch-id5\;PLATFORM=wcl,SDW_JACK=false,NUM_HDMIS=0,NUM_DMICS=4,\
-PDM1_MIC_A_ENABLE=1,PDM1_MIC_B_ENABLE=1,DMIC0_ID=5,DMIC1_ID=6,PREPROCESS_PLUGINS=nhlt,\
-NHLT_BIN=nhlt-sof-wcl-dmic-4ch-id5.bin,DMIC0_ENHANCED_CAPTURE=true,\
-EFX_DMIC0_TDFB_PARAMS=line4_pass,EFX_DMIC0_DRC_PARAMS=dmic_default"
-
 "cavs-es83x6\;sof-ptl-ssp1-jack-id0\;PLATFORM=ptl,PREPROCESS_PLUGINS=nhlt,\
 NHLT_BIN=nhlt-sof-ptl-ssp1-jack-id0.bin,HEADSET_SSP_DAI_INDEX=1,\
 HEADSET_CODEC=true,HEADSET_CODEC_NAME=SSP1-Codec,NUM_HDMIS=0,\
@@ -375,4 +334,16 @@ BT_CP_HOST_PIPELINE_ID=201,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-ssp2-bt
 "cavs-sdw\;sof-ptl-ssp2-bt-id10\;PLATFORM=ptl,ADD_BT=true,SDW_JACK=false,NUM_HDMIS=0,\
 HEADSET_CODEC=false,HDMI_IN_CAPTURE=false,BT_ID=10,BT_PCM_ID=20,BT_PCM_NAME=Bluetooth,\
 BT_CP_HOST_PIPELINE_ID=201,PREPROCESS_PLUGINS=nhlt,NHLT_BIN=nhlt-sof-ptl-ssp2-bt-id10.bin"
+)
+
+list(APPEND SYMLINKS
+# WCL DMIC function topologies are identical to the PTL ones
+"sof-wcl-dmic-2ch-id2\;sof-ptl-dmic-2ch-id2"
+"sof-wcl-dmic-2ch-id3\;sof-ptl-dmic-2ch-id3"
+"sof-wcl-dmic-2ch-id4\;sof-ptl-dmic-2ch-id4"
+"sof-wcl-dmic-2ch-id5\;sof-ptl-dmic-2ch-id5"
+"sof-wcl-dmic-4ch-id2\;sof-ptl-dmic-4ch-id2"
+"sof-wcl-dmic-4ch-id3\;sof-ptl-dmic-4ch-id3"
+"sof-wcl-dmic-4ch-id4\;sof-ptl-dmic-4ch-id4"
+"sof-wcl-dmic-4ch-id5\;sof-ptl-dmic-4ch-id5"
 )


### PR DESCRIPTION
Add support for SYMLINKS array which can be used to create a symlink to an existing topology with a different name to handle duplication.
The first user of this will be WCL's DMIC function topologies since they are identical to the PTL functions.
The resulting target will look like this:
```
-rw-r--r-- 1 pujfalus pujfalus  24403 Sep  7 14:18 sof-ptl-dmic-2ch-id2.tplg
-rw-r--r-- 1 pujfalus pujfalus  24403 Sep  7 14:18 sof-ptl-dmic-2ch-id3.tplg
-rw-r--r-- 1 pujfalus pujfalus  24403 Sep  7 14:18 sof-ptl-dmic-2ch-id4.tplg
-rw-r--r-- 1 pujfalus pujfalus  24403 Sep  7 14:18 sof-ptl-dmic-2ch-id5.tplg
-rw-r--r-- 1 pujfalus pujfalus  23787 Sep  7 14:18 sof-ptl-dmic-4ch-id2.tplg
-rw-r--r-- 1 pujfalus pujfalus  23787 Sep  7 14:18 sof-ptl-dmic-4ch-id3.tplg
-rw-r--r-- 1 pujfalus pujfalus  23787 Sep  7 14:18 sof-ptl-dmic-4ch-id4.tplg
-rw-r--r-- 1 pujfalus pujfalus  23787 Sep  7 14:18 sof-ptl-dmic-4ch-id5.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-2ch-id2.tplg -> sof-ptl-dmic-2ch-id2.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-2ch-id3.tplg -> sof-ptl-dmic-2ch-id3.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-2ch-id4.tplg -> sof-ptl-dmic-2ch-id4.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-2ch-id5.tplg -> sof-ptl-dmic-2ch-id5.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-4ch-id2.tplg -> sof-ptl-dmic-4ch-id2.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-4ch-id3.tplg -> sof-ptl-dmic-4ch-id3.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-4ch-id4.tplg -> sof-ptl-dmic-4ch-id4.tplg
lrwxrwxrwx 1 pujfalus pujfalus     25 Sep  7 14:18 sof-wcl-dmic-4ch-id5.tplg -> sof-ptl-dmic-4ch-id5.tplg
```
We can use this symlink mode to reduce the size of the topology deployment by converting the identical topologies to symlinks later.
