### PR TITLE
acp_7_x: clk: enable tick counter in D0 sequence

### DIFF
--- a/src/platform/amd/acp_7_x/include/platform/platform.h
+++ b/src/platform/amd/acp_7_x/include/platform/platform.h
@@ -65,6 +65,8 @@ struct timer;
 /* debug offset */
 #define ACP_SOF_FW_STATUS	0
 
+void acp_clk_tick_cnt_enable(void);
+
 /* Platform defined panic code */
 static inline void platform_panic(uint32_t p)
 {

--- a/src/platform/amd/acp_7_x/lib/clk.c
+++ b/src/platform/amd/acp_7_x/lib/clk.c
@@ -218,6 +218,18 @@ uint32_t mp1_mailbox_send(uint32_t _reg_id, uint32_t _value)
 	return resp;
 }
 
+void acp_clk_tick_cnt_enable(void)
+{
+	clk_tick_cnt_config_reg_t clk_tick_config;
+
+	clk_tick_config.u32All = acp_reg_read_via_smn(
+			CLK_TICK_CNT_CONFIG_REG, sizeof(uint32_t));
+	clk_tick_config.bitfields.TIMER_ENABLE = 1;
+	clk_tick_config.bitfields.TIMER_THRESHOLD = 0x1E0;
+	acp_reg_write_via_smn(CLK_TICK_CNT_CONFIG_REG,
+			      clk_tick_config.u32All, sizeof(uint32_t));
+}
+
 void acp_clk_d0_sequence(uint32_t clock_freq)
 {
 	/* Send message to PMFW to power on Audio PLL */

--- a/src/platform/amd/acp_7_x/platform.c
+++ b/src/platform/amd/acp_7_x/platform.c
@@ -149,6 +149,7 @@ int platform_init(struct sof *sof)
 
 	/*CONFIG_SYSTICK_PERIOD hardcoded as 200000*/
 	sa_init(sof, 200000);
+	acp_clk_tick_cnt_enable();
 	clock_set_freq(CLK_CPU(cpu_get_id()), CLK_MAX_CPU_HZ);
 	/* init DMA */
 	ret = dmac_init(sof);


### PR DESCRIPTION
Configure CLK_TICK_CNT before change_clock_notify so current clock readback via acp_get_current_clk uses a valid timer threshold.
