### PR TITLE
audio: pipeline: guard against NULL source or sink in pipeline_copy()

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -179,12 +179,22 @@ int pipeline_copy(struct pipeline *p)
 
 	PPL_LOCK(p->core);
 
+	if (!p->source_comp) {
+		PPL_UNLOCK();
+		return 0;
+	}
+
 	if (p->source_comp->direction == SOF_IPC_STREAM_PLAYBACK) {
 		dir = PPL_DIR_UPSTREAM;
 		start = p->sink_comp;
 	} else {
 		dir = PPL_DIR_DOWNSTREAM;
 		start = p->source_comp;
+	}
+
+	if (!start) {
+		PPL_UNLOCK();
+		return 0;
 	}
 
 	data.start = start;


### PR DESCRIPTION
When a pipeline is being stopped or unbound, the component unbind handler may clear pipeline->source_comp before the low-latency copy task finishes its final execution tick. Attempting to access p->source_comp->direction without checking for NULL triggers a synchronous PIF exception (DSP panic).

Add NULL checks for p->source_comp and start before proceeding with the pipeline graph copy walk, returning 0 cleanly if the pipeline endpoints are no longer valid.