### PR TITLE
ipc4: handler: only set pm_prepare_D3 when CONFIG_PM is enabled

### DIFF
--- a/src/ipc/ipc4/handler-kernel.c
+++ b/src/ipc/ipc4/handler-kernel.c
@@ -428,7 +428,9 @@ __cold static int ipc4_module_process_dx(struct ipc4_message_request *ipc4)
 		arch_irq_lock();
 		platform_timer_stop(timer_get());
 #endif
+#if defined(CONFIG_PM)
 		ipc_get()->pm_prepare_D3 = 1;
+#endif
 	}
 
 	return IPC4_SUCCESS;


### PR DESCRIPTION
pm_prepare_D3 gates ipc_send_queued_msg() and is only cleared from ipc_device_resume_handler(), which needs CONFIG_PM to run. On builds with CONFIG_PM=n no one clears it, so the IPC queue stalls after a SET_DX message. Guard the assignment with CONFIG_PM, like the task_mask handling just above.